### PR TITLE
Fix/mentions and emoji suggestion list

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -536,16 +536,24 @@ Item {
                 }
             }
 
-            StatusButton {
-                Layout.fillHeight: true
-                Layout.maximumHeight: chatInput.implicitHeight
-                verticalPadding: 0
+            // Button wrapped into RowLayout as a workaround for QTBUG-146653 causing suggestions list inside
+            // StatusChatInput not clickable.
+            RowLayout {
+                Layout.fillWidth: false
+                Layout.fillHeight: false
                 visible: !!d.activeChatContentModule && d.activeChatContentModule.chatDetails.blocked
-                text: qsTr("Unblock")
-                type: StatusBaseButton.Type.Danger
-                onClicked: {
-                    if (!!d.activeChatContentModule)
-                        d.activeChatContentModule.unblockChat()
+
+                StatusButton {
+                    Layout.fillHeight: true
+                    Layout.maximumHeight: chatInput.implicitHeight
+                    verticalPadding: 0
+                    visible: !!d.activeChatContentModule && d.activeChatContentModule.chatDetails.blocked
+                    text: qsTr("Unblock")
+                    type: StatusBaseButton.Type.Danger
+                    onClicked: {
+                        if (!!d.activeChatContentModule)
+                            d.activeChatContentModule.unblockChat()
+                    }
                 }
             }
         }

--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -513,6 +513,8 @@ Control {
         width: root.width
 
         onClicked: index => {
+            InputMethod.commit()
+
             if (index === undefined) {
                 index = emojiSuggestions.listView.currentIndex
             }

--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -539,6 +539,8 @@ Control {
         property bool shouldHide: false
 
         function selectItem(index: int) {
+            InputMethod.commit()
+
             const item = messageInputField.suggestionsModel.get(index)
 
             messageInputField.forceActiveFocus()

--- a/ui/imports/shared/status/StatusChatInputTextArea.qml
+++ b/ui/imports/shared/status/StatusChatInputTextArea.qml
@@ -249,6 +249,10 @@ StatusQ.StatusTextArea {
         suggestionsFilterAdaptor.invalidateFilter()
     }
 
+    onPreeditTextChanged: {
+        suggestionsFilterAdaptor.invalidateFilter()
+    }
+
     onLinkActivated: {
         const mention = d.getMentionAtPosition(cursorPosition - 1)
         if(mention) {
@@ -738,24 +742,31 @@ StatusQ.StatusTextArea {
 
         sourceModel: root.usersModel
 
-        filter: getFilter().substring(
-                    lastAtPosition + 1,
-                    root.cursorPosition).replace(/\*/g, "")
+        filter: {
+            const effectiveCursor = root.cursorPosition + root.preeditText.length
+            return getFilter().substring(lastAtPosition + 1, effectiveCursor).replace(/\*/g, "")
+        }
 
         property int lastAtPosition: -1 // todo: rename to lastMentionAtPosition
         property int cursorPosition: root.cursorPosition
 
         function getFilter() {
-            if (root.text.length === 0 ||
-                    root.cursorPosition === 0)
-                return ""
-
-            return StatusQUtils.StringUtils.plainText(root.text)
+            const committed = root.text.length > 0
+                ? StatusQUtils.StringUtils.plainText(root.text)
+                : ""
+            if (!root.preeditText)
+                return committed
+            // preeditText sits at cursorPosition in the visual text; splice it
+            // into the committed plain text so the filter sees the full input
+            return committed.substring(0, root.cursorPosition)
+                   + root.preeditText
+                   + committed.substring(root.cursorPosition)
         }
 
         function invalidateFilter() {
             const filter = getFilter()
-            lastAtPosition = filter.substring(0, root.cursorPosition).lastIndexOf("@")
+            const effectiveCursor = root.cursorPosition + root.preeditText.length
+            lastAtPosition = filter.substring(0, effectiveCursor).lastIndexOf("@")
         }
     }
 

--- a/ui/imports/shared/status/StatusChatInputTextArea.qml
+++ b/ui/imports/shared/status/StatusChatInputTextArea.qml
@@ -251,6 +251,23 @@ StatusQ.StatusTextArea {
 
     onPreeditTextChanged: {
         suggestionsFilterAdaptor.invalidateFilter()
+
+        if (!preeditText) {
+            d.emojiFilter = ""
+            return
+        }
+
+        // Reconstruct plain text visible to the user up to the effective cursor
+        const committed = root.text.length > 0
+            ? StatusQUtils.StringUtils.plainText(root.text).substring(0, root.cursorPosition)
+            : ""
+        const beforeCursor = committed + preeditText
+        const colonIndex = beforeCursor.lastIndexOf(':')
+        if (colonIndex >= 0 && d.validSubstr(beforeCursor.substring(colonIndex))) {
+            d.emojiFilter = beforeCursor.substring(colonIndex)
+            return
+        }
+        d.emojiFilter = ""
     }
 
     onLinkActivated: {


### PR DESCRIPTION
### What does the PR do

Fixes two issues related to mention suggestions list:
- no filtering on some Android versions caused by preedit text
- not possible to select mention by tapping - investigation led to pinpointing and reporting qt regression: https://qt-project.atlassian.net/browse/QTBUG-146653

Closes: #20743
Closes: #20798

### Affected areas
`StatusChatInputTextArea`, `StatusChatColumnView`
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screencapture of the functionality

https://github.com/user-attachments/assets/7295b08f-7a07-4923-b04f-1e51d0b1ec27

### How to test
Go to chat, type @ or click @ icon, type to filter mention, select mention from the list.

### Risk 

Medium - change regarding committing preedit text may affect some other scenarios in unexpected way
