### PR TITLE
feat(connector): ephemeral dApp records

### DIFF
--- a/src/app/modules/shared_modules/connector/controller.nim
+++ b/src/app/modules/shared_modules/connector/controller.nim
@@ -234,6 +234,9 @@ QtObject:
   proc disconnect*(self: Controller, dAppUrl: string, clientId: string = ""): bool {.slot.} =
     result = self.service.recallDAppPermission(dAppUrl, clientId)
 
+  proc deleteEphemeralDApps*(self: Controller) {.slot.} =
+    discard self.service.deleteEphemeralDApps()
+
   proc nextWcRequestId(self: Controller, prefix: string): string =
     self.wcRequestCounter += 1
     return prefix & "-" & $self.wcRequestCounter

--- a/src/app_service/service/connector/service.nim
+++ b/src/app_service/service/connector/service.nim
@@ -225,6 +225,14 @@ QtObject:
       error "recallDAppPermissionFinishedRpc failed: ", err=e.msg
       return false
 
+  proc deleteEphemeralDApps*(self: Service): bool =
+    try:
+      return status_go.deleteEphemeralDAppsRpc()
+
+    except Exception as e:
+      error "deleteEphemeralDAppsRpc failed: ", err=e.msg
+      return false
+
   proc getDApps*(self: Service): string =
     try:
       let response = status_go.getPermittedDAppsList()

--- a/src/backend/connector.nim
+++ b/src/backend/connector.nim
@@ -52,6 +52,9 @@ rpc(recallDAppPermissionV2, "connector"):
 rpc(getPermittedDAppsList, "connector"):
   discard
 
+rpc(deleteEphemeralDApps, "connector"):
+  discard
+
 rpc(signAccepted, "connector"):
   args: SignAcceptedArgs
 
@@ -119,6 +122,9 @@ proc sendTransactionRejectedFinishedRpc*(args: RejectedArgs): bool =
 
 proc recallDAppPermissionFinishedRpc*(dAppUrl: string, clientId: string): bool =
   return isSuccessResponse(recallDAppPermissionV2(dAppUrl, clientId))
+
+proc deleteEphemeralDAppsRpc*(): bool =
+  return isSuccessResponse(deleteEphemeralDApps())
 
 proc sendSignAcceptedFinishedRpc*(args: SignAcceptedArgs): bool =
   return isSuccessResponse(signAccepted(args))

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -65,6 +65,12 @@ StatusSectionLayout {
         webViewContext.reloadCurrent()
     }
 
+    function applyIncognitoMode(checked) {
+        webViewContext.setIncognitoCurrent(checked)
+        if (!checked && root.connectorController)
+            root.connectorController.deleteEphemeralDApps()
+    }
+
     Component.onCompleted: {
         savedSessionContext.restoreSession()
     }
@@ -378,7 +384,7 @@ StatusSectionLayout {
                     browserToolbarLoader.activateAddressBar()
                 }
                 function onGoIncognito(checked) {
-                    webViewContext.setIncognitoCurrent(checked)
+                    root.applyIncognitoMode(checked)
                 }
                 function onRequestDownloadsView() {
                     _internal.addNewDownloadTab()
@@ -632,7 +638,7 @@ StatusSectionLayout {
         zoomFactor: _internal.currentWebView?.zoomFactor ?? 1
         onAddNewTab: _internal.addNewTab()
         onAddNewDownloadTab: _internal.addNewDownloadTab()
-        onGoIncognito: (checked) => webViewContext.setIncognitoCurrent(checked)
+        onGoIncognito: (checked) => root.applyIncognitoMode(checked)
         onZoomIn: webViewContext.changeZoomCurrent(0.1)
         onZoomOut: webViewContext.changeZoomCurrent(-0.1)
         onResetZoomFactor: webViewContext.resetZoomCurrent()
@@ -668,7 +674,7 @@ StatusSectionLayout {
         supportsFind: _internal.currentTabSupportsFindInPage
         onLaunchFindBar: _internal.showFindBar()
 
-        onGoIncognito: checked => webViewContext.setIncognitoCurrent(checked)
+        onGoIncognito: checked => root.applyIncognitoMode(checked)
         onSettingsRequested: Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.browserSettings)
     }
 
@@ -777,6 +783,7 @@ StatusSectionLayout {
         userUID: root.userUID
         featureEnabled: root.dappsEnabled
         connectorController: root.dappsEnabled ? root.connectorController : null
+        currentTabIncognito: _internal.currentTabIncognito
         httpUserAgent: {
             if (localAccountSensitiveSettings.compatibilityMode) {
                 // Google doesn't let you connect if the user agent is Chrome-ish and doesn't satisfy some sort of hidden requirement

--- a/ui/app/AppLayouts/Browser/provider/qml/ConnectorBridge.qml
+++ b/ui/app/AppLayouts/Browser/provider/qml/ConnectorBridge.qml
@@ -20,6 +20,7 @@ QtObject {
     property bool featureEnabled: true
     required property var connectorController
     property string httpUserAgent: ""          // Custom user agent for web profiles
+    property bool currentTabIncognito: false   // Drives off-the-record clientId for the active tab
 
     readonly property ProfileParams defaultProfileParams: ProfileParams {
         userId: root.userUID
@@ -51,6 +52,7 @@ QtObject {
     readonly property ConnectorManager connectorManager: ConnectorManager {
         id: connectorManager
         connectorController: root.connectorController  // (shared_modules/connector/controller.nim)
+        offTheRecord: root.currentTabIncognito
 
         // Forward events to Eip1193ProviderAdapter
         onConnectEvent: (info) => eip1193ProviderAdapter.connectEvent(info)

--- a/ui/app/AppLayouts/Browser/provider/qml/ConnectorConstants.qml
+++ b/ui/app/AppLayouts/Browser/provider/qml/ConnectorConstants.qml
@@ -1,0 +1,17 @@
+pragma Singleton
+
+import QtQuick
+
+QtObject {
+    readonly property string baseClientId: "status-desktop/dapp-browser"
+    readonly property string ephemeralClientIdSuffix: "#ephemeral"
+
+    function isEphemeralClientId(id) {
+        const s = id === undefined || id === null ? "" : String(id)
+        return s.length > 0 && s.endsWith(ephemeralClientIdSuffix)
+    }
+
+    function clientIdFor(offTheRecord) {
+        return offTheRecord ? baseClientId + ephemeralClientIdSuffix : baseClientId
+    }
+}

--- a/ui/app/AppLayouts/Browser/provider/qml/ConnectorManager.qml
+++ b/ui/app/AppLayouts/Browser/provider/qml/ConnectorManager.qml
@@ -12,7 +12,10 @@ QtObject {
     property string dappName: ""
     property string dappIconUrl: ""
     property int dappChainId: 1
-    property string clientId: "status-desktop/dapp-browser"
+    property bool offTheRecord: false
+    readonly property string clientId: offTheRecord
+        ? "status-desktop/dapp-browser#ephemeral"
+        : "status-desktop/dapp-browser"
 
     // STATE
     property bool connected: false

--- a/ui/app/AppLayouts/Browser/provider/qml/ConnectorManager.qml
+++ b/ui/app/AppLayouts/Browser/provider/qml/ConnectorManager.qml
@@ -13,9 +13,7 @@ QtObject {
     property string dappIconUrl: ""
     property int dappChainId: 1
     property bool offTheRecord: false
-    readonly property string clientId: offTheRecord
-        ? "status-desktop/dapp-browser#ephemeral"
-        : "status-desktop/dapp-browser"
+    readonly property string clientId: ConnectorConstants.clientIdFor(offTheRecord)
 
     // STATE
     property bool connected: false
@@ -161,7 +159,6 @@ QtObject {
             console.log("[ConnectorManager] Ignoring signal for other origin:", event.url, "expected:", dappOrigin)
             return false
         }
-
         // Filter by clientId
         if (event.clientId !== undefined && event.clientId !== "" && clientId !== "" && event.clientId !== clientId) {
             console.log("[ConnectorManager] Ignoring signal for other clientId:", event.clientId, "expected:", clientId)

--- a/ui/app/AppLayouts/Browser/provider/qml/qmldir
+++ b/ui/app/AppLayouts/Browser/provider/qml/qmldir
@@ -1,3 +1,4 @@
+singleton ConnectorConstants 1.0 ConnectorConstants.qml
 ConnectorBridge 1.0 ConnectorBridge.qml
 ConnectorManager 1.0 ConnectorManager.qml
 Eip1193ProviderAdapter 1.0 Eip1193ProviderAdapter.qml

--- a/ui/app/AppLayouts/Wallet/services/dapps/BCBrowserDappsProvider.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/BCBrowserDappsProvider.qml
@@ -20,6 +20,8 @@ DAppsModel {
     signal connected(string dappUrl)
     signal disconnected(string dappUrl)
     
+    onClientIdFilterChanged: d.refreshModel()
+    
     Connections {
         target: root.connectorController
         enabled: root.enabled

--- a/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
@@ -207,6 +207,11 @@ WalletConnectSDKBase {
                     continue
                 }
 
+                // Wallet section never shows off-the-record (ephemeral) sessions.
+                if ((dapp.clientId || "").indexOf("#ephemeral") > 0) {
+                    continue
+                }
+
                 activeSessions[dapp.url] = d.buildSession(dapp.url, dapp.name, dapp.iconUrl, "", dapp.sharedAccount, [dapp.chainId], dapp.clientId)
             }
             callback(activeSessions)
@@ -225,6 +230,7 @@ WalletConnectSDKBase {
     QtObject {
         id: d
         readonly property var sessionRequests: new Map()
+
         function buildSession(dappUrl, dappName, dappIcon, proposalId, account, chains, clientId) {
             let sessionTemplate = (dappUrl, dappName, dappIcon, proposalId, eipAccount, eipChains, clientId) => {
                 const session = {

--- a/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
@@ -16,6 +16,8 @@ import AppLayouts.Wallet.services.dapps.types
 import shared.stores
 import utils
 
+import AppLayouts.Browser.provider.qml 1.0
+
 import "types"
 
 /// Act as another layer of abstraction to the WalletConnectSDKBase
@@ -207,8 +209,8 @@ WalletConnectSDKBase {
                     continue
                 }
 
-                // Wallet section never shows off-the-record (ephemeral) sessions.
-                if ((dapp.clientId || "").indexOf("#ephemeral") > 0) {
+                // Wallet section never shows off-the-record (ephemeral) sessions (suffix matches DB cleanup).
+                if (ConnectorConstants.isEphemeralClientId(dapp.clientId)) {
                     continue
                 }
 


### PR DESCRIPTION
integration https://github.com/status-im/status-go/pull/7435 

* Incognito tabs use a separate clientId and their connector records are cleaned up properly
* Wallet section ignores ephemeral sessions
* clientId: `status-desktop/dapp-browser` for normal tabs, `status-desktop/dapp-browser#ephemeral` for off-the-record tabs
* on explicit "Exit Incognito" calls `connectorController.deleteEphemeralDApps()`


https://github.com/user-attachments/assets/844db6cd-8c98-40d9-a063-270d68672fad

closes #20676 