### PR TITLE
fix: GifPopup and StickersPopup bottom-sheet layout improved

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusTabBarIconButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTabBarIconButton.qml
@@ -7,8 +7,8 @@ Item {
     id: root
 
     property StatusAssetSettings icon: StatusAssetSettings {
-        width: 24
-        height: 24
+        width: 28
+        height: 28
         name: ""
     }
 
@@ -16,8 +16,8 @@ Item {
 
     signal clicked(var mouse)
 
-    implicitWidth: 40
-    implicitHeight: 40
+    implicitWidth: 44
+    implicitHeight: 44
 
     StatusMouseArea {
         id: sensor

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1316,6 +1316,7 @@ Item {
         active: appMain.rootStore.sectionsLoaded
         sourceComponent: StatusStickersPopup {
             directParent: appMain.Window.contentItem
+            height: 440
             store: appMain.rootChatStore
             isWalletEnabled: appMain.walletProfileStore.isWalletEnabled
             thirdpartyServicesEnabled: appMain.rootStore.thirdpartyServicesEnabled

--- a/ui/app/mainui/Handlers/StatusGifPopupHandler.qml
+++ b/ui/app/mainui/Handlers/StatusGifPopupHandler.qml
@@ -41,6 +41,7 @@ QtObject {
 
             width: 360
             height: 440
+
             directParent: _d.popupParent
             relativeX: _d.relativeX !== undefined ? _d.relativeX : directParent.width - popup.width - Theme.halfPadding
             relativeY: -popup.height - Theme.halfPadding

--- a/ui/imports/shared/status/StatusEmojiPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiPopup.qml
@@ -255,6 +255,9 @@ StatusDropdown {
                 model: root.emojiModel.categoryIcons
 
                 StatusTabBarIconButton {
+                    width: 40
+                    height: 40
+
                     icon.name: modelData
                     highlighted: !!d.searchString ? index === 0 : index == emojiGrid.currentCategoryIndex
                     onClicked: {

--- a/ui/imports/shared/status/StatusGifPopup.qml
+++ b/ui/imports/shared/status/StatusGifPopup.qml
@@ -62,7 +62,10 @@ StatusDropdown {
     signal gifSelected(string url)
     signal enableThirdpartyServicesRequested
 
-    width: 360
+    padding: 0
+    implicitWidth: 360
+
+    fillHeightOnBottomSheet: true
 
     background: Rectangle {
         radius: Theme.radius
@@ -95,19 +98,19 @@ StatusDropdown {
             confirmationPopupLoader.item.close()
     }
 
-    padding: 0
-
     QtObject {
         id: d
 
+        readonly property int minimumContentHeight: 440
         readonly property int headerMargin: root.Theme.halfPadding
     }
 
     contentItem: Item {
-        implicitWidth: parent.width
-        implicitHeight: childrenRect.height
+        implicitHeight: Math.max(d.minimumContentHeight, contentColumn.implicitHeight)
 
         ColumnLayout {
+            id: contentColumn
+
             anchors.fill: parent
             spacing: 0
 
@@ -160,7 +163,7 @@ StatusDropdown {
                 id: gifsLoader
 
                 active: root.thirdpartyServicesEnabled && root.opened && root.gifUnfurlingEnabled
-                visible: active
+                visible: root.thirdpartyServicesEnabled && root.gifUnfurlingEnabled
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 

--- a/ui/imports/shared/status/StatusStickerMarket.qml
+++ b/ui/imports/shared/status/StatusStickerMarket.qml
@@ -40,15 +40,15 @@ Item {
     StatusGridView {
         id: availableStickerPacks
         objectName: "stickerMarketStatusGridView"
-        width: parent.width
-        height: 380
         anchors.left: parent.left
         anchors.leftMargin: Theme.padding
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.topMargin: Theme.padding
+        anchors.bottom: footer.top
+
         cellWidth: parent.width - (Theme.padding * 2)
-        cellHeight: height - 72
+        cellHeight: 308
         visible: root.marketVisible
 
         ScrollBar.vertical: StatusScrollBar {}
@@ -191,7 +191,10 @@ Item {
     Item {
         id: footer
         height: 44
-        anchors.top: availableStickerPacks.bottom
+
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
 
         StatusBackButton {
             id: btnBack

--- a/ui/imports/shared/status/StatusStickerMarket.qml
+++ b/ui/imports/shared/status/StatusStickerMarket.qml
@@ -201,8 +201,8 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.left
             anchors.leftMargin: Theme.padding / 2
-            width: 24
-            height: 24
+            width: 28
+            height: 28
             icon.width: 16
             icon.height: 16
             horizontalPadding: 0

--- a/ui/imports/shared/status/StatusStickerPackIconWithIndicator.qml
+++ b/ui/imports/shared/status/StatusStickerPackIconWithIndicator.qml
@@ -14,8 +14,8 @@ Item {
     property url source: Assets.svg("history")
     signal clicked
 
-    implicitHeight: 24
-    implicitWidth: 24
+    implicitHeight: 28
+    implicitWidth: 28
 
     RoundedImage {
         visible: !useIconInsteadOfImage

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -26,6 +26,8 @@ StatusDropdown {
     signal stickerSelected(string hashId, string packId, string url)
     signal buyClicked(string packId, string price)
 
+    fillHeightOnBottomSheet: true
+
     QtObject {
         id: d
 
@@ -209,6 +211,7 @@ StatusDropdown {
         Item {
             id: stickersContainer
             Layout.fillWidth: true
+            Layout.fillHeight: true
             Layout.leftMargin: 4
             Layout.topMargin: 4
             Layout.bottomMargin: 0

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -29,6 +29,8 @@ StatusDropdown {
     QtObject {
         id: d
 
+        readonly property int minimumContentHeight: 440
+
         // FIXME: move me to store
         readonly property int installedPacksCount: root.store.stickersModuleInst.numInstalledStickerPacks
         readonly property var recentStickers: root.store.stickersModuleInst.recent
@@ -57,8 +59,11 @@ StatusDropdown {
     }
 
     enabled: !!d.recentStickers && !!d.stickerPackList
-    width: 360
-    height: 440
+
+    padding: 0
+    implicitWidth: 360
+    implicitHeight: Math.max(contentItem.implicitHeight, d.minimumContentHeight) + topPadding + bottomPadding
+
     background: Rectangle {
         radius: Theme.radius
         color: Theme.palette.background
@@ -86,8 +91,6 @@ StatusDropdown {
         footerContent.visible = true
         stickersContainer.visible = true
     }
-
-    padding: 0
 
     contentItem: ColumnLayout {
         spacing: 0

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -305,8 +305,8 @@ StatusDropdown {
 
             StatusRoundButton {
                 id: btnAddStickerPack
-                Layout.preferredWidth: 24
-                Layout.preferredHeight: 24
+                Layout.preferredWidth: 28
+                Layout.preferredHeight: 28
                 icon.name: "add"
                 type: StatusFlatRoundButton.Type.Secondary
                 loading: d.stickerPacksLoading


### PR DESCRIPTION
### What does the PR do

Fixes misaligned stickers and gif popups in bottom-sheet mode.
Closes: #20571

### Affected areas
`StatusGifPopup`, `StatusStickersPopup`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screencapture of the functionality

<img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/21faafbb-eb2a-4109-8f27-ccb032770b59" />


### Impact on end user

Low

### How to test

Go to Chat, click stickers and gifs buttons to trigger popups.

### Risk 

Low, changes limited to those 2 popups.
