### PR TITLE
fix(main): prevent the app from going fullscreen on mobile

### DIFF
--- a/mobile/android/qt6/AndroidManifest.xml
+++ b/mobile/android/qt6/AndroidManifest.xml
@@ -22,6 +22,7 @@
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE" />
 
     <!-- features -->
     <uses-feature android:name="android.hardware.camera" android:required="false" />

--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -7,9 +7,18 @@ import android.content.pm.PackageManager;
 import androidx.core.splashscreen.SplashScreen;
 import java.util.concurrent.atomic.AtomicBoolean;
 import android.content.Intent;
+import android.content.Context;
 import android.net.Uri;
 import android.provider.Settings;
 import im.status.mobileui.PushNotificationHelper;
+
+import java.lang.ref.WeakReference;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.View;
+import android.view.WindowInsets;
+import android.view.WindowInsetsController;
+import android.view.WindowManager;
 
 public class StatusQtActivity extends QtActivity {
     private static final AtomicBoolean splashShouldHide = new AtomicBoolean(false);
@@ -34,7 +43,7 @@ public class StatusQtActivity extends QtActivity {
         super.onCreate(savedInstanceState);
         sInstance = this;
         
-        if (Build.VERSION.SDK_INT >= 31) { // Android 12+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) { // Android 12+
             SplashScreen splashScreen = SplashScreen.installSplashScreen(this);
             splashScreen.setKeepOnScreenCondition(() -> !splashShouldHide.get());
         }
@@ -45,11 +54,31 @@ public class StatusQtActivity extends QtActivity {
     }
 
     @Override
+    protected void onStart() {
+        super.onStart();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            Api34Helper.register(this);
+            Api34Helper.triggerIfPending(this, "onStart");
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            Api34Helper.unregister(this);
+        }
+    }
+
+    @Override
     protected void onResume() {
         super.onResume();
         ShakeDetector.onResume(this);
         // Inform the status-go service that UI is visible so it can suppress OS notifications.
         StatusGoStub.setUiVisible(true);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            Api34Helper.triggerIfPending(this, "onResume");
+        }
     }
 
     @Override
@@ -61,10 +90,177 @@ public class StatusQtActivity extends QtActivity {
     }
 
     @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        // Let Qt initialize its internal focus values first
+        super.onWindowFocusChanged(hasFocus);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            Api34Helper.onFocusChanged(this, hasFocus);
+        }
+    }
+
+    @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         setIntent(intent);
         handleDeepLink(intent);
+    }
+
+    /**
+     * Nested class to isolate API 34+ references.
+     * Uses persistent states and window focus tracking to withstand system overlay environments.
+     */
+    private static class Api34Helper {
+        private static android.app.Activity.ScreenCaptureCallback screenshotCallback;
+        private static WeakReference<StatusQtActivity> activityRef;
+        private static final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+        private static int recoveryAttempts = 0;
+        private static final int MAX_ATTEMPTS = 15; // 15 attempts * 300ms = 4.5 seconds per wave
+
+        // Persistent storage access ensures state data survives any background process cleanup
+        private static boolean getPendingRecovery(Context context) {
+            return context.getSharedPreferences("screenshot_recovery_prefs", Context.MODE_PRIVATE)
+                          .getBoolean("pending_recovery", false);
+        }
+
+        private static void setPendingRecovery(Context context, boolean pending) {
+            context.getSharedPreferences("screenshot_recovery_prefs", Context.MODE_PRIVATE)
+                          .edit()
+                          .putBoolean("pending_recovery", pending)
+                          .apply();
+        }
+
+        static void register(final StatusQtActivity activity) {
+            activityRef = new WeakReference<>(activity);
+
+            try {
+                if (screenshotCallback == null) {
+                    screenshotCallback = new android.app.Activity.ScreenCaptureCallback() {
+                        @Override
+                        public void onScreenCaptured() {
+                            StatusQtActivity act = (activityRef != null) ? activityRef.get() : null;
+                            if (act == null || act.isFinishing() || act.isDestroyed()) {
+                                return;
+                            }
+
+                            // Arm persistent recovery state and begin the initial wave
+                            setPendingRecovery(act.getApplicationContext(), true);
+                            startRecoveryWave();
+                        }
+                    };
+                }
+                activity.registerScreenCaptureCallback(activity.getMainExecutor(), screenshotCallback);
+
+            } catch (SecurityException e) {
+                android.util.Log.e("StatusQtActivity", "SecurityException: Missing DETECT_SCREEN_CAPTURE permission.", e);
+            } catch (Throwable t) {
+                android.util.Log.e("StatusQtActivity", "Failed to initialize screen capture hook.", t);
+            }
+        }
+
+        /**
+         * Intercepts standard lifecycle resume methods. If returning from the editor
+         * with an un-resolved recovery state, this initializes a fresh wave.
+         */
+        static void triggerIfPending(StatusQtActivity activity, String source) {
+            if (getPendingRecovery(activity.getApplicationContext())) {
+                android.util.Log.i("StatusQtActivity", "Lifecycle milestone (" + source + ") met. Re-initializing wave.");
+                startRecoveryWave();
+            }
+        }
+
+        /**
+         * Intercepts window focus returns to smash hidden flags loaded during panel closures.
+         */
+        static void onFocusChanged(StatusQtActivity activity, boolean hasFocus) {
+            if (hasFocus && getPendingRecovery(activity.getApplicationContext())) {
+                android.util.Log.i("StatusQtActivity", "Window focus regained. Launching enforcement wave.");
+                startRecoveryWave();
+            }
+        }
+
+        private static void startRecoveryWave() {
+            recoveryAttempts = 0;
+            mainHandler.removeCallbacks(recoveryRunnable);
+            mainHandler.postDelayed(recoveryRunnable, 200);
+        }
+
+        /**
+         * Sustained loop engine that strips immersive configurations and forces native layout recalculations.
+         */
+        private static final Runnable recoveryRunnable = new Runnable() {
+            @Override
+            public void run() {
+                StatusQtActivity act = (activityRef != null) ? activityRef.get() : null;
+                if (act == null || act.isFinishing() || act.isDestroyed()) {
+                    return;
+                }
+
+                Context context = act.getApplicationContext();
+
+                if (recoveryAttempts >= MAX_ATTEMPTS) {
+                    // CRITICAL FIX: Only clear the flag if the wave finishes while the user is actively
+                    // focusing on our window. If focus is absent, the flag remains armed indefinitely.
+                    if (act.hasWindowFocus()) {
+                        android.util.Log.i("StatusQtActivity", "Enforcement wave successfully finalized under focus.");
+                        setPendingRecovery(context, false);
+                    } else {
+                        android.util.Log.w("StatusQtActivity", "Wave timed out in the background/overlay. Keeping flag armed.");
+                    }
+                    return;
+                }
+
+                if (act.getWindow() != null) {
+                    // 1. Modern Layer: Force system bars visible and set behavior to default
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        WindowInsetsController controller = act.getWindow().getInsetsController();
+                        if (controller != null) {
+                            controller.setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_DEFAULT);
+                            controller.show(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
+                        }
+                    }
+
+                    // 2. Legacy Layer: Clear layout parameters from the window frame
+                    act.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+
+                    // 3. View Hierarchy Layer: Clean up hidden UI visibility variables on the DecorView
+                    View decorView = act.getWindow().getDecorView();
+                    if (decorView != null) {
+                        int currentUiVisibility = decorView.getSystemUiVisibility();
+                        int clearedFlags = currentUiVisibility & ~(
+                            View.SYSTEM_UI_FLAG_FULLSCREEN |
+                            View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+                            View.SYSTEM_UI_FLAG_IMMERSIVE |
+                            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                        );
+                        decorView.setSystemUiVisibility(clearedFlags);
+
+                        // 4. Synchronization Pass: Force layout calculations back down into Qt's core engine
+                        decorView.requestLayout();
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+                            decorView.requestApplyInsets();
+                        }
+                    }
+                }
+
+                recoveryAttempts++;
+                mainHandler.postDelayed(this, 300);
+            }
+        };
+
+        static void unregister(StatusQtActivity activity) {
+            try {
+                mainHandler.removeCallbacks(recoveryRunnable);
+                if (screenshotCallback != null) {
+                    activity.unregisterScreenCaptureCallback(screenshotCallback);
+                }
+            } catch (Throwable t) {
+                android.util.Log.e("StatusQtActivity", "Cleanup failed", t);
+            } finally {
+                activityRef = null;
+            }
+        }
     }
 
     @Override

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -114,13 +114,18 @@ Window {
     }
 
     function restoreAppState() {
-        let geometry = localAppSettings.geometry;
-        let visibility = localAppSettings.visibility;
+        // on mobile, we only set the visibility, we don't care about geometry
+        if (SQUtils.Utils.isMobile) {
+            applicationWindow.visibility = Window.Maximized
+            return
+        }
 
+        let visibility = localAppSettings.visibility;
+        let geometry = localAppSettings.geometry;
         if (visibility !== Window.Windowed &&
             visibility !== Window.Maximized &&
             visibility !== Window.FullScreen) {
-            visibility = SQUtils.Utils.isMobile ? Window.Maximized : Window.Windowed
+            visibility = Window.Windowed
         }
 
         if (geometry === undefined ||
@@ -205,8 +210,6 @@ Window {
         readonly property bool macOSWindowed: SQUtils.Utils.isMacOS && applicationWindow.visibility !== Window.FullScreen
 
         function restoreWindowState() {
-            if (SQUtils.Utils.isMobile) // no point in restoring window state
-                return
             switch(lastNonMinVisibility) {
             case Window.Windowed:
                 applicationWindow.showNormal()
@@ -248,6 +251,7 @@ Window {
     }
 
     Action {
+        enabled: !SQUtils.Utils.isMobile
         shortcut: StandardKey.FullScreen
         onTriggered: {
             if (applicationWindow.visibility === Window.FullScreen) {
@@ -318,7 +322,7 @@ Window {
         function onShakeDetected() {
             const nowMs = Date.now()
             if (nowMs - d.lastShakeShareMs < 3000) {
-                openShakeToSharePopup()
+                applicationWindow.openShakeToSharePopup()
                 return
             }
             d.lastShakeShareMs = nowMs
@@ -336,7 +340,7 @@ Window {
         function onVisibilityChanged(visibility) {
             if (applicationWindow.visibility !== Window.Minimized
                         && applicationWindow.visibility !== Window.Hidden) {
-                d.lastNonMinVisibility = applicationWindow.visibility
+                d.lastNonMinVisibility = SQUtils.Utils.isMobile ? Window.Maximized : applicationWindow.visibility
             }
         }
         function onClosing(close) {


### PR DESCRIPTION
### What does the PR do

- also restore only the visibility (always Maximized), ignore the rest and the geometry
- register an Android 14+ specific native screenshot callback to rectify the unintended fullscreen state

Fixes #20612

### Affected areas

main

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

N/A

### Impact on end user

No fullscreen mode on mobile

### How to test

- start the app
- make a screenshot or activate DEX mode

### Risk 

low
