### PR TITLE
fix(ThirdpartyServicesPopup): prevent eliding the instructions

### DIFF
--- a/ui/imports/shared/popups/ThirdpartyServicesPopup.qml
+++ b/ui/imports/shared/popups/ThirdpartyServicesPopup.qml
@@ -106,7 +106,6 @@ StatusDialog {
 
             InformationTag {
                 Layout.fillWidth: true
-                Layout.preferredHeight: 40
 
                 backgroundColor: Theme.palette.primaryColor3
                 bgBorderColor: Theme.palette.primaryColor2
@@ -148,10 +147,6 @@ StatusDialog {
                     root.close()
                 }
             }
-            StatusButton {
-                text: qsTr("Close")
-                onClicked: root.close()
-            }
         }
     }
 
@@ -177,15 +172,20 @@ StatusDialog {
         Repeater {
             id: bodyItem
 
-            Layout.fillWidth: true
-            delegate: StatusItemDelegate {
+            delegate: RowLayout {
                 Layout.fillWidth: true
-                cursorShape: Qt.ArrowCursor
-                icon.width: 20
-                icon.height: 20
-                icon.name: "info"
-                icon.color: Theme.palette.dangerColor1
-                text: model.text
+                spacing: Theme.padding
+                StatusIcon {
+                    Layout.preferredWidth: 20
+                    Layout.preferredHeight: 20
+                    icon: "info"
+                    color: Theme.palette.dangerColor1
+                }
+                StatusBaseText {
+                    Layout.fillWidth: true
+                    wrapMode: Text.Wrap
+                    text: model.text
+                }
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

- use a simple RowLayout with StatusIcon+StatusBaseText, with wrap mode turned on
- don't hardcode the InformationTag pill height
- remove the redundant Close button

Fixes #20706
Fixes https://github.com/status-im/status-app/issues/19981

### Affected areas

ThirdpartyServicesPopup

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="840" height="1800" alt="image" src="https://github.com/user-attachments/assets/4008a2b3-f35b-4dbf-be66-aebb134b1c34" />


### Impact on end user

Better mobile UX

### How to test

- invoke the ThirdpartyServicesPopup on mobile; instructions should not elide, rather wrap

### Risk 

low
