### PR TITLE
fix: handle shutdown process to avoid race conditions on mobile devices

### DIFF
--- a/src/app/core/main.nim
+++ b/src/app/core/main.nim
@@ -23,6 +23,7 @@ proc newStatusFoundation*(): StatusFoundation =
 proc delete*(self: StatusFoundation) =
   self.signalsManager.delete()
   self.urlsManager.delete()
+  self.threadpool.teardown()
 
 proc initUrlSchemeManager*(self: StatusFoundation, urlSchemeEvent: StatusEvent,
     singleInstance: SingleInstance, protocolUriOnStart: string) =

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -23,6 +23,10 @@ featureGuard KEYCARD_ENABLED:
 when defined(macosx) and defined(arm64):
   import posix
 
+when defined(android) or defined(ios):
+  # Bypass libc static destructors on shutdown, anyway the OS reclaims process resources.
+  proc cExit(code: cint) {.importc: "_exit", header: "<unistd.h>".}
+
 when defined(windows):
     {.link: "../status.o".}
 
@@ -274,6 +278,8 @@ proc mainProc() =
     statusFoundation.delete()
     singleInstance.delete()
     app.delete()
+    when defined(android) or defined(ios):
+      cExit(0)
 
   featureGuard SINGLE_STATUS_INSTANCE_ENABLED:
     # Checks below must be always after "defer", in case anything fails destructors will freed a memory.


### PR DESCRIPTION
- Added a custom exit procedure (https://en.cppreference.com/c/program/_Exit) to bypass libc static destructors on mobile devices, preventing potential race conditions during shutdown
- Ensured proper teardown of the threadpool in the StatusFoundation delete method

Fixes #20855