### PR TITLE
Fix/various UI issues

### DIFF
--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -172,13 +172,17 @@ LayoutChooser {
         This method is used to focus the panel that needs to be active.
     */
     function goToNextPanel() {
-        if (portraitView.visible)
+        if (portraitView.visible) {
             portraitView.incrementCurrentIndex()
+            Qt.callLater(d.positionPortraitViewAtCurrentIndex)
+        }
     }
 
     function goToPreviousPanel() {
-        if (portraitView.visible)
+        if (portraitView.visible) {
             portraitView.decrementCurrentIndex()
+            Qt.callLater(d.positionPortraitViewAtCurrentIndex)
+        }
     }
 
     readonly property int windowWidth: root.Window?.width ?? Screen.width
@@ -233,6 +237,20 @@ LayoutChooser {
         invertedLayout: root.invertedLayout
 
         property int currentIndexCache
+
+        QtObject {
+            id: d
+
+            // On Android, changing SwipeView.currentIndex can leave the
+            // internal ListView at the previous contentX. Reposition it after
+            // the index change has been processed so the visible page matches.
+            function positionPortraitViewAtCurrentIndex() {
+                if (!portraitView.contentItem || !portraitView.contentItem.positionViewAtIndex)
+                    return
+
+                portraitView.contentItem.positionViewAtIndex(portraitView.currentIndex, ListView.SnapPosition)
+            }
+        }
 
         onCurrentIndexChanged: {
             root.swiped(currentIndexCache, currentIndex)

--- a/ui/app/AppLayouts/Onboarding/pages/LoginBySyncingPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/LoginBySyncingPage.qml
@@ -22,45 +22,57 @@ OnboardingPage {
 
     title: qsTr("Pair devices to sync")
 
-    contentItem: Item {
-        ColumnLayout {
-            anchors.fill: parent
-            spacing: Theme.xlPadding
+    contentItem: StatusScrollView {
+        id: scrollView
 
-            Item {
-                Layout.fillHeight: true
-            }
+        contentWidth: availableWidth
+        padding: 0
 
-            StatusBaseText {
-                Layout.fillWidth: true
-                text: root.title
-                font.pixelSize: Theme.fontSize(22)
-                font.bold: true
-                wrapMode: Text.WordWrap
-                horizontalAlignment: Text.AlignHCenter
-            }
-            StatusBaseText {
-                Layout.fillWidth: true
-                Layout.topMargin: -Theme.bigPadding
-                text: qsTr("If you have Status on another device")
-                color: Theme.palette.baseColor1
-                wrapMode: Text.WordWrap
-                horizontalAlignment: Text.AlignHCenter
-            }
+        Item {
+            width: scrollView.availableWidth
+            implicitHeight: Math.max(content.implicitHeight, scrollView.availableHeight)
 
-            SyncingEnterCode {
-                Layout.fillWidth: true
-                Layout.fillHeight: false
-                Layout.maximumWidth: implicitWidth * 1.5
-                Layout.alignment: Qt.AlignHCenter
-                validateConnectionString: root.validateConnectionString
+            ColumnLayout {
+                id: content
 
-                onDisplayInstructions: instructionsPopup.createObject(root).open()
-                onProceed: (connectionString) => root.syncProceedWithConnectionString(connectionString)
-            }
+                anchors.fill: parent
+                spacing: Theme.xlPadding
 
-            Item {
-                Layout.fillHeight: true
+                Item {
+                    Layout.fillHeight: true
+                }
+
+                StatusBaseText {
+                    Layout.fillWidth: true
+                    text: root.title
+                    font.pixelSize: Theme.fontSize(22)
+                    font.bold: true
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                }
+                StatusBaseText {
+                    Layout.fillWidth: true
+                    Layout.topMargin: -Theme.bigPadding
+                    text: qsTr("If you have Status on another device")
+                    color: Theme.palette.baseColor1
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                SyncingEnterCode {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: false
+                    Layout.maximumWidth: implicitWidth * 1.5
+                    Layout.alignment: Qt.AlignHCenter
+                    validateConnectionString: root.validateConnectionString
+
+                    onDisplayInstructions: instructionsPopup.createObject(root).open()
+                    onProceed: (connectionString) => root.syncProceedWithConnectionString(connectionString)
+                }
+
+                Item {
+                    Layout.fillHeight: true
+                }
             }
         }
     }


### PR DESCRIPTION
Closes [#20638](https://github.com/status-im/status-app/issues/20638)
Closes [#20771](https://github.com/status-im/status-app/issues/20771)

### What does the PR do

- Make the sync pairing page scrollable so the instructions button stays reachable when the QR scanner content overflows.
- Ensure the portrait `StatusSectionLayout` visually follows `SwipeView.currentIndex` changes on _Android_ by repositioning the internal view after programmatic panel navigation. This prevents the layout from keeping the previous `contentX` while the logical index has already changed.

### Affected areas

- Sync Pairing Page
- Direct navigation to section details in portrait

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screenshot or video
1. Pairing layout:

<img width="1080" height="2528" alt="Screenshot_20260513-152218_Status_Debug" src="https://github.com/user-attachments/assets/467d3e52-245e-458b-aa4c-be5bfb75ae93" />

2. Navigation to profile details:

https://github.com/user-attachments/assets/c83112e4-3d9d-4cac-b640-f2beba5d3dd9

### Impact on end user

- Better UX

### How to test

1. Review the `Sync pairing` page layout is ok
4. Follow the exact steps described on [#20771](https://github.com/status-im/status-app/issues/20771) and ensure the issue is solved. It was only affecting _Android_.

### Risk 

Low
