### PR TITLE
Android: workaround for triggering full-screen mode after screenshot

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -85,6 +85,18 @@ Window {
 
     SafeArea.additionalMargins.bottom: additionalBottomMargin
 
+    // On Android 15 taking a screenshot and invoking sharing popup triggers full-screen mode. It's not restored back
+    // when exiting sharing popup. The change is not reflected in visibility property, so there is no direct way to detect it.
+    // The workaround here tracks safe area margins to detect full screen mode to restore to maximized mode immediately.
+    readonly property int saBottom: SafeArea.margins.bottom
+    readonly property int saLeft: SafeArea.margins.left
+    readonly property int saRight: SafeArea.margins.right
+
+    onSaBottomChanged: if (SQUtils.Utils.isAndroid && saBottom === 0) applicationWindow.showMaximized()
+    onSaLeftChanged: if (SQUtils.Utils.isAndroid && saLeft === 0) applicationWindow.showMaximized()
+    onSaRightChanged: if (SQUtils.Utils.isAndroid && saRight === 0) applicationWindow.showMaximized()
+    // end of screenshot full-screen bug workaround
+
     objectName: "mainWindow"
     color: Theme.palette.background
     title: {


### PR DESCRIPTION
### What does the PR do

On Android 15, taking a screenshot and invoking sharing dialog was triggering full-screen mode, not restored when sharing is finished.

This PR adds a simple QML workaround for that problem. It tracks safe area margins and if detected they are zeroed, maximized mode is requested.

Closes: #20612

It's alternative to https://github.com/status-im/status-app/pull/20828

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`main.qml`

### How to test
1. On Android 15 take a screenshot
2. Press share button on the screenshot tool overlay
3. Close the sharing dialog

The app should have system control buttons in place, no full-screen mode.

### Risk 
Low
