### PR TITLE
test: testing for logos-delivery v0.38.1

### DIFF
--- a/docker-compose.waku.yml
+++ b/docker-compose.waku.yml
@@ -1,6 +1,6 @@
 services:
   boot-1:
-    image: wakuorg/nwaku:v0.36.0
+    image: wakuorg/nwaku:v0.38.1
     ports:
       - "60001:60001"
       - "8645:8645"
@@ -11,6 +11,7 @@ services:
       "--discv5-enr-auto-update=True",
       "--discv5-udp-port=49000",
       "--cluster-id=16",
+      "--dns-addrs-name-server=127.0.0.11",
       "--num-shards-in-network=0",
       "--filter=true",
       "--keep-alive=true",
@@ -22,6 +23,7 @@ services:
       "--nodekey=697b008f979c8ae38c1e4e0b9bc3712dd39e2355f49eaf6c63d92f7edd13704d",
       "--peer-exchange=true",
       "--relay=true",
+      "--rest=true",
       "--rest-address=0.0.0.0",
       "--rest-admin",
       "--rest-port=8645",
@@ -42,7 +44,7 @@ services:
       retries: 10
 
   store:
-    image: wakuorg/nwaku:v0.36.0
+    image: wakuorg/nwaku:v0.38.1
     ports:
       - "60002:60002"
       - "8646:8646"
@@ -53,16 +55,17 @@ services:
       "--discv5-enr-auto-update=True",
       "--discv5-udp-port=49001",
       "--cluster-id=16",
+      "--dns-addrs-name-server=127.0.0.11",
       "--num-shards-in-network=0",
       "--keep-alive=true",
       "--log-level=INFO",
-      "--legacy-store=true",
       "--max-connections=18000",
       "--max-msg-size=1024KiB",
       "--ip-colocation-limit=100",
       "--nodekey=ba4e531d4ef543fabd838ef4e731d35dfa4deceea8f4a5992ad7f29764c70035",
       "--peer-exchange=false",
       "--relay=true",
+      "--rest=true",
       "--rest-address=0.0.0.0",
       "--rest-admin",
       "--rest-port=8646",
@@ -85,7 +88,7 @@ services:
       retries: 10
 
   store-2:
-    image: wakuorg/nwaku:v0.36.0
+    image: wakuorg/nwaku:v0.38.1
     ports:
       - "60003:60003"
       - "8647:8647"
@@ -96,16 +99,17 @@ services:
       "--discv5-enr-auto-update=True",
       "--discv5-udp-port=49002",
       "--cluster-id=16",
+      "--dns-addrs-name-server=127.0.0.11",
       "--num-shards-in-network=0",
       "--keep-alive=true",
       "--log-level=INFO",
-      "--legacy-store=true",
       "--max-connections=18000",
       "--max-msg-size=1024KiB",
       "--ip-colocation-limit=100",
       "--nodekey=c2a4e44652cd44b2b73093e7d2dba0a1e841e24e59db4a3a8c8e660e6e4d1b3a",
       "--peer-exchange=false",
       "--relay=true",
+      "--rest=true",
       "--rest-address=0.0.0.0",
       "--rest-admin",
       "--rest-port=8647",


### PR DESCRIPTION
Drafting PR bcz not yet fully sure about about changes. 

Three v0.38.1 breaking changes required matching config updates:
1. `--legacy-store` CLI flag removed — drop the flag.
2. `--rest` default changed true → false — set `--rest=true` explicitly.
3. nwaku DNS multiaddr resolver uses `--dns-addrs-name-server` strictly