### PR TITLE
fix(dapps): dapp name html injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,6 +395,11 @@ run-statusq-tests: statusq-tests
 STORYBOOK_SOURCE_PATH := storybook
 STORYBOOK_BUILD_PATH := $(STORYBOOK_SOURCE_PATH)/build/Qt$(QT_VERSION)
 STORYBOOK_CMAKE_CACHE := $(STORYBOOK_BUILD_PATH)/CMakeCache.txt
+ifeq ($(mkspecs),macx)
+ STORYBOOK_BINARY := $(STORYBOOK_BUILD_PATH)/bin/Storybook.app/Contents/MacOS/Storybook
+else
+ STORYBOOK_BINARY := $(STORYBOOK_BUILD_PATH)/bin/Storybook
+endif
 
 $(STORYBOOK_CMAKE_CACHE): | check-qt-dir
 	echo -e "\033[92mConfiguring:\033[39m Storybook"
@@ -418,7 +423,7 @@ storybook-build: | storybook-configure
 
 run-storybook: storybook-build
 	echo -e "\033[92mRunning:\033[39m Storybook"
-	$(STORYBOOK_BUILD_PATH)/bin/Storybook ${ARGS}
+	$(STORYBOOK_BINARY) ${ARGS}
 
 run-storybook-tests: storybook-build
 	echo -e "\033[92mRunning:\033[39m Storybook Tests"

--- a/storybook/pages/ConnectDAppModalPage.qml
+++ b/storybook/pages/ConnectDAppModalPage.qml
@@ -61,7 +61,9 @@ Item {
                 }
 
                 dAppUrl: dAppUrlField.text
-                dAppName:  dAppNameField.text
+                dAppName: ctrlHtmlInjection.checked
+                          ? '<font color="#27ae60" size="6"><b>app.uniswap.org</b></font>'
+                          : dAppNameField.text
                 dAppIconUrl: hasIconCheckbox.checked ? "https://avatars.githubusercontent.com/u/37784886" : ""
                 dAppConnectorBadge: Constants.dappImageByType[dAppBadgeComboBox.currentIndex]
                 connectionStatus: pairedCheckbox.checked ? pairedStatusCheckbox.checked ? connectionSuccessfulStatus : connectionFailedStatus : notConnectedStatus
@@ -99,6 +101,13 @@ Item {
                 id: dAppNameField
 
                 text: "React App"
+            }
+            CheckBox {
+                id: ctrlHtmlInjection
+                text: "HTML injection demo"
+                ToolTip.visible: hovered
+                ToolTip.text: "Replaces dappName with an HTML payload to verify "
+                              + "textFormat: Text.PlainText renders literal markup, not styled text."
             }
             Label {
                 text: "DApp URL"

--- a/storybook/pages/DAppSignRequestModalPage.qml
+++ b/storybook/pages/DAppSignRequestModalPage.qml
@@ -38,7 +38,9 @@ SplitView {
             modal: false
             dappUrl: "https://example.com"
             dappIcon: "https://picsum.photos/200/200"
-            dappName: "OpenSea"
+            dappName: ctrlHtmlInjection.checked
+                        ? '<font color="#27ae60" size="6"><b>app.uniswap.org</b></font>'
+                        : "OpenSea"
             accountColor: "blue"
             accountName: "Account Name"
             accountAddress: "0xE2d622C817878dA5143bBE06866ca8E35273Ba8"
@@ -154,6 +156,13 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Fusce nibh. Etiam quis
                 id: signingTransaction
                 text: "Signing transaction"
                 checked: false
+            }
+            CheckBox {
+                id: ctrlHtmlInjection
+                text: "HTML injection demo"
+                ToolTip.visible: hovered
+                ToolTip.text: "Replaces dappName with an HTML payload to verify "
+                              + "textFormat: Text.PlainText renders literal markup, not styled text."
             }
             TextField {
                 Layout.fillWidth: true

--- a/storybook/pages/SendSignModalPage.qml
+++ b/storybook/pages/SendSignModalPage.qml
@@ -130,8 +130,12 @@ SplitView {
                     formatBigNumber: (number, symbol, noSymbolOption) => parseFloat(number).toLocaleString(Qt.locale(), 'f', 2)
                                      + (noSymbolOption ? "" : " " + (symbol || Qt.locale().currencySymbol(Locale.CurrencyIsoCode)))
 
-                    tokenSymbol: ctrlFromSymbol.text
-                    tokenAmount: ctrlFromAmount.text
+                    tokenSymbol: ctrlHtmlInjection.checked
+                                 ? '<font color="#ff0000" size="6"><b>HACKED</b></font>'
+                                 : ctrlFromSymbol.text
+                    tokenAmount: ctrlHtmlInjection.checked
+                                 ? '<a href="https://evil.example/?stolen=1">100</a>'
+                                 : ctrlFromAmount.text
                     tokenContractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F"
                     tokenIcon: Constants.tokenIcon(ctrlFromSymbol.text)
 
@@ -142,7 +146,9 @@ SplitView {
 
                     recipientAddress: priv.selectedRecipient.address
                     recipientName: priv.selectedRecipient.name
-                    recipientEns: priv.selectedRecipient.ens
+                    recipientEns: ctrlHtmlInjection.checked
+                                  ? '<font color="#27ae60" size="6"><b>spoofed.eth</b></font>'
+                                  : priv.selectedRecipient.ens
                     recipientEmoji: priv.selectedRecipient.emoji
                     recipientWalletColor: Utils.getColorForId(Theme.palette, priv.selectedRecipient.colorId)
 
@@ -207,8 +213,11 @@ SplitView {
                                                     collectibleComboBox.currentCollectible.contractAddress: ""
                     collectibleTokenId: !!collectibleComboBox.currentCollectible ?
                                         collectibleComboBox.currentCollectible.tokenId: ""
-                    collectibleName: !!collectibleComboBox.currentCollectible ?
-                                         collectibleComboBox.currentCollectible.name: ""
+                    collectibleName: ctrlHtmlInjection.checked
+                                     ? '<font color="#ff0000" size="6"><b>HACKED</b></font> '
+                                       + '<img src="https://placekitten.com/40/40">'
+                                     : (!!collectibleComboBox.currentCollectible ?
+                                            collectibleComboBox.currentCollectible.name: "")
                     collectibleBackgroundColor: !!collectibleComboBox.currentCollectible ?
                                                     collectibleComboBox.currentCollectible.backgroundColor: ""
                     collectibleMediaUrl: !!collectibleComboBox.currentCollectible ?
@@ -249,6 +258,14 @@ SplitView {
                 id: ctrlFromSymbol
                 text: "DAI"
                 placeholderText: "From symbol"
+            }
+            CheckBox {
+                id: ctrlHtmlInjection
+                text: "HTML injection demo"
+                ToolTip.visible: hovered
+                ToolTip.text: "Replaces token symbol / amount / collectible name with HTML "
+                              + "payloads to demonstrate that StatusBaseText (Text.AutoText) "
+                              + "renders rich text. Reopen the dialog to apply."
             }
             CheckBox {
                 id: isCollectibleCheckbox

--- a/storybook/pages/SwapSignModalPage.qml
+++ b/storybook/pages/SwapSignModalPage.qml
@@ -80,12 +80,20 @@ SplitView {
                     formatBigNumber: (number, symbol, noSymbolOption) => parseFloat(number).toLocaleString(Qt.locale(), 'f', 2)
                                      + (noSymbolOption ? "" : " " + (symbol || Qt.locale().currencySymbol(Locale.CurrencyIsoCode)))
 
-                    fromTokenSymbol: ctrlFromSymbol.text
-                    fromTokenAmount: ctrlFromAmount.text
+                    fromTokenSymbol: ctrlHtmlInjection.checked
+                                     ? '<font color="#ff0000" size="6"><b>HACKED</b></font>'
+                                     : ctrlFromSymbol.text
+                    fromTokenAmount: ctrlHtmlInjection.checked
+                                     ? '<a href="https://evil.example/?stolen=1">100</a>'
+                                     : ctrlFromAmount.text
                     fromTokenContractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F"
 
-                    toTokenSymbol: ctrlToSymbol.text
-                    toTokenAmount: ctrltoAmount.text
+                    toTokenSymbol: ctrlHtmlInjection.checked
+                                   ? '<font color="#27ae60" size="6"><b>USDT</b></font>'
+                                   : ctrlToSymbol.text
+                    toTokenAmount: ctrlHtmlInjection.checked
+                                   ? '<a href="https://evil.example/?stolen=1">100</a>'
+                                   : ctrltoAmount.text
                     toTokenContractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
 
                     accountName: priv.selectedAccount.name
@@ -99,7 +107,9 @@ SplitView {
                     networkBlockExplorerUrl: priv.selectedNetwork.blockExplorerURL
                     networkChainId: priv.selectedNetwork.chainId
 
-                    serviceProviderName: Constants.swap.paraswapName
+                    serviceProviderName: ctrlHtmlInjection.checked
+                                         ? '<font color="#27ae60" size="6"><b>Paraswap</b></font>'
+                                         : Constants.swap.paraswapName
                     serviceProviderURL: Constants.swap.paraswapUrl
                     serviceProviderTandCUrl: Constants.swap.paraswapTermsAndConditionUrl
 
@@ -135,6 +145,14 @@ SplitView {
                 id: ctrlFromSymbol
                 text: "DAI"
                 placeholderText: "From symbol"
+            }
+            CheckBox {
+                id: ctrlHtmlInjection
+                text: "HTML injection demo"
+                ToolTip.visible: hovered
+                ToolTip.text: "Replaces token symbols, amounts, and service provider name with HTML "
+                              + "payloads to verify textFormat: Text.PlainText renders literal markup. "
+                              + "Reopen the dialog to apply."
             }
             TextField {
                 Layout.fillWidth: true

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusTitleSubtitle.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusTitleSubtitle.qml
@@ -29,6 +29,7 @@ Item {
                 bold: true
             }
             elide: Text.ElideMiddle
+            textFormat: Text.PlainText
         }
 
         StatusBaseText {
@@ -39,6 +40,7 @@ Item {
             visible: text !== ""
             color: Theme.palette.baseColor1
             elide: Text.ElideMiddle
+            textFormat: Text.PlainText
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/controls/SwapProvidersTermsAndConditionsText.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SwapProvidersTermsAndConditionsText.qml
@@ -30,6 +30,7 @@ RowLayout {
         Layout.topMargin: 1 // compensate for the underline
         text: "%1.".arg(root.serviceProviderName)
         font.weight: Font.Normal
+        textFormat: Text.PlainText
         onClicked: root.linkClicked()
     }
     StatusBaseText {

--- a/ui/app/AppLayouts/Wallet/panels/SignAccountInfoBox.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SignAccountInfoBox.qml
@@ -50,6 +50,8 @@ ColumnLayout {
         statusListItemTitle.customColor: Theme.palette.directColor1
         statusListItemTitle.font.pixelSize: Theme.additionalTextSize
         statusListItemTitle.elide: Text.ElideMiddle
+        statusListItemTitle.textFormat: Text.PlainText
+        statusListItemSubTitle.textFormat: Text.PlainText
         border.width: 1
         border.color: Theme.palette.baseColor2
 

--- a/ui/app/AppLayouts/Wallet/panels/SignCollectibleInfoBox.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SignCollectibleInfoBox.qml
@@ -96,6 +96,7 @@ Control {
                               root.name : ""
                     font.pixelSize: Theme.additionalTextSize
                     elide: Text.ElideRight
+                    textFormat: Text.PlainText
                 }
                 StatusBaseText {
                     Layout.fillWidth: true
@@ -104,6 +105,7 @@ Control {
                               root.tokenId : ""
                     font.pixelSize: Theme.additionalTextSize
                     color: Theme.palette.baseColor1
+                    textFormat: Text.PlainText
                 }
             }
 

--- a/ui/app/AppLayouts/Wallet/panels/SignInfoBox.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SignInfoBox.qml
@@ -34,8 +34,10 @@ ColumnLayout {
         statusListItemTitle.font.pixelSize: Theme.additionalTextSize
         statusListItemTitle.elide: Text.ElideMiddle
         statusListItemTitle.customColor: root.primaryTextCustomColor
+        statusListItemTitle.textFormat: Text.PlainText
         subTitle: root.secondaryText
         statusListItemSubTitle.font.pixelSize: Theme.additionalTextSize
+        statusListItemSubTitle.textFormat: Text.PlainText
         asset.name: root.icon
         asset.isImage: true
         asset.bgWidth: 40

--- a/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
+++ b/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
@@ -285,6 +285,7 @@ StatusDialog {
                         horizontalAlignment: Text.AlignHCenter
                         lineHeightMode: Text.FixedHeight
                         lineHeight: 22
+                        textFormat: Text.PlainText
                     }
 
                     RowLayout {

--- a/ui/imports/shared/popups/walletconnect/DAppConfirmDisconnectPopup.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppConfirmDisconnectPopup.qml
@@ -26,6 +26,7 @@ StatusDialog {
         text: qsTr("Are you sure you want to disconnect %1 from all accounts?").arg(dappUrl ? StringUtils.extractDomainFromLink(dappUrl) : dappName)
 
         wrapMode: Text.WrapAnywhere
+        textFormat: Text.PlainText
     }
 
     header: StatusDialogHeader {

--- a/ui/imports/shared/popups/walletconnect/private/DAppCard.qml
+++ b/ui/imports/shared/popups/walletconnect/private/DAppCard.qml
@@ -48,6 +48,7 @@ ColumnLayout {
             elide: Text.ElideRight
             font.bold: true
             font.pixelSize: Theme.secondaryAdditionalTextSize
+            textFormat: Text.PlainText
         }
 
         StatusFlatButton {

--- a/ui/imports/shared/popups/walletconnect/private/PermissionsCard.qml
+++ b/ui/imports/shared/popups/walletconnect/private/PermissionsCard.qml
@@ -18,6 +18,7 @@ ColumnLayout {
         font.pixelSize: Theme.additionalTextSize
         elide: Text.ElideMiddle
         color: Theme.palette.baseColor1
+        textFormat: Text.PlainText
     }
 
     StatusBaseText {


### PR DESCRIPTION
vulnarability: sign and connect modals rendered dapp-controlled strings as HTML. `StatusBaseText` is rich-text by default. Which can lead to ui spoofing.

Force `textFormat: Text.PlainText` on the render sites that display these strings:

- `StatusTitleSubtitle` (dialog header title + subtitle)
- `SignTransactionModalBase.headerMainText`
- `SignInfoBox` (Pay / Receive / Network / Fees rows)
- `SignAccountInfoBox` (From / To rows)
- `SignCollectibleInfoBox` (NFT name + tokenId)
- `SwapProvidersTermsAndConditionsText` (Powered by …)
- `DAppCard.appNameText`
- `PermissionsCard` ("X will be able to:")
- `DAppConfirmDisconnectPopup` body

Added "HTML injection demo" toggle to storybook pages.

<img width="448" height="679" alt="image" src="https://github.com/user-attachments/assets/a9814316-6e43-47ab-b82c-bc45fb8ccfff" />

fixes #20879 

Further improvement: we could set `textFormat: Text.PlainText` by default on `StatusBaseText`.