### PR TITLE
fix(android): battery usage while the app is in the background

### DIFF
--- a/mobile/android/qt6/src/app/status/mobile/ipc/NotificationReplyReceiver.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/NotificationReplyReceiver.java
@@ -34,6 +34,20 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
         return t;
     });
 
+    /**
+     * Un-pauses the "messaging" service so a chat message sent while the app is backgrounded
+     * actually transmits (the mvds outbound loop is parked while messaging is paused). The
+     * subsequent CallPrivateRPC persists the message regardless, so a failure here only delays
+     * delivery; the send path schedules a re-pause via StatusGoService.scheduleMessagingRepause().
+     */
+    private static void resumeMessagingForBackgroundSend() {
+        try {
+            final String resp = StatusGoService.callRpc("ResumeService", "[\"messaging\"]");
+        } catch (Throwable t) {
+            Log.w(TAG, "failed to resume messaging for background send", t);
+        }
+    }
+
     @Override
     public void onReceive(Context context, Intent intent) {
         if (intent == null) return;
@@ -71,6 +85,7 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
 
         REPLY_EXECUTOR.execute(() -> {
             try {
+                resumeMessagingForBackgroundSend();
                 // Build sendChatMessage params (same format as Nim backend)
                 JSONObject msg = new JSONObject();
                 msg.put("chatId", conversationId);
@@ -135,6 +150,9 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
                     NotificationManagerCompat.from(appContext).cancel(androidNotificationId);
                 }
             } finally {
+                // We resumed "messaging" above so the send transmits; ask the service to
+                // re-pause after a flush window (a real fg/bg transition supersedes it).
+                StatusGoService.scheduleMessagingRepause();
                 pendingResult.finish();
             }
         });
@@ -157,6 +175,7 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
 
         REPLY_EXECUTOR.execute(() -> {
             try {
+                resumeMessagingForBackgroundSend();
                 JSONObject params = new JSONObject();
                 params.put("id", contactId);
 
@@ -208,6 +227,9 @@ public final class NotificationReplyReceiver extends BroadcastReceiver {
                     NotificationManagerCompat.from(appContext).cancel(androidNotificationId);
                 }
             } finally {
+                // We resumed "messaging" above so the send transmits; ask the service to
+                // re-pause after a flush window (a real fg/bg transition supersedes it).
+                StatusGoService.scheduleMessagingRepause();
                 pendingResult.finish();
             }
         });

--- a/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoService.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoService.java
@@ -7,7 +7,9 @@ import android.app.Service;
 import android.content.Intent;
 import android.os.Binder;
 import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 import android.os.RemoteCallbackList;
 import android.os.RemoteException;
 import android.os.SharedMemory;
@@ -66,6 +68,47 @@ public final class StatusGoService extends Service {
 
     private final ExecutorService lifecycleExecutor = Executors.newSingleThreadExecutor();
     private final AtomicInteger lifecycleGen = new AtomicInteger(0);
+
+    /** Single instance per process; lets background components (NotificationReplyReceiver) reach the service. */
+    private static volatile StatusGoService sInstance;
+
+    /**
+     * Background work (e.g. an inline notification reply) sends a chat message while messaging
+     * is paused. The send path resumes the "messaging" service so the message actually
+     * transmits, then asks us to re-pause after a flush window. This delay must comfortably
+     * cover the mvds outbound loop picking up the queued message after resume.
+     */
+    private static final long MESSAGING_REPAUSE_DELAY_MS = 60_000L;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final Runnable repauseMessagingRunnable = () -> {
+        if (uiVisible) return; // app came to foreground; foregrounding already resumed messaging
+        try {
+            lifecycleExecutor.execute(() -> {
+                if (uiVisible) return;
+                try {
+                    final String resp = nativeCall("PauseService", "[\"messaging\"]");
+                } catch (Throwable t) {
+                    Log.w(TAG, "failed to re-pause messaging after background send", t);
+                }
+            });
+        } catch (java.util.concurrent.RejectedExecutionException ignored) {
+            // service shutting down; nothing to re-pause
+        }
+    };
+
+    /**
+     * Asks the service to re-pause the "messaging" service after a flush window, coalescing
+     * with any pending request. Called from background components after they Resume("messaging")
+     * + send a message while the app is backgrounded. A real foreground/background transition
+     * supersedes it (the pending callback is cancelled in applyUiVisibility, and the runnable
+     * re-checks uiVisible anyway).
+     */
+    public static void scheduleMessagingRepause() {
+        final StatusGoService s = sInstance;
+        if (s == null) return;
+        s.mainHandler.removeCallbacks(s.repauseMessagingRunnable);
+        s.mainHandler.postDelayed(s.repauseMessagingRunnable, MESSAGING_REPAUSE_DELAY_MS);
+    }
 
     private StatusNotificationManager notificationManager;
 
@@ -224,6 +267,9 @@ public final class StatusGoService extends Service {
 
     private void applyUiVisibility(boolean visible) {
         uiVisible = visible;
+        // A real fg/bg transition handles messaging via scheduleBackendLifecycleUpdate;
+        // drop any pending notification-driven re-pause so it can't fire stale.
+        mainHandler.removeCallbacks(repauseMessagingRunnable);
         notificationManager.setUiVisible(visible);
         scheduleBackendLifecycleUpdate(visible);
     }
@@ -294,6 +340,7 @@ public final class StatusGoService extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
+        sInstance = this;
         notificationManager = new StatusNotificationManager(this);
         PushNotificationHelper.initialize(this);
         nativeInit(this);
@@ -323,6 +370,8 @@ public final class StatusGoService extends Service {
 
     @Override
     public void onDestroy() {
+        sInstance = null;
+        mainHandler.removeCallbacksAndMessages(null);
         StatusNotificationManager.clearInstance();
         listeners.kill();
         lifecycleExecutor.shutdownNow();


### PR DESCRIPTION
### What does the PR do

This commit bumps status-go to include https://github.com/status-im/status-go/pull/7440. As a result the message sending is paused while in the background to stop the high frequency mvds loops that will prevent Android from going into sleep. To preserve message sending while the app is in the background/killed we'll have to wake messenger briefly on the OS intent. We'll resume messenger for 60 seconds - enough to push the message through and then it will be paused again unless the app goes back to foreground.

This results in less battery usage and less events piling up in the qt event loop while the app is in the background.

Closes: https://github.com/status-im/status-app/issues/20742

### Affected areas

Actions within the push notifications on android. E.g. Reply, accept contact request

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

The battery usage is reduced while status-go runs in the background.
Restoring the app will be faster after running in the background for a long time.

### How to test

Login and kill the app.
Let it there for a few hours and compare the battery usage.

Receive contact request and message push notifications and respond from within the android notification.

### Risk 

Risk of breaking the push notifications actions.