### PR TITLE
fix(Portal): do not autofocus the Search field

### DIFF
--- a/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
@@ -37,11 +37,6 @@ StatusSectionLayout {
 
     objectName: "communitiesPortalLayout"
 
-    onVisibleChanged: {
-        if(visible)
-            searcher.input.edit.forceActiveFocus()
-    }
-
     QtObject {
         id: d
 
@@ -125,8 +120,6 @@ StatusSectionLayout {
                         Layout.maximumWidth: 327
                         Layout.preferredHeight: 38
                         Layout.alignment: Qt.AlignVCenter
-                        topPadding: 0
-                        bottomPadding: 0
                     }
 
                     // filler


### PR DESCRIPTION
### What does the PR do

Fixes #20870

### Affected areas

Communities Portal

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="1892" height="1800" alt="Snímek obrazovky z 2026-05-15 13-58-31" src="https://github.com/user-attachments/assets/c2202508-10c3-4fb9-ae19-bf300cb7822d" />


### Impact on end user

Better mobile UX

### How to test

- activate the Communities Portal section
- Search field should not be focused, and the virtual keyboard shouldn't be visible

### Risk 

low
