### PR TITLE
fix(browser): android connector 

### DIFF
--- a/src/app_service/service/connector/service.nim
+++ b/src/app_service/service/connector/service.nim
@@ -288,7 +288,7 @@ QtObject:
     try:
       let responseObj = response.parseJson
       let requestId = responseObj{"requestId"}.getInt(0)
-      
+
       var data = ConnectorCallRPCResultArgs()
       data.requestId = requestId
       data.payload = response

--- a/storybook/pages/DAppsWorkflowPage.qml
+++ b/storybook/pages/DAppsWorkflowPage.qml
@@ -129,8 +129,8 @@ Item {
 
                             dappsWorkflow.connectionSuccessful(pairingId, newConnectionId)
                         }
-                        function onConnectDApp(dappChains, dappUrl, dappName, dappIcon, pairingId) {
-                            dappsWorkflow.connectDApp(dappChains, dappUrl, dappName, dappIcon, pairingId)
+                        function onConnectDApp(dappChains, dappUrl, dappName, dappIcon, connectorId, pairingId) {
+                            dappsWorkflow.connectDApp(dappChains, dappUrl, dappName, dappIcon, connectorId, pairingId)
                         }
                     }
                 }

--- a/storybook/qmlTests/tests/tst_BrowserDisconnectDapp.qml
+++ b/storybook/qmlTests/tests/tst_BrowserDisconnectDapp.qml
@@ -1,0 +1,234 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Browser.adapters
+import AppLayouts.Browser.provider.qml
+import AppLayouts.Browser.webview
+
+import "../../../ui/app/AppLayouts/Browser/provider/qml/Utils.js" as Utils
+
+/**
+ * Regression: disconnecting a background dApp (OpenSea) while another tab (hub) is active.
+ *
+ * Bug (BrowserWebViewContext.disconnectDapp): uses currentWebView.bridge only, so Nim
+ * disconnect is invoked from the wrong tab context and the matching tab stays connected.
+ *
+ * Fix: resolve the webview/bridge whose tab URL matches the dApp being disconnected.
+ */
+Item {
+    id: root
+
+    readonly property string hubUrl: "https://hub.status.network"
+    readonly property string openseaUrl: "https://opensea.io"
+
+    Component {
+        id: mockConnectorControllerComponent
+
+        QtObject {
+            id: mock
+
+            signal connected(string payload)
+            signal disconnected(string payload)
+            signal connectorCallRPCResult(int requestId, string payload)
+            signal chainIdSwitched(string payload)
+            signal accountChanged(string payload)
+
+            property string lastDisconnectInvokerOrigin: ""
+            property var disconnectCalls: []
+
+            function connectorCallRPC(requestId, json) {
+                connectorCallRPCResult(requestId, json)
+            }
+
+            function getDApps() { return "[]" }
+
+            function disconnect(hostname, clientId) {
+                const target = Utils.normalizeOrigin(hostname)
+                const invoker = lastDisconnectInvokerOrigin
+                const ok = invoker === target
+                disconnectCalls.push({ target: target, invoker: invoker, ok: ok, clientId: clientId })
+                lastDisconnectInvokerOrigin = ""
+                return ok
+            }
+
+            function changeAccount() {}
+        }
+    }
+
+    Component {
+        id: connectorBridgeComponent
+
+        ConnectorBridge {
+            required property var controller
+            connectorController: controller
+            tabUrl: "about:blank"
+            tabIncognito: false
+        }
+    }
+
+    Component {
+        id: bridgeDisconnectProxyComponent
+
+        QtObject {
+            required property var innerBridge
+            required property var mockController
+
+            readonly property string dappOrigin: innerBridge.dappOrigin
+            readonly property var connectorManager: innerBridge.connectorManager
+            readonly property var eip1193ProviderAdapter: innerBridge.eip1193ProviderAdapter
+
+            function disconnect(hostname) {
+                mockController.lastDisconnectInvokerOrigin = innerBridge.dappOrigin
+                return innerBridge.disconnect(hostname)
+            }
+        }
+    }
+
+    Component {
+        id: tabHostComponent
+
+        Item {
+            id: tabHost
+            property url tabUrl
+            property var bridge
+        }
+    }
+
+    Component {
+        id: tabsModelComponent
+
+        QtObject {
+            property int currentIndex: 0
+            readonly property int count: 2
+            function createEmptyTab() {}
+            function createDownloadTab() {}
+            function removeTab() {}
+        }
+    }
+
+    Component {
+        id: browserWebViewContextComponent
+
+        BrowserWebViewContext {
+            required property Item hostStack
+            required property var tabsModelRef
+            required property var connectorControllerRef
+
+            thirdpartyServicesEnabled: true
+            isDebugEnabled: false
+            isMobile: true
+            hasPopups: false
+            browserSettings: QtObject {}
+            connectorController: connectorControllerRef
+            dappsEnabled: true
+            hostStackLayout: hostStack
+            tabsModel: tabsModelRef
+            defaultProfileParams: ProfileParams {}
+            bookmarksStore: QtObject {}
+            downloadsStore: QtObject {}
+            determineRealURLFn: function(url) { return url }
+            downloadRequestHandler: function() {}
+            sslErrorHandler: function() {}
+            jsDialogHandler: function() {}
+            findTextFinishedHandler: function() {}
+        }
+    }
+
+    TestCase {
+        name: "BrowserDisconnectDapp"
+        when: windowShown
+
+        property var mock: null
+        property Item hostStack: null
+        property var tabsModel: null
+        property BrowserWebViewContext webViewContext: null
+        property var hubBridgeProxy: null
+        property var openseaBridgeProxy: null
+
+        function init() {
+            mock = createTemporaryObject(mockConnectorControllerComponent, root)
+            mock.disconnectCalls = []
+
+            hostStack = createTemporaryObject(tabHostComponent, root, { width: 1, height: 1 })
+            tabsModel = createTemporaryObject(tabsModelComponent, root)
+
+            const hubInner = createTemporaryObject(connectorBridgeComponent, root, {
+                controller: mock,
+                tabUrl: root.hubUrl,
+                tabIncognito: false
+            })
+            const openseaInner = createTemporaryObject(connectorBridgeComponent, root, {
+                controller: mock,
+                tabUrl: root.openseaUrl,
+                tabIncognito: false
+            })
+
+            hubBridgeProxy = createTemporaryObject(bridgeDisconnectProxyComponent, root, {
+                innerBridge: hubInner,
+                mockController: mock
+            })
+            openseaBridgeProxy = createTemporaryObject(bridgeDisconnectProxyComponent, root, {
+                innerBridge: openseaInner,
+                mockController: mock
+            })
+
+            createTemporaryObject(tabHostComponent, hostStack, {
+                tabUrl: root.hubUrl,
+                bridge: hubBridgeProxy
+            })
+            createTemporaryObject(tabHostComponent, hostStack, {
+                tabUrl: root.openseaUrl,
+                bridge: openseaBridgeProxy
+            })
+
+            webViewContext = createTemporaryObject(browserWebViewContextComponent, root, {
+                hostStack: hostStack,
+                tabsModelRef: tabsModel,
+                connectorControllerRef: mock
+            })
+        }
+
+        function connectOpenSea() {
+            const clientId = ConnectorConstants.clientIdFor(false)
+            mock.connected(JSON.stringify({
+                url: root.openseaUrl,
+                clientId: clientId,
+                sharedAccount: "0xda4a19b7aec958688d2531175e2757427372c6d1",
+                chainId: 1
+            }))
+        }
+
+        // Hub is the active tab; disconnect OpenSea from wallet must use OpenSea's bridge.
+        function test_disconnectDappTargetsMatchingTabNotCurrentTab() {
+            connectOpenSea()
+
+            compare(openseaBridgeProxy.connectorManager.connected, true,
+                    "OpenSea tab should be connected before disconnect")
+            compare(hubBridgeProxy.connectorManager.connected, false,
+                    "Hub tab must stay disconnected")
+
+            tabsModel.currentIndex = 0
+            compare(webViewContext.currentWebView.bridge.dappOrigin, root.hubUrl,
+                    "Active tab must be hub while disconnecting background OpenSea")
+
+            webViewContext.disconnectDapp(root.openseaUrl)
+
+            compare(mock.disconnectCalls.length, 1, "disconnect must be invoked once")
+            compare(mock.disconnectCalls[0].invoker, root.openseaUrl,
+                    "disconnect must run through the OpenSea tab bridge, not the active hub tab")
+            compare(mock.disconnectCalls[0].target, root.openseaUrl)
+            verify(mock.disconnectCalls[0].ok,
+                    "backend disconnect must succeed when invoked from the matching tab bridge")
+
+            mock.disconnected(JSON.stringify({
+                url: root.openseaUrl,
+                clientId: ConnectorConstants.clientIdFor(false)
+            }))
+
+            compare(openseaBridgeProxy.connectorManager.connected, false,
+                    "OpenSea provider state must clear after disconnect")
+            compare(hubBridgeProxy.connectorManager.connected, false,
+                    "Hub tab must remain disconnected")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_BrowserDisconnectDapp.qml
+++ b/storybook/qmlTests/tests/tst_BrowserDisconnectDapp.qml
@@ -8,18 +8,15 @@ import AppLayouts.Browser.webview
 import "../../../ui/app/AppLayouts/Browser/provider/qml/Utils.js" as Utils
 
 /**
- * Regression: disconnecting a background dApp (OpenSea) while another tab (hub) is active.
- *
- * Bug (BrowserWebViewContext.disconnectDapp): uses currentWebView.bridge only, so Nim
- * disconnect is invoked from the wrong tab context and the matching tab stays connected.
- *
- * Fix: resolve the webview/bridge whose tab URL matches the dApp being disconnected.
+ * Regression: BrowserWebViewContext.disconnectDapp for browser dApp combobox.
+ * Disconnect goes through connectorController using currentClientId (browser profile).
  */
 Item {
     id: root
 
     readonly property string hubUrl: "https://hub.status.network"
     readonly property string openseaUrl: "https://opensea.io"
+    readonly property string browserClientId: ConnectorConstants.clientIdFor(false)
 
     Component {
         id: mockConnectorControllerComponent
@@ -33,7 +30,6 @@ Item {
             signal chainIdSwitched(string payload)
             signal accountChanged(string payload)
 
-            property string lastDisconnectInvokerOrigin: ""
             property var disconnectCalls: []
 
             function connectorCallRPC(requestId, json) {
@@ -44,11 +40,8 @@ Item {
 
             function disconnect(hostname, clientId) {
                 const target = Utils.normalizeOrigin(hostname)
-                const invoker = lastDisconnectInvokerOrigin
-                const ok = invoker === target
-                disconnectCalls.push({ target: target, invoker: invoker, ok: ok, clientId: clientId })
-                lastDisconnectInvokerOrigin = ""
-                return ok
+                disconnectCalls.push({ target: target, clientId: clientId })
+                return true
             }
 
             function changeAccount() {}
@@ -67,29 +60,11 @@ Item {
     }
 
     Component {
-        id: bridgeDisconnectProxyComponent
-
-        QtObject {
-            required property var innerBridge
-            required property var mockController
-
-            readonly property string dappOrigin: innerBridge.dappOrigin
-            readonly property var connectorManager: innerBridge.connectorManager
-            readonly property var eip1193ProviderAdapter: innerBridge.eip1193ProviderAdapter
-
-            function disconnect(hostname) {
-                mockController.lastDisconnectInvokerOrigin = innerBridge.dappOrigin
-                return innerBridge.disconnect(hostname)
-            }
-        }
-    }
-
-    Component {
         id: tabHostComponent
 
         Item {
             id: tabHost
-            property url tabUrl
+            property url url
             property var bridge
         }
     }
@@ -100,6 +75,18 @@ Item {
         QtObject {
             property int currentIndex: 0
             readonly property int count: 2
+            function createEmptyTab() {}
+            function createDownloadTab() {}
+            function removeTab() {}
+        }
+    }
+
+    Component {
+        id: tabsModelSingleTabComponent
+
+        QtObject {
+            property int currentIndex: 0
+            readonly property int count: 1
             function createEmptyTab() {}
             function createDownloadTab() {}
             function removeTab() {}
@@ -142,8 +129,8 @@ Item {
         property Item hostStack: null
         property var tabsModel: null
         property BrowserWebViewContext webViewContext: null
-        property var hubBridgeProxy: null
-        property var openseaBridgeProxy: null
+        property var hubBridge: null
+        property var openseaBridge: null
 
         function init() {
             mock = createTemporaryObject(mockConnectorControllerComponent, root)
@@ -152,33 +139,24 @@ Item {
             hostStack = createTemporaryObject(tabHostComponent, root, { width: 1, height: 1 })
             tabsModel = createTemporaryObject(tabsModelComponent, root)
 
-            const hubInner = createTemporaryObject(connectorBridgeComponent, root, {
+            hubBridge = createTemporaryObject(connectorBridgeComponent, root, {
                 controller: mock,
                 tabUrl: root.hubUrl,
                 tabIncognito: false
             })
-            const openseaInner = createTemporaryObject(connectorBridgeComponent, root, {
+            openseaBridge = createTemporaryObject(connectorBridgeComponent, root, {
                 controller: mock,
                 tabUrl: root.openseaUrl,
                 tabIncognito: false
             })
 
-            hubBridgeProxy = createTemporaryObject(bridgeDisconnectProxyComponent, root, {
-                innerBridge: hubInner,
-                mockController: mock
-            })
-            openseaBridgeProxy = createTemporaryObject(bridgeDisconnectProxyComponent, root, {
-                innerBridge: openseaInner,
-                mockController: mock
-            })
-
             createTemporaryObject(tabHostComponent, hostStack, {
-                tabUrl: root.hubUrl,
-                bridge: hubBridgeProxy
+                url: root.hubUrl,
+                bridge: hubBridge
             })
             createTemporaryObject(tabHostComponent, hostStack, {
-                tabUrl: root.openseaUrl,
-                bridge: openseaBridgeProxy
+                url: root.openseaUrl,
+                bridge: openseaBridge
             })
 
             webViewContext = createTemporaryObject(browserWebViewContextComponent, root, {
@@ -189,46 +167,79 @@ Item {
         }
 
         function connectOpenSea() {
-            const clientId = ConnectorConstants.clientIdFor(false)
             mock.connected(JSON.stringify({
                 url: root.openseaUrl,
-                clientId: clientId,
+                clientId: root.browserClientId,
                 sharedAccount: "0xda4a19b7aec958688d2531175e2757427372c6d1",
                 chainId: 1
             }))
         }
 
-        // Hub is the active tab; disconnect OpenSea from wallet must use OpenSea's bridge.
-        function test_disconnectDappTargetsMatchingTabNotCurrentTab() {
+        // Hub is active; disconnect OpenSea from combobox must not use the hub tab bridge.
+        function test_disconnectDappUsesControllerNotActiveTabBridge() {
             connectOpenSea()
 
-            compare(openseaBridgeProxy.connectorManager.connected, true,
+            compare(openseaBridge.connectorManager.connected, true,
                     "OpenSea tab should be connected before disconnect")
-            compare(hubBridgeProxy.connectorManager.connected, false,
+            compare(hubBridge.connectorManager.connected, false,
                     "Hub tab must stay disconnected")
 
             tabsModel.currentIndex = 0
             compare(webViewContext.currentWebView.bridge.dappOrigin, root.hubUrl,
                     "Active tab must be hub while disconnecting background OpenSea")
 
-            webViewContext.disconnectDapp(root.openseaUrl)
+            verify(webViewContext.disconnectDapp(root.openseaUrl))
 
             compare(mock.disconnectCalls.length, 1, "disconnect must be invoked once")
-            compare(mock.disconnectCalls[0].invoker, root.openseaUrl,
-                    "disconnect must run through the OpenSea tab bridge, not the active hub tab")
             compare(mock.disconnectCalls[0].target, root.openseaUrl)
-            verify(mock.disconnectCalls[0].ok,
-                    "backend disconnect must succeed when invoked from the matching tab bridge")
+            compare(mock.disconnectCalls[0].clientId, root.browserClientId)
 
             mock.disconnected(JSON.stringify({
                 url: root.openseaUrl,
-                clientId: ConnectorConstants.clientIdFor(false)
+                clientId: root.browserClientId
             }))
 
-            compare(openseaBridgeProxy.connectorManager.connected, false,
+            compare(openseaBridge.connectorManager.connected, false,
                     "OpenSea provider state must clear after disconnect")
-            compare(hubBridgeProxy.connectorManager.connected, false,
+            compare(hubBridge.connectorManager.connected, false,
                     "Hub tab must remain disconnected")
+        }
+
+        // OpenSea tab closed; clientId comes from the active tab profile (currentClientId).
+        function test_disconnectDappUsesCurrentProfileClientIdWhenTabClosed() {
+            const localMock = createTemporaryObject(mockConnectorControllerComponent, root)
+            localMock.disconnectCalls = []
+
+            const localHostStack = createTemporaryObject(tabHostComponent, root, { width: 1, height: 1 })
+            const localTabsModel = createTemporaryObject(tabsModelSingleTabComponent, root)
+
+            const hubBridgeLocal = createTemporaryObject(connectorBridgeComponent, root, {
+                controller: localMock,
+                tabUrl: root.hubUrl,
+                tabIncognito: false
+            })
+
+            createTemporaryObject(tabHostComponent, localHostStack, {
+                url: root.hubUrl,
+                bridge: hubBridgeLocal
+            })
+
+            const localWebViewContext = createTemporaryObject(browserWebViewContextComponent, root, {
+                hostStack: localHostStack,
+                tabsModelRef: localTabsModel,
+                connectorControllerRef: localMock
+            })
+
+            compare(localTabsModel.count, 1, "OpenSea tab must be closed")
+            compare(localWebViewContext.currentWebView.url, root.hubUrl,
+                    "Only hub tab is open while disconnecting OpenSea from combobox")
+
+            verify(localWebViewContext.disconnectDapp(root.openseaUrl),
+                   "disconnect from browser dApp combobox must succeed without a matching tab")
+            compare(localMock.disconnectCalls.length, 1,
+                    "controller.disconnect must be invoked when no tab matches the dApp URL")
+            compare(localMock.disconnectCalls[0].target, root.openseaUrl)
+            compare(localMock.disconnectCalls[0].clientId, root.browserClientId)
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_ConnectorBridgeMultiTab.qml
+++ b/storybook/qmlTests/tests/tst_ConnectorBridgeMultiTab.qml
@@ -1,0 +1,142 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Browser.provider.qml
+
+/**
+ * Regression tests for per-tab ConnectorBridge (hub + OpenSea multi-tab).
+ */
+Item {
+    id: root
+
+    Component {
+        id: mockConnectorControllerComponent
+
+        QtObject {
+            id: mock
+
+            signal connected(string payload)
+            signal disconnected(string payload)
+            signal connectorCallRPCResult(int requestId, string payload)
+            signal chainIdSwitched(string payload)
+            signal accountChanged(string payload)
+
+            property var rpcCalls: []
+
+            function connectorCallRPC(requestId, json) {
+                rpcCalls.push({ requestId: requestId, json: json, parsed: JSON.parse(json) })
+            }
+
+            function getDApps() { return "[]" }
+            function disconnect() { return true }
+            function changeAccount() {}
+        }
+    }
+
+    Component {
+        id: connectorBridgeComponent
+
+        ConnectorBridge {
+            required property var controller
+            connectorController: controller
+            tabUrl: "about:blank"
+            tabIncognito: false
+        }
+    }
+
+    Component {
+        id: requestCompletedSpyComponent
+
+        SignalSpy {
+            required property var manager
+            target: manager
+            signalName: "requestCompletedEvent"
+        }
+    }
+
+    TestCase {
+        name: "ConnectorBridgeMultiTab"
+        when: windowShown
+
+        property var mock: null
+
+        function init() {
+            mock = createTemporaryObject(mockConnectorControllerComponent, root)
+            mock.rpcCalls = []
+        }
+
+        function createBridge(tabUrl) {
+            return createTemporaryObject(connectorBridgeComponent, root, {
+                controller: mock,
+                tabUrl: tabUrl,
+                tabIncognito: false
+            })
+        }
+
+        function createRequestCompletedSpy(manager) {
+            return createTemporaryObject(requestCompletedSpyComponent, root, { manager: manager })
+        }
+
+        // Hub active, OpenSea in background: each tab must keep its own dapp origin in RPC.
+        function test_concurrentTabsKeepIndependentDappOrigin() {
+            const hubBridge = createBridge("https://hub.status.network/")
+            const openseaBridge = createBridge("https://opensea.io/")
+
+            compare(hubBridge.dappOrigin, "https://hub.status.network",
+                    "Hub tab must expose hub origin without switching active tab")
+            compare(openseaBridge.dappOrigin, "https://opensea.io",
+                    "Background OpenSea tab must keep its own origin")
+
+            hubBridge.connectorManager.request({ method: "eth_accounts", requestId: 101 })
+            openseaBridge.connectorManager.request({ method: "eth_requestAccounts", requestId: 202 })
+
+            compare(mock.rpcCalls.length, 2)
+            compare(mock.rpcCalls[0].parsed.url, "https://hub.status.network")
+            compare(mock.rpcCalls[1].parsed.url, "https://opensea.io")
+        }
+
+        // Connect on OpenSea must not flip connected state on an unrelated hub tab.
+        function test_connectEventOnlyUpdatesMatchingTab() {
+            const hubBridge = createBridge("https://hub.status.network/")
+            const openseaBridge = createBridge("https://opensea.io/")
+            const clientId = ConnectorConstants.clientIdFor(false)
+
+            mock.connected(JSON.stringify({
+                url: "https://opensea.io",
+                clientId: clientId,
+                sharedAccount: "0xabc",
+                chainId: 1
+            }))
+
+            compare(openseaBridge.connectorManager.connected, true,
+                    "OpenSea tab should become connected")
+            compare(hubBridge.connectorManager.connected, false,
+                    "Hub tab must not inherit OpenSea connection state")
+            compare(openseaBridge.eip1193ProviderAdapter.accounts[0], "0xabc")
+            compare(hubBridge.eip1193ProviderAdapter.accounts.length, 0)
+        }
+
+        // Shared Nim controller emits one RPC result; only the originating tab may forward it.
+        function test_rpcResultOnlyReachesOriginatingBridge() {
+            const hubBridge = createBridge("https://hub.status.network/")
+            const openseaBridge = createBridge("https://opensea.io/")
+
+            const hubCompletedSpy = createRequestCompletedSpy(hubBridge.connectorManager)
+            const openseaCompletedSpy = createRequestCompletedSpy(openseaBridge.connectorManager)
+
+            hubBridge.connectorManager.request({ method: "eth_chainId", requestId: 1 })
+            openseaBridge.connectorManager.request({ method: "eth_accounts", requestId: 2 })
+
+            mock.connectorCallRPCResult(2, JSON.stringify({
+                jsonrpc: "2.0",
+                id: 2,
+                result: []
+            }))
+
+            compare(hubCompletedSpy.count, 0,
+                    "Hub tab must ignore RPC results from other tabs")
+            compare(openseaCompletedSpy.count, 1,
+                    "OpenSea tab must receive its own RPC result")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
+++ b/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
@@ -648,7 +648,7 @@ Item {
                 "dappUrl": 1,
                 "dappName": 2,
                 "dappIcon": 3,
-                "connectorBadge": 4,
+                "connectorId": 4,
                 "key": 5,
             }
         }
@@ -723,7 +723,7 @@ Item {
             compare(connectArgs[connectDAppSpy.argPos.dappUrl], Testing.dappUrl, "expected dappUrl to be set")
             compare(connectArgs[connectDAppSpy.argPos.dappName], Testing.dappName, "expected dappName to be set")
             compare(connectArgs[connectDAppSpy.argPos.dappIcon], Testing.dappFirstIcon, "expected dappIcon to be set")
-            compare(connectArgs[connectDAppSpy.argPos.connectorBadge], Constants.dappImageByType[Constants.WalletConnect], "expected connectorBadge to be set")
+            compare(connectArgs[connectDAppSpy.argPos.connectorId], Constants.DAppConnectors.WalletConnect, "expected connectorId to be set")
             verify(!!connectArgs[connectDAppSpy.argPos.key], "expected key to be set")
 
             let selectedAccount = accountsModel.get(1).address

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -297,7 +297,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG 71e6bf981ee07284e1f4b4e39decff9540173d80
+      GIT_TAG 503977380c67b734a755642e847132c5203142e2
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -53,7 +53,7 @@ StatusSectionLayout {
     property bool isDebugEnabled: false
     property string platformOS: Qt.platform.os
 
-    readonly property string userAgent: connectorBridge.httpUserAgent
+    readonly property string userAgent: browserConfig.httpUserAgent
 
     signal sendToRecipientRequested(string address)
 
@@ -81,9 +81,6 @@ StatusSectionLayout {
 
     Connections {
         target: _internal.currentWebView
-        function onUrlChanged() {
-            _internal.onCurrentTabUrlChanged()
-        }
         function onScrollPositionChanged() {
             const delta = _internal.currentWebView.scrollPosition.y - _internal.lastScrollPos
             _internal.scrolledUp = delta < 0
@@ -140,12 +137,12 @@ StatusSectionLayout {
         }
 
         function addNewDownloadTab() {
-            webViewContext.createDownloadTab(tabs.count !== 0 ? currentWebView.profileParams : connectorBridge.defaultProfileParams);
+            webViewContext.createDownloadTab(tabs.count !== 0 ? currentWebView.profileParams : browserConfig.defaultProfileParams);
             tabs.activateTab(tabs.count - 1)
         }
 
         function addNewTab(url, initialTitle) {
-            var tab = webViewContext.createEmptyTab(tabs.count !== 0 ? currentWebView.profileParams : connectorBridge.defaultProfileParams, false, true, url, initialTitle);
+            var tab = webViewContext.createEmptyTab(tabs.count !== 0 ? currentWebView.profileParams : browserConfig.defaultProfileParams, false, true, url, initialTitle);
             browserToolbarLoader.activateAddressBar()
             return tab;
         }
@@ -162,20 +159,6 @@ StatusSectionLayout {
                 url = "https://" + url
             }
             webViewContext.setCurrentWebUrl(url);
-        }
-
-        function onCurrentTabUrlChanged() {
-            const rawUrl = _internal.currentWebView?.url ?? ""
-
-            if (!rawUrl)
-                return
-
-            // Update ConnectorBridge with current dApp metadata
-            connectorBridge.connectorManager.updateDAppUrl(
-                        rawUrl,
-                        _internal.currentWebView.title,
-                        _internal.currentWebView.icon
-                        )
         }
 
         function onRequestOpenDapp(url) {
@@ -258,10 +241,11 @@ StatusSectionLayout {
         isMobile: root.isMobile
         hasPopups: SQUtils.Utils.hasPopups(root.Overlay.overlay.children)
         browserSettings: localAccountSensitiveSettings
-        webChannel: connectorBridge.channel
+        connectorController: root.dappsEnabled ? root.connectorController : null
+        dappsEnabled: root.dappsEnabled
         hostStackLayout: webStackView
         tabsModel: tabs
-        defaultProfileParams: connectorBridge.defaultProfileParams
+        defaultProfileParams: browserConfig.defaultProfileParams
         bookmarksStore: root.bookmarksStore
         downloadsStore: root.downloadsStore
         determineRealURLFn: (url) => root.browserRootStore.determineRealURL(url)
@@ -283,7 +267,7 @@ StatusSectionLayout {
         id: savedSessionContext
         webViewContext: webViewContext
         tabs: tabs
-        defaultProfileParams: connectorBridge.defaultProfileParams
+        defaultProfileParams: browserConfig.defaultProfileParams
         determineRealURL: (u) => root.browserRootStore.determineRealURL(u)
     }
 
@@ -342,7 +326,7 @@ StatusSectionLayout {
                     _internal.onRequestOpenDapp(url)
                 }
                 function onRequestDisconnectDapp(dappUrl) {
-                    connectorBridge.disconnect(dappUrl)
+                    webViewContext.disconnectDapp(dappUrl)
                 }
                 function onAddBookmarkRequested() {
                     const currentUrl = favoritesContext.currentUrl
@@ -477,7 +461,7 @@ StatusSectionLayout {
                                           deactivateAddressBar()
                                       }
             onRequestOpenDapp: url => _internal.onRequestOpenDapp(url)
-            onRequestDisconnectDapp: dappUrl => connectorBridge.disconnect(dappUrl)
+            onRequestDisconnectDapp: dappUrl => webViewContext.disconnectDapp(dappUrl)
             onRequestWalletMenu: dialogsContext.openWalletMenu(browserWalletMenu)
         }
 
@@ -603,7 +587,7 @@ StatusSectionLayout {
             networksStore: root.networksStore
 
             onSendTriggered: (address) => root.sendToRecipientRequested(address)
-            onAccountChanged: (newAddress) => connectorBridge.connectorManager.changeAccount(newAddress)
+            onAccountChanged: (newAddress) => webViewContext.changeAccountForCurrentDapp(newAddress)
             onReload: {
                 for (let i = 0; i < tabs.count; ++i){
                     webViewContext.getWebView(i).reload();
@@ -777,13 +761,11 @@ StatusSectionLayout {
         }
     }
 
-    ConnectorBridge {
-        id: connectorBridge
+    BrowserConfig {
+        id: browserConfig
 
         userUID: root.userUID
         featureEnabled: root.dappsEnabled
-        connectorController: root.dappsEnabled ? root.connectorController : null
-        currentTabIncognito: _internal.currentTabIncognito
         httpUserAgent: {
             if (localAccountSensitiveSettings.compatibilityMode) {
                 // Google doesn't let you connect if the user agent is Chrome-ish and doesn't satisfy some sort of hidden requirement
@@ -811,8 +793,8 @@ StatusSectionLayout {
     BCBrowserDappsProvider {
         id: browserDappsProvider
         connectorController: root.dappsEnabled ? root.connectorController : null
-        clientId: connectorBridge.clientId
-        clientIdFilter: connectorBridge.clientId
+        clientId: webViewContext.currentClientId
+        clientIdFilter: clientId
     }
 
     Component {

--- a/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
@@ -64,7 +64,11 @@ AbstractWebView {
     function goBack()             { if (loader.item) loader.item.goBack() }
     function goForward()          { if (loader.item) loader.item.goForward() }
     function goBackOrForward(o)   { if (loader.item) loader.item.goBackOrForward(o) }
-    function reload()             { if (loader.item) loader.item.reload() }
+    function reload() {
+        ensureLoaded()
+        if (loader.item)
+            loader.item.reload()
+    }
     function stop()               { if (loader.item) loader.item.stop() }
     function findText(text, flags){ if (loader.item) loader.item.findText(text, flags) }
     function showFindPanel()      { if (loader.item) loader.item.showFindPanel() }

--- a/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
@@ -91,9 +91,7 @@ AbstractWebView {
     }
 
     function reload() {
-        if (backend.url.toString() !== "") {
-            backend.loadUrl(backend.url)
-        }
+        backend.reload()
     }
 
     function stop() {

--- a/ui/app/AppLayouts/Browser/provider/js/ethereum_injector.js
+++ b/ui/app/AppLayouts/Browser/provider/js/ethereum_injector.js
@@ -1,5 +1,11 @@
 "use strict";
 
+// Clear reinjection guards when user script runs again on same-URL reload
+try {
+    delete window.__STATUS_ETHEREUM_INJECTOR_INIT__;
+    delete window.__STATUS_QWEBCHANNEL_CONNECTED__;
+} catch (e) {}
+
 // Ethereum Injector - Initializes QWebChannel and sets up the Ethereum provider
 // This script handles the connection between the page and the Status wallet
 

--- a/ui/app/AppLayouts/Browser/provider/js/ethereum_wrapper.js
+++ b/ui/app/AppLayouts/Browser/provider/js/ethereum_wrapper.js
@@ -17,9 +17,9 @@ const EthereumWrapper = (function() {
             }
 
             this.listeners = new Map(); // event -> Set<handler>
+            this._signalHandlers = new Map(); // eventName -> handler (for disconnect on unload)
             this.nativeEthereum = nativeEthereum;
-            // Start from a per-instance random base to avoid requestId collisions
-            // between different frames/tabs that share connector callbacks.
+            // Per-instance counter avoids requestId collisions between frames/tabs.
             this.requestIdCounter = Math.floor(Math.random() * 1000000000) + 1;
             this.pendingRequests = new Map(); // requestId -> { resolve, reject, timestamp }
             this.requestTimeout = 600000; // 10min timeout for pending requests. (nim side has it's own timeouts)
@@ -45,9 +45,24 @@ const EthereumWrapper = (function() {
             const event = this.nativeEthereum[eventName];
             if (event && event.connect) {
                 event.connect(handler);
+                this._signalHandlers.set(eventName, handler);
                 return true;
             }
             return false;
+        }
+
+        _disconnectAllSignals() {
+            for (const [eventName, handler] of this._signalHandlers.entries()) {
+                const event = this.nativeEthereum[eventName];
+                if (event && event.disconnect) {
+                    try {
+                        event.disconnect(handler);
+                    } catch (e) {
+                        console.error("[Ethereum Wrapper] Error disconnecting signal:", eventName, e);
+                    }
+                }
+            }
+            this._signalHandlers.clear();
         }
 
         _rejectRequests(requestsToReject, deleteFromPending = false) {
@@ -115,6 +130,7 @@ const EthereumWrapper = (function() {
         _setupPageUnloadHandler() {
             window.addEventListener('beforeunload', () => {
                 this._stopTimeoutChecker();
+                this._disconnectAllSignals();
                 this._rejectAllPendingRequests({
                     code: -32603,
                     message: 'Page is being unloaded'
@@ -241,17 +257,25 @@ const EthereumWrapper = (function() {
                 entry.resolve(resp);
             }
         }
-
         handleRequestCompleted(payload) {
-            const requestId = payload && (payload.requestId || (payload.response && payload.response.id)) || 0;
+            const responseId = (() => {
+                try {
+                    const r = payload?.response;
+                    return (typeof r === "string" ? JSON.parse(r) : r)?.id;
+                } catch (e) {
+                    return undefined;
+                }
+            })();
+            const requestId = (payload && payload.requestId) || responseId || 0;
+
             try {
                 const entry = this.pendingRequests.get(requestId);
-                
+
                 if (!entry) {
                     console.warn("[Ethereum Wrapper] No pending request found for ID:", requestId);
                     return;
                 }
-                
+
                 this._processResponse(payload && payload.response, entry.method, entry);
             } catch (e) {
                 console.error('[Ethereum Wrapper] requestCompletedEvent handler error', e);

--- a/ui/app/AppLayouts/Browser/provider/js/ethereum_wrapper.js
+++ b/ui/app/AppLayouts/Browser/provider/js/ethereum_wrapper.js
@@ -2,6 +2,17 @@
 
 // IIFE start (https://developer.mozilla.org/ru/docs/Glossary/IIFE)
 const EthereumWrapper = (function() {
+    try {
+        const prev = window.__ETHEREUM_WRAPPER_INSTANCE__;
+        delete window.__ETHEREUM_WRAPPER_INSTANCE__;
+        delete window.__ETHEREUM_INSTALLED__;
+        if (window.ethereum && (window.ethereum.__statusStub__
+                || (prev && prev.EthereumProvider
+                    && window.ethereum instanceof prev.EthereumProvider))) {
+            try { delete window.ethereum; } catch (e) {}
+        }
+    } catch (e) {}
+
     if (window.__ETHEREUM_WRAPPER_INSTANCE__) {
         return window.__ETHEREUM_WRAPPER_INSTANCE__;
     }
@@ -355,7 +366,7 @@ const EthereumWrapper = (function() {
             Object.defineProperty(window, 'ethereum', {
                 value: provider,
                 writable: false,
-                configurable: false,
+                configurable: true,
                 enumerable: true
             });
             window.__ETHEREUM_INSTALLED__ = true;

--- a/ui/app/AppLayouts/Browser/provider/qml/BrowserConfig.qml
+++ b/ui/app/AppLayouts/Browser/provider/qml/BrowserConfig.qml
@@ -1,0 +1,38 @@
+import QtQuick
+
+import AppLayouts.Browser.adapters
+
+/**
+ * BrowserConfig
+ *
+ * Window-level browser configuration shared across all tabs:
+ * user agent, injected scripts, and WebEngine ProfileParams templates.
+ */
+QtObject {
+    id: root
+
+    required property string userUID
+    property bool featureEnabled: true
+    property string httpUserAgent: ""
+
+    readonly property var scriptPaths: root.featureEnabled ? [
+        { path: Qt.resolvedUrl("../js/qwebchannel.js"), runOnSubFrames: true },
+        { path: Qt.resolvedUrl("../js/ethereum_wrapper.js"), runOnSubFrames: true },
+        { path: Qt.resolvedUrl("../js/eip6963_announcer.js"), runOnSubFrames: false },
+        { path: Qt.resolvedUrl("../js/ethereum_injector.js"), runOnSubFrames: true }
+    ] : []
+
+    readonly property ProfileParams defaultProfileParams: ProfileParams {
+        userId: root.userUID
+        userAgent: root.httpUserAgent
+        scripts: root.scriptPaths
+        offTheRecord: false
+    }
+
+    readonly property ProfileParams otrProfileParams: ProfileParams {
+        userId: root.userUID
+        userAgent: root.httpUserAgent
+        scripts: root.scriptPaths
+        offTheRecord: true
+    }
+}

--- a/ui/app/AppLayouts/Browser/provider/qml/ConnectorBridge.qml
+++ b/ui/app/AppLayouts/Browser/provider/qml/ConnectorBridge.qml
@@ -1,47 +1,23 @@
 import QtQuick
 import QtWebChannel
 
-import AppLayouts.Browser.adapters
-
 import "Utils.js" as BrowserUtils
 
 /**
  * ConnectorBridge
  *
- * Simplified connector infrastructure for BrowserLayout.
+ * Per-tab connector infrastructure.
  * Provides WebChannel, ConnectorManager, and direct connection to Nim backend.
- *
- * This component bridges the Browser UI with the Connector backend system.
  */
 QtObject {
     id: root
 
-    required property string userUID
-    property bool featureEnabled: true
     required property var connectorController
-    property string httpUserAgent: ""          // Custom user agent for web profiles
-    property bool currentTabIncognito: false   // Drives off-the-record clientId for the active tab
 
-    readonly property ProfileParams defaultProfileParams: ProfileParams {
-        userId: root.userUID
-        userAgent: root.httpUserAgent
-        scripts: root.scriptPaths
-        offTheRecord: false
-    }
-
-    readonly property ProfileParams otrProfileParams: ProfileParams {
-        userId: root.userUID
-        userAgent: root.httpUserAgent
-        scripts: root.scriptPaths
-        offTheRecord: true
-    }
-
-    readonly property var scriptPaths: root.featureEnabled ? [
-        { path: Qt.resolvedUrl("../js/qwebchannel.js"), runOnSubFrames: true },
-        { path: Qt.resolvedUrl("../js/ethereum_wrapper.js"), runOnSubFrames: true },
-        { path: Qt.resolvedUrl("../js/eip6963_announcer.js"), runOnSubFrames: false },
-        { path: Qt.resolvedUrl("../js/ethereum_injector.js"), runOnSubFrames: true }
-    ] : []
+    required property url tabUrl
+    required property bool tabIncognito
+    property string tabTitle: ""
+    property url tabIconUrl: ""
 
     readonly property alias dappUrl: connectorManager.dappUrl
     readonly property alias dappOrigin: connectorManager.dappOrigin
@@ -52,7 +28,7 @@ QtObject {
     readonly property ConnectorManager connectorManager: ConnectorManager {
         id: connectorManager
         connectorController: root.connectorController  // (shared_modules/connector/controller.nim)
-        offTheRecord: root.currentTabIncognito
+        offTheRecord: root.tabIncognito
 
         // Forward events to Eip1193ProviderAdapter
         onConnectEvent: (info) => eip1193ProviderAdapter.connectEvent(info)
@@ -82,41 +58,24 @@ QtObject {
         registeredObjects: [eip1193ProviderAdapter]
     }
 
-    function hasWalletConnected(hostname, address) {
-        if (!connectorController) return false
-
-        const dApps = connectorController.getDApps()
-        try {
-            const dAppsObj = JSON.parse(dApps)
-            if (Array.isArray(dAppsObj)) {
-                return dAppsObj.some(function(dapp) {
-                    return dapp.url && dapp.url.indexOf(hostname) >= 0
-                })
-            }
-        } catch (e) {
-            console.warn("[ConnectorBridge] Error checking wallet connection:", e)
-        }
-        return false
+    function syncTabMetadata() {
+        if (!tabUrl || !tabUrl.toString())
+            return
+        connectorManager.updateDAppUrl(tabUrl, tabTitle, tabIconUrl)
     }
+
+    onTabUrlChanged: syncTabMetadata()
+    onTabTitleChanged: syncTabMetadata()
+    onTabIconUrlChanged: syncTabMetadata()
+    onTabIncognitoChanged: syncTabMetadata()
+
+    Component.onCompleted: syncTabMetadata()
 
     function disconnect(hostname) {
         if (!connectorController) {
             return false
         }
 
-        const result = connectorController.disconnect(hostname, clientId)
-        return result
-    }
-
-    function disconnectCurrentTab() {
-        if (!dappOrigin) {
-            return false
-        }
-
-        return disconnect(dappOrigin)
-    }
-
-    function updateDAppUrl(url, name) {
-        connectorManager.updateDAppUrl(url, name)
+        return connectorController.disconnect(hostname, clientId)
     }
 }

--- a/ui/app/AppLayouts/Browser/provider/qml/ConnectorManager.qml
+++ b/ui/app/AppLayouts/Browser/provider/qml/ConnectorManager.qml
@@ -19,6 +19,7 @@ QtObject {
     property bool connected: false
     property var accounts: []
     property bool _initialConnectionDone: false
+    property var _ownRequestIds: ({})
 
     // SIGNALS
     // Notify to re-read all properties
@@ -67,6 +68,7 @@ QtObject {
         }
 
         connectorController.connectorCallRPC(requestId, JSON.stringify(rpcRequest))
+        _ownRequestIds[requestId] = true
 
         // Return immediately - response comes via connectorCallRPCResult signal
         return JSON.stringify({
@@ -126,14 +128,6 @@ QtObject {
     }
 
     // PUBLIC API
-    function disconnect() {
-        clearState()
-
-        if (connectorController) {
-            connectorController.disconnect(dappOrigin, clientId)
-        }
-    }
-
     function changeAccount(newAccount) {
         if (connectorController) {
             connectorController.disconnect(dappOrigin, clientId)
@@ -209,6 +203,11 @@ QtObject {
         }
 
         function onConnectorCallRPCResult(requestId, payload) {
+            if (!_ownRequestIds[requestId])
+                return
+
+            delete _ownRequestIds[requestId]
+
             // Emit to Eip1193ProviderAdapter → ethereum_wrapper.js
             requestCompletedEvent({
                 requestId: requestId,

--- a/ui/app/AppLayouts/Browser/provider/qml/qmldir
+++ b/ui/app/AppLayouts/Browser/provider/qml/qmldir
@@ -1,4 +1,5 @@
 singleton ConnectorConstants 1.0 ConnectorConstants.qml
+BrowserConfig 1.0 BrowserConfig.qml
 ConnectorBridge 1.0 ConnectorBridge.qml
 ConnectorManager 1.0 ConnectorManager.qml
 Eip1193ProviderAdapter 1.0 Eip1193ProviderAdapter.qml

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts
 import utils
 
 import AppLayouts.Browser.adapters
+import AppLayouts.Browser.provider.qml
 
 QtObject {
     id: root
@@ -15,7 +16,8 @@ QtObject {
     required property bool hasPopups
 
     required property var browserSettings
-    required property var webChannel
+    required property var connectorController
+    required property bool dappsEnabled
 
     required property Item hostStackLayout
     required property var tabsModel
@@ -54,6 +56,9 @@ QtObject {
         return BrowserWebViewContext.ContentMode.WebContent
     }
 
+    readonly property string currentClientId: currentWebView?.bridge?.clientId
+                                              ?? ConnectorConstants.clientIdFor(currentWebView ? currentWebView.offTheRecord : false)
+
     readonly property Connections _currentIndexConnections: Connections {
         target: tabsModel
         function onCurrentIndexChanged() {
@@ -68,6 +73,10 @@ QtObject {
             profileParams: profileParams,
             isDownloadView: false
         })
+        if (!webview) {
+            console.error("[Browser] Failed to create webview")
+            return null
+        }
 
         tabsModel.createEmptyTab(createAsStartPage, focusOnNewTab, webview, initialTitle, initialIcon)
 
@@ -89,6 +98,11 @@ QtObject {
             profileParams: profileParams,
             isDownloadView: true
         })
+        if (!webview) {
+            console.error("[Browser] Failed to create download webview")
+            return null
+        }
+
         tabsModel.createDownloadTab()
         webview.ensureLoaded()
         return webview
@@ -121,6 +135,14 @@ QtObject {
             if (newUrl && newUrl.toString() && typeof target.ensureLoaded === "function")
                 target.ensureLoaded()
         })
+    }
+
+    function disconnectDapp(dappUrl) {
+        currentWebView?.bridge?.disconnect(dappUrl)
+    }
+
+    function changeAccountForCurrentDapp(address) {
+        currentWebView?.bridge?.connectorManager.changeAccount(address)
     }
 
     function goBackCurrent() {
@@ -205,6 +227,8 @@ QtObject {
 
     readonly property var webViewAdapterComponent: Component {
         LazyWebViewAdapter {
+            id: lazyView
+
             // On mobile, only the active tab must be visible; native WKWebView
             // subviews share the same UIKit window and ignore QML z-order,
             // so StackLayout alone cannot hide inactive tabs reliably.
@@ -213,10 +237,19 @@ QtObject {
             // Freeze native webview while QML popup is shown
             freeze: root.isMobile && root.hasPopups
 
+            readonly property ConnectorBridge bridge: ConnectorBridge {
+                connectorController: root.dappsEnabled ? root.connectorController : null
+                tabUrl: lazyView.url
+                tabIncognito: lazyView.offTheRecord
+                tabTitle: lazyView.title
+                tabIconUrl: lazyView.icon
+            }
+
+            webChannel: bridge.channel
+
             bookmarksStore: root.bookmarksStore
             downloadsStore: root.downloadsStore
             profileManager: root.profileManager
-            webChannel: root.webChannel
             enableJsLogs: root.isDebugEnabled
             localAccountSensitiveSettings: root.browserSettings
             devToolsEnabled: root.browserSettings.devToolsEnabled

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -7,6 +7,8 @@ import utils
 import AppLayouts.Browser.adapters
 import AppLayouts.Browser.provider.qml
 
+import "../provider/qml/Utils.js" as BrowserProviderUtils
+
 QtObject {
     id: root
 
@@ -138,7 +140,11 @@ QtObject {
     }
 
     function disconnectDapp(dappUrl) {
-        currentWebView?.bridge?.disconnect(dappUrl)
+        const origin = BrowserProviderUtils.normalizeOrigin(dappUrl)
+        if (!origin || !connectorController)
+            return false
+
+        return connectorController.disconnect(origin, currentClientId)
     }
 
     function changeAccountForCurrentDapp(address) {
@@ -166,6 +172,8 @@ QtObject {
     function reloadCurrent() {
         if (!currentWebView)
             return
+        if (typeof currentWebView.ensureLoaded === "function")
+            currentWebView.ensureLoaded()
         currentWebView.reload()
     }
 

--- a/ui/app/AppLayouts/Wallet/popups/dapps/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/popups/dapps/DAppsWorkflow.qml
@@ -14,6 +14,7 @@ import StatusQ.Popups.Dialog
 import QtModelsToolkit
 import SortFilterProxyModel
 
+import AppLayouts.Browser.provider.qml
 import AppLayouts.Wallet
 import AppLayouts.Wallet.controls
 import AppLayouts.Wallet.services.dapps
@@ -117,8 +118,8 @@ SQUtils.QObject {
     }
 
     /// Request to connect to a dApp
-    function connectDApp(dappChains, dappUrl, dappName, dappIcon, connectorIcon, pairingId) {
-        connectDappLoader.connect(dappChains, dappUrl, dappName, dappIcon, connectorIcon, pairingId)
+    function connectDApp(dappChains, dappUrl, dappName, dappIcon, connectorId, pairingId) {
+        connectDappLoader.connect(dappChains, dappUrl, dappName, dappIcon, connectorId, pairingId)
     }
 
     function openPairing() {
@@ -221,6 +222,7 @@ SQUtils.QObject {
         property string dappName
         property url dappIcon
         property string connectorIcon
+        property int dappConnectorId: Constants.DAppConnectors.WalletConnect
         property var key
         property var topic
 
@@ -238,15 +240,22 @@ SQUtils.QObject {
                         connectionQueue[0].dappUrl,
                         connectionQueue[0].dappName,
                         connectionQueue[0].dappIcon,
-                        connectionQueue[0].connectorIcon,
+                        connectionQueue[0].connectorId,
                         connectionQueue[0].key)
                 connectionQueue.shift()
             }
         }
 
-        function connect(dappChains, dappUrl, dappName, dappIcon, connectorIcon, key) {
+        function connect(dappChains, dappUrl, dappName, dappIcon, connectorId, key) {
+            console.log("[StatusConnect] DAppsWorkflow connect",
+                         "key=" + key,
+                         "url=" + dappUrl,
+                         "connectorId=" + connectorId,
+                         "chains=" + JSON.stringify(dappChains),
+                         "loaderActive=" + connectDappLoader.active,
+                         "queueLen=" + connectionQueue.length)
             if (connectDappLoader.active) {
-                connectionQueue.push({ dappChains, dappUrl, dappName, dappIcon, key, connectorIcon })
+                connectionQueue.push({ dappChains, dappUrl, dappName, dappIcon, connectorId, key })
                 return
             }
 
@@ -255,7 +264,8 @@ SQUtils.QObject {
             connectDappLoader.dappUrl = dappUrl
             connectDappLoader.dappName = dappName
             connectDappLoader.dappIcon = dappIcon
-            connectDappLoader.connectorIcon = connectorIcon
+            connectDappLoader.connectorIcon = Constants.dappImageByType[connectorId] || ""
+            connectDappLoader.dappConnectorId = connectorId
             connectDappLoader.key = key
 
             if (pairWCLoader.item) {
@@ -282,6 +292,12 @@ SQUtils.QObject {
 
         sourceComponent: ConnectDAppModal {
             visible: true
+
+            Component.onCompleted: {
+                console.log("[StatusConnect] ConnectDAppModal shown",
+                             "url=" + connectDappLoader.dappUrl,
+                             "key=" + connectDappLoader.key)
+            }
 
             onClosed: {
                 if (!connectDappLoader.connectRequestHandled && connectDappLoader.key) {
@@ -328,7 +344,17 @@ SQUtils.QObject {
             })
 
             onDisconnect: connectDappLoader.resolve(() => {
-                root.disconnectRequested(connectDappLoader.topic, connectDappLoader.dappUrl, Constants.DAppConnectors.WalletConnect, "walletconnect")
+                const connectorId = connectDappLoader.dappConnectorId
+                const isStatusConnect = connectorId === Constants.DAppConnectors.StatusConnect
+                const clientId = isStatusConnect
+                        ? ConnectorConstants.clientIdFor(false)
+                        : "walletconnect"
+                const topic = connectDappLoader.topic || connectDappLoader.dappUrl
+                console.log("[StatusConnect] ConnectDAppModal disconnect",
+                             "url=" + connectDappLoader.dappUrl,
+                             "connectorId=" + connectorId,
+                             "clientId=" + clientId)
+                root.disconnectRequested(topic, connectDappLoader.dappUrl, connectorId, clientId)
                 close()
             })
         }

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsService.qml
@@ -36,7 +36,7 @@ SQUtils.QObject {
     readonly property bool isServiceOnline: dappsModule.isServiceOnline
 
     // signals
-    signal connectDApp(var dappChains, url dappUrl, string dappName, url dappIcon, string connectorIcon, string key)
+    signal connectDApp(var dappChains, url dappUrl, string dappName, url dappIcon, int connectorId, string key)
     // Emitted as a response to DAppsService.approveSession
     // @param key The key of the session proposal
     // @param error The error message
@@ -200,8 +200,12 @@ SQUtils.QObject {
 
         function onConnectDApp(dappChains, dappUrl, dappName, dappIcon, connectorId, key) {
             timeoutTimer.stop()
-            const connectorIcon = Constants.dappImageByType[connectorId]
-            root.connectDApp(dappChains, dappUrl, dappName, dappIcon, connectorIcon, key)
+            console.log("[StatusConnect] DAppsService connectDApp",
+                         "key=" + key,
+                         "url=" + dappUrl,
+                         "connectorId=" + connectorId,
+                         "chains=" + JSON.stringify(dappChains))
+            root.connectDApp(dappChains, dappUrl, dappName, dappIcon, connectorId, key)
         }
 
         function onDappConnected(proposal, topic, url, connectorId) {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2900,8 +2900,8 @@ Item {
 
                 dappsWorkflow.connectionSuccessful(pairingId, newConnectionId)
             }
-            onConnectDApp: (dappChains, dappUrl, dappName, dappIcon, connectorIcon, pairingId) => {
-                dappsWorkflow.connectDApp(dappChains, dappUrl, dappName, dappIcon, connectorIcon, pairingId)
+            onConnectDApp: (dappChains, dappUrl, dappName, dappIcon, connectorId, pairingId) => {
+                dappsWorkflow.connectDApp(dappChains, dappUrl, dappName, dappIcon, connectorId, pairingId)
             }
         }
     }


### PR DESCRIPTION
* bump mobilewebview: https://github.com/status-im/mobilewebview/pull/9
* addDocumentStartJavaScript ensures earliest scripts injection
fixes #20602 

updated:
* Each tab now gets its own ConnectorBridge and WebChannel
* Tab URL and metadata stay in sync per tab
* RPC results are routed only to the tab that sent the request
* The ethereum wrapper unsubscribes from QWebChannel signals on page unload
