### PR TITLE
fix(chat): restore iOS paste menu behavior

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -69,6 +69,7 @@ TextField {
         id: contextMenu
 
         hideDisabledItems: false
+        popupType: Utils.isIOS ? Popup.Native : Popup.Item
 
         StatusAction {
             text: qsTr("Cut")
@@ -93,5 +94,5 @@ TextField {
         }
     }
 
-    ContextMenu.menu: Utils.isMobile ? null : contextMenu
+    ContextMenu.menu: Utils.isAndroid ? null : contextMenu
 }

--- a/ui/imports/shared/status/StatusChatInputTextArea.qml
+++ b/ui/imports/shared/status/StatusChatInputTextArea.qml
@@ -706,7 +706,11 @@ StatusQ.StatusTextArea {
             // cursor position must be stored in a helper property because setting readonly to true causes change
             // of the cursor position to the end of the input
             d.copyTextStart = root.cursorPosition
-            root.readOnly = true
+            // Toggling readOnly while handling the native iOS edit menu hides
+            // the keyboard, so keep the input editable on that path.
+            const toggleReadOnly = !StatusQUtils.Utils.isIOS
+            if (toggleReadOnly)
+                root.readOnly = true
 
             const copiedText = StatusQUtils.StringUtils.plainText(d.copiedTextPlain)
 
@@ -746,7 +750,8 @@ StatusQ.StatusTextArea {
             // Reset readOnly immediately after paste completes
             // Don't wait for onReleased which might not fire on mobile
             if (StatusQUtils.Utils.isMobile || immediateCleanup) {
-                root.readOnly = false
+                if (toggleReadOnly)
+                    root.readOnly = false
                 root.cursorPosition = (d.copyTextStart + ClipboardUtils.text.length + d.nbEmojisInClipboard)
             }
 
@@ -807,6 +812,8 @@ StatusQ.StatusTextArea {
         id: contextMenu
 
         hideDisabledItems: false
+        // Use the platform popup on iOS to match native text editing behavior.
+        popupType: StatusQUtils.Utils.isIOS ? Popup.Native : Popup.Item
 
         StatusAction {
             text: qsTr("Cut")
@@ -831,5 +838,6 @@ StatusQ.StatusTextArea {
         }
     }
 
-    ContextMenu.menu: StatusQUtils.Utils.isMobile ? null : contextMenu
+    ContextMenu.menu: StatusQUtils.Utils.isAndroid ? null
+                      : contextMenu
 }


### PR DESCRIPTION
Closes #20588

### What does the PR do

Use the platform popup for the chat input context menu on iOS so paste and selection actions follow native text editing behavior.

Avoid toggling readOnly during iOS paste handling, since that dismisses and restores the virtual keyboard. Keep Android using the existing null context menu path.

### Affected areas

Chat Text Area - Paste context menu iOS

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="458" height="915" alt="Screenshot 2026-05-15 at 16 56 09" src="https://github.com/user-attachments/assets/b0b472b7-26ce-4582-a135-38a979fd7a7a" />

### Impact on end user

on iOS user can now paste texts

### How to test

Follow task steps: copy message in a chat, and try to invoke the paste context menu by long pressing on the text area.

### Risk 

Low
