### PR TITLE
fix: Community members in community settins

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunitySettingsLoader.qml
+++ b/ui/app/AppLayouts/Chat/CommunitySettingsLoader.qml
@@ -60,6 +60,7 @@ Loader {
             permissionsModel:               Qt.binding(() => root.communityPermissionsStore.permissionsModel),
             leftPanelWidthOverride:         Qt.binding(() => root.leftPanelWidthOverride),
         })
+        root.rootStore.loadMembersForSectionId(root.sectionItemModel.id)
     }
 
     onActiveChanged: loadSection()


### PR DESCRIPTION
### What does the PR do

Fixing a regression from https://github.com/status-im/status-app/pull/20803 where there's no community member in the members settings view.



<img width="1441" height="682" alt="Screenshot 2026-05-17 at 14 34 59" src="https://github.com/user-attachments/assets/0f307c20-8263-43a4-bcdf-38d4f8c31018" />
<img width="782" height="456" alt="Screenshot 2026-05-17 at 14 34 43" src="https://github.com/user-attachments/assets/e2b57371-1b6a-42b4-af1f-a5b4286472ce" />
