### PR TITLE
Fix/issue 20628

### DIFF
--- a/ui/app/AppLayouts/Profile/helpers/SettingsEntriesModel.qml
+++ b/ui/app/AppLayouts/Profile/helpers/SettingsEntriesModel.qml
@@ -157,7 +157,7 @@ SortFilterProxyModel {
         },
         {
             subsection: Constants.settingsSubsection.notifications,
-            text: qsTr("Notifications & Sounds"),
+            text: qsTr("Notifications"),
             icon: "notification",
             group: root.preferencesGroupTitle,
             isExperimental: false

--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import SortFilterProxyModel
 
 import StatusQ.Core
 import StatusQ.Core.Theme
@@ -162,7 +163,7 @@ SettingsContentBase {
         Rectangle {
             Layout.preferredWidth: root.contentWidth
             implicitHeight: col1.height + 2 * Theme.padding
-            visible: SQUtils.Utils.isMacOS
+            visible: false // It will be evaluated on the next release 2.39
             radius: Constants.settingsSection.radius
             color: Theme.palette.primaryColor3
 
@@ -176,7 +177,7 @@ SettingsContentBase {
 
                 StatusBaseText {
                     Layout.preferredWidth: parent.width
-                    text: qsTr("Enable Notifications in macOS Settings")
+                    text: qsTr("Enable notifications")
                     font.pixelSize: d.infoFontSize
                     lineHeight: d.infoLineHeight
                     lineHeightMode: Text.FixedHeight
@@ -185,7 +186,7 @@ SettingsContentBase {
 
                 StatusBaseText {
                     Layout.preferredWidth: parent.width
-                    text: qsTr("To receive Status notifications, make sure you've enabled them in your computer's settings under <b>System Preferences > Notifications</b>")
+                    text: qsTr("Receive notifications for incoming messages, mentions, and contact requests on your computer so you can stay up to date in real time. Customize anytime in <b>Settings → Notifications</b><br><br>Status delivers notifications directly through your operating system, with no third parties, centralized servers, or intermediaries involved.")
                     font.pixelSize: d.infoFontSize
                     lineHeight: d.infoLineHeight
                     lineHeightMode: Text.FixedHeight
@@ -214,7 +215,7 @@ SettingsContentBase {
             }
 
             contentItem: StatusBaseText {
-                text: qsTr("<font color='%1'>Enable Push notifications in your device Settings</font><br><br>Before enabling mobile push notifications in the app below, enable them in <font color='%1'>your device settings</font> first.").arg(Theme.palette.primaryColor1)
+                text: qsTr("<font color='%1'>Enable notifications in your device Settings</font><br><br>Before enabling notifications in the app below, enable them in <font color='%1'>your device settings</font> first.").arg(Theme.palette.primaryColor1)
                 font.pixelSize: d.infoFontSize
                 lineHeight: d.infoLineHeight
                 lineHeightMode: Text.FixedHeight
@@ -225,9 +226,12 @@ SettingsContentBase {
 
         StatusListItem {
             Layout.preferredWidth: root.contentWidth
-            title: SQUtils.Utils.isMobile
-                   ? qsTr("Enable mobile push notifications")
-                   : qsTr("Allow Notification Bubbles")
+            title: qsTr("Enable notifications")
+            tertiaryTitle:  !SQUtils.Utils.isMobile ?
+                                qsTr("Status delivers notifications directly through your operating system, with no centralized servers or intermediaries. Ensure they are enabled for Status in your system settings") :
+                                SQUtils.Utils.isIOS ?
+                                    qsTr("Status uses APNs (Apple Push Notification service) solely to deliver notification signals on your device; your end-to-end encrypted message content is never passed through or stored there.") :
+                                    qsTr("Status delivers notifications on your device via its on-device background service, with no third parties, centralized servers, or intermediaries involved.")
             components: [
                 StatusSwitch {
                     id: allowNotifSwitch
@@ -440,79 +444,9 @@ SettingsContentBase {
                 }
             }
 
-            StatusListItem {
+            Loader {
                 Layout.preferredWidth: root.contentWidth
-                title: qsTr("Play a Sound When Receiving a Notification")
-                components: [
-                    StatusSwitch {
-                        id: soundSwitch
-                        checked: d.notificationsSettings.notificationSoundsEnabled
-                        onClicked: {
-                            d.notificationsSettings.notificationSoundsEnabled = !d.notificationsSettings.notificationSoundsEnabled
-                        }
-                    }
-                ]
-                onClicked: {
-                    soundSwitch.clicked()
-                }
-            }
-
-            StatusBaseText {
-                Layout.preferredWidth: root.contentWidth
-                Layout.leftMargin: Theme.padding
-                text: qsTr("Volume")
-                color: Theme.palette.directColor1
-            }
-
-            Item {
-                Layout.preferredWidth: root.contentWidth
-                Layout.preferredHeight: Constants.settingsSection.itemHeight + Theme.padding
-
-                StatusSlider {
-                    id: volumeSlider
-                    anchors.top: parent.top
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.topMargin: Theme.bigPadding
-                    anchors.leftMargin: Theme.padding
-                    anchors.rightMargin: Theme.padding
-                    from: 0
-                    to: 100
-                    stepSize: 1
-
-                    onValueChanged: {
-                        d.notificationsSettings.volume = value
-                    }
-
-                    Component.onCompleted: {
-                        value = d.notificationsSettings.volume
-                        volumeSlider.valueChanged.connect(() => {
-                                                            // play a sound preview, but not on startup
-                                                            Global.playNotificationSound()
-                                                        });
-                    }
-                }
-
-                RowLayout {
-                    anchors.top: volumeSlider.bottom
-                    anchors.left: volumeSlider.left
-                    anchors.topMargin: Theme.halfPadding
-                    width: volumeSlider.width
-
-                    StatusBaseText {
-                        font.pixelSize: Theme.primaryTextFontSize
-                        text: volumeSlider.from
-                        Layout.preferredWidth: volumeSlider.width/2
-                        color: Theme.palette.baseColor1
-                    }
-
-                    StatusBaseText {
-                        font.pixelSize: Theme.primaryTextFontSize
-                        text: volumeSlider.to
-                        Layout.alignment: Qt.AlignRight
-                        color: Theme.palette.baseColor1
-                    }
-                }
+                sourceComponent: soundAndVolumeComponent
             }
 
             StatusButton {
@@ -569,10 +503,15 @@ SettingsContentBase {
                     Layout.preferredWidth: root.contentWidth
                     Layout.preferredHeight: Theme.bigPadding
                 }
+
+                StatusBaseText {
+                    Layout.leftMargin: Theme.padding
+                    text: qsTr("Including:")
+                }
+
                 StatusListItem {
                     Layout.preferredWidth: root.contentWidth
-                    title: qsTr("From non-contacts")
-                    subTitle: qsTr("Contact requests and group messages")
+                    title: qsTr("Contact requests and group messages")
                     enabled: d.notificationsSettings.notifSettingAllowNotifications
                     components: [
                         StatusSwitch {
@@ -598,8 +537,7 @@ SettingsContentBase {
 
                 StatusListItem {
                     Layout.preferredWidth: root.contentWidth
-                    title: qsTr("Communities")
-                    subTitle: qsTr("Mentions and replies")
+                    title: qsTr("Mentions and replies in communities")
                     enabled: d.notificationsSettings.notifSettingAllowNotifications
                     components: [
                         StatusSwitch {
@@ -620,6 +558,106 @@ SettingsContentBase {
                     onClicked: {
                         if (enabled)
                             communitiesSwitch.clicked()
+                    }
+                }
+
+                Separator {
+                    Layout.preferredWidth: root.contentWidth
+                    Layout.preferredHeight: Theme.bigPadding
+                }
+
+                Loader {
+                    Layout.preferredWidth: root.contentWidth
+                    sourceComponent: soundAndVolumeComponent
+                }
+
+                StatusButton {
+                    Layout.leftMargin: Theme.padding
+                    text: qsTr("Send a Test Notification")
+                    onClicked: {
+                        root.notificationsStore.sendTestNotification("Status",
+                                                                    qsTr("You have a new message"))
+                    }
+                }
+            }
+        }
+
+        Component {
+            id: soundAndVolumeComponent
+
+            ColumnLayout {
+                StatusListItem {
+                    Layout.preferredWidth: root.contentWidth
+                    title: qsTr("Play a Sound When Receiving a Notification")
+                    components: [
+                        StatusSwitch {
+                            id: soundSwitch
+                            checked: d.notificationsSettings.notificationSoundsEnabled
+                            onClicked: {
+                                d.notificationsSettings.notificationSoundsEnabled = !d.notificationsSettings.notificationSoundsEnabled
+                            }
+                        }
+                    ]
+                    onClicked: {
+                        soundSwitch.clicked()
+                    }
+                }
+
+                StatusBaseText {
+                    Layout.preferredWidth: root.contentWidth
+                    Layout.leftMargin: Theme.padding
+                    text: qsTr("Volume")
+                    color: Theme.palette.directColor1
+                }
+
+                Item {
+                    Layout.preferredWidth: root.contentWidth
+                    Layout.preferredHeight: Constants.settingsSection.itemHeight + Theme.padding
+
+                    StatusSlider {
+                        id: volumeSlider
+                        anchors.top: parent.top
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.topMargin: Theme.bigPadding
+                        anchors.leftMargin: Theme.padding
+                        anchors.rightMargin: Theme.padding
+                        from: 0
+                        to: 100
+                        stepSize: 1
+
+                        onValueChanged: {
+                            d.notificationsSettings.volume = value
+                        }
+
+                        Component.onCompleted: {
+                            value = d.notificationsSettings.volume
+                            volumeSlider.valueChanged.connect(() => {
+                                                            // play a sound preview, but not on startup
+                                                            Global.playNotificationSound()
+                                                        });
+                        }
+                    }
+
+                    RowLayout {
+                        anchors.top: volumeSlider.bottom
+                        anchors.left: volumeSlider.left
+                        anchors.topMargin: Theme.halfPadding
+                        width: volumeSlider.width
+
+                        StatusBaseText {
+                            font.pixelSize: Theme.primaryTextFontSize
+                            text: volumeSlider.from
+                            Layout.preferredWidth: volumeSlider.width/2
+                            color: Theme.palette.baseColor1
+                        }
+
+                        StatusBaseText {
+                            font.pixelSize: Theme.primaryTextFontSize
+                            text: volumeSlider.to
+                            Layout.alignment: Qt.AlignRight
+                            color: Theme.palette.baseColor1
+                        }
                     }
                 }
             }

--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -35,6 +35,7 @@ SettingsContentBase {
         readonly property int infoSpacing: 5
 
         readonly property var notificationsSettings: root.notificationsStore.notificationsSettings
+        property real unfilteredExemptionsListHeight: 0
     }
 
     Component.onCompleted: root.notificationsStore.loadExemptions()
@@ -59,13 +60,7 @@ SettingsContentBase {
         Component {
             id: exemptionDelegateComponent
             StatusListItem {
-                property string lowerCaseSearchString: searchBox.text.toLowerCase()
-
                 width: ListView.view.width
-                height: visible ? implicitHeight : 0
-                visible: lowerCaseSearchString === "" ||
-                         model.itemId.toLowerCase().includes(lowerCaseSearchString) ||
-                         model.name.toLowerCase().includes(lowerCaseSearchString)
                 title: model.name
                 subTitle: {
                     if(model.type === Constants.settingsSection.exemptions.community)
@@ -487,10 +482,40 @@ SettingsContentBase {
 
             StatusListView {
                 Layout.preferredWidth: root.contentWidth
-                Layout.preferredHeight: this.contentHeight
+                Layout.preferredHeight: this.isFiltering && d.unfilteredExemptionsListHeight > 0 ?
+                                            Math.max(this.contentHeight,
+                                                     Math.min(d.unfilteredExemptionsListHeight,
+                                                              root.availableHeight)) :
+                                            this.contentHeight
                 visible: root.notificationsStore.exemptionsModel.count > 0
 
-                model: root.notificationsStore.exemptionsModel
+                readonly property bool isFiltering: searchBox.text.trim() !== ""
+
+                onContentHeightChanged: {
+                    if (!isFiltering)
+                        d.unfilteredExemptionsListHeight = contentHeight
+                }
+
+                model: SortFilterProxyModel {
+                    id: exemptionsSearchModel
+
+                    readonly property string searchText: searchBox.text.trim()
+
+                    sourceModel: root.notificationsStore.exemptionsModel
+                    filters: AnyOf {
+                        enabled: exemptionsSearchModel.searchText !== ""
+
+                        SQUtils.SearchFilter {
+                            roleName: "itemId"
+                            searchPhrase: exemptionsSearchModel.searchText
+                        }
+
+                        SQUtils.SearchFilter {
+                            roleName: "name"
+                            searchPhrase: exemptionsSearchModel.searchText
+                        }
+                    }
+                }
                 delegate: exemptionDelegateComponent
             }
             }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -909,6 +909,9 @@ Item {
         property var whitelistedUnfurledDomains: []
         property bool introduceYourselfPopupSeen
         property bool enableMessageBackupPopupSeen
+        property bool enablePushNotificationsFreshInstallSeen
+        property bool enablePushNotificationsDontAskAgain
+        property string enablePushNotificationsLastShownVersion
         property var recentEmojis
         property string skinColor // NB: must be a string for the twemoji lib to work; we don't want the `#` in the name
         property int theme: ThemeUtils.Style.System
@@ -1011,6 +1014,7 @@ Item {
         tokensStore: appMain.tokensStore
         rootChatStore: appMain.rootChatStore
         ensUsernamesStore: appMain.ensUsernamesStore
+        aboutStore: appMain.aboutStore
         privacyStore: appMain.privacyStore
         keychain: appMain.keychain
 

--- a/ui/app/mainui/Handlers/HandlersManager.qml
+++ b/ui/app/mainui/Handlers/HandlersManager.qml
@@ -47,6 +47,7 @@ QtObject {
 
     required property ChatStores.RootStore rootChatStore
 
+    required property ProfileStores.AboutStore aboutStore
     required property ProfileStores.EnsUsernamesStore ensUsernamesStore
     required property ProfileStores.PrivacyStore privacyStore
 
@@ -212,6 +213,12 @@ QtObject {
             destroyOnClose: true
             hasPermission: PushNotifications.status === PushNotifications.Granted
 
+            onClosed: {
+                appMainLocalSettings.enablePushNotificationsFreshInstallSeen = true
+                appMainLocalSettings.enablePushNotificationsDontAskAgain = enablePushNotificationsPopup.dontAskAgain
+                appMainLocalSettings.enablePushNotificationsLastShownVersion = currentMinorVersion()
+            }
+
             onContinueRequested: {
                 PushNotifications.request()
 
@@ -249,6 +256,27 @@ QtObject {
         }
     }
 
+    function currentMinorVersion(): string {
+        const match = /^v?(\d+)\.(\d+)/.exec(root.aboutStore.getCurrentVersion() || "")
+        if (!match) {
+            return ""
+        }
+        return "%1.%2".arg(match[1]).arg(match[2])
+    }
+
+    function isAtLeastMinorVersion(version: string, minimum: string): bool {
+        const versionParts = version.split(".").map(Number)
+        const minimumParts = minimum.split(".").map(Number)
+        if (versionParts.length < 2 || minimumParts.length < 2 ||
+                isNaN(versionParts[0]) || isNaN(versionParts[1]) ||
+                isNaN(minimumParts[0]) || isNaN(minimumParts[1])) {
+            return false
+        }
+
+        return versionParts[0] > minimumParts[0] ||
+                (versionParts[0] === minimumParts[0] && versionParts[1] >= minimumParts[1])
+    }
+
     function showEnablePushNotificationsPopup() {
         enablePushNotificationsPopupComponent.createObject(root.popupParent).open()
     }
@@ -283,6 +311,18 @@ QtObject {
 
         if (PushNotifications.status === PushNotifications.Granted) {
             PushNotifications.requestToken()
+            return
+        }
+
+        const version = currentMinorVersion()
+        const shouldDisplayAfterFreshInstall = !appMainLocalSettings.enablePushNotificationsFreshInstallSeen
+        const shouldDisplayAfterMinorUpdate = !appSettings.notifSettingAllowNotifications &&
+                !appMainLocalSettings.enablePushNotificationsDontAskAgain &&
+                version !== "" &&
+                isAtLeastMinorVersion(version, "2.38") &&
+                appMainLocalSettings.enablePushNotificationsLastShownVersion !== version
+
+        if (!shouldDisplayAfterFreshInstall && !shouldDisplayAfterMinorUpdate) {
             return
         }
 

--- a/ui/app/mainui/sectionLoaders/HandlersManagerLoader.qml
+++ b/ui/app/mainui/sectionLoaders/HandlersManagerLoader.qml
@@ -35,6 +35,7 @@ Loader {
 
     required property ChatStores.RootStore rootChatStore
 
+    required property ProfileStores.AboutStore aboutStore
     required property ProfileStores.EnsUsernamesStore ensUsernamesStore
     required property ProfileStores.PrivacyStore privacyStore
 
@@ -79,6 +80,7 @@ Loader {
             transactionStoreNew:    Qt.binding(() => root.transactionStoreNew),
             tokensStore:            Qt.binding(() => root.tokensStore),
             rootChatStore:          Qt.binding(() => root.rootChatStore),
+            aboutStore:             Qt.binding(() => root.aboutStore),
             ensUsernamesStore:      Qt.binding(() => root.ensUsernamesStore),
             privacyStore:           Qt.binding(() => root.privacyStore),
             keychain:               Qt.binding(() => root.keychain),

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -6860,7 +6860,15 @@ key pair. Keycard will be required for signing</source>
 <context>
     <name>EnablePushNotificationsPopup</name>
     <message>
-        <source>Enable push notifications</source>
+        <source>Enable notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Receive notification alerts for incoming messages, mentions, and contact requests on your device so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Status uses APNs (Apple Push Notification service) solely to deliver notification signals; your end-to-end encrypted message content is never passed through or stored there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Receive real-time notifications for incoming messages, mentions, and contact requests on your device so you can stay up to date and reply or react without opening the app. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6877,14 +6885,6 @@ key pair. Keycard will be required for signing</source>
     </message>
     <message>
         <source>Continue</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13053,15 +13053,23 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable Notifications in macOS Settings</source>
+        <source>Enable notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>To receive Status notifications, make sure you&apos;ve enabled them in your computer&apos;s settings under &lt;b&gt;System Preferences &gt; Notifications&lt;/b&gt;</source>
+        <source>Receive notifications for incoming messages, mentions, and contact requests on your computer so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications directly through your operating system, with no third parties, centralized servers, or intermediaries involved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow Notification Bubbles</source>
+        <source>&lt;font color=&apos;%1&apos;&gt;Enable notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status uses APNs (Apple Push Notification service) solely to deliver notification signals on your device; your end-to-end encrypted message content is never passed through or stored there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status delivers notifications on your device via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -13149,6 +13157,10 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Status delivers notifications directly through your operating system, with no centralized servers or intermediaries. Ensure they are enabled for Status in your system settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Exemptions</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13161,27 +13173,15 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>From non-contacts</source>
+        <source>Including:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mentions and replies in communities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Contact requests and group messages</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Communities</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mentions and replies</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;font color=&apos;%1&apos;&gt;Enable Push notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling mobile push notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable mobile push notifications</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16135,7 +16135,7 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notifications &amp; Sounds</source>
+        <source>Notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -18249,10 +18249,6 @@ This action cannot be undone.</source>
     </message>
     <message>
         <source>Share feedback or suggest improvements on our %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -6872,6 +6872,10 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Don&apos;t ask me again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Maybe later</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -8382,9 +8382,19 @@
   <context>
     <name>EnablePushNotificationsPopup</name>
     <message>
-      <source>Enable push notifications</source>
+      <source>Enable notifications</source>
       <comment>EnablePushNotificationsPopup</comment>
-      <translation>Enable push notifications</translation>
+      <translation>Enable notifications</translation>
+    </message>
+    <message>
+      <source>Receive notification alerts for incoming messages, mentions, and contact requests on your device so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Status uses APNs (Apple Push Notification service) solely to deliver notification signals; your end-to-end encrypted message content is never passed through or stored there.</source>
+      <comment>EnablePushNotificationsPopup</comment>
+      <translation>Receive notification alerts for incoming messages, mentions, and contact requests on your device so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Status uses APNs (Apple Push Notification service) solely to deliver notification signals; your end-to-end encrypted message content is never passed through or stored there.</translation>
+    </message>
+    <message>
+      <source>Receive real-time notifications for incoming messages, mentions, and contact requests on your device so you can stay up to date and reply or react without opening the app. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</source>
+      <comment>EnablePushNotificationsPopup</comment>
+      <translation>Receive real-time notifications for incoming messages, mentions, and contact requests on your device so you can stay up to date and reply or react without opening the app. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</translation>
     </message>
     <message>
       <source>Maybe later</source>
@@ -8405,16 +8415,6 @@
       <source>Continue</source>
       <comment>EnablePushNotificationsPopup</comment>
       <translation>Continue</translation>
-    </message>
-    <message>
-      <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.</source>
-      <comment>EnablePushNotificationsPopup</comment>
-      <translation>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.</translation>
-    </message>
-    <message>
-      <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.</source>
-      <comment>EnablePushNotificationsPopup</comment>
-      <translation>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.</translation>
     </message>
   </context>
   <context>
@@ -15908,19 +15908,29 @@
       <translation>Multiple Exemptions</translation>
     </message>
     <message>
-      <source>Enable Notifications in macOS Settings</source>
+      <source>Enable notifications</source>
       <comment>NotificationsView</comment>
-      <translation>Enable Notifications in macOS Settings</translation>
+      <translation>Enable notifications</translation>
     </message>
     <message>
-      <source>To receive Status notifications, make sure you&#39;ve enabled them in your computer&#39;s settings under &lt;b&gt;System Preferences &gt; Notifications&lt;/b&gt;</source>
+      <source>Receive notifications for incoming messages, mentions, and contact requests on your computer so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications directly through your operating system, with no third parties, centralized servers, or intermediaries involved.</source>
       <comment>NotificationsView</comment>
-      <translation>To receive Status notifications, make sure you&#39;ve enabled them in your computer&#39;s settings under &lt;b&gt;System Preferences &gt; Notifications&lt;/b&gt;</translation>
+      <translation>Receive notifications for incoming messages, mentions, and contact requests on your computer so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications directly through your operating system, with no third parties, centralized servers, or intermediaries involved.</translation>
     </message>
     <message>
-      <source>Allow Notification Bubbles</source>
+      <source>&lt;font color=&#39;%1&#39;&gt;Enable notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling notifications in the app below, enable them in &lt;font color=&#39;%1&#39;&gt;your device settings&lt;/font&gt; first.</source>
       <comment>NotificationsView</comment>
-      <translation>Allow Notification Bubbles</translation>
+      <translation>&lt;font color=&#39;%1&#39;&gt;Enable notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling notifications in the app below, enable them in &lt;font color=&#39;%1&#39;&gt;your device settings&lt;/font&gt; first.</translation>
+    </message>
+    <message>
+      <source>Status uses APNs (Apple Push Notification service) solely to deliver notification signals on your device; your end-to-end encrypted message content is never passed through or stored there.</source>
+      <comment>NotificationsView</comment>
+      <translation>Status uses APNs (Apple Push Notification service) solely to deliver notification signals on your device; your end-to-end encrypted message content is never passed through or stored there.</translation>
+    </message>
+    <message>
+      <source>Status delivers notifications on your device via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</source>
+      <comment>NotificationsView</comment>
+      <translation>Status delivers notifications on your device via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</translation>
     </message>
     <message>
       <source>Messages</source>
@@ -16028,6 +16038,11 @@
       <translation>Send a Test Notification</translation>
     </message>
     <message>
+      <source>Status delivers notifications directly through your operating system, with no centralized servers or intermediaries. Ensure they are enabled for Status in your system settings</source>
+      <comment>NotificationsView</comment>
+      <translation>Status delivers notifications directly through your operating system, with no centralized servers or intermediaries. Ensure they are enabled for Status in your system settings</translation>
+    </message>
+    <message>
       <source>Exemptions</source>
       <comment>NotificationsView</comment>
       <translation>Exemptions</translation>
@@ -16043,34 +16058,19 @@
       <translation>Most recent</translation>
     </message>
     <message>
-      <source>From non-contacts</source>
+      <source>Including:</source>
       <comment>NotificationsView</comment>
-      <translation>From non-contacts</translation>
+      <translation>Including:</translation>
+    </message>
+    <message>
+      <source>Mentions and replies in communities</source>
+      <comment>NotificationsView</comment>
+      <translation>Mentions and replies in communities</translation>
     </message>
     <message>
       <source>Contact requests and group messages</source>
       <comment>NotificationsView</comment>
       <translation>Contact requests and group messages</translation>
-    </message>
-    <message>
-      <source>Communities</source>
-      <comment>NotificationsView</comment>
-      <translation>Communities</translation>
-    </message>
-    <message>
-      <source>Mentions and replies</source>
-      <comment>NotificationsView</comment>
-      <translation>Mentions and replies</translation>
-    </message>
-    <message>
-      <source>&lt;font color=&#39;%1&#39;&gt;Enable Push notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling mobile push notifications in the app below, enable them in &lt;font color=&#39;%1&#39;&gt;your device settings&lt;/font&gt; first.</source>
-      <comment>NotificationsView</comment>
-      <translation>&lt;font color=&#39;%1&#39;&gt;Enable Push notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling mobile push notifications in the app below, enable them in &lt;font color=&#39;%1&#39;&gt;your device settings&lt;/font&gt; first.</translation>
-    </message>
-    <message>
-      <source>Enable mobile push notifications</source>
-      <comment>NotificationsView</comment>
-      <translation>Enable mobile push notifications</translation>
     </message>
   </context>
   <context>
@@ -19662,9 +19662,9 @@
       <translation>Appearance</translation>
     </message>
     <message>
-      <source>Notifications &amp; Sounds</source>
+      <source>Notifications</source>
       <comment>SettingsEntriesModel</comment>
-      <translation>Notifications &amp; Sounds</translation>
+      <translation>Notifications</translation>
     </message>
     <message>
       <source>Language &amp; Currency</source>
@@ -22217,11 +22217,6 @@
       <source>Share feedback or suggest improvements on our %1.</source>
       <comment>ThirdpartyServicesPopup</comment>
       <translation>Share feedback or suggest improvements on our %1.</translation>
-    </message>
-    <message>
-      <source>Close</source>
-      <comment>ThirdpartyServicesPopup</comment>
-      <translation>Close</translation>
     </message>
     <message>
       <source>Disable services and restart the app</source>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -8397,6 +8397,11 @@
       <translation>Receive real-time notifications for incoming messages, mentions, and contact requests on your device so you can stay up to date and reply or react without opening the app. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</translation>
     </message>
     <message>
+      <source>Don&#39;t ask me again</source>
+      <comment>EnablePushNotificationsPopup</comment>
+      <translation>Don&#39;t ask me again</translation>
+    </message>
+    <message>
       <source>Maybe later</source>
       <comment>EnablePushNotificationsPopup</comment>
       <translation>Maybe later</translation>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -6909,6 +6909,10 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Don&apos;t ask me again</source>
+        <translation type="unfinished">Už se mě neptat</translation>
+    </message>
+    <message>
         <source>Maybe later</source>
         <translation type="unfinished">Možná později</translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -6897,7 +6897,15 @@ key pair. Keycard will be required for signing</source>
 <context>
     <name>EnablePushNotificationsPopup</name>
     <message>
-        <source>Enable push notifications</source>
+        <source>Enable notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Receive notification alerts for incoming messages, mentions, and contact requests on your device so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Status uses APNs (Apple Push Notification service) solely to deliver notification signals; your end-to-end encrypted message content is never passed through or stored there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Receive real-time notifications for incoming messages, mentions, and contact requests on your device so you can stay up to date and reply or react without opening the app. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6915,14 +6923,6 @@ key pair. Keycard will be required for signing</source>
     <message>
         <source>Continue</source>
         <translation type="unfinished">Pokračovat</translation>
-    </message>
-    <message>
-        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -13153,16 +13153,24 @@ selhalo</translation>
         <translation>Více výjimek</translation>
     </message>
     <message>
-        <source>Enable Notifications in macOS Settings</source>
-        <translation>Povolit oznámení v nastavení macOS</translation>
+        <source>Enable notifications</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>To receive Status notifications, make sure you&apos;ve enabled them in your computer&apos;s settings under &lt;b&gt;System Preferences &gt; Notifications&lt;/b&gt;</source>
-        <translation>Chcete-li dostávat oznámení Statusu, ujistěte se, že jste je povolili v nastavení počítače v části &lt;b&gt;Předvolby systému &gt; Oznámení&lt;/b&gt;</translation>
+        <source>Receive notifications for incoming messages, mentions, and contact requests on your computer so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications directly through your operating system, with no third parties, centralized servers, or intermediaries involved.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow Notification Bubbles</source>
-        <translation>Povolit bubliny oznámení</translation>
+        <source>&lt;font color=&apos;%1&apos;&gt;Enable notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status uses APNs (Apple Push Notification service) solely to deliver notification signals on your device; your end-to-end encrypted message content is never passed through or stored there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status delivers notifications on your device via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Messages</source>
@@ -13249,6 +13257,10 @@ selhalo</translation>
         <translation>Odeslat zkušební oznámení</translation>
     </message>
     <message>
+        <source>Status delivers notifications directly through your operating system, with no centralized servers or intermediaries. Ensure they are enabled for Status in your system settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Exemptions</source>
         <translation>Výjimky</translation>
     </message>
@@ -13261,27 +13273,15 @@ selhalo</translation>
         <translation>Nejnovější</translation>
     </message>
     <message>
-        <source>&lt;font color=&apos;%1&apos;&gt;Enable Push notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling mobile push notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
+        <source>Including:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable mobile push notifications</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>From non-contacts</source>
+        <source>Mentions and replies in communities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Contact requests and group messages</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Communities</source>
-        <translation type="unfinished">Komunity</translation>
-    </message>
-    <message>
-        <source>Mentions and replies</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16245,8 +16245,8 @@ selhalo</translation>
         <translation>Vzhled</translation>
     </message>
     <message>
-        <source>Notifications &amp; Sounds</source>
-        <translation>Upozornění a zvuk</translation>
+        <source>Notifications</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Language &amp; Currency</source>
@@ -18375,10 +18375,6 @@ Tuto akci nelze vzít zpět.</translation>
     <message>
         <source>Share feedback or suggest improvements on our %1.</source>
         <translation>Sdílejte zpětnou vazbu nebo navrhněte vylepšení na našem %1.</translation>
-    </message>
-    <message>
-        <source>Close</source>
-        <translation>Zavřít</translation>
     </message>
     <message>
         <source>Disable services and restart the app</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -6885,6 +6885,10 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Don&apos;t ask me again</source>
+        <translation type="unfinished">No me vuelvas a preguntar</translation>
+    </message>
+    <message>
         <source>Maybe later</source>
         <translation type="unfinished">Quizás más tarde</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -6873,7 +6873,15 @@ key pair. Keycard will be required for signing</source>
 <context>
     <name>EnablePushNotificationsPopup</name>
     <message>
-        <source>Enable push notifications</source>
+        <source>Enable notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Receive notification alerts for incoming messages, mentions, and contact requests on your device so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Status uses APNs (Apple Push Notification service) solely to deliver notification signals; your end-to-end encrypted message content is never passed through or stored there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Receive real-time notifications for incoming messages, mentions, and contact requests on your device so you can stay up to date and reply or react without opening the app. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6891,14 +6899,6 @@ key pair. Keycard will be required for signing</source>
     <message>
         <source>Continue</source>
         <translation type="unfinished">Continuar</translation>
-    </message>
-    <message>
-        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -13069,16 +13069,24 @@ al cargar</translation>
         <translation>Múltiples exenciones</translation>
     </message>
     <message>
-        <source>Enable Notifications in macOS Settings</source>
-        <translation>Habilitar notificaciones en Configuración de macOS</translation>
+        <source>Enable notifications</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>To receive Status notifications, make sure you&apos;ve enabled them in your computer&apos;s settings under &lt;b&gt;System Preferences &gt; Notifications&lt;/b&gt;</source>
-        <translation>Para recibir notificaciones de Status, asegúrate de haberlas habilitado en la configuración de tu computadora en &lt;b&gt;Preferencias del Sistema &gt; Notificaciones&lt;/b&gt;</translation>
+        <source>Receive notifications for incoming messages, mentions, and contact requests on your computer so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications directly through your operating system, with no third parties, centralized servers, or intermediaries involved.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow Notification Bubbles</source>
-        <translation>Permitir burbujas de notificación</translation>
+        <source>&lt;font color=&apos;%1&apos;&gt;Enable notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status uses APNs (Apple Push Notification service) solely to deliver notification signals on your device; your end-to-end encrypted message content is never passed through or stored there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status delivers notifications on your device via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Messages</source>
@@ -13165,6 +13173,10 @@ al cargar</translation>
         <translation>Enviar una notificación de prueba</translation>
     </message>
     <message>
+        <source>Status delivers notifications directly through your operating system, with no centralized servers or intermediaries. Ensure they are enabled for Status in your system settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Exemptions</source>
         <translation>Exenciones</translation>
     </message>
@@ -13177,27 +13189,15 @@ al cargar</translation>
         <translation>Más reciente</translation>
     </message>
     <message>
-        <source>&lt;font color=&apos;%1&apos;&gt;Enable Push notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling mobile push notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
+        <source>Including:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable mobile push notifications</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>From non-contacts</source>
+        <source>Mentions and replies in communities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Contact requests and group messages</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Communities</source>
-        <translation type="unfinished">Comunidades</translation>
-    </message>
-    <message>
-        <source>Mentions and replies</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16157,8 +16157,8 @@ al cargar</translation>
         <translation>Apariencia</translation>
     </message>
     <message>
-        <source>Notifications &amp; Sounds</source>
-        <translation>Notificaciones y Sonidos</translation>
+        <source>Notifications</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Language &amp; Currency</source>
@@ -18285,10 +18285,6 @@ This action cannot be undone.</source>
     <message>
         <source>Enable services and restart the app</source>
         <translation>Habilitar servicios y reiniciar la aplicación</translation>
-    </message>
-    <message>
-        <source>Close</source>
-        <translation>Cerrar</translation>
     </message>
     <message>
         <source>Browser (browse web-pages, connect dApps)</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -6848,7 +6848,15 @@ key pair. Keycard will be required for signing</source>
 <context>
     <name>EnablePushNotificationsPopup</name>
     <message>
-        <source>Enable push notifications</source>
+        <source>Enable notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Receive notification alerts for incoming messages, mentions, and contact requests on your device so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;.&lt;br&gt;&lt;br&gt;Status uses APNs (Apple Push Notification service) solely to deliver notification signals; your end-to-end encrypted message content is never passed through or stored there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Receive real-time notifications for incoming messages, mentions, and contact requests on your device so you can stay up to date and reply or react without opening the app. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6866,14 +6874,6 @@ key pair. Keycard will be required for signing</source>
     <message>
         <source>Continue</source>
         <translation type="unfinished">계속</translation>
-    </message>
-    <message>
-        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -13028,16 +13028,24 @@ to load</source>
         <translation>다중 면제</translation>
     </message>
     <message>
-        <source>Enable Notifications in macOS Settings</source>
-        <translation>macOS 설정에서 알림 활성화</translation>
+        <source>Enable notifications</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>To receive Status notifications, make sure you&apos;ve enabled them in your computer&apos;s settings under &lt;b&gt;System Preferences &gt; Notifications&lt;/b&gt;</source>
-        <translation>Status 알림을 받으려면, 컴퓨터 설정의 &lt;b&gt;시스템 환경설정 &gt; 알림&lt;/b&gt;에서 알림이 활성화되어 있는지 확인하세요</translation>
+        <source>Receive notifications for incoming messages, mentions, and contact requests on your computer so you can stay up to date in real time. Customize anytime in &lt;b&gt;Settings → Notifications&lt;/b&gt;&lt;br&gt;&lt;br&gt;Status delivers notifications directly through your operating system, with no third parties, centralized servers, or intermediaries involved.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow Notification Bubbles</source>
-        <translation>알림 버블 허용</translation>
+        <source>&lt;font color=&apos;%1&apos;&gt;Enable notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status uses APNs (Apple Push Notification service) solely to deliver notification signals on your device; your end-to-end encrypted message content is never passed through or stored there.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status delivers notifications on your device via its on-device background service, with no third parties, centralized servers, or intermediaries involved.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Messages</source>
@@ -13124,6 +13132,10 @@ to load</source>
         <translation>테스트 알림 보내기</translation>
     </message>
     <message>
+        <source>Status delivers notifications directly through your operating system, with no centralized servers or intermediaries. Ensure they are enabled for Status in your system settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Exemptions</source>
         <translation>면제</translation>
     </message>
@@ -13136,27 +13148,15 @@ to load</source>
         <translation>최신순</translation>
     </message>
     <message>
-        <source>&lt;font color=&apos;%1&apos;&gt;Enable Push notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling mobile push notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
+        <source>Including:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable mobile push notifications</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>From non-contacts</source>
+        <source>Mentions and replies in communities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Contact requests and group messages</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Communities</source>
-        <translation type="unfinished">커뮤니티</translation>
-    </message>
-    <message>
-        <source>Mentions and replies</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16104,8 +16104,8 @@ to load</source>
         <translation>테마</translation>
     </message>
     <message>
-        <source>Notifications &amp; Sounds</source>
-        <translation>알림 및 사운드</translation>
+        <source>Notifications</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Language &amp; Currency</source>
@@ -18215,10 +18215,6 @@ This action cannot be undone.</source>
     <message>
         <source>Enable third-party services</source>
         <translation>서드파티 서비스 활성화</translation>
-    </message>
-    <message>
-        <source>Close</source>
-        <translation>닫기</translation>
     </message>
     <message>
         <source>Disable services and restart the app</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -6860,6 +6860,10 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Don&apos;t ask me again</source>
+        <translation type="unfinished">다시 묻지 않기</translation>
+    </message>
+    <message>
         <source>Maybe later</source>
         <translation type="unfinished">나중에</translation>
     </message>

--- a/ui/imports/shared/popups/EnablePushNotificationsPopup.qml
+++ b/ui/imports/shared/popups/EnablePushNotificationsPopup.qml
@@ -18,6 +18,7 @@ StatusDialog {
     property bool hasPermission: false
     property bool attemptedRequest: false
     property bool loading: false
+    property bool dontAskAgain: false
 
     signal continueRequested()
     signal openSettingsRequested()
@@ -38,6 +39,14 @@ StatusDialog {
             text: SQUtils.Utils.isIOS
                   ? qsTr("Receive notification alerts for incoming messages, mentions, and contact requests on your device so you can stay up to date in real time. Customize anytime in <b>Settings → Notifications</b>.<br><br>Status uses APNs (Apple Push Notification service) solely to deliver notification signals; your end-to-end encrypted message content is never passed through or stored there.")
                   : qsTr("Receive real-time notifications for incoming messages, mentions, and contact requests on your device so you can stay up to date and reply or react without opening the app. Customize anytime in <b>Settings → Notifications</b><br><br>Status delivers notifications via its on-device background service, with no third parties, centralized servers, or intermediaries involved.")
+        }
+
+        StatusSwitch {
+            Layout.fillWidth: true
+            Layout.bottomMargin: Theme.defaultPadding
+            text: qsTr("Don't ask me again")
+            checked: root.dontAskAgain
+            onToggled: root.dontAskAgain = checked
         }
     }
 

--- a/ui/imports/shared/popups/EnablePushNotificationsPopup.qml
+++ b/ui/imports/shared/popups/EnablePushNotificationsPopup.qml
@@ -23,7 +23,7 @@ StatusDialog {
     signal openSettingsRequested()
 
     width: 480
-    title: qsTr("Enable push notifications")
+    title: qsTr("Enable notifications")
     modal: true
     closePolicy: Popup.NoAutoClose
 
@@ -36,8 +36,8 @@ StatusDialog {
             Layout.bottomMargin: Theme.defaultPadding
             wrapMode: Text.WordWrap
             text: SQUtils.Utils.isIOS
-                  ? qsTr("Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications & Sounds.<br><br>Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.")
-                  : qsTr("Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications & Sounds.<br><br>Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.")
+                  ? qsTr("Receive notification alerts for incoming messages, mentions, and contact requests on your device so you can stay up to date in real time. Customize anytime in <b>Settings → Notifications</b>.<br><br>Status uses APNs (Apple Push Notification service) solely to deliver notification signals; your end-to-end encrypted message content is never passed through or stored there.")
+                  : qsTr("Receive real-time notifications for incoming messages, mentions, and contact requests on your device so you can stay up to date and reply or react without opening the app. Customize anytime in <b>Settings → Notifications</b><br><br>Status delivers notifications via its on-device background service, with no third parties, centralized servers, or intermediaries involved.")
         }
     }
 
@@ -77,4 +77,3 @@ StatusDialog {
         }
     }
 }
-


### PR DESCRIPTION
Closes https://github.com/status-im/status-app/issues/20628
Closes https://github.com/status-im/status-app/issues/20628

### What does the PR do
 - Refresh notification settings wording across desktop and mobile, renaming the settings entry to “Notifications” and updating the enable notifications popup copy for iOS and other platforms.

- Add clearer privacy messaging for APNs, on-device mobile delivery, and desktop OS notifications. Restore the iOS centralized notification options section and reuse the sound/volume controls across general and iOS notification settings, while keeping platform-specific test notification behavior.

- Update mobile notification banner display logic.

### Affected areas

Notifications Settings and Push Notifications Popup

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

**iOS**

<img width="477" height="1008" alt="Screenshot 2026-05-18 at 12 33 48" src="https://github.com/user-attachments/assets/e3f0c288-5e0b-4571-ad1d-6ad8cdd3f3a1" />

<img width="477" height="1008" alt="Screenshot 2026-05-18 at 12 33 58" src="https://github.com/user-attachments/assets/751bfedb-c5bf-4a1a-a203-690f2f767fea" />

**Android**

<img width="477" height="1008" alt="Screenshot 2026-05-18 at 12 34 26" src="https://github.com/user-attachments/assets/4d84de2a-d113-49b6-9c0b-81f277cecf56" />

<img width="477" height="1008" alt="Screenshot 2026-05-18 at 12 34 39" src="https://github.com/user-attachments/assets/8a59d463-bba3-47c8-bc18-a934d06682cb" />

**Desktop**

<img width="1162" height="639" alt="Screenshot 2026-05-18 at 12 56 54" src="https://github.com/user-attachments/assets/8f29a81b-15d6-46be-b4e5-c1933fcdc882" />

### Impact on end user

Better UX

### How to test

- Check requirements on task description and review the Notifications View and Popup behavior

### Risk 

Low
