### PR TITLE
fix(MessageView): unbreak opening URLs when clicking on a text message

### DIFF
--- a/storybook/pages/NotificationContentBlockPage.qml
+++ b/storybook/pages/NotificationContentBlockPage.qml
@@ -60,7 +60,7 @@ SplitView {
                 imageClickable: contentBlockEditor.areImagesClickable
                 imageCursorShape: contentBlockEditor.changeImageCursorShape ? Qt.PointingHandCursor : Qt.ArrowCursor
 
-                onImageClicked: (image, mouse, imageSource) => logs.logEvent("NotificationContentBlock::onImageClicked: " + imageSource)
+                onImageClicked: (image, mouse, imageSource, pos) => logs.logEvent("NotificationContentBlock::onImageClicked: " + imageSource)
                 onLinkActivated: href => logs.logEvent("NotificationContentBlock::onLinkActivated --> Link clicked: " + href)
             }
         }

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -88,6 +88,7 @@ Control {
     signal senderNameClicked(var sender)
     signal replyProfileClicked(var sender, var mouse)
     signal replyMessageClicked(var mouse)
+    signal contextMenuRequested(point pos)
 
     signal addReactionClicked(var sender, var mouse)
     signal toggleReactionClicked(string hexcode)
@@ -287,6 +288,7 @@ Control {
                             textField.onHoveredLinkChanged: {
                                 root.hoveredLink = hoveredLink;
                             }
+                            onContextMenuRequested: pos => root.contextMenuRequested(pos)
                         }
                     }
                     Loader {
@@ -315,6 +317,7 @@ Control {
                                     textField.onHoveredLinkChanged: {
                                         root.hoveredLink = hoveredLink
                                     }
+                                    onContextMenuRequested: pos => root.contextMenuRequested(pos)
                                 }
                             }
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -92,7 +92,7 @@ Control {
 
     signal addReactionClicked(var sender, var mouse)
     signal toggleReactionClicked(string hexcode)
-    signal imageClicked(var image, var mouse, var imageSource)
+    signal imageClicked(var image, var mouse, var imageSource, point pos)
     signal stickerClicked()
     signal resendClicked()
 
@@ -330,7 +330,7 @@ Control {
                                     albumCount: root.messageDetails.albumCount > 0 ? root.messageDetails.albumCount : 1
                                     imageWidth: Math.min(messageLayout.width / root.messageDetails.albumCount - 9 * (root.messageDetails.albumCount - 1), 144)
                                     shapeType: StatusImageMessage.ShapeType.LEFT_ROUNDED
-                                    onImageClicked: (image, mouse, imageSource) => root.imageClicked(image, mouse, imageSource)
+                                    onImageClicked: (image, mouse, imageSource, pos) => root.imageClicked(image, mouse, imageSource, pos)
                                 }
                             }
                         }
@@ -346,7 +346,7 @@ Control {
                                 model: attachmentsModel
                                 delegate: StatusImageMessage {
                                     source: model.source
-                                    onClicked: (image, mouse, imageSource) => root.imageClicked(image, mouse, imageSource)
+                                    onClicked: (image, mouse, imageSource, pos) => root.imageClicked(image, mouse, imageSource, pos)
                                     shapeType: StatusImageMessage.ShapeType.LEFT_ROUNDED
                                 }
                             }

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusImageMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusImageMessage.qml
@@ -40,7 +40,7 @@ Item {
     property string loadingImageText: ""
     property string errorLoadingImageText: ""
 
-    signal clicked(var image, var mouse, var imageSource)
+    signal clicked(var image, var mouse, var imageSource, point pos)
 
     implicitWidth: imageMessage.width
     implicitHeight: imageMessage.paintedHeight
@@ -113,12 +113,12 @@ Item {
                     _internal.pausePlaying = !_internal.pausePlaying
                     return
                 }
-                imageContainer.clicked(imageMessage, { button }, imageMessage.source)
+                imageContainer.clicked(imageMessage, { button }, imageMessage.source, eventPoint.position)
             }
             onLongPressed: {
                 if (point.device.type !== PointerDevice.TouchScreen)
                     return
-                imageContainer.clicked(imageMessage, { button: Qt.RightButton }, imageMessage.source)
+                imageContainer.clicked(imageMessage, { button: Qt.RightButton }, imageMessage.source, point.position)
             }
         }
     }

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageImageAlbum.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageImageAlbum.qml
@@ -39,7 +39,7 @@ RowLayout {
     // - Common alternatives: Qt.ArrowCursor, Qt.CrossCursor, etc.
     property int imageCursorShape: Qt.PointingHandCursor
 
-    signal imageClicked(var image, var mouse, var imageSource)
+    signal imageClicked(var image, var mouse, var imageSource, point pos)
 
     QtObject {
         id: d
@@ -76,7 +76,7 @@ RowLayout {
             imageClickable: root.imageClickable
             imageCursorShape: root.imageCursorShape
 
-            onClicked: (image, mouse, imageSource) => root.imageClicked(image, mouse, imageSource)
+            onClicked: (image, mouse, imageSource, pos) => root.imageClicked(image, mouse, imageSource, pos)
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -27,6 +27,7 @@ Item {
     property bool allowShowMore: true
 
     signal linkActivated(string link)
+    signal contextMenuRequested(point pos)
 
     implicitWidth: chatText.implicitWidth
     implicitHeight: chatText.height + d.showMoreHeight / 2
@@ -88,7 +89,7 @@ Item {
         color: Theme.palette.baseColor1
     }
 
-    TextEdit {
+    StatusTextArea {
         id: chatText
         objectName: "StatusTextMessage_chatText"
 
@@ -101,28 +102,39 @@ Item {
         anchors.leftMargin: d.isQuote ? Theme.halfPadding : 0
         anchors.right: parent.right
         opacity: !showMoreOpacityMask.active && !horizontalOpacityMask.active ? 1 : 0
+        background: null
+        leftPadding: 0
+        rightPadding: 0
+        topPadding: 0
+        bottomPadding: 0
         text: d.text
         selectedTextColor: Theme.palette.directColor1
-        selectionColor: Theme.palette.primaryColor3
         color: d.isQuote ? Theme.palette.baseColor1 : Theme.palette.directColor1
-        font.family: Fonts.baseFont.family
-        font.pixelSize: Theme.primaryTextFontSize
         textFormat: Text.RichText
         wrapMode: root.convertToSingleLine ? Text.NoWrap : Text.Wrap
         readOnly: true
         selectByMouse: true  // applies to mouse only, not touch
-        enabled: !Utils.isMobile // eats the internal touch events to enable the external context menu on long press
-
-        // disable native (edit) context menu; we're really not an edit control
-        inputMethodHints: Qt.ImhNoEditMenu
 
         onLinkActivated: function(link) {
             if(d.showDisabledTooltipForAddressEnsName(link)) {
                 return
             }
             root.linkActivated(link)
+            chatText.deselect()
         }
         onLinkHovered: (link) => disabledLinkTooltip.visible = d.showDisabledTooltipForAddressEnsName(link)
+
+        // context menu handlers
+        ContextMenu.menu: null // disable builtin "edit" menu; we're not an edit control
+        inputMethodHints: Qt.ImhNoEditMenu // ditto for mobile
+        onPressAndHold: event => root.contextMenuRequested(Qt.point(event.x, event.y))
+        onPressed: function(event) {
+            if (event.button === Qt.RightButton) {
+                event.accepted = true
+                root.contextMenuRequested(Qt.point(event.x, event.y))
+            }
+        }
+
         HoverHandler {
             id: hoverHandler
         }

--- a/ui/app/AppLayouts/ActivityCenter/controls/NotificationContentBlock.qml
+++ b/ui/app/AppLayouts/ActivityCenter/controls/NotificationContentBlock.qml
@@ -113,7 +113,7 @@ Control {
 
     // Interactions
     signal linkActivated(string href)
-    signal imageClicked(var image, var mouse, var imageSource)
+    signal imageClicked(var image, var mouse, var imageSource, point pos)
 
     // ──────────────────────────────────────────────────────────────────────────
     // Content (Banner (preImage) (Optional) + Text + Media sripe (Optional))
@@ -195,7 +195,7 @@ Control {
             imageClickable: root.imageClickable
             imageCursorShape: root.imageCursorShape
 
-            onImageClicked: (image, mouse, imageSource) => root.imageClicked(image, mouse, imageSource)
+            onImageClicked: (image, mouse, imageSource, pos) => root.imageClicked(image, mouse, imageSource, pos)
         }
     }
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -887,7 +887,6 @@ Item {
                 return
             }
             globalConns.onAppSectionBySectionTypeChanged(Constants.appSection.browser)
-            changeAppSectionBySectionId(Constants.appSection.browser)
             Qt.callLater(() => browserLayoutContainer.item.openUrlInNewTab(link))
         }
 

--- a/ui/imports/shared/status/StatusImageModal.qml
+++ b/ui/imports/shared/status/StatusImageModal.qml
@@ -30,9 +30,9 @@ StatusDialog {
     QtObject {
         id: d
 
-        property int maxHeight: root.contentItem.Window.window.height - 80
-        property int maxWidth: root.contentItem.Window.window.width - 80
-        readonly property int radius: Theme.radius
+        readonly property int maxHeight: root.contentItem.Window.window.height - 80
+        readonly property int maxWidth: root.contentItem.Window.window.width - 80
+        readonly property int radius: root.Theme.radius
     }
 
     onOpened: imageLoader.source = root.image.source;
@@ -52,7 +52,7 @@ StatusDialog {
         StatusMouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton | Qt.RightButton
-            onClicked: {
+            onClicked: function (mouse) {
                 if (mouse.button === Qt.LeftButton)
                     root.close()
                 if (imageLoader.isError || imageLoader.isLoading || mouse.button !== Qt.RightButton)
@@ -60,7 +60,7 @@ StatusDialog {
                 const isGif = (!root.plain && imageLoader.item && imageLoader.item.playing)
                 Global.openMenu(imageContextMenu,
                                 imageLoader.item,
-                                { imageSource: imageLoader.source, url: root.url, isGif: isGif})
+                                { imageSource: imageLoader.source, url: root.url, isGif: isGif}, Qt.point(mouse.x, mouse.y))
             }
         }
 

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -499,15 +499,16 @@ Loader {
             d.emojiPopupOpened = true
         }
 
-        function onImageClicked(image, mouse, imageSource, url = "") {
+        function onImageClicked(image, mouse, imageSource, url = "", pos = undefined) {
             switch (mouse.button) {
             case Qt.LeftButton:
+            case Qt.NoButton: // touch event
                 d.preventVirtualKeyboardOpening()
                 Global.openImagePopup(image, url, false)
                 break;
             case Qt.RightButton:
                 d.preventVirtualKeyboardOpening()
-                Global.openMenu(imageContextMenuComponent, image, { imageSource, url })
+                Global.openMenu(imageContextMenuComponent, image, { imageSource, url }, pos)
                 break;
             }
         }
@@ -879,8 +880,8 @@ Loader {
 
                 onEditCompleted: delegate.editCompletedHandler(newMsgText)
 
-                onImageClicked: (image, mouse, imageSource) => {
-                    d.onImageClicked(image, mouse, imageSource)
+                onImageClicked: (image, mouse, imageSource, pos) => {
+                    d.onImageClicked(image, mouse, imageSource, "", pos)
                 }
 
                 onLinkActivated: link => {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -254,6 +254,11 @@ Loader {
         if (root.isChatBlocked && !d.addReactionAllowed)
             return
 
+        if (chatLogView?.moving)
+            return
+
+        d.contextMenu?.close() // will run destruction/cleanup
+
         const params = {
             myPublicKey: userProfile.pubKey,
             amIChatAdmin: root.amIChatAdmin,
@@ -270,7 +275,8 @@ Loader {
         }
 
         d.preventVirtualKeyboardOpening()
-        messageContextMenuComponent.createObject(root, params).popup(point)
+        d.contextMenu = messageContextMenuComponent.createObject(root, params)
+        d.contextMenu.popup(point)
     }
 
     function setMessageActive(messageId, active) {
@@ -518,6 +524,16 @@ Loader {
         function preventVirtualKeyboardOpening() {
             if (!SystemUtils.androidKeyboardVisible && !SystemUtils.iosKeyboardVisible && !Qt.inputMethod.visible) {
                 root.forceActiveFocus()
+            }
+        }
+
+        // messageContextMenuComponent lifetime trackers
+        property var contextMenu: null
+        readonly property var _contextMenuConn: Connections {
+            target: root?.chatLogView ?? null
+            function onMovementEnded() {
+                // prevent spurios context menus coming from the Flickable, at the end of the move/drag operations
+                d.contextMenu?.close() // will run destruction/cleanup
             }
         }
     }
@@ -920,6 +936,7 @@ Loader {
                     root.messageStore.resendMessage(root.messageId)
                 }
 
+                onContextMenuRequested: pos => root.openMessageContextMenu(pos) // for StatusTextMessage which would eat the press events internally
                 TapHandler {
                     gesturePolicy: TapHandler.ReleaseWithinBounds // exclusive grab on press
                     acceptedDevices: PointerDevice.TouchScreen


### PR DESCRIPTION
### What does the PR do

- use a StatusTextArea as the internal part (renderer) of the StatusTextMessage and make it always enabled (disabling prevents the URLs from being opened)
- by using a (Status)TextArea instead of a TextEdit, we can handle the context menu events correctly w/o disabling the edit control
- additional commit to fix opening the chat image previews (and their ctx menus)

Fixes #20894
Fixes #20897

### Affected areas

MessageView/Status(Text)Message

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Opening a link:
<img width="3296" height="2060" alt="image" src="https://github.com/user-attachments/assets/69ac7823-2c2d-4fbc-82cd-86fdcabda928" />

Context menu (on touch):
<img width="3296" height="2060" alt="image" src="https://github.com/user-attachments/assets/6beff97d-28d9-4936-9309-14c39bbd3157" />

### Impact on end user

- can open web links

### How to test

- click on a link in chat
- long press / right click on a text message (both in and outside of the text)

### Risk 

low
