### PR TITLE
fix: exclude seed phrase words from accessibility tree before Reveal tap

### DIFF
--- a/ui/imports/shared/panels/SeedPhrase.qml
+++ b/ui/imports/shared/panels/SeedPhrase.qml
@@ -21,6 +21,11 @@ Control {
         cellHeight: 48
         interactive: false
         visible: root.seedPhraseRevealed
+        // Exclude word nodes from the accessibility tree until the user
+        // explicitly reveals the phrase. `visible: false` alone does not
+        // remove QML items from the a11y tree, so accessibility services
+        // could read the words before the reveal button is tapped.
+        Accessible.ignored: !root.seedPhraseRevealed
         model: 12
         readonly property var wordIndex: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]
         readonly property int spacing: 4
@@ -30,6 +35,10 @@ Control {
             height: (grid.cellHeight - grid.spacing)
             textEdit.input.edit.enabled: false
             text: {
+                // Only populate word text after the user taps Reveal so the
+                // phrase is never present in the object tree before that point.
+                if (!root.seedPhraseRevealed)
+                    return "";
                 const idx = parseInt(leftComponentText) - 1;
                 if (!root.seedPhrase || idx < 0 || idx > root.seedPhrase.length - 1)
                     return "";


### PR DESCRIPTION
## Problem

`visible: false` in QML hides elements visually but does **not** remove them from the accessibility tree. In `SeedPhrase.qml`, all 12 word delegates are instantiated and populated with the actual seed phrase words before the user taps "Reveal recovery phrase". Any app with an accessibility service permission can read all 12 words silently via the a11y API.

Reported in #20931. Confirmed via `adb shell uiautomator dump` on build `2.38.0-rc.1-61-g61e695896`.

## Fix

Two-layer defence in `ui/imports/shared/panels/SeedPhrase.qml`:

1. **`Accessible.ignored: !seedPhraseRevealed`** on the `StatusGridView` — marks the entire word list as ignored by accessibility APIs when not revealed
2. **Guard in `text` binding** — returns `""` when `!seedPhraseRevealed` so the word data is never present in the object tree before the user explicitly reveals it

Either fix alone would address the a11y exposure; both together ensure defence in depth.

## Testing

- Verify `uiautomator dump` on the Recovery Phrase screen before tapping Reveal shows no word content
- Verify words are readable by screen readers after tapping Reveal (legitimate a11y use case preserved)
- Verify the blur overlay and reveal flow still work correctly visually

Closes #20931