### PR TITLE
fix(EphemeralNotifications): Suppress message ephemeral toasts

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1687,15 +1687,18 @@ method displayEphemeralNotification*[T](
   self.view.ephemeralNotificationModel().addItem(item)
 
 method displayEphemeralNotification*[T](self: Module[T], title: string, subTitle: string, details: NotificationDetails) =
+  # Message toasts create high-frequency UI noise, so keep them disabled until their value is reassessed.
   if details.notificationType == NotificationType.NewMessage or
       details.notificationType == NotificationType.NewMessageWithPersonalMention or
-      details.notificationType == NotificationType.CommunityTokenPermissionCreated or
+      details.notificationType == NotificationType.NewMessageWithGlobalMention:
+    return
+
+  if details.notificationType == NotificationType.CommunityTokenPermissionCreated or
       details.notificationType == NotificationType.CommunityTokenPermissionUpdated or
       details.notificationType == NotificationType.CommunityTokenPermissionDeleted or
       details.notificationType == NotificationType.CommunityTokenPermissionCreationFailed or
       details.notificationType == NotificationType.CommunityTokenPermissionUpdateFailed or
-      details.notificationType == NotificationType.CommunityTokenPermissionDeletionFailed or
-      details.notificationType == NotificationType.NewMessageWithGlobalMention:
+      details.notificationType == NotificationType.CommunityTokenPermissionDeletionFailed:
     self.displayEphemeralNotification(
       title,
       subTitle,


### PR DESCRIPTION
Fixes #20877

### What does the PR do

Prevent chat message notification types from being added to the  ephemeral notifications model shown in AppMain.

Message toasts are currently considered too noisy for the in-app experience, so _NewMessage_, _NewMessageWithPersonalMention_, and _NewMessageWithGlobalMention_ are skipped until their usefulness is reassessed.

### Affected areas

Messenger related Toasts (new messages)

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

Improve UX while reducing notifications noise

### How to test

Ensure toasts are not shown when a new message is recevied.

### Risk 

Low
