### PR TITLE
fix: IOS push notifications

### DIFF
--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -27,6 +27,10 @@ const KEY_PREVIEW_PRIVACY* = "preview-privacy?"
 const KEY_PUBLIC_KEY* = "public-key"
 const KEY_DEFAULT_SYNC_PERIOD* = "default-sync-period"
 const KEY_SEND_PUSH_NOTIFICATIONS* = "send-push-notifications?"
+const KEY_REMOTE_PUSH_NOTIFICATIONS_ENABLED* = "remote-push-notifications-enabled?"
+const KEY_PUSH_NOTIFICATIONS_FROM_CONTACTS_ONLY* = "push-notifications-from-contacts-only?"
+const KEY_PUSH_NOTIFICATIONS_BLOCK_MENTIONS* = "push-notifications-block-mentions?"
+const KEY_PUSH_NOTIFICATIONS_SERVER_ENABLED* = "push-notifications-server-enabled?"
 const KEY_APPEARANCE* = "appearance"
 const KEY_USE_MAILSERVERS* = "use-mailservers?"
 const KEY_WALLET_ROOT_ADDRESS* = "wallet-root-address"
@@ -137,6 +141,10 @@ type
     publicKey*: string
     defaultSyncPeriod*: int
     sendPushNotifications*: bool
+    remotePushNotificationsEnabled*: bool
+    pushNotificationsFromContactsOnly*: bool
+    pushNotificationsBlockMentions*: bool
+    pushNotificationsServerEnabled*: bool
     appearance*: int
     useMailservers*: bool
     walletRootAddress*: string
@@ -217,6 +225,10 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
   discard jsonObj.getProp(KEY_PUBLIC_KEY, result.publicKey)
   discard jsonObj.getProp(KEY_DEFAULT_SYNC_PERIOD, result.defaultSyncPeriod)
   discard jsonObj.getProp(KEY_SEND_PUSH_NOTIFICATIONS, result.sendPushNotifications)
+  discard jsonObj.getProp(KEY_REMOTE_PUSH_NOTIFICATIONS_ENABLED, result.remotePushNotificationsEnabled)
+  discard jsonObj.getProp(KEY_PUSH_NOTIFICATIONS_FROM_CONTACTS_ONLY, result.pushNotificationsFromContactsOnly)
+  discard jsonObj.getProp(KEY_PUSH_NOTIFICATIONS_BLOCK_MENTIONS, result.pushNotificationsBlockMentions)
+  discard jsonObj.getProp(KEY_PUSH_NOTIFICATIONS_SERVER_ENABLED, result.pushNotificationsServerEnabled)
   discard jsonObj.getProp(KEY_APPEARANCE, result.appearance)
   discard jsonObj.getProp(KEY_USE_MAILSERVERS, result.useMailservers)
   discard jsonObj.getProp(KEY_WALLET_ROOT_ADDRESS, result.walletRootAddress)

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -61,6 +61,7 @@ QtObject:
     settings: SettingsDto
     initialized: bool
     notifExemptionsCache: Table[string, NotificationsExemptions]
+    deviceToken: string
 
   # Forward declaration
   proc saveSyncingOnMobileNetwork*(self: Service, value: bool): bool
@@ -75,6 +76,7 @@ QtObject:
   proc getNotificationSoundsEnabled*(self: Service): bool
   proc getNotificationVolume*(self: Service): int
   proc getNotificationMessagePreview*(self: Service): int
+  proc initPushNotificationsSettings*(self: Service)
 
   proc delete*(self: Service)
   proc newService*(events: EventEmitter): Service =
@@ -163,6 +165,8 @@ QtObject:
 
     self.initialized = true
 
+    initPushNotificationsSettings(self)
+
   # Backup Path migration
   # New local setting needs to be initialized from old setting value
   # TODO remove this migration in 2.37 (one release cycle interval)
@@ -186,6 +190,59 @@ QtObject:
     discard self.getNotificationSoundsEnabled()
     discard self.getNotificationVolume()
     discard self.getNotificationMessagePreview()
+
+  proc updateCentralizedPushNotifications*(self: Service, deviceToken: string, enable: bool): bool {.slot.} =
+    if enable and deviceToken.len == 0:
+      error "cannot enable push notifications without device token"
+      return false
+    try:
+      let response = 
+        if enable:
+          status_push_notifications.registerForPushNotifications(deviceToken, PUSH_TOPIC, PUSH_TOKEN_TYPE)
+        else:
+          status_push_notifications.unregisterFromPushNotifications()
+      if not response.error.isNil:
+        error "error registering for push notifications", errDescription = response.error.message
+        return false
+    except Exception as e:
+      error "error registering for push notifications", errDescription = e.msg
+      return false
+    return true
+
+  proc updatePushNotificationsFromContactsOnly(self: Service, enable: bool): bool {.slot.} =
+    try:
+      let response =
+        if enable:
+          status_push_notifications.enablePushNotificationsFromContactsOnly()
+        else:
+          status_push_notifications.disablePushNotificationsFromContactsOnly()
+      if not response.error.isNil:
+        error "error updating push notifications from contacts only", errDescription = response.error.message
+        return false
+    except Exception as e:
+      error "error updating push notifications from contacts only", errDescription = e.msg
+      return false
+    return true
+
+  proc updatePushNotificationsBlockMentions(self: Service, enable: bool): bool {.slot.} =
+    try:
+      let response =
+        if enable:
+          status_push_notifications.enablePushNotificationsBlockMentions()
+        else:
+          status_push_notifications.disablePushNotificationsBlockMentions()
+      if not response.error.isNil:
+        error "error updating push notifications block mentions", errDescription = response.error.message
+        return false
+    except Exception as e:
+      error "error updating push notifications block mentions", errDescription = e.msg
+      return false
+    return true
+
+  proc initPushNotificationsSettings*(self: Service) =
+    discard self.updateCentralizedPushNotifications(self.deviceToken, self.settings.remotePushNotificationsEnabled)
+    discard self.updatePushNotificationsFromContactsOnly(self.settings.pushNotificationsFromContactsOnly)
+    discard self.updatePushNotificationsBlockMentions(self.settings.pushNotificationsBlockMentions)
 
 
   proc saveSetting(self: Service, attribute: string, value: string | JsonNode | bool | int | int64): bool =
@@ -377,59 +434,96 @@ QtObject:
   proc getSendPushNotifications*(self: Service): bool =
     self.settings.sendPushNotifications
 
-  proc registerForCentralizedPushNotifications*(self: Service, deviceToken: string) {.slot.} =
-    try:
-      let response = status_push_notifications.registerForPushNotifications(deviceToken, PUSH_TOPIC, PUSH_TOKEN_TYPE)
-      if not response.error.isNil:
-        error "error registering for push notifications", errDescription = response.error.message
-        return
-    except Exception as e:
-      error "error registering for push notifications", errDescription = e.msg
+  proc getDeviceToken*(self: Service): string {.slot.} =
+    self.deviceToken
 
-  proc unregisterFromPushNotifications*(self: Service) {.slot.} =
-    try:
-      let response = status_push_notifications.unregisterFromPushNotifications()
-      if not response.error.isNil:
-        error "error unregistering from push notifications", errDescription = response.error.message
-        return
-    except Exception as e:
-      error "error unregistering from push notifications", errDescription = e.msg
+  proc deviceTokenChanged*(self: Service) {.signal.}
+  proc setDeviceToken*(self: Service, value: string) {.slot.} =
+    if (self.deviceToken != value):
+      self.deviceToken = value
+      if self.initialized:
+        self.initPushNotificationsSettings()
 
-  proc enablePushNotificationsFromContactsOnly*(self: Service) {.slot.} =
-    try:
-      let response = status_push_notifications.enablePushNotificationsFromContactsOnly()
-      if not response.error.isNil:
-        error "error enabling push notifications from contacts only", errDescription = response.error.message
-        return
-    except Exception as e:
-      error "error enabling push notifications from contacts only", errDescription = e.msg
+      self.deviceTokenChanged()
 
-  proc disablePushNotificationsFromContactsOnly*(self: Service) {.slot.} =
-    try:
-      let response = status_push_notifications.disablePushNotificationsFromContactsOnly()
-      if not response.error.isNil:
-        error "error disabling push notifications from contacts only", errDescription = response.error.message
-        return
-    except Exception as e:
-      error "error disabling push notifications from contacts only", errDescription = e.msg
+  QtProperty[string] deviceToken:
+    read = getDeviceToken
+    write = setDeviceToken
+    notify = deviceTokenChanged
 
-  proc enablePushNotificationsBlockMentions*(self: Service) {.slot.} =
-    try:
-      let response = status_push_notifications.enablePushNotificationsBlockMentions()
-      if not response.error.isNil:
-        error "error enabling push notifications block mentions", errDescription = response.error.message
-        return
-    except Exception as e:
-      error "error enabling push notifications block mentions", errDescription = e.msg
+  proc pushNotificationsFromContactsOnlyChanged*(self: Service) {.signal.}
 
-  proc disablePushNotificationsBlockMentions*(self: Service) {.slot.} =
-    try:
-      let response = status_push_notifications.disablePushNotificationsBlockMentions()
-      if not response.error.isNil:
-        error "error disabling push notifications block mentions", errDescription = response.error.message
-        return
-    except Exception as e:
-      error "error disabling push notifications block mentions", errDescription = e.msg
+  proc getPushNotificationsFromContactsOnly*(self: Service): bool {.slot.} =
+    self.settings.pushNotificationsFromContactsOnly
+
+  proc setPushNotificationsFromContactsOnly*(self: Service, value: bool) {.slot.} =
+    if self.settings.pushNotificationsFromContactsOnly == value:
+      return
+    if not self.updatePushNotificationsFromContactsOnly(value):
+      return
+    self.settings.pushNotificationsFromContactsOnly = value
+    self.pushNotificationsFromContactsOnlyChanged()
+
+  QtProperty[bool] pushNotificationsFromContactsOnly:
+    read = getPushNotificationsFromContactsOnly
+    write = setPushNotificationsFromContactsOnly
+    notify = pushNotificationsFromContactsOnlyChanged
+
+  proc pushNotificationsBlockMentionsChanged*(self: Service) {.signal.}
+
+  proc getPushNotificationsBlockMentions*(self: Service): bool {.slot.} =
+    self.settings.pushNotificationsBlockMentions
+
+  proc setPushNotificationsBlockMentions*(self: Service, value: bool) {.slot.} =
+    if self.settings.pushNotificationsBlockMentions == value:
+      return
+    if not self.updatePushNotificationsBlockMentions(value):
+      return
+    self.settings.pushNotificationsBlockMentions = value
+    self.pushNotificationsBlockMentionsChanged()
+
+  QtProperty[bool] pushNotificationsBlockMentions:
+    read = getPushNotificationsBlockMentions
+    write = setPushNotificationsBlockMentions
+    notify = pushNotificationsBlockMentionsChanged
+
+  proc remotePushNotificationsEnabledChanged*(self: Service) {.signal.}
+
+  proc getRemotePushNotificationsEnabled*(self: Service): bool {.slot.} =
+    self.settings.remotePushNotificationsEnabled
+
+  proc setRemotePushNotificationsEnabled*(self: Service, value: bool) {.slot.} =
+    if self.settings.remotePushNotificationsEnabled == value:
+      return
+    discard self.saveSendPushNotifications(value)
+    self.settings.remotePushNotificationsEnabled = value
+    self.remotePushNotificationsEnabledChanged()
+    # Just discard. It also depends on device token. We'll enable the setting value even if we cannot register for push
+    # The push registration will be attempted when the device token changes if this setting is enabled.
+    discard self.updateCentralizedPushNotifications(self.deviceToken, value)
+
+  QtProperty[bool] remotePushNotificationsEnabled:
+    read = getRemotePushNotificationsEnabled
+    write = setRemotePushNotificationsEnabled
+    notify = remotePushNotificationsEnabledChanged
+
+  proc pushNotificationsServerEnabledChanged*(self: Service) {.signal.}
+
+  proc getPushNotificationsServerEnabled*(self: Service): bool {.slot.} =
+    self.settings.pushNotificationsServerEnabled
+
+  proc setPushNotificationsServerEnabled*(self: Service, value: bool) =
+    if self.settings.pushNotificationsServerEnabled == value:
+      return
+    if not self.saveSetting(KEY_PUSH_NOTIFICATIONS_SERVER_ENABLED, value):
+      return
+    self.settings.pushNotificationsServerEnabled = value
+    self.pushNotificationsServerEnabledChanged()
+
+  QtProperty[bool] pushNotificationsServerEnabled:
+    read = getPushNotificationsServerEnabled
+    write = setPushNotificationsServerEnabled
+    notify = pushNotificationsServerEnabledChanged
 
   proc saveAppearance*(self: Service, value: int): bool =
     if(self.saveSetting(KEY_APPEARANCE, value)):

--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -195,7 +195,8 @@ SettingsContentBase {
             id: mobileHelperBanner
             Layout.preferredWidth: root.contentWidth
             visible: SQUtils.Utils.isMobile &&
-                    d.notificationsSettings.notifSettingAllowNotifications &&
+                    (SQUtils.Utils.isIOS ? d.notificationsSettings.remotePushNotificationsEnabled
+                                         : d.notificationsSettings.notifSettingAllowNotifications) &&
                     PushNotifications.status !== PushNotifications.Granted
 
             padding: Theme.defaultPadding
@@ -219,33 +220,6 @@ SettingsContentBase {
             }
         }
 
-        StatusListItem {
-            Layout.preferredWidth: root.contentWidth
-            title: qsTr("Enable notifications")
-            tertiaryTitle:  !SQUtils.Utils.isMobile ?
-                                qsTr("Status delivers notifications directly through your operating system, with no centralized servers or intermediaries. Ensure they are enabled for Status in your system settings") :
-                                SQUtils.Utils.isIOS ?
-                                    qsTr("Status uses APNs (Apple Push Notification service) solely to deliver notification signals on your device; your end-to-end encrypted message content is never passed through or stored there.") :
-                                    qsTr("Status delivers notifications on your device via its on-device background service, with no third parties, centralized servers, or intermediaries involved.")
-            components: [
-                StatusSwitch {
-                    id: allowNotifSwitch
-                    checked: d.notificationsSettings.notifSettingAllowNotifications
-                    onClicked: {
-                        d.notificationsSettings.notifSettingAllowNotifications = !d.notificationsSettings.notifSettingAllowNotifications
-                        if (d.notificationsSettings.notifSettingAllowNotifications) {
-                            PushNotifications.request()
-                        } else {
-                            appSettings.unregisterFromPushNotifications()
-                        }
-                    }
-                }
-            ]
-            onClicked: {
-                allowNotifSwitch.clicked()
-            }
-        }
-
         Loader {
             Layout.preferredWidth: root.contentWidth
             sourceComponent: SQUtils.Utils.isIOS ? centralizedPushNotificationsMenuComponent : generalMenuComponent
@@ -256,6 +230,23 @@ SettingsContentBase {
             id: generalMenuComponent
             ColumnLayout {
             id: generalMenu
+            StatusListItem {
+                Layout.preferredWidth: root.contentWidth
+                title: qsTr("Enable notifications")
+                tertiaryTitle:  SQUtils.Utils.isAndroid ?
+                                    qsTr("Status delivers notifications on your device via its on-device background service, with no third parties, centralized servers, or intermediaries involved.") :
+                                    qsTr("Status delivers notifications directly through your operating system, with no centralized servers or intermediaries. Ensure they are enabled for Status in your system settings")
+                components: [
+                    StatusSwitch {
+                        id: allowNotifSwitch
+                        checked: d.notificationsSettings.notifSettingAllowNotifications
+                        onClicked: () => d.notificationsSettings.notifSettingAllowNotifications = !d.notificationsSettings.notifSettingAllowNotifications
+                    }
+                ]
+                onClicked: {
+                    allowNotifSwitch.clicked()
+                }
+            }
             StatusBaseText {
                 Layout.preferredWidth: root.contentWidth
                 Layout.leftMargin: Theme.padding
@@ -524,6 +515,21 @@ SettingsContentBase {
         Component {
             id: centralizedPushNotificationsMenuComponent
             ColumnLayout {
+                StatusListItem {
+                    Layout.preferredWidth: root.contentWidth
+                    title: qsTr("Enable notifications")
+                    tertiaryTitle: qsTr("Status uses APNs (Apple Push Notification service) solely to deliver notification signals on your device; your end-to-end encrypted message content is never passed through or stored there.")
+                    components: [
+                        StatusSwitch {
+                            id: allowNotifSwitch
+                            checked: d.notificationsSettings.remotePushNotificationsEnabled
+                            onClicked: () => d.notificationsSettings.remotePushNotificationsEnabled = !d.notificationsSettings.remotePushNotificationsEnabled
+                        }
+                    ]
+                    onClicked: {
+                        allowNotifSwitch.clicked()
+                    }
+                }
                 Separator {
                     Layout.preferredWidth: root.contentWidth
                     Layout.preferredHeight: Theme.bigPadding
@@ -537,21 +543,13 @@ SettingsContentBase {
                 StatusListItem {
                     Layout.preferredWidth: root.contentWidth
                     title: qsTr("Contact requests and group messages")
-                    enabled: d.notificationsSettings.notifSettingAllowNotifications
+                    enabled: d.notificationsSettings.remotePushNotificationsEnabled
                     components: [
                         StatusSwitch {
                             id: nonContactsSwitch
-                            checked: !d.notificationsSettings.notifSettingAllowNotifications ? false : nonContactsSwitch.allowFromNonContacts
-                            property bool allowFromNonContacts: true
-                            enabled: d.notificationsSettings.notifSettingAllowNotifications
-                            onClicked: {
-                                allowFromNonContacts = !allowFromNonContacts
-                                if (allowFromNonContacts) {
-                                    appSettings.disablePushNotificationsFromContactsOnly()
-                                } else {
-                                    appSettings.enablePushNotificationsFromContactsOnly()
-                                }
-                            }
+                            checked: !d.notificationsSettings.pushNotificationsFromContactsOnly
+                            enabled: d.notificationsSettings.remotePushNotificationsEnabled
+                            onClicked: () => d.notificationsSettings.pushNotificationsFromContactsOnly = !d.notificationsSettings.pushNotificationsFromContactsOnly
                         }
                     ]
                     onClicked: {
@@ -563,21 +561,13 @@ SettingsContentBase {
                 StatusListItem {
                     Layout.preferredWidth: root.contentWidth
                     title: qsTr("Mentions and replies in communities")
-                    enabled: d.notificationsSettings.notifSettingAllowNotifications
+                    enabled: d.notificationsSettings.remotePushNotificationsEnabled
                     components: [
                         StatusSwitch {
                             id: communitiesSwitch
-                            checked: !d.notificationsSettings.notifSettingAllowNotifications ? false : communitiesSwitch.allowCommunities
-                            property bool allowCommunities: true
-                            enabled: d.notificationsSettings.notifSettingAllowNotifications
-                            onClicked: {
-                                allowCommunities = !allowCommunities
-                                if (allowCommunities) {
-                                    appSettings.disablePushNotificationsBlockMentions()
-                                } else {
-                                    appSettings.enablePushNotificationsBlockMentions()
-                                }
-                            }
+                            checked: !d.notificationsSettings.pushNotificationsBlockMentions
+                            enabled: d.notificationsSettings.remotePushNotificationsEnabled
+                            onClicked: () => d.notificationsSettings.pushNotificationsBlockMentions = !d.notificationsSettings.pushNotificationsBlockMentions
                         }
                     ]
                     onClicked: {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -57,6 +57,7 @@ import mainui.sectionLoaders
 
 import QtModelsToolkit
 import SortFilterProxyModel
+import MobileUI
 
 Item {
     id: appMain
@@ -1017,6 +1018,7 @@ Item {
         aboutStore: appMain.aboutStore
         privacyStore: appMain.privacyStore
         keychain: appMain.keychain
+        notificationsStore: appMain.notificationsStore
 
         Component.onCompleted: {
             Qt.callLater(() => popupRequestsHandler.maybeDisplayEnablePushNotificationsPopup())
@@ -1173,6 +1175,57 @@ Item {
                 appMain.rootStore.windowActivated()
             else
                 appMain.rootStore.windowDeactivated()
+        }
+    }
+
+    /**
+        * iOS Push Notifications flow:
+        * - When the app is opened, if the user has already granted permissions, we get the token immediately and set it in the store
+        * - If the user hasn't granted permissions yet, we wait for them to change (onStatusChanged). If they grant permissions, we request the token and set it in the store
+        * Additionally, when the user enables notifications from our in-app settings, we request the OS permission at that moment
+        * (showing the native dialog when it hasn't been decided yet), and request the token in case we don't have it yet
+    */
+    Connections {
+        target: PushNotifications
+        enabled: SQUtils.Utils.isIOS
+
+        function onTokenChanged() {
+            appMain.notificationsStore.notificationsSettings.deviceToken = PushNotifications.token
+        }
+
+        function onStatusChanged() {
+            if (PushNotifications.status === PushNotifications.Granted && PushNotifications.token === "") {
+                PushNotifications.requestToken()
+            }
+        }
+
+        // in case PushNotifications has already processed the token
+        Component.onCompleted: {
+            if (SQUtils.Utils.isIOS && !!PushNotifications.token && !!appMain.notificationsStore.notificationsSettings)
+                appMain.notificationsStore.notificationsSettings.deviceToken = PushNotifications.token
+        }
+    }
+
+    Connections {
+        target: appMain.notificationsStore.notificationsSettings
+        enabled: SQUtils.Utils.isIOS
+
+        function onRemotePushNotificationsEnabledChanged() {
+            if (!appMain.notificationsStore.notificationsSettings.remotePushNotificationsEnabled)
+                return
+            if (PushNotifications.status !== PushNotifications.Granted)
+                PushNotifications.request()
+            else if (appMain.notificationsStore.notificationsSettings.deviceToken === "")
+                PushNotifications.requestToken()
+        }
+    }
+
+    Connections {
+        target: appMain.notificationsStore
+        enabled: SQUtils.Utils.isIOS
+        function onNotificationsSettingsChanged() {
+            if (!!appMain.notificationsStore.notificationsSettings)
+                appMain.notificationsStore.notificationsSettings.deviceToken = PushNotifications.token
         }
     }
 

--- a/ui/app/mainui/Handlers/HandlersManager.qml
+++ b/ui/app/mainui/Handlers/HandlersManager.qml
@@ -50,6 +50,7 @@ QtObject {
     required property ProfileStores.AboutStore aboutStore
     required property ProfileStores.EnsUsernamesStore ensUsernamesStore
     required property ProfileStores.PrivacyStore privacyStore
+    required property ProfileStores.NotificationsStore notificationsStore
 
     required property Keychain keychain
 
@@ -211,7 +212,8 @@ QtObject {
         EnablePushNotificationsPopup {
             id: enablePushNotificationsPopup
             destroyOnClose: true
-            hasPermission: PushNotifications.status === PushNotifications.Granted
+            hasPermission: PushNotifications.status === PushNotifications.Granted &&
+                            root.notificationsStore.notificationsSettings.remotePushNotificationsEnabled
 
             onClosed: {
                 appMainLocalSettings.enablePushNotificationsFreshInstallSeen = true
@@ -219,10 +221,17 @@ QtObject {
                 appMainLocalSettings.enablePushNotificationsLastShownVersion = currentMinorVersion()
             }
 
-            onContinueRequested: {
-                PushNotifications.request()
-
-                enablePushNotificationsPopup.loading = true
+            onEnablePushNotifications: {
+                if (SQUtils.Utils.isIOS) {
+                    root.notificationsStore.notificationsSettings.remotePushNotificationsEnabled = true
+                } else {
+                    root.notificationsStore.notificationsSettings.notifSettingAllowNotifications = true
+                }
+                if (PushNotifications.status !== PushNotifications.Granted) {
+                    pushNotificationsConnections.enabled = true
+                    PushNotifications.request()
+                    enablePushNotificationsPopup.loading = true
+                }
             }
 
             onOpenSettingsRequested: {
@@ -232,6 +241,7 @@ QtObject {
 
 
             Connections {
+                id: pushNotificationsConnections
                 target: PushNotifications
 
                 function onStatusChanged() {
@@ -247,8 +257,8 @@ QtObject {
                             Constants.ephemeralNotificationType.success,
                             ""
                         )
-                        PushNotifications.requestToken()
                         enablePushNotificationsPopup.close()
+                        pushNotificationsConnections.enabled = false
                         return
                     }
                 }
@@ -281,57 +291,28 @@ QtObject {
         enablePushNotificationsPopupComponent.createObject(root.popupParent).open()
     }
 
-    readonly property Connections pushNotificationsConnections: Connections {
-        target: PushNotifications
-        function onTokenChanged() {
-            if (PushNotifications.token !== "" && SQUtils.Utils.isIOS) {
-                appSettings.registerForCentralizedPushNotifications(PushNotifications.token)
-            }
-        }
-    }
-
-    readonly property Connections pushNotificationsStatusConnections: Connections {
-        target: PushNotifications
-        enabled: false
-        function onStatusChanged() {
-            if (PushNotifications.status !== PushNotifications.Granted) {
-                showEnablePushNotificationsPopup()
-            }
-
-            Qt.callLater(() => {
-                pushNotificationsStatusConnections.enabled = false
-            })
-        }
-    }
-
     function maybeDisplayEnablePushNotificationsPopup() {
         if (!SQUtils.Utils.isMobile) {
             return
         }
 
-        if (PushNotifications.status === PushNotifications.Granted) {
-            PushNotifications.requestToken()
+        const inAppNotificationsEnabled = SQUtils.Utils.isIOS ? root.notificationsStore.notificationsSettings.remotePushNotificationsEnabled :
+                root.notificationsStore.notificationsSettings.notifSettingAllowNotifications
+
+        if (inAppNotificationsEnabled &&
+                PushNotifications.status === PushNotifications.Granted) {
             return
         }
 
         const version = currentMinorVersion()
         const shouldDisplayAfterFreshInstall = !appMainLocalSettings.enablePushNotificationsFreshInstallSeen
-        const shouldDisplayAfterMinorUpdate = !appSettings.notifSettingAllowNotifications &&
+        const shouldDisplayAfterMinorUpdate = !inAppNotificationsEnabled &&
                 !appMainLocalSettings.enablePushNotificationsDontAskAgain &&
                 version !== "" &&
                 isAtLeastMinorVersion(version, "2.38") &&
                 appMainLocalSettings.enablePushNotificationsLastShownVersion !== version
 
         if (!shouldDisplayAfterFreshInstall && !shouldDisplayAfterMinorUpdate) {
-            return
-        }
-
-        // Delay the popup display to avoid false negative when the status is unknown
-        // If might take a while to get the status, so we delay the popup display
-        // Platform specifics - iOS might take a while to get the status, so we delay the popup display
-        // Platform specifics - Android won't return the status until the first request is made
-        if (PushNotifications.status === PushNotifications.Unknown && SQUtils.Utils.isIOS) {
-            pushNotificationsStatusConnections.enabled = true
             return
         }
 

--- a/ui/app/mainui/sectionLoaders/HandlersManagerLoader.qml
+++ b/ui/app/mainui/sectionLoaders/HandlersManagerLoader.qml
@@ -32,7 +32,8 @@ Loader {
     required property WalletStores.CollectiblesStore walletCollectiblesStore
     required property WalletStores.TransactionStoreNew transactionStoreNew
     required property WalletStores.TokensStore tokensStore
-
+    required property ProfileStores.NotificationsStore notificationsStore
+    
     required property ChatStores.RootStore rootChatStore
 
     required property ProfileStores.AboutStore aboutStore
@@ -84,6 +85,7 @@ Loader {
             ensUsernamesStore:      Qt.binding(() => root.ensUsernamesStore),
             privacyStore:           Qt.binding(() => root.privacyStore),
             keychain:               Qt.binding(() => root.keychain),
+            notificationsStore:     Qt.binding(() => root.notificationsStore)
         })
     }
 

--- a/ui/imports/shared/popups/EnablePushNotificationsPopup.qml
+++ b/ui/imports/shared/popups/EnablePushNotificationsPopup.qml
@@ -20,8 +20,8 @@ StatusDialog {
     property bool loading: false
     property bool dontAskAgain: false
 
-    signal continueRequested()
     signal openSettingsRequested()
+    signal enablePushNotifications()
 
     width: 480
     title: qsTr("Enable notifications")
@@ -65,22 +65,21 @@ StatusDialog {
                 objectName: "btnPushNotificationsPrimary"
                 loading: root.loading
                 text: {
-                    if (root.hasPermission) return qsTr("Done")
                     if (root.attemptedRequest) return qsTr("Open settings")
                     return qsTr("Continue")
                 }
                 onClicked: {
-                    if (root.hasPermission) {
-                        root.close()
-                        return
-                    }
                     if (root.attemptedRequest) {
                         root.openSettingsRequested()
                         return
                     }
 
+                    root.enablePushNotifications()
+                    if (root.hasPermission) {
+                        root.close()
+                        return
+                    }
                     root.attemptedRequest = true
-                    root.continueRequested()
                 }
             }
         }


### PR DESCRIPTION
### What does the PR do

Closes https://github.com/status-im/status-app/issues/20781

- use status-go dedicated settings to track centralized push notifications `pushNotifications`, `PushNotificationsFromContactsOnly`, `PushNotificationsBlockMentions`
- AppMain.qml implements the glue-code between OS push notifications permissions and in-app push notifications settings and config. Previously either HandlersManager or NotificationsView would partially implement the glue code.
- Remove the `Done` CTA from push permissions popup. It will only have 2 states: `Continue` - whenever we need to enable app or os level push permissions. `Open in settings` - whenever OS push permissions cannot be requested (previously denied by the user)
- Update the conditions to open the push notifications popup. Will open whenever OS or app permissions are disabled (+ the other existing conditions)
- Fixing an issue where a newly installed app on IOS would not show push notifications options in OS level app settings. The flow would be: Fresh install -> create profile -> `Maybe later` in the PN popup -> settings -> notifications -> open settings. In this case the user had no way to enable push notifications once `Maybe later` was clicked.


### Affected areas

Push notifications IOS and Android

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

Go through all the PN options after onboarding:
- new app, new user
- new app, synced user
- app update, new user
- app update, synced user
Go through all the PN popup options:
- Maybe later -> settings -> enable
- Continue -> settings -> notifications -> disable
- Continue -> reject -> settings -> notifications -> enable (With settings)
Go through IOS granular controls:
- non-contact PN
- community mentions PN

### Risk 

Low