### PR TITLE
fix: Android connectivity issues

### DIFF
--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -9,9 +9,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import android.content.Intent;
 import android.net.Uri;
 import android.provider.Settings;
+import android.util.Log;
 import im.status.mobileui.PushNotificationHelper;
 
 public class StatusQtActivity extends QtActivity {
+    private static final String TAG = "StatusQtActivity";
+
+    // QtActivityBase.onDestroy() can deadlock on Android during Qt/EGL teardown;
+    // if it hasn't completed within this window we force-kill the UI process.
+    private static final long TEARDOWN_WATCHDOG_MS = 3000L;
+
     private static final AtomicBoolean splashShouldHide = new AtomicBoolean(false);
     private static StatusQtActivity sInstance = null;
 
@@ -70,7 +77,35 @@ public class StatusQtActivity extends QtActivity {
     @Override
     protected void onDestroy() {
         sInstance = null;
+        // QtActivityBase.onDestroy() can deadlock on Android: the Qt render
+        // thread blocks in eglSwapBuffers on a Surface Android already
+        // destroyed, the Qt GUI thread waits on it, and this (Android UI)
+        // thread waits on the GUI thread inside flushWindowSystemEvents.
+        // When the activity is really finishing, guarantee the process dies
+        // so the task clears from recents and the next launch is a clean
+        // cold start. Armed before super.onDestroy() since that call is what
+        // hangs; runs on its own daemon thread because the main thread is
+        // exactly what gets stuck.
+        if (isFinishing()) {
+            Thread watchdog = new Thread(() -> {
+                try { Thread.sleep(TEARDOWN_WATCHDOG_MS); }
+                catch (InterruptedException ignored) {}
+                Log.w(TAG, "Qt teardown did not complete within "
+                        + TEARDOWN_WATCHDOG_MS + "ms; force-killing UI process "
+                        + android.os.Process.myPid());
+                android.os.Process.killProcess(android.os.Process.myPid());
+            }, "status-teardown-watchdog");
+            watchdog.setDaemon(true);
+            watchdog.start();
+        }
         super.onDestroy();
+        if (isFinishing()) {
+            // Teardown returned without deadlocking — still ensure the
+            // process exits so no stale activity lingers in the task.
+            Log.w(TAG, "onDestroy complete; force-killing UI process "
+                    + android.os.Process.myPid() + " to clear the task");
+            android.os.Process.killProcess(android.os.Process.myPid());
+        }
     }
 
     // Called from Qt via JNI when main window is visible

--- a/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoService.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoService.java
@@ -4,7 +4,11 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
 import android.os.Binder;
 import android.os.Build;
 import android.os.Handler;
@@ -68,6 +72,17 @@ public final class StatusGoService extends Service {
 
     private final ExecutorService lifecycleExecutor = Executors.newSingleThreadExecutor();
     private final AtomicInteger lifecycleGen = new AtomicInteger(0);
+
+    /**
+     * Native network connectivity monitoring. On Android the status-go lib runs in this
+     * process; the QML NetworkChecker path (which lives in the killable/pausable UI
+     * process) is a no-op here, so we observe connectivity natively and push it into
+     * status-go via the ConnectionChange RPC.
+     */
+    private ConnectivityManager connectivityManager;
+    private ConnectivityManager.NetworkCallback networkCallback;
+    /** Last (type|expensive) sent to status-go. Accessed only on the lifecycleExecutor thread. */
+    private String lastConnectionKey = null;
 
     /** Single instance per process; lets background components (NotificationReplyReceiver) reach the service. */
     private static volatile StatusGoService sInstance;
@@ -265,6 +280,113 @@ public final class StatusGoService extends Service {
         });
     }
 
+    /**
+     * Observes the default network and pushes connectivity state into status-go.
+     *
+     * onCapabilitiesChanged fires immediately on registration for the current network and
+     * again on every capability change; onLost fires when the (single) default network is
+     * gone. onAvailable is not overridden — onCapabilitiesChanged always follows it and
+     * carries the data we need.
+     */
+    private final class NetworkConnectivityCallback extends ConnectivityManager.NetworkCallback {
+        @Override
+        public void onCapabilitiesChanged(Network network, NetworkCapabilities caps) {
+            dispatchConnectionChange(typeFromCapabilities(caps), meteredFromCapabilities(caps));
+        }
+
+        @Override
+        public void onLost(Network network) {
+            dispatchConnectionChange("none", false);
+        }
+    }
+
+    /** Maps Android transports to a status-go connection type ("wifi"/"cellular"/"unknown"). */
+    private static String typeFromCapabilities(NetworkCapabilities caps) {
+        if (caps == null) return "unknown";
+        // VPN networks normally retain the underlying transport bits, so checking the real
+        // transports first classifies VPN-over-wifi/cellular correctly. Wi-Fi takes priority
+        // over cellular so a Wi-Fi+VPN combo is never mislabeled.
+        if (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) return "wifi";
+        // status-go has no ethernet type; "wifi" is the closest fast/non-expensive class.
+        if (caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) return "wifi";
+        if (caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) return "cellular";
+        return "unknown";
+    }
+
+    /** A network is "expensive" (metered) when it lacks the NOT_METERED capability. */
+    private static boolean meteredFromCapabilities(NetworkCapabilities caps) {
+        if (caps == null) return false;
+        return !caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED);
+    }
+
+    /**
+     * Serializes a ConnectionChange RPC onto lifecycleExecutor (the JNI-call thread),
+     * de-duplicating so status-go only sees calls when (type, expensive) actually changed.
+     * De-dup matters: onCapabilitiesChanged fires often for capability churn that does not
+     * change the pair, and each offline->online transition triggers a hystrix.Flush() in
+     * status-go.
+     */
+    private void dispatchConnectionChange(String type, boolean expensive) {
+        final String key = type + "|" + expensive;
+        try {
+            lifecycleExecutor.execute(() -> {
+                if (key.equals(lastConnectionKey)) return;
+                try {
+                    final JSONObject payload = new JSONObject();
+                    payload.put("type", type);
+                    payload.put("expensive", expensive);
+                    // nativeCall expects a JSON array of string args; ConnectionChange takes
+                    // a single JSON-object string.
+                    final String argsJson = "[" + JSONObject.quote(payload.toString()) + "]";
+                    Log.d(TAG, "ConnectionChange args: " + argsJson);
+                    final String resp = nativeCall("ConnectionChange", argsJson);
+                    lastConnectionKey = key; // only on success, so a transient failure can retry
+                    if (resp != null && !resp.isEmpty()) {
+                        final String err = new JSONObject(resp).optString("error", "");
+                        if (!err.isEmpty()) Log.w(TAG, "ConnectionChange returned error: " + err);
+                    }
+                } catch (Throwable t) {
+                    Log.w(TAG, "Failed to push ConnectionChange to status-go", t);
+                }
+            });
+        } catch (java.util.concurrent.RejectedExecutionException ignored) {
+            // service shutting down; nothing to push
+        }
+    }
+
+    /**
+     * Registers a default-network callback. registerDefaultNetworkCallback delivers the
+     * current network's onCapabilitiesChanged immediately, which — together with StartNode
+     * re-applying the stored connection state — seeds status-go with connectivity at start.
+     */
+    private void registerNetworkCallback() {
+        try {
+            connectivityManager =
+                    (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+            if (connectivityManager == null) {
+                Log.w(TAG, "ConnectivityManager unavailable; network monitoring disabled");
+                return;
+            }
+            networkCallback = new NetworkConnectivityCallback();
+            connectivityManager.registerDefaultNetworkCallback(networkCallback);
+        } catch (Throwable t) {
+            // e.g. RuntimeException("TOO_MANY_REQUESTS"); best-effort only.
+            Log.w(TAG, "Failed to register network callback", t);
+            networkCallback = null;
+        }
+    }
+
+    private void unregisterNetworkCallback() {
+        if (connectivityManager != null && networkCallback != null) {
+            try {
+                connectivityManager.unregisterNetworkCallback(networkCallback);
+            } catch (Throwable t) {
+                Log.w(TAG, "Failed to unregister network callback", t);
+            }
+        }
+        networkCallback = null;
+    }
+
     private void applyUiVisibility(boolean visible) {
         uiVisible = visible;
         // A real fg/bg transition handles messaging via scheduleBackendLifecycleUpdate;
@@ -344,6 +466,7 @@ public final class StatusGoService extends Service {
         notificationManager = new StatusNotificationManager(this);
         PushNotificationHelper.initialize(this);
         nativeInit(this);
+        registerNetworkCallback();
     }
 
     @Override
@@ -372,6 +495,7 @@ public final class StatusGoService extends Service {
     public void onDestroy() {
         sInstance = null;
         mainHandler.removeCallbacksAndMessages(null);
+        unregisterNetworkCallback();
         StatusNotificationManager.clearInstance();
         listeners.kill();
         lifecycleExecutor.shutdownNow();

--- a/src/app_service/service/general/service.nim
+++ b/src/app_service/service/general/service.nim
@@ -113,6 +113,10 @@ QtObject:
       self.events.emit(SIGNAL_LOCAL_BACKUP_IMPORT_COMPLETED, LocalBackupImportArg(error: e.msg))
 
   proc connectionChange*(self: Service, connectionType: string, isExpensive: bool) =
+    when defined(android):
+      # Connectivity is driven natively by StatusGoService on Android — see
+      # mobile/android/qt6/.../ipc/StatusGoService.java. This QML path is a no-op.
+      return
     try:
       let response = status_go.connectionChange($(%* {"type": connectionType, "expensive": isExpensive}))
       let rpcResponseObj = response.parseJson


### PR DESCRIPTION
### What does the PR do

Closes https://github.com/status-im/status-app/issues/20587 https://github.com/status-im/status-app/issues/20663 https://github.com/status-im/status-app/issues/20781

Fixing multiple deadlocks on instable connectivity and on app restarts.

- go-waku deadlocks and peer reconnection storm fixed by https://github.com/logos-messaging/logos-delivery-go/pull/1302. This issue was deadlocking the messenger and any client restart would end-up in the same deadlock.

- status-go filters the connection change and propagates only when the state actually changes https://github.com/status-im/status-go/pull/7447. This would trigger a peer reconnection storm with tens of changes on app kill/app start.

- Handle dns failure at start-up, leaving the clients with no lightpush peer. App should start now with more peers. Send message should work from the start. https://github.com/status-im/status-go/pull/7447

- Make nim's connectionChange no-op on android. The connectionChange is managed by the android service itself since the service is persistent and the client is not.

- Add a destruction watchdog for the android activity. If qt's onDestry blocks for more than 3 seconds we'll forcefully kill the app. Otherwise it can deadlock, making app restart impossible. There's still a deadlock in the client - looks like a race condition between the android surface and the threaded renderer. This prevents qt or nim to deadlock on close.


### Affected areas

lightpush peers
android app start-up
android app close

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

The user should not get into an unrecoverable app state on android.
IOS and android should have more peers at start-up.

### How to test

Start the app with a new profile. Enable node manangement from advanced settings, observe the number of peers - should be similar to desktop or relay mode.

Start the android app, login and run app restart flows multiple times. Close, quickly open again, wait for loading to complete, close, quickly start and so on.

### Risk 

Medium