### PR TITLE
fix: handle shutdown process to avoid race conditions - more appropriate

### DIFF
--- a/src/app/global/global_singleton.nim
+++ b/src/app/global/global_singleton.nim
@@ -18,6 +18,26 @@ export global_events
 export loader_deactivator
 export feature_flags
 
+
+# #########################################################
+# Application Handle
+# #########################################################
+type
+  ApplicationHandle* = object
+    app: QGuiApplication
+
+when defined(ios) or defined(android):
+  proc c_exit(code: cint) {.importc: "_exit", header: "<unistd.h>".}
+
+proc quit*(self: ApplicationHandle) =
+  if not self.app.isNil:
+    self.app.quit()
+
+  when defined(ios) or defined(android):
+    c_exit(0) # terminates the process immediately without running any static destructors or atexit handlers — no cascade possible.
+# #########################################################
+
+
 type
   GlobalSingleton = object
   # Don't export GlobalSingleton type.
@@ -30,6 +50,14 @@ proc engine*(self: GlobalSingleton): QQmlApplicationEngine =
   if (qmlEngine.isNil):
     qmlEngine = newQQmlApplicationEngine()
   return qmlEngine
+
+var qGuiApplicationInstance {.global.}: QGuiApplication
+
+proc setApplication*(self: GlobalSingleton, app: QGuiApplication) =
+  qGuiApplicationInstance = app
+
+proc application*(self: GlobalSingleton): ApplicationHandle =
+  ApplicationHandle(app: qGuiApplicationInstance)
 
 proc localAccountSettings*(self: GlobalSingleton): LocalAccountSettings =
   var localAccountSettings {.global.}: LocalAccountSettings

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -2103,7 +2103,7 @@ proc runStartUsingKeycardForProfilePopup[T](self: Module[T]) =
 method signOutAndQuit*[T](self: Module[T]) =
   info "signOutAndQuit: logging out and quitting"
   self.controller.logout()
-  quit()
+  singletonInstance.application.quit()
 
 method checkAndPerformProfileMigrationIfNeeded*[T](self: Module[T]) =
   let keyUid = singletonInstance.userProfile.getKeyUid()
@@ -2111,7 +2111,8 @@ method checkAndPerformProfileMigrationIfNeeded*[T](self: Module[T]) =
   let profileKeypair = self.walletAccountService.getKeypairByKeyUid(keyUid)
   if profileKeypair.isNil:
     info "quit the app because of unresolved profile keypair", keyUid
-    quit() # quit the app
+    singletonInstance.application.quit()
+    return
   if not migrationNeeded:
     if not self.keycardSharedModule.isNil:
       let currentFlow = self.keycardSharedModule.getCurrentFlowType()

--- a/src/app/modules/main/node_section/module.nim
+++ b/src/app/modules/main/node_section/module.nim
@@ -56,7 +56,7 @@ method sendRPCMessageRaw*(self: Module, inputJSON: string): string =
 
 method setLightClient*(self: Module, enabled: bool) =
   if(self.controller.setLightClient(enabled)):
-    quit(QuitSuccess) # quits the app TODO: change this to logout instead when supported
+    singletonInstance.application.quit() # TODO: change this to logout instead when supported
 
 method isLightClient*(self: Module): bool =
   return self.controller.isLightClient()

--- a/src/app/modules/main/profile_section/advanced/module.nim
+++ b/src/app/modules/main/profile_section/advanced/module.nim
@@ -5,6 +5,7 @@ import view, controller
 
 import ../../../../../constants
 import ../../../../core/eventemitter
+import ../../../../global/global_singleton
 import ../../../../../app_service/service/settings/service as settings_service
 import ../../../../../app_service/service/stickers/service as stickers_service
 import ../../../../../app_service/service/node_configuration/service as node_configuration_service
@@ -60,7 +61,7 @@ method setFleet*(self: Module, fleet: string) =
 
 method onFleetSet*(self: Module) =
   info "quit the app because of successful fleet change"
-  quit(QuitSuccess) # quits the app TODO: change this to logout instead when supported
+  singletonInstance.application.quit() # TODO: change this to logout instead when supported
 
 method getLogDir*(self: Module): string =
   return constants.LOGDIR
@@ -73,7 +74,7 @@ method setWakuV2LightClientEnabled*(self: Module, enabled: bool) =
 
 method onWakuV2LightClientSet*(self: Module) =
   info "quit the app because of successful WakuV2 light client change"
-  quit(QuitSuccess) # quits the app TODO: change this to logout instead when supported
+  singletonInstance.application.quit() # TODO: change this to logout instead when supported
 
 method isDebugEnabled*(self: Module): bool =
   self.controller.isDebugEnabled()

--- a/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_failure_state.nim
@@ -20,7 +20,7 @@ method executePrePrimaryStateCommand*(self: KeyPairMigrateFailureState, controll
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
     return
   info "quit the app because of profile migration failure"
-  quit() # quit the app
+  singletonInstance.application.quit()
 
 method executeCancelCommand*(self: KeyPairMigrateFailureState, controller: Controller) =
   var profileMigrated = false
@@ -34,4 +34,4 @@ method executeCancelCommand*(self: KeyPairMigrateFailureState, controller: Contr
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
     return
   info "quit the app because of profile migration failure"
-  quit() # quit the app
+  singletonInstance.application.quit()

--- a/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_success_state.nim
@@ -13,18 +13,20 @@ method executeCancelCommand*(self: KeyPairMigrateSuccessState, controller: Contr
     let profileMigrated = controller.getSelectedKeyPairIsProfile()
     if profileMigrated:
       info "quit the app cause this is not an available option in the context of SetupNewKeycard flow for profile keypair"
-      quit() # quit the app
+      singletonInstance.application.quit()
+      return
 
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
   if self.flowType == FlowType.MigrateFromKeycardToApp:
     if controller.getKeyPairForProcessing().getKeyUid() == singletonInstance.userProfile.getKeyUid():
       info "quit the app cause this is not an available option in the context of MigrateFromKeycardToApp flow for profile keypair"
-      quit() # quit the app
+      singletonInstance.application.quit()
+      return
 
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
   if self.flowType == FlowType.MigrateFromAppToKeycard:
     info "quit the app cause this is not an available option in the context of MigrateFromAppToKeycard"
-    quit() # quit the app
+    singletonInstance.application.quit()
 
 method executePrePrimaryStateCommand*(self: KeyPairMigrateSuccessState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
@@ -32,16 +34,18 @@ method executePrePrimaryStateCommand*(self: KeyPairMigrateSuccessState, controll
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
     if profileMigrated:
       info "restart the app because of successfully migrated profile keypair"
-      quit() # quit the app
+      singletonInstance.application.quit()
+      return
   if self.flowType == FlowType.MigrateFromKeycardToApp:
     let profileMigrated = controller.getKeyPairForProcessing().getKeyUid() == singletonInstance.userProfile.getKeyUid()
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
     if profileMigrated:
       info "restart the app because of successfully migrated profile keypair"
-      quit() # quit the app
+      singletonInstance.application.quit()
+      return
   if self.flowType == FlowType.MigrateFromAppToKeycard:
     info "restart the app because of successfully migrated profile keypair"
-    quit() # quit the app
+    singletonInstance.application.quit()
 
 method executePreSecondaryStateCommand*(self: KeyPairMigrateSuccessState, controller: Controller) =
   if self.flowType == FlowType.MigrateFromKeycardToApp:

--- a/src/app/modules/shared_modules/keycard_popup/internal/state_factory.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state_factory.nim
@@ -1,4 +1,4 @@
-import parseutils, sequtils, sugar, chronicles
+import parseutils, sequtils, sugar, chronicles, nimqml
 
 import app/global/global_singleton
 import app_service/service/keycard/constants

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -671,7 +671,8 @@ proc proceedWithRunFlow[T](self: Module[T], flowToRun: FlowType, keyUid: string,
     if keyUid != singletonInstance.userProfile.getKeyUid():
       error "sm_cannot MigrateFromAppToKeycard flow can be run only for the profile keypair and should not be run directly"
       self.controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
-      quit() # quit the app
+      singletonInstance.application.quit()
+      return
     self.prepareKeyPairForProcessing(keyUid)
     self.view.setCurrentState(newMigrateKeypairToKeycardState(flowToRun, nil))
     self.controller.readyToDisplayPopup()

--- a/src/app_service/service/network/service.nim
+++ b/src/app_service/service/network/service.nim
@@ -1,6 +1,7 @@
-import json, json_serialization, chronicles, sugar, sequtils
+import json, json_serialization, chronicles, sugar, sequtils, nimqml
 
 import ../../../app/core/eventemitter
+import ../../../app/global/global_singleton
 import backend/network as backend
 import ../settings/service as settings_service
 import ./network_item
@@ -117,7 +118,7 @@ proc getAppNetwork*(self: Service): NetworkItem =
   if network.isNil:
     # we should not be here ever
     error "the app network cannot be resolved"
-    quit() # quit the app
+    singletonInstance.application.quit()
   return network
 
 proc updateNetworkEndPointValues*(self: Service, chainId: int, newMainRpcInput, newFailoverRpcUrl: string) =

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -23,10 +23,6 @@ featureGuard KEYCARD_ENABLED:
 when defined(macosx) and defined(arm64):
   import posix
 
-when defined(android) or defined(ios):
-  # Bypass libc static destructors on shutdown, anyway the OS reclaims process resources.
-  proc cExit(code: cint) {.importc: "_exit", header: "<unistd.h>".}
-
 when defined(windows):
     {.link: "../status.o".}
 
@@ -200,6 +196,7 @@ proc mainProc() =
   installSelfSignedCertificate(imageCert)
 
   let app = newQGuiApplication()
+  singletonInstance.setApplication(app)
 
   # force default language ("en") if not "Settings/Advanced/Enable translations"
   if not singletonInstance.localAppSettings.getTranslationsEnabled():
@@ -263,9 +260,7 @@ proc mainProc() =
     appController.delete()
     statusFoundation.delete()
     singleInstance.delete()
-    app.delete()
-    when defined(android) or defined(ios):
-      cExit(0)
+    singletonInstance.application.quit()
 
   featureGuard SINGLE_STATUS_INSTANCE_ENABLED:
     # Checks below must be always after "defer", in case anything fails destructors will freed a memory.


### PR DESCRIPTION
- Added a global singleton instance for QGuiApplication to manage application lifecycle.
- Replaced direct quit calls with singletonInstance.application.quit() for consistent application termination.