### PR TITLE
fix(Chat): Adjust chat lists margins and scrollbar spacing

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusChatListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatListItem.qml
@@ -36,6 +36,9 @@ Rectangle {
     property bool dragged: false
     property alias sensor: sensor
 
+    readonly property int verticalPadding: 4
+    readonly property int horizontalMargin: Math.max(Theme.halfPadding, 8)
+
     signal clicked(var mouse)
     signal unmute()
 
@@ -55,7 +58,7 @@ Rectangle {
     }
 
     implicitWidth: 288
-    implicitHeight: 40
+    implicitHeight: 40 + 2 * verticalPadding
 
     radius: Theme.radius
 
@@ -84,7 +87,7 @@ Rectangle {
         StatusSmartIdenticon {
             id: identicon
             anchors.left: parent.left
-            anchors.leftMargin: Theme.halfPadding
+            anchors.leftMargin: root.horizontalMargin
             anchors.verticalCenter: parent.verticalCenter
             asset: root.asset
             name: root.name
@@ -141,7 +144,7 @@ Rectangle {
             anchors.leftMargin: statusIcon.visible ? 1 : Theme.halfPadding
             anchors.right: mutedIcon.visible ? mutedIcon.left :
                                                statusBadge.visible ? statusBadgeContainer.left : parent.right
-            anchors.rightMargin: Theme.halfPadding
+            anchors.rightMargin: root.horizontalMargin
             anchors.verticalCenter: parent.verticalCenter
 
             text: root.name
@@ -169,7 +172,7 @@ Rectangle {
         StatusIcon {
             id: mutedIcon
             anchors.right: statusBadge.visible ? statusBadgeContainer.left : parent.right
-            anchors.rightMargin: Theme.halfPadding
+            anchors.rightMargin: root.horizontalMargin
             anchors.verticalCenter: parent.verticalCenter
             width: 14
             opacity: mutedIconSensor.containsMouse ? 1.0 : 0.2
@@ -194,7 +197,7 @@ Rectangle {
             width: 32
             height: parent.height
             anchors.right: parent.right
-            anchors.rightMargin: Theme.halfPadding
+            anchors.rightMargin: root.horizontalMargin
             StatusBadge {
                 id: statusBadge
                 readonly property bool onlyUnread: !root.muted && root.notificationsCount === 0 && root.hasUnreadMessages

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -42,6 +42,15 @@ ColumnLayout {
 
     spacing: Theme.halfPadding
 
+    QtObject {
+        id: d
+
+        readonly property int delegateHorizontalPadding: Math.max(Theme.halfPadding, 8)
+        readonly property int scrollBarWidth: Math.max(Theme.halfPadding, 8)
+        // Includes the scrollbar width and a 1px gap before it.
+        readonly property int delegateRightSpacing: scrollBarWidth + 1
+    }
+
     RowLayout {
         Layout.fillWidth: true
         Layout.margins: Theme.padding
@@ -113,7 +122,10 @@ ColumnLayout {
         Layout.fillWidth: true
         Layout.fillHeight: true
         Layout.leftMargin: Theme.padding
-        Layout.rightMargin: Theme.padding
+        Layout.rightMargin: 0
+
+        verticalScrollBar.implicitWidth: d.scrollBarWidth
+        verticalScrollBar.width: d.scrollBarWidth
 
         model: SortFilterProxyModel {
             sourceModel: root.usersModel
@@ -138,7 +150,8 @@ ColumnLayout {
         section.property: "onlineStatus"
         section.delegate: (root.width > 58) ? sectionDelegateComponent : null
         delegate: StatusMemberListItem {
-            width: ListView.view.width
+            width: Math.max(0, ListView.view.width - d.delegateRightSpacing)
+            horizontalPadding: d.delegateHorizontalPadding
 
             usesDefaultName: model.usesDefaultName
             nickName: model.localNickname
@@ -185,7 +198,7 @@ ColumnLayout {
         id: sectionDelegateComponent
 
         Item {
-            width: ListView.view.width
+            width: Math.max(0, ListView.view.width - d.delegateRightSpacing)
             height: 24
 
             StatusBaseText {

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -36,6 +36,16 @@ Item {
     property RootStore store
     property var emojiPopup
 
+    QtObject {
+        id: d
+
+        readonly property int listContentLeftMarginOffset: 1
+        readonly property int listContentLeftMargin: SQUtils.Utils.swipeIndicatorWidth + listContentLeftMarginOffset
+        readonly property int scrollBarWidth: Math.max(Theme.halfPadding, 8)
+        // Includes StatusScrollView's 1px scrollbar inset and 1px gap before it.
+        readonly property int scrollBarSpacing: 2
+    }
+
     signal shareOwnProfileRequested()
     signal openAppSearch()
     signal addRemoveGroupMemberClicked()
@@ -131,12 +141,15 @@ Item {
         StatusScrollView {
             id: scrollView
             Layout.fillWidth: true
-            Layout.leftMargin: Theme.halfPadding
             Layout.fillHeight: true
 
             topPadding: 0
-            leftPadding: 0
+            leftPadding: d.listContentLeftMargin
+            rightPadding: d.scrollBarWidth + d.scrollBarSpacing
             contentWidth: availableWidth
+
+            ScrollBar.vertical.implicitWidth: d.scrollBarWidth
+            ScrollBar.vertical.width: d.scrollBarWidth
 
             StatusChatList {
                 id: channelList

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -87,6 +87,12 @@ Item {
 
         readonly property int requestToJoinState: root.communitySectionModule.requestToJoinState
         readonly property bool invitationPending: d.requestToJoinState !== Constants.RequestToJoinState.None
+
+        readonly property int listContentLeftMarginOffset: 1
+        readonly property int listContentLeftMargin: SQUtils.Utils.swipeIndicatorWidth + listContentLeftMarginOffset
+        readonly property int scrollBarWidth: Math.max(Theme.halfPadding, 8)
+        // Includes StatusScrollView's 1px scrollbar inset and 1px gap before it.
+        readonly property int scrollBarSpacing: 2
     }
 
     ColumnLayout {
@@ -199,17 +205,20 @@ Item {
             id: scrollView
 
             Layout.fillWidth: true
-            Layout.leftMargin: Theme.halfPadding
             Layout.fillHeight: true
 
             ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
             topPadding: 0
-            leftPadding: 0
+            leftPadding: d.listContentLeftMargin
+            rightPadding: d.scrollBarWidth + d.scrollBarSpacing
             contentWidth: availableWidth
             contentHeight: communityChatListAndCategories.height
                            + bannerColumn.height
                            + bannerColumn.anchors.topMargin
+
+            ScrollBar.vertical.implicitWidth: d.scrollBarWidth
+            ScrollBar.vertical.width: d.scrollBarWidth
 
             StatusChatListAndCategories {
                 id: communityChatListAndCategories


### PR DESCRIPTION
Closes #20593

### What does the PR do

1. Adjust 1:1 chat list margins and scrollbar spacing
2. Align community channel list margins and scrollbar spacing
3. Align member list margins and scrollbar spacing

    - Sets a thinner scrollbar width matching the Activity Center list pattern
    - Adds left content padding based on the swipe indicator width plus the standard minimum margin
    - Reserves right padding for the scrollbar and a small gap so delegates do not overlap it
    - Keeps the chat list geometry driven by `StatusScrollView` padding instead of manual child offsets
    - Refines chat list spacing to improve visual balance and consistency.

### Affected areas

- 1:1 chats list
- Community channels list
- Members list (group chat and channels)

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/c2f357c4-9cc9-4128-ae83-75be0d44fdc9

### Impact on end user

Better UX

### How to test

Navigate to the affected lists and verify that the margins, scrollbar spacing, and overall items layouts now appear more balanced and visually aligned with the navigation bar handler.

### Risk 

Low
