### PR TITLE
Chat input: minor padding alignments, Chat view: text overflow fixed

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -393,6 +393,8 @@ Item {
                     width: parent.width
                     visible: !!d.activeChatContentModule
 
+                    Theme.padding: Theme.defaultPadding
+
                     property string replyMessageId
 
                     // When `enabled` is switched true->false, `textInput.text` is cleared before d.activeChatContentModule updates.

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -163,6 +163,10 @@ Page {
 
             StatusChatInputNew {
                 id: chatInput
+
+                // Pinpoint default padding
+                Theme.padding: Theme.defaultPadding
+
                 Layout.alignment: Qt.AlignBottom
                 Layout.fillWidth: true
                 visible: membersSelector.model.count > 0

--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -723,7 +723,7 @@ Control {
 
                         topPadding: 9
                         bottomPadding: 9
-                        leftPadding: 0
+                        leftPadding: Theme.halfPadding // for the nav bar handle
                         rightPadding: Theme.halfPadding // for the scrollbar
 
                         messageLimit: root.messageLimit

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -657,9 +657,11 @@ Loader {
             font.pixelSize: Theme.secondaryTextFontSize
             width: parent.width - 120
             horizontalAlignment: Text.AlignHCenter
-            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.left: parent.left
+            anchors.right: parent.right
             textFormat: Text.RichText
             topPadding: root.prevMessageIndex === 1 ? Theme.bigPadding : 0
+            wrapMode: Text.Wrap
         }
     }
 


### PR DESCRIPTION
### What does the PR do

- Adds some paddings and fix them to constant size no matter padding size set in settings for chat input.
- Fixes overflow of system message text

Closes: https://github.com/status-im/status-app/issues/20570
Closes: https://github.com/status-im/status-app/issues/20495
Closes: https://github.com/status-im/status-app/issues/20976

### Affected areas
`StatusChatInputNew`

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="558" height="1242" alt="image" src="https://github.com/user-attachments/assets/7eca6ec7-a357-4795-b1b2-519ced08e4b4" />


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Low

### How to test

- Go to chat, inspect paddings around chat input field.
- Check if long system messages (long user names help) are wrapped

### Risk 
Low
