### PR TITLE
fix(display-name): fix editing display name is very laggy when in a comm

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -17,6 +17,7 @@ import "../controls"
 import "./profile"
 
 import StatusQ.Core
+import StatusQ.Core.Backpressure
 import StatusQ.Core.Theme
 import StatusQ.Core.Utils
 import StatusQ.Components
@@ -305,9 +306,38 @@ SettingsContentBase {
                 displayName.input.edit.readOnly: isEnsName
                 displayName.text: profileStore.displayName
                 displayName.placeholderText: profileStore.compressedPubKey
-                displayName.validationMode: StatusInput.ValidationMode.Always
-                displayName.validators: isEnsName || (profileStore.displayName === displayName.text) ? [] : displayNameValidators.validators
+                displayName.validators: []
                 bio.text: profileStore.bio
+
+                function setDisplayNameValidityAndErrorMessage(isValid, message) {
+                    displayName.valid = isValid
+                    displayName.errorMessage = message
+                    displayName.errorMessageCmp.text = message
+                }
+
+                function runFastDisplayNameValidation() {
+                    const value = descriptionPanel.displayName.text
+
+                    if (isEnsName || (profileStore.displayName === value)) {
+                        descriptionPanel.setDisplayNameValidityAndErrorMessage(true, "")
+                        return true
+                    }
+
+                    for (let idx in displayNameValidators.validators) {
+                        const validator = displayNameValidators.validators[idx]
+                        const result = validator.validate(value)
+                        const isValid = typeof result === "boolean" ? result : result.valid
+
+                        if (!isValid) {
+                            const message = (typeof result === "object" && result.errorMessage) ? result.errorMessage : validator.errorMessage
+                            descriptionPanel.setDisplayNameValidityAndErrorMessage(false, message)
+                            return false
+                        }
+                    }
+
+                    descriptionPanel.setDisplayNameValidityAndErrorMessage(true, "")
+                    return true
+                }
 
                 DisplayNameValidators {
                     id: displayNameValidators
@@ -315,6 +345,30 @@ SettingsContentBase {
                     utilsStore: root.utilsStore
                     myDisplayName: root.profileStore.name
                     communitiesStore: root.communitiesStore
+                }
+
+                Connections {
+                    target: descriptionPanel.displayName
+
+                    function onTextChanged() {
+                        if (!descriptionPanel.runFastDisplayNameValidation()) {
+                            return
+                        }
+
+                        Backpressure.debounce(root, 500, () => {
+                            const displayName = descriptionPanel.displayName.text
+                            if (!root.communitiesStore || displayName === root.profileStore.name) {
+                                descriptionPanel.setDisplayNameValidityAndErrorMessage(true, "")
+                                return
+                            }
+
+                            if (root.communitiesStore.isDisplayNameDupeOfCommunityMember(displayName)) {
+                                descriptionPanel.setDisplayNameValidityAndErrorMessage(false, qsTr("This Display Name is already in use in one of your joined communities"))
+                            } else {
+                                descriptionPanel.setDisplayNameValidityAndErrorMessage(true, "")
+                            }
+                        })()
+                    }
                 }
             }
         }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -6151,10 +6151,6 @@ key pair. Keycard will be required for signing</source>
         <source>Adjective-animal Display Name formats are not allowed</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>This Display Name is already in use in one of your joined communities</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>DisplaySeedPhrase</name>
@@ -12611,6 +12607,10 @@ to load</source>
     </message>
     <message>
         <source>Web</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This Display Name is already in use in one of your joined communities</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -7514,11 +7514,6 @@
       <comment>DisplayNameValidators</comment>
       <translation>Adjective-animal Display Name formats are not allowed</translation>
     </message>
-    <message>
-      <source>This Display Name is already in use in one of your joined communities</source>
-      <comment>DisplayNameValidators</comment>
-      <translation>This Display Name is already in use in one of your joined communities</translation>
-    </message>
   </context>
   <context>
     <name>DisplaySeedPhrase</name>
@@ -15375,6 +15370,11 @@
       <source>Web</source>
       <comment>MyProfileView</comment>
       <translation>Web</translation>
+    </message>
+    <message>
+      <source>This Display Name is already in use in one of your joined communities</source>
+      <comment>MyProfileView</comment>
+      <translation>This Display Name is already in use in one of your joined communities</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -6186,10 +6186,6 @@ key pair. Keycard will be required for signing</source>
         <source>Adjective-animal Display Name formats are not allowed</source>
         <translation>Formáty zobrazovaných jmen Přídavné jméno-zvíře nejsou povoleny</translation>
     </message>
-    <message>
-        <source>This Display Name is already in use in one of your joined communities</source>
-        <translation>Toto zobrazované jméno se již používá v jedné z vašich připojených komunit</translation>
-    </message>
 </context>
 <context>
     <name>DisplaySeedPhrase</name>
@@ -12710,6 +12706,10 @@ selhalo</translation>
     <message>
         <source>Web</source>
         <translation>Web</translation>
+    </message>
+    <message>
+        <source>This Display Name is already in use in one of your joined communities</source>
+        <translation type="unfinished">Toto zobrazované jméno se již používá v jedné z vašich připojených komunit</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -6164,10 +6164,6 @@ key pair. Keycard will be required for signing</source>
         <source>Adjective-animal Display Name formats are not allowed</source>
         <translation>No se permiten nombres públicos con el formato adjetivo-animal</translation>
     </message>
-    <message>
-        <source>This Display Name is already in use in one of your joined communities</source>
-        <translation>Este nombre público ya está en uso en una de tus comunidades unidas</translation>
-    </message>
 </context>
 <context>
     <name>DisplaySeedPhrase</name>
@@ -12628,6 +12624,10 @@ al cargar</translation>
     <message>
         <source>Web</source>
         <translation>Web</translation>
+    </message>
+    <message>
+        <source>This Display Name is already in use in one of your joined communities</source>
+        <translation type="unfinished">Este nombre público ya está en uso en una de tus comunidades unidas</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -6141,10 +6141,6 @@ key pair. Keycard will be required for signing</source>
         <source>Adjective-animal Display Name formats are not allowed</source>
         <translation>형용사-동물 형태의 표시 이름은 허용되지 않습니다</translation>
     </message>
-    <message>
-        <source>This Display Name is already in use in one of your joined communities</source>
-        <translation>이 표시 이름은 당신이 가입한 커뮤니티 중 하나에서 이미 사용 중입니다</translation>
-    </message>
 </context>
 <context>
     <name>DisplaySeedPhrase</name>
@@ -12589,6 +12585,10 @@ to load</source>
     <message>
         <source>Web</source>
         <translation>웹</translation>
+    </message>
+    <message>
+        <source>This Display Name is already in use in one of your joined communities</source>
+        <translation type="unfinished">이 표시 이름은 당신이 가입한 커뮤니티 중 하나에서 이미 사용 중입니다</translation>
     </message>
 </context>
 <context>

--- a/ui/imports/shared/validators/DisplayNameValidators.qml
+++ b/ui/imports/shared/validators/DisplayNameValidators.qml
@@ -48,16 +48,6 @@ QtObject {
             name: "isAliasValidator"
             validate: function (t) { return !root.utilsStore.isAlias(t) }
             errorMessage: qsTr("Adjective-animal Display Name formats are not allowed")
-        },
-        StatusValidator {
-            name: "isDuplicateInComunitiesValidator"
-            validate: displayName => {
-                if (!root.communitiesStore || displayName === root.myDisplayName)
-                    return true
-
-                return !communitiesStore.isDisplayNameDupeOfCommunityMember(displayName)
-            }
-            errorMessage: qsTr("This Display Name is already in use in one of your joined communities")
         }
     ]
 }


### PR DESCRIPTION
### What does the PR do

Fixes #20963

The problem was that we called `isDisplayNameDupeOfCommunityMember` for each character on the display name edit.

To fix it, I use a debounce on that function. I had to do the rest of the validation manually, since you cannot edit the error message from the outside if there is already a validation happening internally (it gets overwritten).

### Affected areas

MyProfileView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/68d8d58b-2475-4746-824c-4187b53194b7

### Impact on end user

Makes editing the input fast again

### How to test

- Join a big community
- Try to edit your display name
- try to use a name of someone in the community

### Risk 

Low