### PR TITLE
fix: assets page remains empty for ~15s for new user with 0 balances

### DIFF
--- a/src/app/modules/main/wallet_section/assets/balances_model.nim
+++ b/src/app/modules/main/wallet_section/assets/balances_model.nim
@@ -9,7 +9,8 @@ type
     TokenKey,
     ChainId,
     TokenAddress,
-    Balance
+    Balance,
+    Loading
 
 QtObject:
   type BalancesModel* = ref object of QAbstractListModel
@@ -43,7 +44,8 @@ QtObject:
       ModelRole.TokenKey.int:"tokenKey",
       ModelRole.ChainId.int:"chainId",
       ModelRole.TokenAddress.int:"tokenAddress",
-      ModelRole.Balance.int:"balance"
+      ModelRole.Balance.int:"balance",
+      ModelRole.Loading.int:"loading"
     }.toTable
 
   method data(self: BalancesModel, index: QModelIndex, role: int): QVariant =
@@ -67,6 +69,8 @@ QtObject:
         result = newQVariant(item.tokenAddress)
       of ModelRole.Balance:
         result = newQVariant(item.balance.toString(10))
+      of ModelRole.Loading:
+        result = newQVariant(item.loading)
 
   proc setup(self: BalancesModel) =
     self.QAbstractListModel.setup

--- a/src/app_service/service/wallet_account/dto/asset_group_item.nim
+++ b/src/app_service/service/wallet_account/dto/asset_group_item.nim
@@ -8,6 +8,7 @@ type
     chainId*: int
     tokenAddress*: string
     balance*: Uint256
+    loading*: bool ## true while status-go has no fetched balance for this (account, chain, token) yet
 
 type
   AssetGroupItem* = ref object of RootObj

--- a/src/app_service/service/wallet_account/service_token.nim
+++ b/src/app_service/service/wallet_account/service_token.nim
@@ -59,7 +59,8 @@ proc onAllTokensBuilt(self: Service, response: string) {.slot.} =
             if not rawBalanceStr.contains("nil"):
               rawBalance = rawBalanceStr.parse(Uint256)
 
-            if not balanceDetail{"hasError"}.getBool:
+            let hasError = balanceDetail{"hasError"}.getBool
+            if not hasError:
               allTokensHaveError = false
 
             let groupKey = token.groupKey
@@ -72,16 +73,17 @@ proc onAllTokensBuilt(self: Service, response: string) {.slot.} =
               tokenKey: token.key,
               tokenAddress: token.address,
               chainId: token.chainId,
-              balance: rawBalance
+              balance: rawBalance,
+              loading: hasError
             ))
 
         # set assetsLoading to false once the tokens are loaded
         self.updateAssetsLoadingState(accountAddress, false)
 
     groupedAssets = toSeq(groupedAssetsBalances.values)
+    self.groupedAssets = groupedAssets
     if not allTokensHaveError:
       self.hasBalanceCache = true
-      self.groupedAssets = groupedAssets
   except Exception as e:
     error "error: ", procName="onAllTokensBuilt", errName = e.name, errDesription = e.msg
 

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -6880,10 +6880,6 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Done</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -8407,11 +8407,6 @@
       <translation>Maybe later</translation>
     </message>
     <message>
-      <source>Done</source>
-      <comment>EnablePushNotificationsPopup</comment>
-      <translation>Done</translation>
-    </message>
-    <message>
       <source>Open settings</source>
       <comment>EnablePushNotificationsPopup</comment>
       <translation>Open settings</translation>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -6917,10 +6917,6 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished">Možná později</translation>
     </message>
     <message>
-        <source>Done</source>
-        <translation type="unfinished">Hotovo</translation>
-    </message>
-    <message>
         <source>Open settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -6893,10 +6893,6 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished">Quizás más tarde</translation>
     </message>
     <message>
-        <source>Done</source>
-        <translation type="unfinished">Listo</translation>
-    </message>
-    <message>
         <source>Open settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -6868,10 +6868,6 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished">나중에</translation>
     </message>
     <message>
-        <source>Done</source>
-        <translation type="unfinished">완료</translation>
-    </message>
-    <message>
         <source>Open settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/imports/shared/controls/TokenDelegate.qml
+++ b/ui/imports/shared/controls/TokenDelegate.qml
@@ -16,6 +16,7 @@ StatusListItem {
     property string name
     property url icon
     property string balance
+    property bool balanceLoading: false
 
     property bool marketDetailsAvailable: false
     property string marketBalance
@@ -46,6 +47,7 @@ StatusListItem {
 
     title: root.name
     subTitle: root.balance
+    loadingSubTitle: root.balanceLoading
     asset.name: root.icon
     asset.isImage: true
     asset.width: 32
@@ -86,7 +88,7 @@ StatusListItem {
                 anchors.right: parent.right
                 visible: !errorIcon.visible && root.marketDetailsAvailable
 
-                loading: root.marketDetailsLoading
+                loading: root.marketDetailsLoading || root.balanceLoading
                 text: loading ? Constants.dummyText : root.marketBalance
             }
             Row {

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -80,6 +80,7 @@ Control {
         detailsLoading              [bool]      - `true` if details are still being loaded
         balance                     [double]    - tokens balance is the commonly used unit, e.g. 1.2 for 1.2 ETH, used for sorting and computing market value
         balanceText                 [string]    - formatted and localized balance. This is not done internally because it may depend on many external factors
+        balanceLoading              [bool]      - true while at least one of the per-(chain, account) balances has not been fetched yet
         error                       [string]    - error message related to balance
         marketDetailsAvailable      [bool]      - specifies if market datails are available for given token
         marketDetailsLoading        [bool]      - specifies if market datails are available for given token
@@ -282,6 +283,7 @@ Control {
                 name: model.name
                 icon: model.logoUri
                 balance: model.balanceText
+                balanceLoading: model.balanceLoading
                 marketBalance: root.formatFiat(model.marketBalance)
 
                 marketDetailsAvailable: model.marketDetailsAvailable

--- a/ui/imports/shared/views/AssetsViewAdaptor.qml
+++ b/ui/imports/shared/views/AssetsViewAdaptor.qml
@@ -65,12 +65,14 @@ QObject {
         All roles from the source model are passed directly to the output model,
         additionally:
 
-        key         [string] - refers to token group key
-        icon        [url]    - from image or fetched by symbol for well-known tokens
-        balance     [double] - tokens balance is the commonly used unit, e.g. 1.2 for 1.2 ETH,
-                               computed from balances according to provided criteria
-        balanceText [string] - formatted and localized balance
-        error       [string] - error message related to balance
+        key            [string] - refers to token group key
+        icon           [url]    - from image or fetched by symbol for well-known tokens
+        balance        [double] - tokens balance is the commonly used unit, e.g. 1.2 for 1.2 ETH,
+                                  computed from balances according to provided criteria
+        balanceText    [string] - formatted and localized balance
+        balanceLoading [bool]   - true while any per-(chain, account) balance matching the
+                                  active filter has not been fetched yet from status-go
+        error          [string] - error message related to balance
 
         marketDetailsAvailable [bool]   - specifies if market datails are available for given token
         marketDetailsLoading   [bool]   - specifies if market datails are available for given token
@@ -103,6 +105,7 @@ QObject {
             readonly property double balance:
                 AmountsArithmetic.toNumber(totalBalanceAggregator.value, model.decimals)
             readonly property string balanceText: root.formatBalance(balance, model.key)
+            readonly property bool balanceLoading: loadingBalancesAggregator.value > 0
 
             readonly property bool marketDetailsAvailable: !hasCommunityId
             readonly property bool marketDetailsLoading: model.detailsLoading
@@ -117,6 +120,11 @@ QObject {
                     return false
 
                 if (hasCommunityId)
+                    return true
+
+                // Keep mandatory/known tokens visible while their balances are still being fetched,
+                // so the user sees them in a loading state instead of having an empty Assets tab.
+                if (balanceLoading)
                     return true
 
                 return balance * marketPrice >= root.marketValueThreshold
@@ -179,6 +187,16 @@ QObject {
 
                 aggregateFunction: (aggr, value) => [...aggr, value]
             }
+
+            FunctionAggregator {
+                id: loadingBalancesAggregator
+
+                model: filteredBalances
+                initialValue: 0
+                roleName: "loading"
+
+                aggregateFunction: (aggr, value) => aggr + (value ? 1 : 0)
+            }
         }
 
         expectedRoles:
@@ -186,7 +204,7 @@ QObject {
              "detailsLoading", "marketDetails", "communityId", "communityImage",
              "visible"]
         exposedRoles:
-            ["error", "balance", "balanceText", "icon",
+            ["error", "balance", "balanceText", "balanceLoading", "icon",
              "visible", "canBeHidden", "marketDetailsAvailable", "marketDetailsLoading",
              "marketPrice", "marketChangePct24hour", "communityIcon"]
     }


### PR DESCRIPTION
- Added a `loading` property to the `AssetGroupItem` type to track balance fetching status.
- Updated `BalancesModel` to include loading state in data retrieval.
- Modified `onAllTokensBuilt` to set loading state based on balance errors.
- Loading states for balances introduced to the assets tab.

Closes: #20980