### PR TITLE
StatusModal: StatusModal footer layout improved

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import StatusQ.Core
 import StatusQ.Controls
@@ -232,24 +233,27 @@ StatusDialog {
 
     footer: ToolBar {
         visible: root.showFooter || root.showAdvancedFooter
-        background: StatusDialogBackground {
-            implicitHeight: footerImpl.implicitHeight
-        }
+        background: StatusDialogBackground {}
         position: ToolBar.Bottom
-        Spares.StatusModalFooter {
-            id: footerImpl
-            anchors.bottom: parent.bottom
-            width: visible ? parent.width : 0
-            height: visible ? implicitHeight : 0
-            showFooter: root.showFooter
-            visible: root.showFooter
-        }
 
-        Loader {
-            id: advancedFooter
-            anchors.bottom: parent.bottom
-            width: visible ? parent.width : 0
-            active: root.showAdvancedFooter
+        ColumnLayout {
+            anchors.fill: parent
+
+            Spares.StatusModalFooter {
+                id: footerImpl
+
+                Layout.fillWidth: true
+                showFooter: root.showFooter
+                visible: root.showFooter
+            }
+
+            Loader {
+                id: advancedFooter
+
+                Layout.fillWidth: true
+                active: root.showAdvancedFooter
+                visible: active
+            }
         }
     }
 }


### PR DESCRIPTION
### What does the PR do

Fixes layout of `StatusModal`'s footer resulting with broken layout when safe area is present.

### Affected areas
`StatusModal`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="558" height="1242" alt="image" src="https://github.com/user-attachments/assets/daa36489-89e5-4297-8f3b-4fbe74a24e2d" />

<img width="558" height="1242" alt="image" src="https://github.com/user-attachments/assets/5e57da7a-8ba3-4ce1-a4ac-afab466fa84e" />


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user
Somehow important, gives access to ui elements which were previously clipped.

### How to test
- On mobile long press on owned community (on the left nav bar) to trigger menu, click "Invite People".
- Open owned community, click "Add channels" button, scroll to bottom

### Risk 
Low
