### PR TITLE
chore: introduces a new mandatory usds token

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/ManageTokensDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ManageTokensDelegate.qml
@@ -87,7 +87,7 @@ DropArea {
         hasImage: true
         icon.source: {
             // TODO unify via backend model for both assets and collectibles; handle communityPrivilegesLevel
-            let source = root.isCollectible || root.isCommunityToken ? model.imageUrl : ""
+            let source = model.imageUrl
             if (source === "")
                 source = Constants.tokenIcon(model.symbol)
             return source

--- a/ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml
@@ -87,9 +87,21 @@ QtObject {
         ]
     }
 
+    /* PRIVATE: Adds an "imageUrl" proxy role mirroring "logoUri" (ManageTokensController can still use existing imageUrl)
+        while the original "logoUri" role is here. */
+    readonly property var _tokenGroupsModelWithImageUrl: SortFilterProxyModel {
+        sourceModel: root.walletTokensStore.tokenGroupsModel
+        proxyRoles: [
+            JoinRole {
+              name: "imageUrl"
+              roleNames: ["logoUri"]
+            }
+        ]
+    }
+
     /* PRIVATE: This model joins the "Token Groups Model" and "Communities Model" by communityId */
     property LeftJoinModel _tokenGroupsModelWithCommunityInfo: LeftJoinModel {
-        leftModel: root.walletTokensStore.tokenGroupsModel
+        leftModel: _tokenGroupsModelWithImageUrl
         rightModel: _renamedCommunitiesModel
         joinRole: "communityId"
     }


### PR DESCRIPTION
Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/7455

Changes:
- introduces a new mandatory usds token
- use a real token image that is coming from the token lists instead of locally stored images

Closes #20979