### PR TITLE
fix(android): back navigation

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
@@ -150,6 +150,19 @@ QC.Popup {
        }
     }
 
+    // Take focus while open so the section Back shortcut (handled by AppMain)
+    // isn't delivered there; the Shortcut below closes the dropdown instead.
+    focus: true
+
+    // Close on the Back shortcut. A Shortcut (not Keys) is used because QC.Popup
+    // is not an Item, so Keys handlers on it / its background never receive the
+    // event. Mobile's Qt.Key_Back is already routed to closePolicy by Qt.
+    Shortcut {
+        sequences: [StandardKey.Back]
+        enabled: root.opened
+        onActivated: root.close()
+    }
+
     // workaround for https://bugreports.qt.io/browse/QTBUG-87804
     Binding on margins {
         id: workaroundBinding

--- a/ui/StatusQ/src/StatusQ/Core/Utils/NavigationHistory.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/NavigationHistory.qml
@@ -25,9 +25,7 @@ QtObject {
     readonly property bool canGoBack: d.depth > 0
 
     onMaxDepthChanged: {
-        while (d.stack.length > root.maxDepth)
-            d.stack.shift()
-        d.depth = d.stack.length
+        d.trim()
     }
 
     /*!
@@ -40,9 +38,7 @@ QtObject {
         if (d.stack.length > 0 && d.stack[d.stack.length - 1] === token)
             return
         d.stack.push(token)
-        while (d.stack.length > root.maxDepth)
-            d.stack.shift()
-        d.depth = d.stack.length
+        d.trim()
     }
 
     /*!
@@ -72,5 +68,11 @@ QtObject {
         // depth mirrors d.stack.length; updated by every mutator so canGoBack stays reactive
         property var stack: []
         property int depth: 0
+
+        function trim() {
+            while (d.stack.length > Math.max(0, root.maxDepth))
+                d.stack.shift()
+            d.depth = d.stack.length
+        }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Core/Utils/NavigationHistory.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/NavigationHistory.qml
@@ -41,6 +41,13 @@ QtObject {
         d.trim()
     }
 
+    /*! Returns the top token without popping it, or "" when the stack is empty. */
+    function peek() {
+        if (d.stack.length === 0)
+            return ""
+        return d.stack[d.stack.length - 1]
+    }
+
     /*!
        Pops and returns the top token. The recorder pushes the *previous*
        section id whenever the active section changes, so the popped value

--- a/ui/StatusQ/src/StatusQ/Core/Utils/NavigationHistory.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/NavigationHistory.qml
@@ -1,0 +1,76 @@
+import QtQml
+
+/*!
+   \qmltype NavigationHistory
+   \inqmlmodule StatusQ.Core.Utils
+
+   A generic, opaque bounded stack of navigation tokens. Pure data structure —
+   no backend, no model access, no UI. Designed to be instantiated wherever
+   ordered back-navigation history is needed (e.g. section-scope inside
+   AppMain, or subsection-scope inside a section).
+
+   Consecutive duplicates (record(t) when t === top) are silently dropped.
+   Empty / null / undefined tokens are ignored. Stack length is bounded by
+   maxDepth; the oldest entry is evicted on overflow.
+*/
+QtObject {
+    id: root
+
+    /*! Maximum stack depth. Oldest entry is evicted on overflow. */
+    property int maxDepth: 16
+
+    // canGoBack depends on d.depth — a scalar mirror of d.stack.length —
+    // because QML does not notify on Array.push/pop mutations of a var array.
+    /*! True when there is at least one token to pop. */
+    readonly property bool canGoBack: d.depth > 0
+
+    onMaxDepthChanged: {
+        while (d.stack.length > root.maxDepth)
+            d.stack.shift()
+        d.depth = d.stack.length
+    }
+
+    /*!
+       Push a token. No-op if equal to the current top (consecutive de-dup),
+       or if the token is empty / null / undefined. Caps the stack to maxDepth.
+    */
+    function record(token) {
+        if (token === undefined || token === null || token === "")
+            return
+        if (d.stack.length > 0 && d.stack[d.stack.length - 1] === token)
+            return
+        d.stack.push(token)
+        while (d.stack.length > root.maxDepth)
+            d.stack.shift()
+        d.depth = d.stack.length
+    }
+
+    /*!
+       Pops and returns the top token. The recorder pushes the *previous*
+       section id whenever the active section changes, so the popped value
+       IS the next navigation destination — callers should navigate directly
+       to the returned token. Returns "" when the stack is empty.
+    */
+    function back() {
+        if (d.stack.length === 0)
+            return ""
+        const token = d.stack.pop()
+        d.depth = d.stack.length
+        return token
+    }
+
+    /*! Empty the stack. */
+    function clear() {
+        if (d.stack.length === 0)
+            return
+        d.stack = []
+        d.depth = 0
+    }
+
+    readonly property QtObject _d: QtObject {
+        id: d
+        // depth mirrors d.stack.length; updated by every mutator so canGoBack stays reactive
+        property var stack: []
+        property int depth: 0
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/Utils/SubsectionNavigationHistory.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/SubsectionNavigationHistory.qml
@@ -1,0 +1,103 @@
+import QtQml
+
+import StatusQ.Core.Utils as SQUtils
+
+/*!
+   \qmltype SubsectionNavigationHistory
+   \inqmlmodule StatusQ.Core.Utils
+
+   Subsection-scope back history for a single app section. Records the previous
+   \c currentKey whenever it changes; \c tryGoBack() pops the newest still-valid
+   key and emits \c navigateRequested for the owner to navigate to it.
+
+   The recording is async-safe: it ignores the \c currentKey change caused by our
+   own back-navigation (matched by token), so it stays correct even when the
+   section's setter applies asynchronously (e.g. chat's \c setActiveItem).
+*/
+QtObject {
+    id: root
+
+    /*! Bound by the owner to the active-subsection identity (string or int). */
+    property var currentKey
+
+    /*!
+       Optional \c {function(token) -> bool}; tokens it rejects (subsections that
+       no longer exist) are skipped on pop. The token is always a string, so
+       coerce as needed, e.g.
+       \c {validateFn: key => ModelUtils.indexOf(model, role, parseInt(key)) >= 0}.
+    */
+    property var validateFn: null
+
+    /*! Emitted when the owner should navigate to \c key (wire to its setter). */
+    signal navigateRequested(var key)
+
+    /*! True when there is at least one key to pop. */
+    readonly property bool canGoBack: d.history.canGoBack
+
+    /*! Pop the newest still-valid key and request navigation to it. */
+    function tryGoBack() {
+        while (d.history.canGoBack) {
+            const token = d.history.back()
+            if (token === "")
+                continue
+            if (root.validateFn && !root.validateFn(token))
+                continue // subsection gone; pop next
+            d.pendingBackTarget = token
+            root.navigateRequested(token)
+            return true
+        }
+        return false
+    }
+
+    /*!
+       Dismiss the active subsection: it won't be recorded when the user next
+       navigates away. Call when Back returns to the section's list/root view —
+       an explicit dismissal must not be retraced later.
+    */
+    function dropLeaf() {
+        d.lastKey = ""
+    }
+
+    /*! Empty the history and clear any in-flight back guard. */
+    function clear() {
+        d.history.clear()
+        d.pendingBackTarget = undefined
+    }
+
+    onCurrentKeyChanged: {
+        const cur = d.norm(root.currentKey)
+        const prev = d.norm(d.lastKey)
+        d.lastKey = root.currentKey
+
+        // Our own back-navigation settling: consume the guard, don't record.
+        if (d.pendingBackTarget !== undefined && cur === d.norm(d.pendingBackTarget)) {
+            d.pendingBackTarget = undefined
+            return
+        }
+        // Any other change while a back is in flight cancels the guard.
+        d.pendingBackTarget = undefined
+
+        if (prev !== "")
+            d.history.record(prev)
+    }
+
+    Component.onCompleted: d.lastKey = root.currentKey
+
+    readonly property QtObject _d: QtObject {
+        id: d
+
+        // Token currentKey is expected to settle to from our own tryGoBack();
+        // while set, the matching currentKey change is not recorded.
+        property var pendingBackTarget: undefined
+        property var lastKey: undefined
+
+        readonly property NavigationHistory history: SQUtils.NavigationHistory {}
+
+        // Normalize to a string token (ints and strings share one path).
+        function norm(k) {
+            if (k === undefined || k === null)
+                return ""
+            return "" + k
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
@@ -16,6 +16,7 @@ RecursiveStackView 0.1 RecursiveStackView.qml
 SearchFilter 0.1 SearchFilter.qml
 StackViewStates 0.1 StackViewStates.qml
 StatesStack 0.1 StatesStack.qml
+SubsectionNavigationHistory 0.1 SubsectionNavigationHistory.qml
 Subscription 0.1 Subscription.qml
 SubscriptionBroker 0.1 SubscriptionBroker.qml
 SubscriptionBrokerCommunities 0.1 SubscriptionBrokerCommunities.qml

--- a/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
@@ -10,6 +10,7 @@ ModelChangeGuard 0.1 ModelChangeGuard.qml
 ModelChangeTracker 0.1 ModelChangeTracker.qml
 ModelEntryChangeTracker 0.1 ModelEntryChangeTracker.qml
 ModelsComparator 0.1 ModelsComparator.qml
+NavigationHistory 0.1 NavigationHistory.qml
 QObject 0.1 QObject.qml
 RecursiveStackView 0.1 RecursiveStackView.qml
 SearchFilter 0.1 SearchFilter.qml

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -181,11 +181,44 @@ LayoutChooser {
             portraitView.decrementCurrentIndex()
     }
 
+    /*!
+        Optional StatusQ.Core.Utils.SubsectionNavigationHistory. When set, Back
+        steps the portrait SwipeView panels first, then retraces subsection
+        navigation within the section before the section is left.
+    */
+    property var subsectionHistory: null
+
     function tryGoBack() {
-        if (portraitView.visible)
-            return portraitView.tryGoBack()
+        if (portraitView.visible && portraitView.tryGoBack()) // view tier
+            return true
+        if (root.subsectionHistory && root.subsectionHistory.tryGoBack()) { // subsection tier
+            // Advance to the central panel so the restored subsection's detail is
+            // shown (mirrors a normal item click); no-op in landscape.
+            root.goToNextPanel()
+            return true
+        }
         return false
     }
+
+    // Returning to the leaf (left) panel — via Back, the header back button or a
+    // swipe — dismisses the active subsection so it isn't retraced later.
+    Connections {
+        target: portraitView
+        enabled: !!root.subsectionHistory
+        function onCurrentIndexChanged() {
+            if (portraitView.currentIndex === 0)
+                root.subsectionHistory.dropLeaf()
+        }
+    }
+
+    /*!
+        True when Back can step the portrait SwipeView, trigger the header back
+        button, or retrace subsection history. Used by AppMain to enable the
+        desktop Back shortcut / mouse button for in-section navigation.
+    */
+    readonly property bool canGoBack:
+        (portraitView.visible && portraitView.canGoBackInternally)
+        || (!!root.subsectionHistory && root.subsectionHistory.canGoBack)
 
     readonly property int windowWidth: root.Window?.width ?? Screen.width
 

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -182,6 +182,19 @@ LayoutChooser {
     }
 
     /*!
+        Optional innermost Back tier, offered the press before the view tier.
+        Duck-typed as \c {{ readonly property bool canGoBack; function tryGoBack(): bool }} —
+        the same interface as \c subsectionHistory. Set it to give a section
+        navigation that lives *inside* its content, e.g. the Browser's web history.
+
+        Prefer this over redeclaring \c tryGoBack() in a derived component: QML has
+        no way to call the shadowed base implementation, so an override silently
+        drops the view and subsection tiers, and \c canGoBack (being \c readonly)
+        cannot be extended to match.
+    */
+    property var contentHistory: null
+
+    /*!
         Optional StatusQ.Core.Utils.SubsectionNavigationHistory. When set, Back
         steps the portrait SwipeView panels first, then retraces subsection
         navigation within the section before the section is left.
@@ -189,6 +202,8 @@ LayoutChooser {
     property var subsectionHistory: null
 
     function tryGoBack() {
+        if (root.contentHistory && root.contentHistory.tryGoBack()) // content tier
+            return true
         if (portraitView.visible && portraitView.tryGoBack()) // view tier
             return true
         if (root.subsectionHistory && root.subsectionHistory.tryGoBack()) { // subsection tier
@@ -212,12 +227,15 @@ LayoutChooser {
     }
 
     /*!
-        True when Back can step the portrait SwipeView, trigger the header back
-        button, or retrace subsection history. Used by AppMain to enable the
-        desktop Back shortcut / mouse button for in-section navigation.
+        True when Back can step the section's content, the portrait SwipeView,
+        trigger the header back button, or retrace subsection history. Used by
+        AppMain to enable the desktop Back shortcut / mouse button for in-section
+        navigation. Must stay the exact disjunction of the tiers tried by
+        \c tryGoBack(), or the entry points will be gated on a stale predicate.
     */
     readonly property bool canGoBack:
-        (portraitView.visible && portraitView.canGoBackInternally)
+        (!!root.contentHistory && root.contentHistory.canGoBack)
+        || (portraitView.visible && portraitView.canGoBackInternally)
         || (!!root.subsectionHistory && root.subsectionHistory.canGoBack)
 
     readonly property int windowWidth: root.Window?.width ?? Screen.width

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -181,6 +181,12 @@ LayoutChooser {
             portraitView.decrementCurrentIndex()
     }
 
+    function tryGoBack() {
+        if (portraitView.visible)
+            return portraitView.tryGoBack()
+        return false
+    }
+
     readonly property int windowWidth: root.Window?.width ?? Screen.width
 
     criteria: [

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayoutPortrait.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayoutPortrait.qml
@@ -155,24 +155,48 @@ SwipeView {
         // Cache wrapper items removed from the swipe view
         property list<Item> items: []
 
+        function canGoBack() {
+            return root.currentIndex > 0 || !!root.backButtonName
+        }
+
         function handleBackAction() {
             if (!!root.backButtonName) {
                 root.backButtonClicked()
                 return
             }
-
-            if (root.currentIndex > 0) {
+            if (root.currentIndex > 0)
                 root.currentIndex--
-            }
         }
     }
 
     Keys.onPressed: function(e) {
-        if (e.key === Qt.Key_Back && root.currentIndex > 0) {
+        if (e.key === Qt.Key_Back && d.canGoBack()) {
             e.accepted = true
             d.handleBackAction()
         }
     }
+
+    function tryGoBack() {
+        if (d.canGoBack()) {
+            d.handleBackAction()
+            return true
+        }
+        return false
+    }
+
+    onCurrentItemChanged: {
+        if (currentItem) {
+            currentItem.focus = true
+            currentItem.forceActiveFocus()
+        }
+    }
+
+    onVisibleChanged: {
+         if (visible && currentItem) {
+             currentItem.focus = true
+             currentItem.forceActiveFocus()
+         }
+     }
 
     component BaseProxyPanel : Control {
         id: baseProxyPanel

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayoutPortrait.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayoutPortrait.qml
@@ -150,14 +150,13 @@ SwipeView {
     */
     signal backButtonClicked()
 
+    // Bound (not a function) so StatusSectionLayout.canGoBack stays reactive.
+    readonly property bool canGoBackInternally: root.currentIndex > 0 || !!root.backButtonName
+
     QtObject {
         id: d
         // Cache wrapper items removed from the swipe view
         property list<Item> items: []
-
-        function canGoBack() {
-            return root.currentIndex > 0 || !!root.backButtonName
-        }
 
         function handleBackAction() {
             if (!!root.backButtonName) {
@@ -170,14 +169,14 @@ SwipeView {
     }
 
     Keys.onPressed: function(e) {
-        if (e.key === Qt.Key_Back && d.canGoBack()) {
+        if (e.key === Qt.Key_Back && root.canGoBackInternally) {
             e.accepted = true
             d.handleBackAction()
         }
     }
 
     function tryGoBack() {
-        if (d.canGoBack()) {
+        if (root.canGoBackInternally) {
             d.handleBackAction()
             return true
         }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -190,6 +190,14 @@ Dialog {
         id: background
     }
 
+    Connections {
+        target: background
+        ignoreUnknownSignals: true
+        function onCloseRequested() {
+            root.closeHandler()
+        }
+    }
+
     header: StatusDialogHeader {
         id: dialogHeader
         visible: root.title || root.subtitle

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogBackground.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogBackground.qml
@@ -28,7 +28,6 @@ Rectangle {
         onClicked: function(mouse) {
             if (mouse.button !== Qt.BackButton)
                 return
-            mouse.accepted = true
             root.closeRequested()
         }
     }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogBackground.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogBackground.qml
@@ -4,8 +4,12 @@ import QtQuick.Controls
 import StatusQ.Core.Theme
 
 Rectangle {
+    id: root
+
     color: Theme.palette.statusModal.backgroundColor
     radius: Theme.radius
+
+    signal closeRequested()
 
     MouseArea { // eat every event behind the control
         anchors.fill: parent
@@ -14,6 +18,19 @@ Rectangle {
         onPressed: event => event.accepted = true
         onPressAndHold: event => event.accepted = true
         onWheel: wheel => wheel.accepted = true
+    }
+
+    // "Back" handler
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.BackButton
+        cursorShape: undefined // fall thru
+        onClicked: function(mouse) {
+            if (mouse.button !== Qt.BackButton)
+                return
+            mouse.accepted = true
+            root.closeRequested()
+        }
     }
 
     ContextMenu.onRequested: ;

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -216,6 +216,7 @@
         <file>StatusQ/Core/Utils/Subscription.qml</file>
         <file>StatusQ/Core/Utils/SubscriptionBroker.qml</file>
         <file>StatusQ/Core/Utils/SubscriptionBrokerCommunities.qml</file>
+        <file>StatusQ/Core/Utils/SubsectionNavigationHistory.qml</file>
         <file>StatusQ/Core/Utils/TextDocumentUtils.qml</file>
         <file>StatusQ/Core/Utils/Utils.qml</file>
         <file>StatusQ/Core/Utils/big.min.mjs</file>

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -205,6 +205,7 @@
         <file>StatusQ/Core/Utils/ModelEntryChangeTracker.qml</file>
         <file>StatusQ/Core/Utils/ModelUtils.qml</file>
         <file>StatusQ/Core/Utils/ModelsComparator.qml</file>
+        <file>StatusQ/Core/Utils/NavigationHistory.qml</file>
         <file>StatusQ/Core/Utils/OperatorsUtils.qml</file>
         <file>StatusQ/Core/Utils/QObject.qml</file>
         <file>StatusQ/Core/Utils/RecursiveStackView.qml</file>

--- a/ui/StatusQ/tests/TestCore/TestUtils/tst_NavigationHistory.qml
+++ b/ui/StatusQ/tests/TestCore/TestUtils/tst_NavigationHistory.qml
@@ -1,0 +1,101 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Core.Utils
+
+Item {
+    id: root
+
+    Component {
+        id: testComponent
+        NavigationHistory {}
+    }
+
+    TestCase {
+        name: "NavigationHistory"
+
+        function test_initial_state() {
+            const h = createTemporaryObject(testComponent, root)
+            verify(!!h)
+            compare(h.canGoBack, false)
+            compare(h.back(), "")
+        }
+
+        function test_record_and_back() {
+            const h = createTemporaryObject(testComponent, root)
+            h.record("A")
+            h.record("B")
+            h.record("C")
+            compare(h.canGoBack, true)
+            compare(h.back(), "C")
+            compare(h.back(), "B")
+            compare(h.back(), "A")
+            compare(h.canGoBack, false)
+            compare(h.back(), "")
+        }
+
+        function test_consecutive_dedup() {
+            const h = createTemporaryObject(testComponent, root)
+            h.record("A")
+            h.record("A")
+            h.record("A")
+            compare(h.canGoBack, true)
+            compare(h.back(), "A")
+            compare(h.canGoBack, false)
+        }
+
+        function test_non_consecutive_duplicates_kept() {
+            const h = createTemporaryObject(testComponent, root)
+            h.record("A")
+            h.record("B")
+            h.record("A")
+            compare(h.back(), "A")
+            compare(h.back(), "B")
+            compare(h.back(), "A")
+            compare(h.canGoBack, false)
+        }
+
+        function test_record_ignores_empty_token() {
+            const h = createTemporaryObject(testComponent, root)
+            h.record("")
+            h.record(null)
+            h.record(undefined)
+            compare(h.canGoBack, false)
+        }
+
+        function test_maxDepth_eviction() {
+            const h = createTemporaryObject(testComponent, root)
+            h.maxDepth = 3
+            h.record("A")
+            h.record("B")
+            h.record("C")
+            h.record("D") // evicts A
+            compare(h.back(), "D")
+            compare(h.back(), "C")
+            compare(h.back(), "B")
+            compare(h.canGoBack, false)
+        }
+
+        function test_clear() {
+            const h = createTemporaryObject(testComponent, root)
+            h.record("A")
+            h.record("B")
+            h.clear()
+            compare(h.canGoBack, false)
+            compare(h.back(), "")
+        }
+
+        function test_maxDepth_reduction_trims_existing_entries() {
+            const h = createTemporaryObject(testComponent, root)
+            h.record("A")
+            h.record("B")
+            h.record("C")
+            h.record("D")
+            compare(h.canGoBack, true)
+            h.maxDepth = 2  // should evict A and B
+            compare(h.back(), "D")
+            compare(h.back(), "C")
+            compare(h.canGoBack, false)
+        }
+    }
+}

--- a/ui/StatusQ/tests/TestCore/TestUtils/tst_NavigationHistory.qml
+++ b/ui/StatusQ/tests/TestCore/TestUtils/tst_NavigationHistory.qml
@@ -27,11 +27,14 @@ Item {
             h.record("B")
             h.record("C")
             compare(h.canGoBack, true)
+            compare(h.peek(), "C")
             compare(h.back(), "C")
+            compare(h.peek(), "B")
             compare(h.back(), "B")
             compare(h.back(), "A")
             compare(h.canGoBack, false)
             compare(h.back(), "")
+            compare(h.peek(), "")
         }
 
         function test_consecutive_dedup() {

--- a/ui/StatusQ/tests/TestCore/TestUtils/tst_SubsectionNavigationHistory.qml
+++ b/ui/StatusQ/tests/TestCore/TestUtils/tst_SubsectionNavigationHistory.qml
@@ -1,0 +1,153 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Core.Utils
+
+Item {
+    id: root
+
+    // Test helper: applies navigateRequested back to currentKey, the way a real
+    // section's setter eventually would. `applyNavigation` lets a test choose to
+    // apply it synchronously (default) or defer it (to model the async case).
+    Component {
+        id: testComponent
+        SubsectionNavigationHistory {
+            property var lastRequested: undefined
+            property bool applyNavigation: true
+            onNavigateRequested: (key) => {
+                lastRequested = key
+                if (applyNavigation)
+                    currentKey = key
+            }
+        }
+    }
+
+    TestCase {
+        name: "SubsectionNavigationHistory"
+
+        function make(props) {
+            const h = createTemporaryObject(testComponent, root, props)
+            verify(!!h)
+            return h
+        }
+
+        function test_initial_state() {
+            const h = make({ currentKey: "A" })
+            compare(h.canGoBack, false)
+            compare(h.tryGoBack(), false)
+        }
+
+        function test_records_previous_on_change() {
+            const h = make({ currentKey: "A" })
+            h.currentKey = "B" // records A
+            compare(h.canGoBack, true)
+            h.currentKey = "C" // records B
+            compare(h.canGoBack, true)
+        }
+
+        function test_back_navigates_and_does_not_rerecord() {
+            const h = make({ currentKey: "A" })
+            h.currentKey = "B" // records A
+            h.currentKey = "C" // records B
+            // Back to B (applies synchronously via the test handler).
+            compare(h.tryGoBack(), true)
+            compare(h.lastRequested, "B")
+            compare(h.currentKey, "B")
+            // The settling of our own back navigation must NOT have been recorded.
+            compare(h.tryGoBack(), true)
+            compare(h.lastRequested, "A")
+            compare(h.currentKey, "A")
+            compare(h.canGoBack, false)
+        }
+
+        function test_async_back_guard() {
+            // Model the async setter: navigateRequested does not immediately
+            // change currentKey; the change arrives later. The guard must still
+            // suppress the re-record.
+            const h = make({ currentKey: "A", applyNavigation: false })
+            h.currentKey = "B" // records A
+            h.currentKey = "C" // records B
+            compare(h.tryGoBack(), true)
+            compare(h.lastRequested, "B")
+            compare(h.currentKey, "C") // not applied yet
+            // Now the async change lands:
+            h.currentKey = "B"
+            // It was the pending back target, so nothing new is recorded; A remains.
+            h.applyNavigation = true
+            compare(h.tryGoBack(), true)
+            compare(h.lastRequested, "A")
+            compare(h.canGoBack, false)
+        }
+
+        function test_unrelated_change_cancels_guard() {
+            const h = make({ currentKey: "A", applyNavigation: false })
+            h.currentKey = "B" // records A
+            h.currentKey = "C" // records B
+            h.tryGoBack()      // pending target = B, not yet applied
+            // User navigates somewhere else instead of the back settling:
+            h.currentKey = "D" // cancels guard, records C
+            h.applyNavigation = true
+            // History should now be A, B, C (B was the popped one; C recorded on D).
+            compare(h.tryGoBack(), true)
+            compare(h.lastRequested, "C")
+        }
+
+        function test_stale_token_skipped_via_validateFn() {
+            const h = make({ currentKey: "A" })
+            h.validateFn = (token) => token !== "B" // B is "gone"
+            h.currentKey = "B" // records A
+            h.currentKey = "C" // records B
+            // Top of stack is B (invalid) → skipped; pops A.
+            compare(h.tryGoBack(), true)
+            compare(h.lastRequested, "A")
+            compare(h.canGoBack, false)
+        }
+
+        function test_clear() {
+            const h = make({ currentKey: "A" })
+            h.currentKey = "B"
+            h.currentKey = "C"
+            h.clear()
+            compare(h.canGoBack, false)
+            compare(h.tryGoBack(), false)
+        }
+
+        function test_dropLeaf_discards_dismissed_subsection() {
+            // list -> sub1 -> back(list) -> sub2 : sub1 was dismissed via Back,
+            // so it must NOT be retraceable.
+            const h = make({ currentKey: "" })
+            h.currentKey = "sub1"   // open sub1 (prev "" not recorded)
+            h.dropLeaf()            // Back to list dismisses sub1
+            h.currentKey = "sub2"   // open sub2 — sub1 must not be recorded
+            compare(h.canGoBack, false)
+            compare(h.tryGoBack(), false)
+        }
+
+        function test_without_dropLeaf_previous_is_recorded() {
+            // Contrast: without the Back-to-list dismissal, switching does record.
+            const h = make({ currentKey: "" })
+            h.currentKey = "sub1"
+            h.currentKey = "sub2"   // records sub1
+            compare(h.canGoBack, true)
+            compare(h.tryGoBack(), true)
+            compare(h.lastRequested, "sub1")
+        }
+
+        function test_dropLeaf_keeps_earlier_history() {
+            // X active, sub1 opened over it (records X), back-to-list dismisses
+            // sub1, but X remains retraceable.
+            const h = make({ currentKey: "X" })
+            h.currentKey = "sub1"   // records X
+            h.dropLeaf()            // dismiss sub1
+            compare(h.tryGoBack(), true)
+            compare(h.lastRequested, "X")
+            compare(h.canGoBack, false)
+        }
+
+        function test_empty_keys_ignored() {
+            const h = make({ currentKey: "" })
+            h.currentKey = "A"  // previous was "" → not recorded
+            compare(h.canGoBack, false)
+        }
+    }
+}

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -75,13 +75,17 @@ StatusSectionLayout {
     function saveBrowserSession() {
         savedSessionContext.saveSession()
     }
-    // Overrides StatusSectionLayout.tryGoBack: web history first, then tab history.
-    function tryGoBack() {
-        if (!!_internal.currentWebView && _internal.currentWebView.canGoBack) {
+    // Innermost Back tier: the current tab's web history. StatusSectionLayout
+    // tries this before the view tier and the tab (subsection) tier.
+    contentHistory: QtObject {
+        readonly property bool canGoBack: _internal.currentWebView?.canGoBack ?? false
+
+        function tryGoBack() {
+            if (!canGoBack)
+                return false
             webViewContext.goBackCurrent()
             return true
         }
-        return subsectionHistory.tryGoBack()
     }
 
     // Subsection back history: each tab keyed by the webview's stable `uid`

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -596,6 +596,7 @@ StatusSectionLayout {
         active: root.visible
         sourceComponent: BrowserShortcutActions {
             currentWebView: _internal.currentWebView
+            isMobile: SQUtils.Utils.isMobile
             onActivateAddressBar: browserToolbarLoader.activateAddressBar()
             onHideFindBar: _internal.hideFindBar()
             onFindNextRequested: findBar.findNext()

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -75,19 +75,43 @@ StatusSectionLayout {
     function saveBrowserSession() {
         savedSessionContext.saveSession()
     }
-    //Back integration: step backward through web history first; only
-    // when the current tab is at the top of its history does Back fall through
-    // to AppMain's section-history pop. Wired into AppMain.tryGoBack().
+    // Overrides StatusSectionLayout.tryGoBack: web history first, then tab history.
     function tryGoBack() {
         if (!!_internal.currentWebView && _internal.currentWebView.canGoBack) {
             webViewContext.goBackCurrent()
             return true
         }
-        return false
+        return subsectionHistory.tryGoBack()
+    }
+
+    // Subsection back history: each tab keyed by the webview's stable `uid`
+    // (indices shift when tabs close).
+    subsectionHistory: SQUtils.SubsectionNavigationHistory {
+        id: tabHistory
+        currentKey: _internal.currentWebView ? _internal.currentWebView.uid : ""
+        validateFn: (uid) => {
+            for (let i = 0; i < tabs.count; i++) {
+                const wv = webViewContext.getWebView(i)
+                if (wv && wv.uid === uid)
+                    return true
+            }
+            return false
+        }
+        onNavigateRequested: (uid) => {
+            for (let i = 0; i < tabs.count; i++) {
+                const wv = webViewContext.getWebView(i)
+                if (wv && wv.uid === uid) {
+                    tabs.activateTab(i)
+                    return
+                }
+            }
+        }
     }
 
     Component.onCompleted: {
         savedSessionContext.restoreSession()
+        // Session-restore tab churn must not be treated as user navigation.
+        tabHistory.clear()
     }
 
     Component.onDestruction: {

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -75,6 +75,16 @@ StatusSectionLayout {
     function saveBrowserSession() {
         savedSessionContext.saveSession()
     }
+    //Back integration: step backward through web history first; only
+    // when the current tab is at the top of its history does Back fall through
+    // to AppMain's section-history pop. Wired into AppMain.tryGoBack().
+    function tryGoBack() {
+        if (!!_internal.currentWebView && _internal.currentWebView.canGoBack) {
+            webViewContext.goBackCurrent()
+            return true
+        }
+        return false
+    }
 
     Component.onCompleted: {
         savedSessionContext.restoreSession()

--- a/ui/app/AppLayouts/Browser/views/BrowserShortcutActions.qml
+++ b/ui/app/AppLayouts/Browser/views/BrowserShortcutActions.qml
@@ -128,10 +128,6 @@ QObject {
         onActivated: triggerWebAction(AbstractWebView.WebAction.Redo)
     }
     Shortcut {
-        sequences: [StandardKey.Back]
-        onActivated: triggerWebAction(AbstractWebView.WebAction.Back)
-    }
-    Shortcut {
         sequences: [StandardKey.Forward]
         onActivated: triggerWebAction(AbstractWebView.WebAction.Forward)
     }

--- a/ui/app/AppLayouts/Browser/views/BrowserShortcutActions.qml
+++ b/ui/app/AppLayouts/Browser/views/BrowserShortcutActions.qml
@@ -59,6 +59,11 @@ QObject {
 
     property var currentWebView
 
+    // On Android the hardware/gesture Back key matches StandardKey.PreviousChild,
+    // so the tab-navigation shortcuts must be disabled on mobile or Back triggers a
+    // phantom "previous tab" switch. Mobile switches tabs via the tab-bar UI anyway.
+    property bool isMobile: false
+
     function triggerWebAction(action) {
         if (!currentWebView)
             return
@@ -153,10 +158,12 @@ QObject {
     }
     Shortcut {
         sequences: [StandardKey.NextChild]
+        enabled: !root.isMobile
         onActivated: root.nextTabRequested()
     }
     Shortcut {
         sequences: [StandardKey.PreviousChild]
+        enabled: !root.isMobile // Android Back matches PreviousChild; see isMobile
         onActivated: root.previousTabRequested()
     }
 }

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -166,6 +166,26 @@ StackLayout {
         d.openCommunitySettingsSubsection(subsection, subsectionItem)
     }
 
+    // --- Back-navigation contract, forwarded to the inner ChatView
+    function tryGoBack() {
+        // On the community settings sub-page, Back returns to the chat content.
+        if (root.currentIndex === d.settingsPageIndex) {
+            root.currentIndex = 0
+            return true
+        }
+        const view = mainViewLoader.item
+        if (view && typeof view.tryGoBack === "function")
+            return view.tryGoBack()
+        return false
+    }
+
+    readonly property bool canGoBack: {
+        if (root.currentIndex === d.settingsPageIndex)
+            return true
+        const view = mainViewLoader.item
+        return !!view && view.canGoBack === true
+    }
+
     QtObject {
         id: d
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -86,6 +86,16 @@ StatusSectionLayout {
 
     property int extraLeftPadding: 0
 
+    // Subsection back history keyed by the active chat/channel id.
+    subsectionHistory: SubsectionNavigationHistory {
+        currentKey: {
+            const m = root.rootStore.chatCommunitySectionModule
+            return m && m.activeItem ? m.activeItem.id : ""
+        }
+        validateFn: (id) => ModelUtils.indexOf(root.rootStore.chatCommunitySectionModule.model, "itemId", id) >= 0
+        onNavigateRequested: (key) => root.rootStore.chatCommunitySectionModule.setActiveItem(key)
+    }
+
     readonly property bool contentLocked: {
         if (!rootStore.chatCommunitySectionModule.isCommunity()) {
             return false

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -173,6 +173,13 @@ StatusSectionLayout {
         messagingBadgeCount: root.pendingReceivedContactsCount
     }
 
+    // Subsection back history keyed by the settingsSubsection enum.
+    subsectionHistory: SQUtils.SubsectionNavigationHistory {
+        currentKey: root.settingsSubsection
+        validateFn: (key) => SQUtils.ModelUtils.indexOf(settingsEntriesModel, "subsection", parseInt(key)) >= 0
+        onNavigateRequested: (key) => root.settingsSubsection = parseInt(key)
+    }
+
     leftPanel: SettingsLeftTabView {
         id: leftPanel
         anchors.fill: parent

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -327,7 +327,9 @@ Item {
         anchors.fill: parent
         backButtonName: RootStore.backButtonName
         onBackButtonClicked: {
-            rightPanelStackView.currentItem.resetStack();
+            if (rightPanelStackView.currentItem && !!rightPanelStackView.currentItem.resetStack) {
+                rightPanelStackView.currentItem.resetStack()
+            }
         }
 
         leftPanel: LeftTabView {

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -33,6 +33,14 @@ import "popups/buy"
 Item {
     id: root
 
+    // --- Back-navigation contract, forwarded to the inner StatusSectionLayout
+    // (walletSectionLayout). This Item wrapper would otherwise be a dead-end
+    // for AppMain's Link 2 on desktop. See AppMain.tryGoBack().
+    function tryGoBack() {
+        return walletSectionLayout.tryGoBack()
+    }
+    readonly property bool canGoBack: walletSectionLayout.canGoBack
+
     property WalletStores.RootStore walletRootStore
     property SharedStores.RootStore sharedRootStore
     property AppLayoutsStores.RootStore store
@@ -330,6 +338,14 @@ Item {
             if (rightPanelStackView.currentItem && !!rightPanelStackView.currentItem.resetStack) {
                 rightPanelStackView.currentItem.resetStack()
             }
+        }
+
+        // Subsection back history keyed by the selected account. Navigates via
+        // d.displayAddress (not changeSelectedAccount, which advances the panel).
+        subsectionHistory: StatusQUtils.SubsectionNavigationHistory {
+            currentKey: RootStore.selectedAddress
+            validateFn: (address) => StatusQUtils.ModelUtils.indexOf(RootStore.accounts, "address", address) >= 0
+            onNavigateRequested: (address) => d.displayAddress(address)
         }
 
         leftPanel: LeftTabView {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -164,6 +164,12 @@ Item {
 
     readonly property bool isPortraitMode: appMain.width < ThemeUtils.portraitBreakpoint.width
 
+    // Whether Back has anything to do: an open overlay, the active section's
+    // internal back, or the cross-section history. Drives the desktop Back entry
+    // points (StandardKey shortcut + mouse Back button).
+    readonly property bool canGoBackAnywhere: createChatView.opened
+            || d.sectionCanGoBack || sectionNavigationHistory.canGoBack
+
     function showEnableBiometricsFlow() {
         popupRequestsHandler.openEnableBiometricsPopup()
     }
@@ -173,13 +179,8 @@ Item {
         maxDepth: 16
     }
 
-    // Records the *previous* active section id onto the back-navigation
-    // history whenever the active section changes — unless the change was
-    // triggered by the back-handler itself (re-entrancy guard).
-    //
-    // NOTE: Consolidated single-handler form so the record-previous /
-    // write-current ordering is explicit and cannot be reordered by an
-    // intervening handler.
+    // Records the *previous* active section id whenever the active section
+    // changes, unless the change came from the back-handler (re-entrancy guard).
     Connections {
         target: appMain.rootStore
         function onActiveSectionIdChanged() {
@@ -871,13 +872,27 @@ Item {
                                                         && !d.messagingNetworkBannerDismissed
                                                         && d.networkChecker.isOnline
 
-        // True while the back-handler is navigating; suppresses recording
-        // the synthetic section change as a new history entry.
+        // True while the back-handler is navigating; suppresses recording the
+        // synthetic section change as a new history entry.
         property bool navigatingBack: false
 
-        // Tracker for the most-recently-observed activeSectionId. Used by the
-        // history recorder to push the *previous* id when activeSectionId changes.
+        // Most-recently-observed activeSectionId; the recorder pushes the
+        // *previous* id when activeSectionId changes.
         property string lastRecordedSectionId: ""
+
+        // The active section's loaded item (appView's children stay in sync with
+        // currentIndex). May be null while a section is still loading.
+        function activeSectionItem() {
+            const loader = appView.children[appView.currentIndex]
+            return loader ? loader.item : null
+        }
+
+        // True when the active section can step back internally (e.g. portrait
+        // SwipeView panels). Reactive on section switch, lazy load and canGoBack.
+        readonly property bool sectionCanGoBack: {
+            const item = d.activeSectionItem()
+            return !!item && item.canGoBack === true
+        }
 
         // strict online/offline checker, doesn't care about the wallet services
         readonly property var networkChecker: NetworkChecker {
@@ -2377,6 +2392,20 @@ Item {
                     }
                 }
             }
+
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.BackButton
+                enabled: appMain.canGoBackAnywhere
+                cursorShape: undefined // fall thru
+                onClicked: function(mouse) {
+                    if (mouse.button !== Qt.BackButton)
+                        return
+                    if (tryGoBack()) {
+                        mouse.accepted = true
+                    }
+                }
+            }
         }
     } // ColumnLayout
 
@@ -3055,17 +3084,9 @@ Item {
         value: appMain.Theme.palette
     }
 
-    // ----- Android system back button (Key_Back) -----
-    // The four-link chain: link 1 (popup) and link 2 (section internal back)
-    // accept the event before it reaches here. This handler implements
-    // link 3 (section history) and link 4 (Quit confirmation).
-    //
-    // NOTE: On Android the key event may not reach this handler due to
-    // focus-chain quirks — Qt's Android platform may close the window
-    // before delivering Key_Back to QML. In that case main.qml's onClosing
-    // is the catch-all, and it calls tryGoBack() (defined below) to
-    // run the same link 3 logic. Both paths are kept so behaviour is
-    // identical whether the key event reaches QML or not.
+    // Back entry point for the mobile Back key and the StandardKey.Back shortcut
+    // (Alt+←). On Android the event may not reach QML (the platform can close the
+    // window first); main.qml's onClosing is the catch-all and calls tryGoBack().
     Keys.onPressed: function(event) {
         if (event.key !== Qt.Key_Back // Back key on mobile
                 && !event.matches(StandardKey.Back)) // Back std shortcut, e.g. Alt+←
@@ -3081,9 +3102,11 @@ Item {
     }
 
     Keys.onShortcutOverride: function (event) {
+        // Browser is excluded: QtWebEngine handles StandardKey.Back natively for
+        // web-history navigation, so we let the event reach the web view.
         event.accepted = d.activeSectionType !== Constants.appSection.browser &&
                 event.matches(StandardKey.Back) &&
-                sectionNavigationHistory.canGoBack
+                appMain.canGoBackAnywhere
     }
 
     MouseArea {
@@ -3100,25 +3123,20 @@ Item {
         }
     }
 
-    // Links 2 + 3 of the back-navigation chain, callable from main.qml's
-    // onClosing as well as from the Keys.onPressed above. Returns true if
-    // the Back press was handled (either by the active section internally
-    // or by popping section history); false if everything is exhausted and
-    // the caller should fall through to link 4 (Quit confirmation).
+    // The back-navigation chain, also callable from main.qml's onClosing.
+    // Returns true if the Back press was handled, false if exhausted (caller
+    // then falls through to Quit/minimize).
     function tryGoBack() {
-        // Link 1a: AppMain-level overlay-loader components (e.g. CreateChatView).
-        // These are Loaders with an `opened` property, NOT Qt Popups — so
-        // Qt's native popup-close doesn't reach them.
+        // Link 1: AppMain overlay-loaders (e.g. CreateChatView) — Loaders with an
+        // `opened` property, not Qt Popups, so native popup-close misses them.
         if (createChatView.opened) {
             createChatView.opened = false
             return true
         }
 
-        // Link 2: ask the active section to handle Back internally first
-        // (e.g. browser navigates web history; sections with sub-panels can
-        // step them). Sections that don't expose tryGoBack() are skipped.
-        const sectionLoader = appView.children[appView.currentIndex]
-        const sectionItem = sectionLoader ? sectionLoader.item : null
+        // Link 2: let the active section handle Back internally (web history,
+        // sub-panels, subsection history). Sections without tryGoBack() are skipped.
+        const sectionItem = d.activeSectionItem()
         if (sectionItem && typeof sectionItem.tryGoBack === "function"
                 && sectionItem.tryGoBack()) {
             return true

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -62,6 +62,14 @@ import MobileUI
 Item {
     id: appMain
 
+    focus: true
+    Component.onCompleted: {
+        // Ensure the app is focused on start to properly receive key events
+        appMain.forceActiveFocus()
+        // record only the initial value - no binding
+        d.lastRecordedSectionId = appMain.rootStore.activeSectionId
+    }
+
     // Primary store container — all additional stores should be initialized under this root
     readonly property AppStores.RootStore rootStore: AppStores.RootStore {
         localBackupEnabled: appMain.featureFlagsStore.localBackupEnabled
@@ -158,6 +166,28 @@ Item {
 
     function showEnableBiometricsFlow() {
         popupRequestsHandler.openEnableBiometricsPopup()
+    }
+
+    SQUtils.NavigationHistory {
+        id: sectionNavigationHistory
+        maxDepth: 16
+    }
+
+    // Records the *previous* active section id onto the back-navigation
+    // history whenever the active section changes — unless the change was
+    // triggered by the back-handler itself (re-entrancy guard).
+    //
+    // NOTE: Consolidated single-handler form so the record-previous /
+    // write-current ordering is explicit and cannot be reordered by an
+    // intervening handler.
+    Connections {
+        target: appMain.rootStore
+        function onActiveSectionIdChanged() {
+            if (!d.navigatingBack && d.lastRecordedSectionId) {
+                sectionNavigationHistory.record(d.lastRecordedSectionId)
+            }
+            d.lastRecordedSectionId = appMain.rootStore.activeSectionId
+        }
     }
 
     ContactDetails {
@@ -840,6 +870,14 @@ Item {
                                                         && d.isMessagingRelatedSectionType
                                                         && !d.messagingNetworkBannerDismissed
                                                         && d.networkChecker.isOnline
+
+        // True while the back-handler is navigating; suppresses recording
+        // the synthetic section change as a new history entry.
+        property bool navigatingBack: false
+
+        // Tracker for the most-recently-observed activeSectionId. Used by the
+        // history recorder to push the *previous* id when activeSectionId changes.
+        property string lastRecordedSectionId: ""
 
         // strict online/offline checker, doesn't care about the wallet services
         readonly property var networkChecker: NetworkChecker {
@@ -3015,5 +3053,72 @@ Item {
         target: appMain.walletRootStore
         property: "palette"
         value: appMain.Theme.palette
+    }
+
+    // ----- Android system back button (Key_Back) -----
+    // The four-link chain: link 1 (popup) and link 2 (section internal back)
+    // accept the event before it reaches here. This handler implements
+    // link 3 (section history) and link 4 (Quit confirmation).
+    //
+    // NOTE: On Android the key event may not reach this handler due to
+    // focus-chain quirks — Qt's Android platform may close the window
+    // before delivering Key_Back to QML. In that case main.qml's onClosing
+    // is the catch-all, and it calls tryGoBack() (defined below) to
+    // run the same link 3 logic. Both paths are kept so behaviour is
+    // identical whether the key event reaches QML or not.
+    Keys.onPressed: function(event) {
+        if (event.key !== Qt.Key_Back)
+            return
+        if (!SQUtils.Utils.isMobile)
+            return
+
+        if (tryGoBack()) {
+            event.accepted = true
+            return
+        }
+
+        event.accepted = true
+        MobileUI.backToHomeScreen()
+    }
+
+    // Links 2 + 3 of the back-navigation chain, callable from main.qml's
+    // onClosing as well as from the Keys.onPressed above. Returns true if
+    // the Back press was handled (either by the active section internally
+    // or by popping section history); false if everything is exhausted and
+    // the caller should fall through to link 4 (Quit confirmation).
+    function tryGoBack() {
+        // Link 1a: AppMain-level overlay-loader components (e.g. CreateChatView).
+        // These are Loaders with an `opened` property, NOT Qt Popups — so
+        // Qt's native popup-close doesn't reach them.
+        if (createChatView.opened) {
+            createChatView.opened = false
+            return true
+        }
+
+        // Link 2: ask the active section to handle Back internally first
+        // (e.g. browser navigates web history; sections with sub-panels can
+        // step them). Sections that don't expose tryGoBack() are skipped.
+        const sectionLoader = appView.children[appView.currentIndex]
+        const sectionItem = sectionLoader ? sectionLoader.item : null
+        if (sectionItem && typeof sectionItem.tryGoBack === "function"
+                && sectionItem.tryGoBack()) {
+            return true
+        }
+
+        // Link 3: pop section history, skipping stale tokens.
+        while (sectionNavigationHistory.canGoBack) {
+            const token = sectionNavigationHistory.back()
+            if (SQUtils.ModelUtils.indexOf(appMain.rootStore.sectionsModel, "id", token) >= 0) {
+                d.navigatingBack = true
+                try {
+                    appMain.rootStore.setActiveSectionById(token)
+                } finally {
+                    d.navigatingBack = false
+                }
+                return true
+            }
+            // token referred to a section no longer in the model; pop again
+        }
+        return false
     }
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -3067,9 +3067,8 @@ Item {
     // run the same link 3 logic. Both paths are kept so behaviour is
     // identical whether the key event reaches QML or not.
     Keys.onPressed: function(event) {
-        if (event.key !== Qt.Key_Back)
-            return
-        if (!SQUtils.Utils.isMobile)
+        if (event.key !== Qt.Key_Back // Back key on mobile
+                && !event.matches(StandardKey.Back)) // Back std shortcut, e.g. Alt+←
             return
 
         if (tryGoBack()) {
@@ -3079,6 +3078,26 @@ Item {
 
         event.accepted = true
         MobileUI.backToHomeScreen()
+    }
+
+    Keys.onShortcutOverride: function (event) {
+        event.accepted = d.activeSectionType !== Constants.appSection.browser &&
+                event.matches(StandardKey.Back) &&
+                sectionNavigationHistory.canGoBack
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.BackButton
+        enabled: sectionNavigationHistory.canGoBack
+        cursorShape: undefined // fall thru
+        onClicked: function(mouse) {
+            if (mouse.button !== Qt.BackButton)
+                return
+            if (tryGoBack()) {
+                mouse.accepted = true
+            }
+        }
     }
 
     // Links 2 + 3 of the back-navigation chain, callable from main.qml's

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -77,6 +77,7 @@ Item {
                                    appMain.privacyStore.thirdpartyServicesEnabled: true
         onOpenUrl: (link) => Global.requestOpenLink(link)
         onOpenActivityCenter: () => {
+            d.closeActivityCenterOnNextBack = false
             mainLayoutItem.openACCenterPanel = true
         }
         onWcLinkActivated: (link) => {
@@ -168,6 +169,8 @@ Item {
     // internal back, or the cross-section history. Drives the desktop Back entry
     // points (StandardKey shortcut + mouse Back button).
     readonly property bool canGoBackAnywhere: createChatView.opened
+            || (appMain.isPortraitMode && mainLayoutItem.openACCenterPanel)
+            || (mainLayoutItem.openACCenterPanel && d.closeActivityCenterOnNextBack)
             || d.sectionCanGoBack || sectionNavigationHistory.canGoBack
 
     function showEnableBiometricsFlow() {
@@ -184,7 +187,10 @@ Item {
     Connections {
         target: appMain.rootStore
         function onActiveSectionIdChanged() {
-            if (!d.navigatingBack && d.lastRecordedSectionId) {
+            if (d.skipNextSectionHistoryRecordFor !== ""
+                    && d.lastRecordedSectionId === d.skipNextSectionHistoryRecordFor) {
+                d.skipNextSectionHistoryRecordFor = ""
+            } else if (!d.navigatingBack && d.lastRecordedSectionId) {
                 sectionNavigationHistory.record(d.lastRecordedSectionId)
             }
             d.lastRecordedSectionId = appMain.rootStore.activeSectionId
@@ -879,6 +885,40 @@ Item {
         // Most-recently-observed activeSectionId; the recorder pushes the
         // *previous* id when activeSectionId changes.
         property string lastRecordedSectionId: ""
+
+        readonly property string activityCenterHistoryToken: "__activityCenterPanel"
+        property string skipNextSectionHistoryRecordFor: ""
+        property bool closeActivityCenterOnNextBack: false
+
+        function recordActivityCenterHistory() {
+            d.skipNextSectionHistoryRecordFor = appMain.rootStore.activeSectionId
+            sectionNavigationHistory.record(appMain.rootStore.activeSectionId)
+            sectionNavigationHistory.record(d.activityCenterHistoryToken)
+            Backpressure.setTimeout(appMain, 100, () => {
+                d.skipNextSectionHistoryRecordFor = ""
+            })
+        }
+
+        function restoreActivityCenterFromHistory() {
+            if (sectionNavigationHistory.peek() !== d.activityCenterHistoryToken)
+                return false
+
+            sectionNavigationHistory.back()
+            d.closeActivityCenterOnNextBack = true
+            mainLayoutItem.openACCenterPanel = true
+            return true
+        }
+
+        function tryHandleActivityCenterBack() {
+            if (mainLayoutItem.openACCenterPanel
+                    && (appMain.isPortraitMode || d.closeActivityCenterOnNextBack)) {
+                d.closeActivityCenterOnNextBack = false
+                mainLayoutItem.openACCenterPanel = false
+                return true
+            }
+
+            return d.restoreActivityCenterFromHistory()
+        }
 
         // The active section's loaded item (appView's children stay in sync with
         // currentIndex). May be null while a section is still loading.
@@ -1705,6 +1745,8 @@ Item {
                 } else if (isPortraitMode && !openACCenterPanel) {
                     acPortraitPopup.close()
                 }
+                if (!openACCenterPanel)
+                    d.closeActivityCenterOnNextBack = false
             }
 
             // Ensure closing the popup when changing from portrait to landscape,
@@ -1825,6 +1867,12 @@ Item {
                     anchors.fill: parent
                 }
 
+                Shortcut {
+                    enabled: acPortraitPopup.opened
+                    sequences: [StandardKey.Back, StandardKey.Cancel]
+                    onActivated: d.tryHandleActivityCenterBack()
+                }
+
                 // Sync the main property when autoclose
                 onClosed: { mainLayoutItem.openACCenterPanel = false }
             }
@@ -1888,6 +1936,7 @@ Item {
                 onMarkNotificationUnread: (notificationId) => { appMain.activityCenterStore.markActivityCenterNotificationUnread(notificationId) }
                 onAvatarClicked: (avatarId) => { Global.openProfilePopup(avatarId) }
                 onRedirectToDetails: (sectionId, subsectionId, subsectionItemId) => {
+                                         d.recordActivityCenterHistory()
                                          appMain.rootStore.setNavToMsgDetailsFlag(true) // It covers in-app link navigation in portrait mode
                                          appMain.activityCenterStore.switchTo(sectionId, subsectionId, subsectionItemId)
 
@@ -1895,12 +1944,14 @@ Item {
                                          acPortraitPopup.close()
                                      }
                 onRedirectToSection: (sectionId) => {
+                                         d.recordActivityCenterHistory()
                                          appMain.changeAppSectionBySectionId(sectionId)
 
                                          // Guard in case of portrait
                                          acPortraitPopup.close()
                                      }
                 onRedirectToCommunitySettingsSubsection: (communityId, subsection, subsectionItem) => {
+                                                             d.recordActivityCenterHistory()
                                                              appMain.changeAppSectionBySectionId(communityId)
                                                              Global.switchToCommunitySettingsSubsection(communityId, subsection, subsectionItem)
 
@@ -1908,6 +1959,7 @@ Item {
                                                              acPortraitPopup.close()
                                                          }
                 onRedirectToPopup: (notification) => {
+                                       d.recordActivityCenterHistory()
                                        // Right now, this is the only popup open, when more, we can add a popup type to determine it
                                        Global.openNewsMessagePopupRequested(notification)
 
@@ -1915,6 +1967,7 @@ Item {
                                        acPortraitPopup.close()
                                    }
                 onRedirectToWallet: (address, txHash) => {
+                                        d.recordActivityCenterHistory()
                                         Global.changeAppSectionBySectionType(Constants.appSection.wallet,
                                                                              WalletLayout.LeftPanelSelection.Address,
                                                                              WalletLayout.RightPanelSelection.Activity,
@@ -2366,7 +2419,10 @@ Item {
                 }
                 thirdpartyServicesEnabled: appMain.rootStore.thirdpartyServicesEnabled
 
-                onActivityCenterRequested: function(shouldShow) { mainLayoutItem.openACCenterPanel = shouldShow }
+                onActivityCenterRequested: function(shouldShow) {
+                    d.closeActivityCenterOnNextBack = false
+                    mainLayoutItem.openACCenterPanel = shouldShow
+                }
                 onSetCurrentUserStatusRequested: status => appMain.rootStore.setCurrentUserStatus(status)
                 onViewProfileRequested: pubKey => Global.openProfilePopup(pubKey)
                 onShareOwnProfileRequested: Global.shareProfileDialogRequested(ownContactDetails.publicKey)
@@ -3116,8 +3172,11 @@ Item {
     // Returns true if the Back press was handled, false if exhausted (caller
     // then falls through to Quit/minimize).
     function tryGoBack() {
-        // Link 1: AppMain overlay-loaders (e.g. CreateChatView) — Loaders with an
-        // `opened` property, not Qt Popups, so native popup-close misses them.
+        // Link 1: AppMain overlays/panels (e.g. Activity Center, CreateChatView)
+        // that are not always native Qt Popups, so native popup-close misses them.
+        if (d.tryHandleActivityCenterBack())
+            return true
+
         if (createChatView.opened) {
             createChatView.opened = false
             return true
@@ -3134,6 +3193,11 @@ Item {
         // Link 3: pop section history, skipping stale tokens.
         while (sectionNavigationHistory.canGoBack) {
             const token = sectionNavigationHistory.back()
+            if (token === d.activityCenterHistoryToken) {
+                d.closeActivityCenterOnNextBack = true
+                mainLayoutItem.openACCenterPanel = true
+                return true
+            }
             if (SQUtils.ModelUtils.indexOf(appMain.rootStore.sectionsModel, "id", token) >= 0) {
                 d.navigatingBack = true
                 try {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2392,7 +2392,6 @@ Item {
                     }
                 }
             }
-
         }
     } // ColumnLayout
 
@@ -3084,8 +3083,10 @@ Item {
             return
         }
 
-        event.accepted = true
-        MobileUI.backToHomeScreen()
+         if (SQUtils.Utils.isMobile) {
+             event.accepted = true
+             MobileUI.backToHomeScreen()
+         }
     }
 
     Keys.onShortcutOverride: function (event) {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2393,19 +2393,6 @@ Item {
                 }
             }
 
-            MouseArea {
-                anchors.fill: parent
-                acceptedButtons: Qt.BackButton
-                enabled: appMain.canGoBackAnywhere
-                cursorShape: undefined // fall thru
-                onClicked: function(mouse) {
-                    if (mouse.button !== Qt.BackButton)
-                        return
-                    if (tryGoBack()) {
-                        mouse.accepted = true
-                    }
-                }
-            }
         }
     } // ColumnLayout
 
@@ -3112,14 +3099,12 @@ Item {
     MouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.BackButton
-        enabled: sectionNavigationHistory.canGoBack
+        enabled: appMain.canGoBackAnywhere
         cursorShape: undefined // fall thru
         onClicked: function(mouse) {
             if (mouse.button !== Qt.BackButton)
                 return
-            if (tryGoBack()) {
-                mouse.accepted = true
-            }
+            tryGoBack()
         }
     }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -3070,12 +3070,13 @@ Item {
         value: appMain.Theme.palette
     }
 
-    // Back entry point for the mobile Back key and the StandardKey.Back shortcut
-    // (Alt+←). On Android the event may not reach QML (the platform can close the
-    // window first); main.qml's onClosing is the catch-all and calls tryGoBack().
+    // Back entry point for the mobile Back key. On Android the event may not reach
+    // QML at all (e.g. during onboarding, before AppMain is loaded); main.qml's
+    // onClosing is the failsafe and offers the press to tryGoBack() before
+    // minimizing. The desktop StandardKey.Back shortcut is handled by the Shortcut
+    // below, not here.
     Keys.onPressed: function(event) {
-        if (event.key !== Qt.Key_Back // Back key on mobile
-                && !event.matches(StandardKey.Back)) // Back std shortcut, e.g. Alt+←
+        if (event.key !== Qt.Key_Back) // Back key on mobile
             return
 
         if (tryGoBack()) {
@@ -3089,12 +3090,14 @@ Item {
          }
     }
 
-    Keys.onShortcutOverride: function (event) {
-        // Browser is excluded: QtWebEngine handles StandardKey.Back natively for
-        // web-history navigation, so we let the event reach the web view.
-        event.accepted = d.activeSectionType !== Constants.appSection.browser &&
-                event.matches(StandardKey.Back) &&
-                appMain.canGoBackAnywhere
+    // Desktop Back (Alt+← / Cmd+[). A Shortcut, not Keys.onPressed: the shortcut map
+    // is consulted before the key event reaches the focus chain, which is the only
+    // route that works in the Browser — a focused WebEngineView accepts every key
+    // event and nothing bubbles out of it.
+    Shortcut {
+        sequences: [StandardKey.Back]
+        enabled: !SQUtils.Utils.isMobile && appMain.canGoBackAnywhere
+        onActivated: appMain.tryGoBack()
     }
 
     MouseArea {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -346,7 +346,6 @@ Window {
         function onClosing(close) {
             // save the geometry just before closing
             applicationWindow.storeAppState() // noop on mobile
-            // on mobile, we minimize to background (no tray icon or quitOnClose setting)
             if (SQUtils.Utils.isMobile) {
                 close.accepted = true
                 return

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -347,7 +347,13 @@ Window {
             // save the geometry just before closing
             applicationWindow.storeAppState() // noop on mobile
             if (SQUtils.Utils.isMobile) {
-                close.accepted = true
+                close.accepted = false
+                if (loader.item && loader.item.tryGoBack())
+                    return
+                if (SQUtils.Utils.isAndroid)
+                    MobileUI.backToHomeScreen()
+                else
+                    applicationWindow.showMinimized()
                 return
             } else if (!loader.item) {
                 close.accepted = true

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -348,12 +348,8 @@ Window {
             applicationWindow.storeAppState() // noop on mobile
             // on mobile, we minimize to background (no tray icon or quitOnClose setting)
             if (SQUtils.Utils.isMobile) {
-                close.accepted = false
-                if (SQUtils.Utils.isAndroid)
-                    MobileUI.backToHomeScreen()
-                else
-                    applicationWindow.showMinimized()
-            // In case not logged in or loading, quit app
+                close.accepted = true
+                return
             } else if (!loader.item) {
                 close.accepted = true
             }


### PR DESCRIPTION
### What does the PR do

This commit implements back navigation on 3 levels:
- popups will close on back (already handled by qt)
OR
- sections will swipe back from right panels to left panels (handled generally in the portrait layout)
OR
- the app will move to the previous panel in history (handled in appMain)
OR
- app will be minimised (handled in appMain)

window.onClose will not prevent app close anymore.

closes https://github.com/status-im/status-app/issues/20997

### Affected areas

app navigation
IOS, Android app close

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/ec1e15c6-8ebb-404b-8e3f-404ac9866294


### Impact on end user

implements nav

### How to test

navigate using back

### Risk 

low