### PR TITLE
StatusChatInput: no jumps on backspace on ios

### DIFF
--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -794,7 +794,15 @@ Control {
             Theme.fontSizeOffset: ThemeUtils.fontSizeOffsetM
 
             styleButtonVisible: false
-            showFormatting: messageInputField.selectionStart !== messageInputField.selectionEnd
+
+            // On iOS, backspace temporarily creates a selection (selectionStart != selectionEnd)
+            // around the character being removed. The binding is configured as delayed to avoid
+            // briefly setting showFormatting=true and therefore unnecessarily triggering the
+            // animation within the toolbar.
+            Binding on showFormatting {
+                delayed: true
+                value: messageInputField.selectionStart !== messageInputField.selectionEnd
+            }
 
             cameraButton.visible: false
 


### PR DESCRIPTION
### What does the PR do

Fixes a subtle bug causing that on every single character removal on ios the tool bar icons were jumping a bit to the right and back immediately to normal position.

Closes: #20898

### Affected areas
`StatusChatInputNew`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/c1f5d413-efdb-4826-9e41-9e778a5c3062



### Impact on end user

Low

### How to test

Go to chat on ios, type something, then remove char by char.

### Risk 

Low