### PR TITLE
fix: Allow navigating to the same chat

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -219,6 +219,13 @@ StatusSectionLayout {
         return root.chatContentModule.chatDetails.isUsersListAvailable
     }
 
+    onNavToMsgDetailsChanged: {
+        if (root.navToMsgDetails && root.visible) {
+            root.currentIndex = StatusSectionLayout.CentralPanel
+            root.navToMsgDetailsRequested(false)
+        }
+    }
+
     rightPanel: UserListPanel {
         anchors.fill: parent
 


### PR DESCRIPTION
### What does the PR do

closes https://github.com/status-im/status-app/issues/20996 https://github.com/status-im/status-app/issues/20995

React to `onNavToMsgDetailsChanged`

### Affected areas

Chat navigation

### Screencapture of the functionality

https://github.com/user-attachments/assets/96c04eab-2148-4b81-99e3-8233516aad8c

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

IMPORTANT:
Select a 1-1/group chat
goback to left panel

Try to navigate to that same chat (through push notifications or activity center)

### Risk 

low