### PR TITLE
feat(ios): Background wake and PN deep links

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -2164,7 +2164,6 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
   # Matched before the chat/community/contact routes so the reserved keywords never
   # collide with a public-chat link of the form `status-app://<id>`.
   let genericNavTarget = extractGenericNavTargetFromDeepLink(statusDeepLink)
-  info "activateStatusDeepLink", statusDeepLink, genericNavTarget # TODO(deep-link debug): remove
   case genericNavTarget
   of DEEP_LINK_NAV_ACTIVITY_CENTER:
     self.view.emitOpenActivityCenterSignal()
@@ -2173,6 +2172,7 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
     self.setActiveSectionById(singletonInstance.userProfile.getPubKey())
     return
   else:
+    info "No generic navigation target found in deep link"
     discard
   if self.activateChatDeepLink(statusDeepLink):
     return

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -90,6 +90,12 @@ const STATUS_INTERNAL_DEEP_LINK_PREFIX = "status-app://"
 const STATUS_EXTERNAL_DEEP_LINK_PREFIX = "https://status.app/"
 const STATUS_EXTERNAL_DEEP_LINK_PREFIX_HTTP = "http://status.app/"
 
+# Reserved, id-less navigation keywords used by generic deep links (e.g. bundled in
+# remote push notifications: `status-app://ac`, `status-app://chats`). They carry no
+# chat/community id, so they map to a fixed destination rather than a specific item.
+const DEEP_LINK_NAV_ACTIVITY_CENTER = "ac"
+const DEEP_LINK_NAV_CHATS = "chats"
+
 type
   SpectateRequest = object
     communityId*: string
@@ -1886,6 +1892,13 @@ proc extractGroupChatIdFromDeepLink(statusDeepLink: string): string =
 
   return extractDeepLinkValueUntilSeparator(deepLinkPath[idx + groupChatQueryParam.len .. ^1])
 
+proc extractGenericNavTargetFromDeepLink(statusDeepLink: string): string =
+  ## Returns the reserved navigation keyword (e.g. `ac`, `chats`) for a generic,
+  ## id-less deep link, or "" for any link that carries a path/id (those are handled
+  ## by the regular chat/community/contact routes).
+  let path = extractDeepLinkValueUntilSeparator(extractStatusDeepLinkPath(statusDeepLink))
+  return path.strip(chars = {'/'})
+
 proc activateChatDeepLink[T](self: Module[T], statusDeepLink: string): bool =
   let oneToOneChatId = extractOneToOneChatIdFromDeepLink(statusDeepLink)
   if oneToOneChatId.len > 0:
@@ -2147,6 +2160,20 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
   if statusDeepLink.contains("/wc?"):
     self.view.wcLinkActivated(statusDeepLink)
     return
+  # Generic, id-less navigation deep links (e.g. bundled in remote push notifications).
+  # Matched before the chat/community/contact routes so the reserved keywords never
+  # collide with a public-chat link of the form `status-app://<id>`.
+  let genericNavTarget = extractGenericNavTargetFromDeepLink(statusDeepLink)
+  info "activateStatusDeepLink", statusDeepLink, genericNavTarget # TODO(deep-link debug): remove
+  case genericNavTarget
+  of DEEP_LINK_NAV_ACTIVITY_CENTER:
+    self.view.emitOpenActivityCenterSignal()
+    return
+  of DEEP_LINK_NAV_CHATS:
+    self.setActiveSectionById(singletonInstance.userProfile.getPubKey())
+    return
+  else:
+    discard
   if self.activateChatDeepLink(statusDeepLink):
     return
   let urlData = self.sharedUrlsModule.parseSharedUrl(statusDeepLink)

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -332,7 +332,7 @@ FetchContent_Declare(
   MobileUI
 
   GIT_REPOSITORY https://github.com/status-im/MobileUI.git
-  GIT_TAG 5767756951ebefcd90c5329e0bc533b7cca2df27
+  GIT_TAG 50917eb9cde14cf96e61646cbed71f835ee72d1b
 )
 FetchContent_MakeAvailable(MobileUI)
 

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -332,7 +332,7 @@ FetchContent_Declare(
   MobileUI
 
   GIT_REPOSITORY https://github.com/status-im/MobileUI.git
-  GIT_TAG 12802e2a1931917f84011bafecb2a86880ff110c
+  GIT_TAG 5767756951ebefcd90c5329e0bc533b7cca2df27
 )
 FetchContent_MakeAvailable(MobileUI)
 

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -200,6 +200,10 @@ QtObject {
                 root.openUrl(url)
             }
 
+            function onOpenActivityCenter() {
+                root.openActivityCenter()
+            }
+
             function onNavigateToMessageDetails() {
                 root.setNavToMsgDetailsFlag(true)
             }
@@ -230,6 +234,7 @@ QtObject {
 
     signal ensNameResolved(string resolvedPubKey, string resolvedAddress, string uuid)
     signal openUrl(string link)
+    signal openActivityCenter()
     signal wcLinkActivated(string link)
     signal displayUserProfile(string publicKey)
     signal showToastPairingFallbackCompleted()

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -69,6 +69,10 @@ Item {
         thirdpartyServicesEnabled: appMain.featureFlagsStore.privacyModeFeatureEnabled ?
                                    appMain.privacyStore.thirdpartyServicesEnabled: true
         onOpenUrl: (link) => Global.requestOpenLink(link)
+        onOpenActivityCenter: () => {
+            appMain.activityCenterStore.setActiveNotificationGroup(ActivityCenterTypes.ActivityCenterGroup.All)
+            mainLayoutItem.openACCenterPanel = true
+        }
         onWcLinkActivated: (link) => {
             const wcUri = Utils.walletConnectUriFromStatusLink(link)
             if (!!wcUri) {


### PR DESCRIPTION
### What does the PR do

- Fixing the contact code advertisment processing.
- The light clients can now store and send push notifications.
- Includes a status-go update for the push notifications text
- Increases the push notifications priority, use the default PN sound (configurable on the device), adds content-available flag in the push request to wake the app
- adds PN deep link support for AC and chats view (in MobileUI)

Bump status-go and MobileUI

https://github.com/user-attachments/assets/21dbfe26-bab1-422e-96d7-d4905239e0a2




Closes https://github.com/status-im/status-app/issues/21016