### PR TITLE
fix: navigating to subsections in portrait mode 

### DIFF
--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -172,17 +172,13 @@ LayoutChooser {
         This method is used to focus the panel that needs to be active.
     */
     function goToNextPanel() {
-        if (portraitView.visible) {
+        if (portraitView.visible)
             portraitView.incrementCurrentIndex()
-            Qt.callLater(d.positionPortraitViewAtCurrentIndex)
-        }
     }
 
     function goToPreviousPanel() {
-        if (portraitView.visible) {
+        if (portraitView.visible)
             portraitView.decrementCurrentIndex()
-            Qt.callLater(d.positionPortraitViewAtCurrentIndex)
-        }
     }
 
     readonly property int windowWidth: root.Window?.width ?? Screen.width
@@ -237,20 +233,6 @@ LayoutChooser {
         invertedLayout: root.invertedLayout
 
         property int currentIndexCache
-
-        QtObject {
-            id: d
-
-            // On Android, changing SwipeView.currentIndex can leave the
-            // internal ListView at the previous contentX. Reposition it after
-            // the index change has been processed so the visible page matches.
-            function positionPortraitViewAtCurrentIndex() {
-                if (!portraitView.contentItem || !portraitView.contentItem.positionViewAtIndex)
-                    return
-
-                portraitView.contentItem.positionViewAtIndex(portraitView.currentIndex, ListView.SnapPosition)
-            }
-        }
 
         onCurrentIndexChanged: {
             root.swiped(currentIndexCache, currentIndex)

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -255,6 +255,10 @@ LayoutChooser {
         onCurrentIndexChanged: {
             root.swiped(currentIndexCache, currentIndex)
             currentIndexCache = currentIndex
+
+            // Workaround for QTBUG-74328
+            interactive = false
+            interactive = true
         }
 
         onBackButtonClicked: root.backButtonClicked()

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -8,7 +8,7 @@ import StatusQ.Controls
 import StatusQ.Core
 import StatusQ.Core.Backpressure
 import StatusQ.Core.Theme
-import StatusQ.Core.Utils
+import StatusQ.Core.Utils as SQUtils
 
 import shared
 import shared.controls
@@ -110,6 +110,14 @@ Item {
         root.createChatPropertiesStore.resetProperties()
     }
 
+    onVisibleChanged: {
+        // Refocus from input field to chat list when changing to not visible on mobile.
+        // It prevents opening keyboard automatically when component becomes visible again,
+        // e.g. when notification is clicked.
+        if (SQUtils.Utils.isMobile && !visible)
+            chatRepeater.forceActiveFocus()
+    }
+
     QtObject {
         id: d
         readonly property var activeChatContentModule: d.getChatContentModule(root.activeChatId)
@@ -121,10 +129,10 @@ Item {
                 return
             }
             urlsModelChangeTracker.revision
-            ModelUtils.modelToFlatArray(d.activeChatContentModule.inputAreaModule.urlsModel, "url")
+            SQUtils.ModelUtils.modelToFlatArray(d.activeChatContentModule.inputAreaModule.urlsModel, "url")
         }
 
-        readonly property ModelChangeTracker urlsModelChangeTracker: ModelChangeTracker {
+        readonly property SQUtils.ModelChangeTracker urlsModelChangeTracker: SQUtils.ModelChangeTracker {
             model: !!d.activeChatContentModule ? d.activeChatContentModule.inputAreaModule.urlsModel : null
         }
 
@@ -153,7 +161,7 @@ Item {
             if (!!d.activeChatContentModule)
                 d.activeChatContentModule.inputAreaModule.preservedProperties.replyMessageId = messageId
 
-            const msg = ModelUtils.getByKey(d.activeMessagesStore.messagesModel, "id", messageId)
+            const msg = SQUtils.ModelUtils.getByKey(d.activeMessagesStore.messagesModel, "id", messageId)
 
             const senderColor = Theme.palette.userCustomizationColors[Utils.colorIdForPubkey(obj.senderId)]
 
@@ -240,13 +248,13 @@ Item {
         function getSymbolAndDecimalsForTokenFomModel(model, key) {
             let decimals = 0
             let symbol = ""
-            const tokenGroup = ModelUtils.getByKey(model, "key", key)
+            const tokenGroup = SQUtils.ModelUtils.getByKey(model, "key", key)
             if (!!tokenGroup) {
                 return [tokenGroup.symbol, tokenGroup.decimals]
             } else {
                 for (let i = 0; i < model.ModelCount.count; i++) {
-                    let tG = ModelUtils.get(model, i)
-                    const token = ModelUtils.getByKey(tG.tokens, "key", key)
+                    let tG = SQUtils.ModelUtils.get(model, i)
+                    const token = SQUtils.ModelUtils.getByKey(tG.tokens, "key", key)
                     if (!!token) {
                         return [token.symbol, token.decimals]
                     }
@@ -280,7 +288,7 @@ Item {
                 return "0"
             }
 
-            const num = AmountsArithmetic.toNumber(amount, decimals)
+            const num = SQUtils.AmountsArithmetic.toNumber(amount, decimals)
             return root.rootStore.currencyStore.formatCurrencyAmount(num, symbol, {noSymbol: true})
         }
     }

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -220,7 +220,7 @@ StatusSectionLayout {
     }
 
     onNavToMsgDetailsChanged: {
-        if (root.navToMsgDetails && root.visible) {
+        if (root.navToMsgDetails) {
             root.currentIndex = StatusSectionLayout.CentralPanel
             root.navToMsgDetailsRequested(false)
         }

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -77,8 +77,6 @@ StatusSectionLayout {
 
     required property Keychain keychain
 
-    property bool forceSubsectionNavigation: false
-
     property bool isKeycardEnabled: true
     property bool isBrowserEnabled: true
     required property bool privacyModeFeatureEnabled
@@ -139,12 +137,8 @@ StatusSectionLayout {
         root.settingsSubSubsection = -1
     }
 
-    // In portrait mode, it automatically swipes to the detailed content
-    onForceSubsectionNavigationChanged: {
-        if(root.forceSubsectionNavigation) {
-            root.goToNextPanel()
-            root.forceSubsectionNavigation = false
-        }
+    function forceSubsectionNavigation() {
+        root.goToNextPanel()
     }
 
     Component.onCompleted: {

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -42,6 +42,10 @@ QtObject {
     readonly property bool navToMsgDetails: internal.forceNavToMsgDetails
     function setNavToMsgDetailsFlag(navigate) {
         internal.forceNavToMsgDetails = navigate
+
+        // force actions even if the value is not changed to support deep navigation
+        // within swipe view if necessary (portrait mode)
+        internal.forceNavToMsgDetailsChanged()
     }
 
     // Here define the needed properties that access to `Context Properties`:

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1082,7 +1082,7 @@ Item {
             if (sectionType === Constants.appSection.profile) {
                 profileLoader.settingsSubsection = subsection || Constants.settingsSubsection.profile
                 profileLoader.settingsSubSubsection = subSubsection
-                profileLoader.forceSubsectionNavigation = true
+                profileLoader.forceSubsectionNavigation()
             } else if (sectionType === Constants.appSection.wallet) {
                 appView.children[Constants.appViewStackIndex.wallet].item.openDesiredView(subsection, subSubsection, data)
             } else if (sectionType === Constants.appSection.swap) {

--- a/ui/app/mainui/sectionLoaders/ProfileLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ProfileLoader.qml
@@ -64,7 +64,12 @@ Loader {
     property int settingsSubsection: -1
     property int settingsSubSubsection: -1
     property real leftPanelWidthOverride: 0
-    property bool forceSubsectionNavigation: false
+
+    function forceSubsectionNavigation() {
+        if (root.item && root.item.forceSubsectionNavigation) {
+            root.item.forceSubsectionNavigation()
+        }
+    }
 
     onSettingsSubsectionChanged: {
         if (root.item && root.item.settingsSubsection !== root.settingsSubsection) {
@@ -78,17 +83,10 @@ Loader {
         }
     }
 
-    onForceSubsectionNavigationChanged: {
-        if (root.item && root.item.forceSubsectionNavigation !== root.forceSubsectionNavigation) {
-            root.item.forceSubsectionNavigation = root.forceSubsectionNavigation
-        }
-    }
-
     Binding {
         when: !!root.item
         root.settingsSubsection: root.item.settingsSubsection
         root.settingsSubSubsection: root.item.settingsSubSubsection
-        root.forceSubsectionNavigation: root.item.forceSubsectionNavigation
     }
 
     // Signals re-emitted so AppMain can mutate appMainLocalSettings / Theme outside the loader
@@ -155,8 +153,7 @@ Loader {
             whitelistedDomainsModel:                Qt.binding(() => root.whitelistedDomainsModel),
             leftPanelWidthOverride:                 Qt.binding(() => root.leftPanelWidthOverride),
             settingsSubsection:                     Qt.binding(() => root.settingsSubsection),
-            settingsSubSubsection:                  Qt.binding(() => root.settingsSubSubsection),
-            forceSubsectionNavigation:              Qt.binding(() => root.forceSubsectionNavigation)
+            settingsSubSubsection:                  Qt.binding(() => root.settingsSubSubsection)
         })
     }
 


### PR DESCRIPTION
### What does the PR do

It's amendment to https://github.com/status-im/status-app/pull/21005 (the navigation to the same chat not working on a second attempt)

Moreover:
- fixes navigation to settings
- restores swipe animation when navigating from settings menu to specific settings page
- prevents automatic opening virtual keyboard when it was left with active focus on chat input

Closes: #20996
Closes: #20995
Closes: #20771

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Chat navigation

### Quality checklist

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user
Low

### How to test

IMPORTANT:
Select a 1-1/group chat
goback to left panel

Try to navigate to that same chat (through push notifications or activity center)

After navigation, go back to chats list, open AC and repeat navigation to the same list.

### Risk 
Low
