### PR TITLE
fix(StatusTextMessage): provide mobile/desktop specific implementations

### DIFF
--- a/storybook/pages/StatusMessagePage.qml
+++ b/storybook/pages/StatusMessagePage.qml
@@ -46,12 +46,25 @@ SplitView {
             outgoingStatus: StatusMessage.OutgoingStatus.Delivered,
             reactionsModel: d.reactionsModels.twentyReactions
         }]
+        readonly property var longMessage: [{
+            timestamp: 1667937830123,
+            senderId: "zq123456791",
+            senderDisplayName: "Paperback Writer",
+            contentType: StatusMessage.ContentType.Text,
+            message: ModelsData.descriptions.longLoremIpsum,
+            isContact: false,
+            isAReply: false,
+            trustIndicator: StatusContactVerificationIcons.TrustedType.None,
+            outgoingStatus: StatusMessage.OutgoingStatus.Delivered,
+            reactionsModel: []
+        }]
 
 
         readonly property var messagesModel: ListModel {
             Component.onCompleted:  {
                 append(d.messageWithThreeReactions)
                 append(d.messageWithTwentyReactions)
+                append(d.longMessage)
             }
 
             ListElement {
@@ -97,7 +110,7 @@ SplitView {
                 senderId: "zqdeadbeef"
                 senderDisplayName: "replicator.stateofus.eth"
                 contentType: StatusMessage.ContentType.Text
-                message: "Test message with a link https://github.com/. Try to copy the link!"
+                message: "Test message with a link https://github.com/. Try to click the link!"
                 isContact: true
                 isAReply: true
                 trustIndicator: StatusContactVerificationIcons.TrustedType.None
@@ -216,10 +229,22 @@ SplitView {
                 senderId: "zq123456790"
                 senderDisplayName: "Alice"
                 contentType: StatusMessage.ContentType.Image
-                message: "This message contains images"
+                message: "This message contains 2 images"
                 isContact: true
                 isAReply: false
                 trustIndicator: StatusContactVerificationIcons.TrustedType.None
+                outgoingStatus: StatusMessage.OutgoingStatus.Delivered
+                reactionsModel: []
+            }
+            ListElement {
+                timestamp: 1719769718000
+                senderId: "zq12345676767"
+                senderDisplayName: "Bob"
+                contentType: StatusMessage.ContentType.Text
+                message: "<blockquote>This is a block quoted text paragraph from a verified contact</blockquote>"
+                isContact: true
+                isAReply: false
+                trustIndicator: StatusContactVerificationIcons.TrustedType.Verified
                 outgoingStatus: StatusMessage.OutgoingStatus.Delivered
                 reactionsModel: []
             }
@@ -252,6 +277,7 @@ SplitView {
                     disabledTooltipText: disableLinkCheckbox.checked ? "Send not available": ""
                     reactionsModel: model.reactionsModel
                     maxEmojiReactionsPerMessage: 20
+                    isMobile: ctrlIsMobile.checked
 
                     messageDetails {
                         readonly property bool isEnsVerified: model.senderDisplayName.endsWith(".eth")
@@ -305,9 +331,17 @@ SplitView {
 
             logsView.logText: logs.logText
 
-            CheckBox {
-                id: disableLinkCheckbox
-                text: "Disable Address/Ens link"
+            ColumnLayout {
+                anchors.fill: parent
+                CheckBox {
+                    id: ctrlIsMobile
+                    text: "Is mobile"
+                }
+
+                CheckBox {
+                    id: disableLinkCheckbox
+                    text: "Disable Address/Ens link"
+                }
             }
         }
     }

--- a/storybook/qmlTests/tests/tst_StatusMessage.qml
+++ b/storybook/qmlTests/tests/tst_StatusMessage.qml
@@ -80,7 +80,7 @@ Item {
             verify(!!statusTextMessage)
 
             // Use regular expression to match all <a> tags in the text
-            var linkMatches = statusTextMessage.textField.text.match(/<a\b[^>]*>(.*?)<\/a>/gi)
+            var linkMatches = statusTextMessage.textField.item.text.match(/<a\b[^>]*>(.*?)<\/a>/gi)
             var actualLinkCount = linkMatches ? linkMatches.length : 0
 
             compare(actualLinkCount, data.validAddressEnsCount, "TextEdit should contain a link %1".arg(data.messageText))

--- a/test/e2e/gui/screens/messages.py
+++ b/test/e2e/gui/screens/messages.py
@@ -8,7 +8,7 @@ import allure
 
 import configs
 import driver
-from driver.objects_access import walk_children
+from driver.objects_access import is_descendant_of, walk_children
 from gui.components.settings.send_contact_request_popup import SendContactRequestFromProfile
 from gui.components.community.pinned_messages_popup import PinnedMessagesPopup
 from gui.components.context_menu import ContextMenu
@@ -152,6 +152,8 @@ class Message:
                         self.community_invitation['description'] = str(getattr(child, 'text', ''))
                     elif child_id == 'titleLayout':
                         self.link_preview_title_object = child
+                    elif object_name == 'StatusTextMessage_chatText':
+                        self.text = str(getattr(child, 'text', ''))
                     else:
                         match child_id:
                             case 'profileImage':
@@ -178,6 +180,12 @@ class Message:
         except (RuntimeError, AttributeError, LookupError):
             # If walking children fails, continue with minimal initialization
             pass
+
+        if self.text is None:
+            for chat_text in driver.findAllObjects({'objectName': 'StatusTextMessage_chatText'}):
+                if is_descendant_of(self.object, chat_text):
+                    self.text = str(getattr(chat_text, 'text', ''))
+                    break
 
     @allure.step('Open community invitation')
     def open_community_invitation(self, attempts: int = 4):

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -81,6 +81,8 @@ Control {
     property bool linkAddressAndEnsName
     property string disabledTooltipText
 
+    property bool isMobile: Utils.isMobile
+
     property StatusMessageDetails messageDetails: StatusMessageDetails {}
     property StatusMessageDetails replyDetails: StatusMessageDetails {}
 
@@ -208,6 +210,7 @@ Control {
                 visible: active
                 sourceComponent: StatusMessageReply {
                     objectName: "StatusMessage_replyDetails"
+                    isMobile: root.isMobile
                     replyDetails: root.replyDetails
                     profileClickable: root.profileClickable
                     onReplyProfileClicked: (sender, mouse) => root.replyProfileClicked(sender, mouse)
@@ -275,21 +278,7 @@ Control {
                                      (root.messageDetails.contentType === StatusMessage.ContentType.Invitation) ||
                                      (root.messageDetails.contentType === StatusMessage.ContentType.BridgeMessage)))
                         visible: active
-                        sourceComponent: StatusTextMessage {
-                            objectName: "StatusMessage_textMessage"
-                            messageDetails: root.messageDetails
-                            isEdited: root.isEdited
-                            allowShowMore: !root.isInPinnedPopup
-                            textField.anchors.rightMargin: root.isInPinnedPopup ? Theme.xlPadding : 0 // margin for the "Unpin" floating button
-                            highlightedLink: root.highlightedLink
-                            linkAddressAndEnsName: root.linkAddressAndEnsName
-                            disabledTooltipText: root.disabledTooltipText
-                            onLinkActivated: link => root.linkActivated(link)
-                            textField.onHoveredLinkChanged: {
-                                root.hoveredLink = hoveredLink;
-                            }
-                            onContextMenuRequested: pos => root.contextMenuRequested(pos)
-                        }
+                        sourceComponent: StatusTextMessageCommon {}
                     }
                     Loader {
                         active: root.messageDetails.contentType === StatusMessage.ContentType.Image && !editMode
@@ -304,21 +293,7 @@ Control {
                                 anchors.left: parent.left
                                 anchors.right: parent.right
                                 visible: active
-                                sourceComponent: StatusTextMessage {
-                                    objectName: "StatusMessage_textMessage"
-                                    messageDetails: root.messageDetails
-                                    isEdited: root.isEdited
-                                    allowShowMore: !root.isInPinnedPopup
-                                    textField.anchors.rightMargin: root.isInPinnedPopup ? Theme.xlPadding : 0 // margin for the "Unpin" floating button
-                                    highlightedLink: root.highlightedLink
-                                    linkAddressAndEnsName: root.linkAddressAndEnsName
-                                    disabledTooltipText: root.disabledTooltipText
-                                    onLinkActivated: link => root.linkActivated(link)
-                                    textField.onHoveredLinkChanged: {
-                                        root.hoveredLink = hoveredLink
-                                    }
-                                    onContextMenuRequested: pos => root.contextMenuRequested(pos)
-                                }
+                                sourceComponent: StatusTextMessageCommon {}
                             }
 
                             Loader {
@@ -428,5 +403,20 @@ Control {
         Component.onCompleted: {
             root.prepareAttachmentsModel()
         }
+    }
+
+    component StatusTextMessageCommon: StatusTextMessage {
+        objectName: "StatusMessage_textMessage"
+        messageDetails: root.messageDetails
+        isEdited: root.isEdited
+        allowShowMore: !root.isInPinnedPopup
+        textField.anchors.rightMargin: root.isInPinnedPopup ? Theme.xlPadding : 0 // margin for the "Unpin" floating button
+        highlightedLink: root.highlightedLink
+        linkAddressAndEnsName: root.linkAddressAndEnsName
+        disabledTooltipText: root.disabledTooltipText
+        isMobile: root.isMobile
+        onLinkActivated: link => root.linkActivated(link)
+        onHoveredLinkChanged: root.hoveredLink = hoveredLink
+        onContextMenuRequested: pos => root.contextMenuRequested(pos)
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
@@ -14,6 +14,7 @@ Item {
 
     property StatusMessageDetails replyDetails
     property bool profileClickable: true
+    property bool isMobile: Utils.isMobile
 
     signal replyProfileClicked(var sender, var mouse)
     signal messageClicked(var mouse)
@@ -124,8 +125,8 @@ Item {
                             visible: active
                             sourceComponent: StatusTextMessage {
                                 objectName: "StatusMessage_replyDetails_textMessage"
-                                textField.font.pixelSize: Theme.secondaryTextFontSize
-                                textField.color: Theme.palette.baseColor1
+                                isReply: true
+                                isMobile: root.isMobile
                                 allowShowMore: false
                                 stripHtmlTags: true
                                 convertToSingleLine: true

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -12,7 +12,7 @@ import StatusQ.Core.Utils
 Item {
     id: root
 
-    readonly property alias hoveredLink: chatText.hoveredLink
+    readonly property alias hoveredLink: chatTextLoader.hoveredLink
 
     property string highlightedLink: ""
     property bool linkAddressAndEnsName
@@ -22,23 +22,27 @@ Item {
     property bool isEdited: false
     property bool convertToSingleLine: false
     property bool stripHtmlTags: false
-
-    property alias textField: chatText
     property bool allowShowMore: true
+    property bool isReply
+
+    property bool isMobile
+
+    property alias textField: chatTextLoader
 
     signal linkActivated(string link)
     signal contextMenuRequested(point pos)
 
-    implicitWidth: chatText.implicitWidth
-    implicitHeight: chatText.height + d.showMoreHeight / 2
+    implicitWidth: chatTextLoader.width
+    implicitHeight: chatTextLoader.height + d.showMoreHeight / 2
 
     QtObject {
         id: d
-        property string hoveredLink: chatText.hoveredLink || root.highlightedLink
+        readonly property string hoveredLink: chatTextLoader.hoveredLink || root.highlightedLink
 
         property bool readMore: false
         property bool isQuote: false
         readonly property int showMoreHeight: showMoreButtonLoader.visible ? showMoreButtonLoader.height : 0
+        readonly property int maxHeight: 200
 
         readonly property string text: {
             if (root.messageDetails.contentType === StatusMessage.ContentType.Sticker)
@@ -49,7 +53,7 @@ Item {
 
             let formattedMessage = Utils.linkifyAndXSS(root.messageDetails.messageText, root.linkAddressAndEnsName);
 
-            isQuote = (formattedMessage.startsWith("<blockquote>") && formattedMessage.endsWith("</blockquote>"));
+            isQuote = formattedMessage.startsWith("<blockquote>") && formattedMessage.endsWith("</blockquote>")
 
             if (root.isEdited) {
                 const index = formattedMessage.endsWith("code>") ? formattedMessage.length : (formattedMessage.endsWith(">") ? formattedMessage.length - 4 : formattedMessage.length);
@@ -73,7 +77,7 @@ Item {
                 return formattedMessage
 
             return Utils.getMessageWithStyle(root.Theme.palette, formattedMessage,
-                                             chatText.hoveredLink, !!root.disabledTooltipText)
+                                             chatTextLoader.hoveredLink, !!root.disabledTooltipText)
         }
 
         function showDisabledTooltipForAddressEnsName(link) {
@@ -83,57 +87,27 @@ Item {
 
     Rectangle {
         width: 1
-        height: chatText.height
+        height: chatTextLoader.height
         radius: Theme.radius
         visible: d.isQuote
         color: Theme.palette.baseColor1
     }
 
-    StatusTextArea {
-        id: chatText
-        objectName: "StatusTextMessage_chatText"
+    Loader {
+        id: chatTextLoader
 
-        readonly property int effectiveHeight: showMoreButtonLoader.active && !d.readMore
-                                               ? 200
-                                               : chatText.implicitHeight
+        readonly property string hoveredLink: item ? item.hoveredLink : ""
 
+        readonly property int effectiveHeight: showMoreButtonLoader.active && !d.readMore ? d.maxHeight
+                                                                                          : item.implicitHeight
         height: effectiveHeight + d.showMoreHeight / 2
         anchors.left: parent.left
         anchors.leftMargin: d.isQuote ? Theme.halfPadding : 0
         anchors.right: parent.right
+
         opacity: !showMoreOpacityMask.active && !horizontalOpacityMask.active ? 1 : 0
-        background: null
-        leftPadding: 0
-        rightPadding: 0
-        topPadding: 0
-        bottomPadding: 0
-        text: d.text
-        selectedTextColor: Theme.palette.directColor1
-        color: d.isQuote ? Theme.palette.baseColor1 : Theme.palette.directColor1
-        textFormat: Text.RichText
-        wrapMode: root.convertToSingleLine ? Text.NoWrap : Text.Wrap
-        readOnly: true
-        selectByMouse: true  // applies to mouse only, not touch
 
-        onLinkActivated: function(link) {
-            if(d.showDisabledTooltipForAddressEnsName(link)) {
-                return
-            }
-            root.linkActivated(link)
-            chatText.deselect()
-        }
-        onLinkHovered: (link) => disabledLinkTooltip.visible = d.showDisabledTooltipForAddressEnsName(link)
-
-        // context menu handlers
-        ContextMenu.menu: null // disable builtin "edit" menu; we're not an edit control
-        inputMethodHints: Qt.ImhNoEditMenu // ditto for mobile
-        onPressAndHold: event => root.contextMenuRequested(Qt.point(event.x, event.y))
-        onPressed: function(event) {
-            if (event.button === Qt.RightButton) {
-                event.accepted = true
-                root.contextMenuRequested(Qt.point(event.x, event.y))
-            }
-        }
+        sourceComponent: root.isMobile ? chatTextMobileComp : chatTextDesktopComp
 
         HoverHandler {
             id: hoverHandler
@@ -147,8 +121,71 @@ Item {
         }
     }
 
+    Component {
+        id: chatTextMobileComp
+        StatusBaseText {
+            objectName: "StatusTextMessage_chatText"
+            text: d.text
+            color: d.isQuote || root.isReply ? Theme.palette.baseColor1 : Theme.palette.directColor1
+            font.pixelSize: root.isReply ? Theme.secondaryTextFontSize : Theme.primaryTextFontSize
+            textFormat: Text.RichText
+            wrapMode: root.convertToSingleLine ? Text.NoWrap : Text.Wrap
+
+            onLinkActivated: function(link) {
+                if(d.showDisabledTooltipForAddressEnsName(link)) {
+                    return
+                }
+                root.linkActivated(link)
+            }
+            onLinkHovered: (link) => disabledLinkTooltip.visible = d.showDisabledTooltipForAddressEnsName(link)
+        }
+    }
+
+    Component {
+        id: chatTextDesktopComp
+        StatusTextArea {
+            objectName: "StatusTextMessage_chatText"
+            background: null
+            leftPadding: 0
+            rightPadding: 0
+            topPadding: 0
+            bottomPadding: 0
+            text: d.text
+            selectedTextColor: Theme.palette.directColor1
+            color: d.isQuote || root.isReply ? Theme.palette.baseColor1 : Theme.palette.directColor1
+            font.pixelSize: root.isReply ? Theme.secondaryTextFontSize : Theme.primaryTextFontSize
+            textFormat: Text.RichText
+            wrapMode: root.convertToSingleLine ? Text.NoWrap : Text.Wrap
+            readOnly: true
+            selectByMouse: true  // applies to mouse only, not touch
+
+            onLinkActivated: function(link) {
+                if(d.showDisabledTooltipForAddressEnsName(link)) {
+                    return
+                }
+                root.linkActivated(link)
+                deselect()
+            }
+            onLinkHovered: (link) => disabledLinkTooltip.visible = d.showDisabledTooltipForAddressEnsName(link)
+
+            // context menu handlers
+            ContextMenu.menu: null // disable builtin "edit" menu; we're not an edit control
+            inputMethodHints: Qt.ImhNoEditMenu
+            onPressAndHold: function(event) {
+                event.accepted = true
+                root.contextMenuRequested(Qt.point(event.x, event.y))
+            }
+            onPressed: function(event) {
+                if (event.button === Qt.RightButton) {
+                    event.accepted = true
+                    root.contextMenuRequested(Qt.point(event.x, event.y))
+                }
+            }
+        }
+    }
+
     StatusSyntaxHighlighter {
-        quickTextDocument: chatText.textDocument
+        quickTextDocument: chatTextLoader.item?.textDocument ?? null
         hyperlinkHoverColor: Theme.palette.primaryColor3
         highlightedHyperlink: d.hoveredLink
         features: StatusSyntaxHighlighter.HighlightedHyperlink
@@ -157,12 +194,12 @@ Item {
     // Horizontal crop mask
     Loader {
         id: horizontalClipMask
-        anchors.fill: chatText
+        anchors.fill: chatTextLoader
         active: horizontalOpacityMask.active
         visible: false
         sourceComponent: LinearGradient {
             start: Qt.point(0, 0)
-            end: Qt.point(chatText.width, 0)
+            end: Qt.point(chatTextLoader.width, 0)
             gradient: Gradient {
                 GradientStop { position: 0.0; color: "white" }
                 GradientStop { position: 0.85; color: "white" }
@@ -173,24 +210,23 @@ Item {
 
     Loader {
         id: horizontalOpacityMask
-        active: root.convertToSingleLine && chatText.implicitWidth > chatText.width
-        anchors.fill: chatText
+        active: root.convertToSingleLine && chatTextLoader.implicitWidth > chatTextLoader.width
+        anchors.fill: chatTextLoader
         sourceComponent: OpacityMask {
-            source: chatText
+            source: chatTextLoader
             maskSource: horizontalClipMask
         }
     }
 
-    // Vertical "show more" mask
-
+    // Vertical "show more" mask + button
     Loader {
         id: showMoreMaskGradient
-        anchors.fill: chatText
+        anchors.fill: chatTextLoader
         active: showMoreButtonLoader.active && !d.readMore
         visible: false
         sourceComponent: LinearGradient {
             start: Qt.point(0, 0)
-            end: Qt.point(0, chatText.height)
+            end: Qt.point(0, chatTextLoader.height)
             gradient: Gradient {
                 GradientStop { position: 0.0; color: "white" }
                 GradientStop { position: 0.85; color: "white" }
@@ -202,18 +238,18 @@ Item {
     Loader {
         id: showMoreOpacityMask
         active: showMoreButtonLoader.active && !d.readMore
-        anchors.fill: chatText
+        anchors.fill: chatTextLoader
         sourceComponent: OpacityMask {
-            source: chatText
+            source: chatTextLoader
             maskSource: showMoreMaskGradient
         }
     }
 
     Loader {
         id: showMoreButtonLoader
-        active: root.allowShowMore && chatText.implicitHeight > 200
+        active: root.allowShowMore && chatTextLoader.item.implicitHeight > d.maxHeight
         visible: active
-        anchors.verticalCenter: chatText.bottom
+        anchors.verticalCenter: chatTextLoader.bottom
         anchors.horizontalCenter: parent.horizontalCenter
         sourceComponent: StatusRoundButton {
             implicitWidth: 24


### PR DESCRIPTION
### What does the PR do

- StatusTextArea for desktop (as before), more lightweight StatusBaseText for mobile, wrapped in a Loader
- extended the SB page coverage

Fixes #20360
Fixes #21006

### Affected areas

Status(Text)Message

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="1550" height="1800" alt="image" src="https://github.com/user-attachments/assets/d44d1dbf-a58d-4849-8a9b-f432aacf3380" />

### Impact on end user

Correct chat message context menu behavior on mobile

### How to test

- flick the messages list
- no context menu should appear at the end of the flick/drag

### Risk 

low
