### PR TITLE
fix: toggling otr flag mutated non-otr Profile params

### DIFF
--- a/storybook/qmlTests/tests/tst_BrowserDisconnectDapp.qml
+++ b/storybook/qmlTests/tests/tst_BrowserDisconnectDapp.qml
@@ -110,7 +110,18 @@ Item {
             dappsEnabled: true
             hostStackLayout: hostStack
             tabsModel: tabsModelRef
-            defaultProfileParams: ProfileParams {}
+            defaultProfileParams: ProfileParams {
+                userId: ""
+                userAgent: ""
+                scripts: []
+                offTheRecord: false
+            }
+            otrProfileParams: ProfileParams {
+                userId: ""
+                userAgent: ""
+                scripts: []
+                offTheRecord: true
+            }
             bookmarksStore: QtObject {}
             downloadsStore: QtObject {}
             determineRealURLFn: function(url) { return url }

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -266,6 +266,7 @@ StatusSectionLayout {
         hostStackLayout: webStackView
         tabsModel: tabs
         defaultProfileParams: browserConfig.defaultProfileParams
+        otrProfileParams: browserConfig.otrProfileParams
         bookmarksStore: root.bookmarksStore
         downloadsStore: root.downloadsStore
         determineRealURLFn: (url) => root.browserRootStore.determineRealURL(url)

--- a/ui/app/AppLayouts/Browser/adapters/ProfileParams.qml
+++ b/ui/app/AppLayouts/Browser/adapters/ProfileParams.qml
@@ -1,8 +1,10 @@
 import QtQuick
 
+// Value object: all fields must be set at construction; do not mutate after create.
+// To switch incognito mode, swap the tab's profileParams reference (default vs otr).
 QtObject {
-    property string userId: ""
-    property string userAgent: ""
-    property var scripts: []
-    property bool offTheRecord: false
+    required property string userId
+    required property string userAgent
+    required property var scripts
+    required property bool offTheRecord
 }

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -26,6 +26,7 @@ QtObject {
     required property Item hostStackLayout
     required property var tabsModel
     required property ProfileParams defaultProfileParams
+    required property ProfileParams otrProfileParams
 
     required property var bookmarksStore
     required property var downloadsStore
@@ -206,7 +207,9 @@ QtObject {
     function setIncognitoCurrent(checked) {
         if (!currentWebView)
             return
-        currentWebView.profileParams.offTheRecord = checked
+        const target = checked ? otrProfileParams : defaultProfileParams
+        if (currentWebView.profileParams !== target)
+            currentWebView.profileParams = target
     }
 
     function changeZoomCurrent(delta) {


### PR DESCRIPTION
Regression: toggling Incognito mutated a shared non-incognitor `ProfileParams` object used by  normal tabs. So all open tabs switched to incognito. 

Fixed choosing between dedicated profiles (otr, default)
fixes #21032

https://github.com/user-attachments/assets/616c9e8d-b057-4541-83dd-1dc9c70636df

