### PR TITLE
fix(browser): tap overlay fix

### DIFF
--- a/mobile/android/qt6/src/app/status/mobile/NativeSwipeHandlerHelper.java
+++ b/mobile/android/qt6/src/app/status/mobile/NativeSwipeHandlerHelper.java
@@ -3,6 +3,7 @@ package app.status.mobile;
 import android.app.Activity;
 import android.graphics.Rect;
 import android.os.Build;
+import android.os.SystemClock;
 import android.view.MotionEvent;
 import android.view.VelocityTracker;
 import android.view.View;
@@ -164,14 +165,7 @@ public class NativeSwipeHandlerHelper {
                         dispatchToTarget(passthroughTarget, event, action);
                     }
 
-                    if (velocityTracker != null) {
-                        velocityTracker.recycle();
-                        velocityTracker = null;
-                    }
-                    active = false;
-                    activePointerId = -1;
-                    swiping = false;
-                    passthroughTarget = null;
+                    resetGestureState();
                     return true;
                 }
 
@@ -226,13 +220,39 @@ public class NativeSwipeHandlerHelper {
     public void hideTouchOverlay() {
         if (activity == null) return;
         activity.runOnUiThread(() -> {
-            if (swiping) nativeOnSwipeEnded(nativePtr, 0f, 0f, true);
-            if (velocityTracker != null) { velocityTracker.recycle(); velocityTracker = null; }
-            active = swiping = false;
-            passthroughTarget = null;
+            if (touchOverlayView != null
+                    && touchOverlayView.getVisibility() == View.GONE
+                    && !active) {
+                return;
+            }
+            cancelActiveGesture();
+            resetGestureState();
             dismissTapMode = false;
             if (touchOverlayView != null) touchOverlayView.setVisibility(View.GONE);
         });
+    }
+
+    /** Sends ACTION_CANCEL to in-flight passthrough target and ends any active swipe. UI-thread only. */
+    private void cancelActiveGesture() {
+        if (active && passthroughTarget != null) {
+            long t = SystemClock.uptimeMillis();
+            MotionEvent cancel = MotionEvent.obtain(t, t, MotionEvent.ACTION_CANCEL, 0f, 0f, 0);
+            dispatchToTarget(passthroughTarget, cancel, MotionEvent.ACTION_CANCEL);
+            cancel.recycle();
+        }
+        if (swiping) nativeOnSwipeEnded(nativePtr, 0f, 0f, true);
+    }
+
+    /** Releases per-gesture resources and resets flags. UI-thread only. */
+    private void resetGestureState() {
+        if (velocityTracker != null) {
+            velocityTracker.recycle();
+            velocityTracker = null;
+        }
+        active = false;
+        swiping = false;
+        activePointerId = -1;
+        passthroughTarget = null;
     }
 
     private void updateGestureExclusion() {
@@ -298,13 +318,7 @@ public class NativeSwipeHandlerHelper {
                 if (parent != null) parent.removeView(touchOverlayView);
                 touchOverlayView = null;
             }
-
-            if (velocityTracker != null) {
-                velocityTracker.recycle();
-                velocityTracker = null;
-            }
-            active = false;
-            activePointerId = -1;
+            resetGestureState();
         });
     }
 }

--- a/mobile/android/qt6/src/app/status/mobile/NativeSwipeHandlerHelper.java
+++ b/mobile/android/qt6/src/app/status/mobile/NativeSwipeHandlerHelper.java
@@ -212,12 +212,26 @@ public class NativeSwipeHandlerHelper {
             touchOverlayView.setX(handlerX);
             touchOverlayView.setY(handlerY);
             touchOverlayView.setElevation(dismissMode ? 48f : 1f);
+            touchOverlayView.setVisibility(View.VISIBLE);
 
             ViewGroup parent = (ViewGroup) touchOverlayView.getParent();
             if (parent != null && dismissMode) {
                 parent.bringChildToFront(touchOverlayView);
             }
             updateGestureExclusion();
+        });
+    }
+
+    /** Hide overlay when QML handler is disabled (e.g. popup opens). Reversible via applyTouchOverlayState. */
+    public void hideTouchOverlay() {
+        if (activity == null) return;
+        activity.runOnUiThread(() -> {
+            if (swiping) nativeOnSwipeEnded(nativePtr, 0f, 0f, true);
+            if (velocityTracker != null) { velocityTracker.recycle(); velocityTracker = null; }
+            active = swiping = false;
+            passthroughTarget = null;
+            dismissTapMode = false;
+            if (touchOverlayView != null) touchOverlayView.setVisibility(View.GONE);
         });
     }
 

--- a/ui/StatusQ/src/StatusQ/Controls/NativeSwipeHandlerItem_android.cpp
+++ b/ui/StatusQ/src/StatusQ/Controls/NativeSwipeHandlerItem_android.cpp
@@ -164,8 +164,13 @@ void NativeSwipeHandlerItem_Android::updatePolish()
 
 void NativeSwipeHandlerItem_Android::updateOverlayBounds()
 {
-    if (!m_javaHelper.isValid() || !canHandleInput())
+    if (!m_javaHelper.isValid())
         return;
+
+    if (!canHandleInput()) {
+        m_javaHelper.callMethod<void>("hideTouchOverlay");
+        return;
+    }
 
     qreal xPx = 0;
     qreal yPx = 0;


### PR DESCRIPTION
Android native tap overlay staying active after the sidebar swipe handler is disabled. When a popup opens (e.g. Activity Center), hide the overlay immediately so taps reach Qt content instead of being intercepted by a stale full-screen dismiss rect.

Not seen on dApp popups because the nav bar was already closed, so the dismiss overlay was inactive.

https://github.com/user-attachments/assets/3d7b9956-e972-4bc9-968a-6f46b5cf9db7


fixes #20698 