### PR TITLE
ci: allow to override status-go reference

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -34,6 +34,11 @@ pipeline {
       description: 'Level of verbosity based on nimbus-build-system setup.',
       choices: ['0','1','2','3']
     )
+    string(
+      name: 'STATUS_GO_REF',
+      description: 'Override vendor/status-go submodule to this SHA/ref.',
+      defaultValue: ''
+    )
   }
 
   options {
@@ -98,6 +103,13 @@ pipeline {
     stage('Fetch submodules') {
       steps {
         sh 'git submodule update --init --recursive'
+      }
+    }
+
+    stage('Override status-go ref') {
+      when { expression { params.STATUS_GO_REF?.trim() } }
+      steps {
+        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
       }
     }
 

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -31,6 +31,11 @@ pipeline {
       description: 'TestFlight build polling interval in seconds.',
       defaultValue: '30'
     )
+    string(
+      name: 'STATUS_GO_REF',
+      description: 'Override vendor/status-go submodule to this SHA/ref.',
+      defaultValue: ''
+    )
   }
 
   options {
@@ -103,6 +108,13 @@ pipeline {
     stage('Fetch submodules') {
       steps {
         sh 'git submodule update --init --recursive'
+      }
+    }
+
+    stage('Override status-go ref') {
+      when { expression { params.STATUS_GO_REF?.trim() } }
+      steps {
+        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
       }
     }
 

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -49,6 +49,11 @@ pipeline {
       description: 'Build with the simulated (jcardsim) keycard backend (used by keycard e2e tests).',
       defaultValue: false
     )
+    string(
+      name: 'STATUS_GO_REF',
+      description: 'Override vendor/status-go submodule to this SHA/ref.',
+      defaultValue: ''
+    )
   }
 
   options {
@@ -93,7 +98,7 @@ pipeline {
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
     VERBOSE =                "${params.VERBOSE}"
-    USE_SIMULATED_KEYCARD = "${params.USE_SIMULATED_KEYCARD}"
+    USE_SIMULATED_KEYCARD =  "${params.USE_SIMULATED_KEYCARD}"
     /* FIXME: figure out why NIMFLAGS are not respected */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}"
     /* Ensure nimcache is not shared between builds. */
@@ -109,6 +114,12 @@ pipeline {
     stage('Fetch submodules') {
       steps {
         sh 'git submodule update --init --recursive'
+      }
+    }
+    stage('Override status-go ref') {
+      when { expression { params.STATUS_GO_REF?.trim() } }
+      steps {
+        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
       }
     }
     stage('Deps') {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -43,6 +43,11 @@ pipeline {
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
       defaultValue: ''
     )
+    string(
+      name: 'STATUS_GO_REF',
+      description: 'Override vendor/status-go submodule to this SHA/ref.',
+      defaultValue: ''
+    )
   }
 
   options {
@@ -94,7 +99,7 @@ pipeline {
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
     VERBOSE =                "${params.VERBOSE}"
-    USE_SIMULATED_KEYCARD = "${params.USE_SIMULATED_KEYCARD}"
+    USE_SIMULATED_KEYCARD =  "${params.USE_SIMULATED_KEYCARD}"
     /* FIXME: figure out why NIMFLAGS are not respected */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
     /* Ensure nimcache is not shared between builds. */
@@ -113,6 +118,12 @@ pipeline {
     stage('Fetch submodules') {
       steps {
         sh 'git submodule update --init --recursive'
+      }
+    }
+    stage('Override status-go ref') {
+      when { expression { params.STATUS_GO_REF?.trim() } }
+      steps {
+        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
       }
     }
     stage('Deps') {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -46,6 +46,11 @@ pipeline {
         'https://freetsa.org',
       ]
     )
+    string(
+      name: 'STATUS_GO_REF',
+      description: 'Override vendor/status-go submodule to this SHA/ref.',
+      defaultValue: ''
+    )
   }
 
   options {
@@ -96,7 +101,7 @@ pipeline {
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
     VERBOSE =                "${params.VERBOSE}"
-    USE_SIMULATED_KEYCARD = "${params.USE_SIMULATED_KEYCARD}"
+    USE_SIMULATED_KEYCARD =  "${params.USE_SIMULATED_KEYCARD}"
     /* FIXME: figure out why NIMFLAGS are not respected */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
     /* Nim build on Windows puts nimcache in user HOME. */
@@ -116,6 +121,12 @@ pipeline {
     stage('Fetch submodules') {
       steps {
         sh 'git submodule update --init --recursive'
+      }
+    }
+    stage('Override status-go ref') {
+      when { expression { params.STATUS_GO_REF?.trim() } }
+      steps {
+        sh "./scripts/override-status-go-ref.sh ${params.STATUS_GO_REF}"
       }
     }
     stage('Deps') {

--- a/scripts/override-status-go-ref.sh
+++ b/scripts/override-status-go-ref.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Override vendor/status-go submodule to given ref (SHA, branch, or PR head).
+set -euo pipefail
+
+REF="${1:?Usage: $(basename "$0") <status-go-ref>}"
+
+cd vendor/status-go
+git fetch --no-tags origin \
+  '+refs/heads/*:refs/remotes/origin/*' \
+  '+refs/pull/*/head:refs/remotes/origin/pr/*'
+git checkout --detach "${REF}"
+git submodule update --init --recursive


### PR DESCRIPTION
## Summary

- Allow to override status-go ref, useful to execute status-app jobs from status-go CI

needed for : https://github.com/status-im/status-go/pull/7480