### PR TITLE
chore(NotificationsView): speedup and split into several components

### DIFF
--- a/src/app/modules/main/profile_section/notifications/model.nim
+++ b/src/app/modules/main/profile_section/notifications/model.nim
@@ -16,6 +16,7 @@ type
     PersonalMentions
     GlobalMentions
     OtherMessages
+    JoinedTimestamp
 
 QtObject:
   type
@@ -27,13 +28,6 @@ QtObject:
   proc newModel*(): Model =
     new(result, delete)
     result.setup
-
-  proc countChanged(self: Model) {.signal.}
-  proc getCount(self: Model): int {.slot.} =
-    self.items.len
-  QtProperty[int] count:
-    read = getCount
-    notify = countChanged
 
   method rowCount(self: Model, index: QModelIndex = nil): int =
     return self.items.len
@@ -49,7 +43,8 @@ QtObject:
       ModelRole.MuteAllMessages.int:"muteAllMessages",
       ModelRole.PersonalMentions.int:"personalMentions",
       ModelRole.GlobalMentions.int:"globalMentions",
-      ModelRole.OtherMessages.int:"otherMessages"
+      ModelRole.OtherMessages.int:"otherMessages",
+      ModelRole.JoinedTimestamp.int:"joinedTimestamp"
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -83,42 +78,31 @@ QtObject:
       result = newQVariant(item.globalMentions)
     of ModelRole.OtherMessages:
       result = newQVariant(item.otherMessages)
+    of ModelRole.JoinedTimestamp:
+      result = newQVariant(item.joinedTimestamp)
 
   proc addItem*(self: Model, item: Item) =
-    # add most recent item on top
-    var position = -1
-    for i in 0 ..< self.items.len:
-      if(item.joinedTimestamp >= self.items[i].joinedTimestamp):
-        position = i
-        break
-
-    if(position == -1):
-      position = self.items.len
-
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
 
+    let position = self.items.len
+
     self.beginInsertRows(parentModelIndex, position, position)
-    self.items.insert(item, position)
+    self.items.add(item)
     self.endInsertRows()
-    self.countChanged()
 
   proc setItems*(self: Model, items: seq[Item]) =
     if items.len == 0:
       return
 
-    let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
-
-    self.beginInsertRows(parentModelIndex, 0, items.len - 1)
+    self.beginResetModel()
     self.items = items
-    self.endInsertRows()
-    self.countChanged()
+    self.endResetModel()
 
   proc findIndexForItemId*(self: Model, id: string): int =
     var ind = 0
     for it in self.items:
-      if(it.id == id):
+      if it.id == id:
         return ind
       ind.inc
     return -1
@@ -135,16 +119,10 @@ QtObject:
     self.items.delete(ind)
     self.endRemoveRows()
 
-    self.countChanged()
-
-  iterator modelIterator*(self: Model): Item =
-    for i in 0 ..< self.items.len:
-      yield self.items[i]
-
   proc updateExemptions*(self: Model, id: string, muteAllMessages = false, personalMentions = VALUE_NOTIF_SEND_ALERTS, 
     globalMentions = VALUE_NOTIF_SEND_ALERTS, otherMessages = VALUE_NOTIF_TURN_OFF) =
     let ind = self.findIndexForItemId(id)
-    if(ind == -1):
+    if ind == -1:
       return
     
     var roles: seq[int] = @[]

--- a/src/app/modules/main/profile_section/notifications/module.nim
+++ b/src/app/modules/main/profile_section/notifications/module.nim
@@ -44,11 +44,6 @@ method delete*(self: Module) =
   self.viewVariant.delete
   self.controller.delete
 
-proc comp[T](x,y: T):int = 
-  if x.joinedTimestamp > y.joinedTimestamp: return 1
-  elif x.joinedTimestamp < y.joinedTimestamp: return -1
-  else: return 0
-
 method load*(self: Module) =
   self.controller.init()
   self.view.load()
@@ -96,8 +91,6 @@ method initModel(self: Module) =
     )
     items.add(item)
 
-  # Sort to get most recent first
-  items.sort(comp, SortOrder.Descending)
   self.view.exemptionsModel().setItems(items)
 
 method viewDidLoad*(self: Module) =
@@ -121,7 +114,7 @@ method saveExemptions*(self: Module, itemId: string, muteAllMessages: bool, pers
   
 method addCommunity*(self: Module, communityDto: CommunityDto) =
   let ind = self.view.exemptionsModel().findIndexForItemId(communityDto.id)
-  if(ind != -1):
+  if ind != -1:
     return
   let item = self.createItem(communityDto.id, communityDto.name, communityDto.images.thumbnail, communityDto.color, 
     joinedTimestamp = 0, item.Type.Community)

--- a/src/app/modules/main/profile_section/notifications/view.nim
+++ b/src/app/modules/main/profile_section/notifications/view.nim
@@ -33,12 +33,10 @@ QtObject:
   proc exemptionsModel*(self: View): Model =
     return self.exemptionsModel
 
-  proc exemptionsModelChanged*(self: View) {.signal.}
   proc getExemptionsModel(self: View): QVariant {.slot.} =
     return self.exemptionsModelVariant
   QtProperty[QVariant] exemptionsModel:
     read = getExemptionsModel
-    notify = exemptionsModelChanged
 
   proc saveExemptions*(self: View, itemId: string, muteAllMessages: bool, personalMentions: string, 
     globalMentions: string, otherMessages: string) {.slot.} =

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -31,7 +31,7 @@ Rectangle {
     property bool highlighted: false
     property bool propagateTitleClicks: true
     property int type: StatusListItem.Type.Primary
-    property list<Item> components
+    property alias components: statusListItemComponentsSlot.children
     property var bottomModel: []
     property Component bottomDelegate
     property alias tagsModel: tagsRepeater.model
@@ -131,14 +131,6 @@ Rectangle {
         return Theme.palette.statusListItem.backgroundColor
     }
     radius: Theme.radius
-
-    onComponentsChanged: {
-        if (components.length) {
-            for (let idx in components) {
-                components[idx].parent = statusListItemComponentsSlot
-            }
-        }
-    }
 
     StatusMouseArea {
         anchors.fill: parent

--- a/ui/StatusQ/src/StatusQ/Platform/StatusMacNotification.qml
+++ b/ui/StatusQ/src/StatusQ/Platform/StatusMacNotification.qml
@@ -32,10 +32,7 @@ Control {
             Layout.preferredHeight: root.availableHeight
             Layout.preferredWidth: root.availableHeight
 
-            source: Qt.resolvedUrl("../../assets/png/status-logo-icon.png")
-
-            sourceSize.width: width * 2
-            sourceSize.height: height * 2
+            source: Assets.png("status-logo")
 
             fillMode: Image.PreserveAspectFit
         }

--- a/ui/app/AppLayouts/Profile/controls/NotificationSelect.qml
+++ b/ui/app/AppLayouts/Profile/controls/NotificationSelect.qml
@@ -32,39 +32,34 @@ Item {
                                                                                                                                                                      d.sendAlertsText
         icon.name: "chevron-down"
 
-        onClicked: {
-            if (selectMenu.opened) {
-                selectMenu.close()
-            } else {
-                selectMenu.popup(button.x, button.y + button.height + 8)
-            }
-        }
+        onClicked: Global.openMenu(selectMenu, button, {}, Qt.point(button.x, button.y + button.height + 8))
     }
 
-    StatusMenu {
+    Component {
         id: selectMenu
-        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
-        width: parent.width
-        clip: true
+        StatusMenu {
+            width: parent.width
+            onClosed: destroy()
 
-        StatusAction {
-            text: d.sendAlertsText
-            onTriggered: {
-                root.sendAlertsClicked()
+            StatusAction {
+                text: d.sendAlertsText
+                onTriggered: {
+                    root.sendAlertsClicked()
+                }
             }
-        }
 
-        StatusAction {
-            text: d.deliverQuietlyText
-            onTriggered: {
-                root.deliverQuietlyClicked()
+            StatusAction {
+                text: d.deliverQuietlyText
+                onTriggered: {
+                    root.deliverQuietlyClicked()
+                }
             }
-        }
 
-        StatusAction {
-            text: d.turnOffText
-            onTriggered: {
-                root.turnOffClicked()
+            StatusAction {
+                text: d.turnOffText
+                onTriggered: {
+                    root.turnOffClicked()
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/panels/NotificationAppearancePreviewPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/NotificationAppearancePreviewPanel.qml
@@ -7,15 +7,15 @@ import StatusQ.Core
 import StatusQ.Core.Theme
 
 Control {
+    id: root
+
     property bool checked: false
     property string name
     property string notificationTitle
     property string notificationMessage
     property var buttonGroup
     property bool isHovered: false
-    signal radioCheckedChanged(checked: bool)
-
-    id: root
+    signal radioCheckedChanged(bool checked)
 
     background: Rectangle {
         color: radioButton.checked ? Theme.palette.secondaryBackground :
@@ -37,7 +37,7 @@ Control {
             text: root.name
             ButtonGroup.group: root.buttonGroup || null
             checked: root.checked
-            onCheckedChanged: root.radioCheckedChanged(checked)
+            onToggled: root.radioCheckedChanged(checked)
         }
 
         StatusNotificationWithDropShadowPanel {
@@ -55,12 +55,8 @@ Control {
         hoverEnabled: true
         onEntered: root.isHovered = true
         onExited: root.isHovered = false
-        onClicked: {
-            if (!radioButton.checked)
-                root.radioCheckedChanged(true)
-        }
+        onClicked: radioButton.click()
 
         cursorShape: Qt.PointingHandCursor
     }
 }
-

--- a/ui/app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml
@@ -6,18 +6,15 @@ import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Controls
 import StatusQ.Components
-import StatusQ.Popups
+import StatusQ.Popups.Dialog
 
 import utils
 import shared.panels
 
 import "../controls"
-import "../stores"
 
-StatusModal {
+StatusDialog {
     id: root
-
-    property NotificationsStore notificationsStore
 
     property string name
     property int type: Constants.settingsSection.exemptions.community
@@ -29,21 +26,24 @@ StatusModal {
     property string globalMentions: Constants.settingsSection.notifications.sendAlertsValue
     property string otherMessages: Constants.settingsSection.notifications.turnOffValue
 
-    headerSettings.title: qsTr("%1 exemption").arg(root.name)
-    headerSettings.asset: StatusAssetSettings {
-        // Once we introduce StatusSmartIdenticon in popup header, we should use the folowing
-//        color: root.type === Constants.settingsSection.exemptions.oneToOneChat?
-//                   Theme.palette.userCustomizationColors[Utils.colorIdForPubkey(root.itemId)] :
-//                   root.color
-        // until then the following is used
-        bgColor: d.isOneToOneChat ? Utils.colorForPubkey(root.Theme.palette, root.itemId) : root.color
-        name: root.image
-        isImage: !!root.image
-        charactersLen: d.isOneToOneChat ? 2 : 1
-        isLetterIdenticon: root.image === ""
-        height: 40
-        width: 40
+    signal saveExemptionsRequested(string itemId, bool muteAllMessages, string personalMentions, string globalMentions, string allMessages)
+
+    header: StatusDialogHeader {
+        headline.title: qsTr("%1 exemption").arg(root.name)
+        actions.closeButton.onClicked: root.closeHandler()
+
+        leftComponent: StatusSmartIdenticon {
+            asset.color: d.isOneToOneChat ? Utils.colorForPubkey(Theme.palette, root.itemId) : root.color
+            name: root.name
+            asset.name: root.image
+            asset.isImage: !!root.image
+            asset.charactersLen: d.isOneToOneChat ? 2 : 1
+            asset.isLetterIdenticon: root.image === ""
+            height: 32
+            width: 32
+        }
     }
+    width: 480
 
     QtObject {
         id: d
@@ -60,7 +60,6 @@ StatusModal {
     }
 
     contentItem: Column {
-        width: root.width
         spacing: d.contentSpacing
 
         StatusListItem {
@@ -127,28 +126,30 @@ StatusModal {
         }
     }
 
-    rightButtons: [
-        StatusFlatButton {
-            text: qsTr("Clear Exemptions")
-            enabled: d.customized
-            onClicked: {
-                d.muteAllMessages = false
-                d.personalMentions = Constants.settingsSection.notifications.sendAlertsValue
-                d.globalMentions = Constants.settingsSection.notifications.sendAlertsValue
-                d.otherMessages = Constants.settingsSection.notifications.turnOffValue
+    footer: StatusDialogFooter {
+        rightButtons: ObjectModel {
+            StatusFlatButton {
+                text: qsTr("Clear Exemptions")
+                enabled: d.customized
+                onClicked: {
+                    d.muteAllMessages = false
+                    d.personalMentions = Constants.settingsSection.notifications.sendAlertsValue
+                    d.globalMentions = Constants.settingsSection.notifications.sendAlertsValue
+                    d.otherMessages = Constants.settingsSection.notifications.turnOffValue
+                }
             }
-        },
-        StatusButton {
-            id: btnCreateEdit
-            text: qsTr("Done")
-            onClicked: {
-                root.notificationsStore.saveExemptions(root.itemId,
-                                                       d.muteAllMessages,
-                                                       d.personalMentions,
-                                                       d.globalMentions,
-                                                       d.otherMessages)
-                root.close()
+            StatusButton {
+                id: btnCreateEdit
+                text: qsTr("Done")
+                onClicked: {
+                    root.saveExemptionsRequested(root.itemId,
+                                                 d.muteAllMessages,
+                                                 d.personalMentions,
+                                                 d.globalMentions,
+                                                 d.otherMessages)
+                    root.close()
+                }
             }
         }
-    ]
+    }
 }

--- a/ui/app/AppLayouts/Profile/popups/qmldir
+++ b/ui/app/AppLayouts/Profile/popups/qmldir
@@ -12,3 +12,4 @@ WalletKeypairAccountMenu 1.0 WalletKeypairAccountMenu.qml
 WalletAddressMenu 1.0 WalletAddressMenu.qml
 ConfirmChangePasswordModal 1.0 ConfirmChangePasswordModal.qml
 SearchEngineModal 1.0 SearchEngineModal.qml
+ExemptionNotificationsModal 1.0 ExemptionNotificationsModal.qml

--- a/ui/app/AppLayouts/Profile/stores/NotificationsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/NotificationsStore.qml
@@ -1,13 +1,12 @@
-import QtQuick
-import utils
+import QtQml
 
 QtObject {
     id: root
 
     property var notificationsModule
-    property var notificationsSettings: appSettings
+    readonly property var notificationsSettings: appSettings
 
-    property var exemptionsModel: notificationsModule.exemptionsModel
+    readonly property var exemptionsModel: notificationsModule.exemptionsModel
 
     function loadExemptions() {
         root.notificationsModule.loadExemptions()

--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import SortFilterProxyModel
 
 import StatusQ.Core
 import StatusQ.Core.Theme
@@ -16,10 +15,14 @@ import utils
 import shared.panels
 import shared.controls
 
+import SortFilterProxyModel
+import QtModelsToolkit
+
 import "../stores"
 import "../controls"
 import "../panels"
 import "../popups"
+import "notifications"
 
 SettingsContentBase {
     id: root
@@ -30,23 +33,13 @@ SettingsContentBase {
     QtObject {
         id: d
 
-        readonly property int infoFontSize: root.Theme.primaryTextFontSize
         readonly property int infoLineHeight: 22
         readonly property int infoSpacing: 5
 
         readonly property var notificationsSettings: root.notificationsStore.notificationsSettings
-        property real unfilteredExemptionsListHeight: 0
     }
 
     Component.onCompleted: root.notificationsStore.loadExemptions()
-
-    Component {
-        id: exemptionNotificationsModal
-        ExemptionNotificationsModal {
-            notificationsStore: root.notificationsStore
-            destroyOnClose: true
-        }
-    }
 
     content: ColumnLayout {
         id: contentColumn
@@ -55,104 +48,6 @@ SettingsContentBase {
 
         ButtonGroup {
             id: messageSetting
-        }
-
-        Component {
-            id: exemptionDelegateComponent
-            StatusListItem {
-                width: ListView.view.width
-                title: model.name
-                subTitle: {
-                    if(model.type === Constants.settingsSection.exemptions.community)
-                        return qsTr("Community")
-                    else if(model.type === Constants.settingsSection.exemptions.oneToOneChat)
-                        return qsTr("1:1 Chat")
-                    else if(model.type === Constants.settingsSection.exemptions.groupChat)
-                        return qsTr("Group Chat")
-                    else
-                        return ""
-                }
-                label: {
-                    if(!model.customized)
-                        return ""
-
-                    let l = ""
-                    if(model.muteAllMessages)
-                        l += qsTr("Muted")
-                    else {
-                        let nbOfChanges = 0
-
-                        if(model.personalMentions !== Constants.settingsSection.notifications.sendAlertsValue)
-                        {
-                            nbOfChanges++
-                            let valueText = model.personalMentions === Constants.settingsSection.notifications.turnOffValue?
-                                    qsTr("Off") :
-                                    qsTr("Quiet")
-                            l = qsTr("Personal @ Mentions %1").arg(valueText)
-                        }
-
-                        if(model.globalMentions !== Constants.settingsSection.notifications.sendAlertsValue)
-                        {
-                            nbOfChanges++
-                            let valueText = model.globalMentions === Constants.settingsSection.notifications.turnOffValue?
-                                    qsTr("Off") :
-                                    qsTr("Quiet")
-                            l = qsTr("Global @ Mentions %1").arg(valueText)
-                        }
-
-                        if(model.otherMessages !== Constants.settingsSection.notifications.turnOffValue)
-                        {
-                            nbOfChanges++
-                            let valueText = model.otherMessages === Constants.settingsSection.notifications.sendAlertsValue?
-                                    qsTr("Alerts") :
-                                    qsTr("Quiet")
-                            l = qsTr("Other Messages %1").arg(valueText)
-                        }
-
-                        if(nbOfChanges > 1)
-                            l = qsTr("Multiple Exemptions")
-                    }
-
-                    return l
-                }
-
-                asset: StatusAssetSettings {
-                    name: model.image
-                    isImage: !!model.image && model.image !== ""
-                    color: model.type === Constants.settingsSection.exemptions.oneToOneChat?
-                               Utils.colorForPubkey(root.Theme.palette, model.itemId) :
-                               model.color
-                    charactersLen: model.type === Constants.settingsSection.exemptions.oneToOneChat? 2 : 1
-                    isLetterIdenticon: !model.image || model.image === ""
-                    height: 40
-                    width: 40
-                }
-
-                components: [
-                    StatusIcon {
-                        icon: model.customized ? "next" : "add"
-                        color: model.customized ? Theme.palette.baseColor1 : Theme.palette.primaryColor1
-                        StatusMouseArea {
-                            anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: {
-                                const props = {
-                                    name: model.name,
-                                    type: model.type,
-                                    itemId: model.itemId,
-                                    color: model.color,
-                                    image: model.image,
-                                    muteAllMessages: model.muteAllMessages,
-                                    personalMentions: model.personalMentions,
-                                    globalMentions: model.globalMentions,
-                                    otherMessages: model.otherMessages
-                                }
-                                exemptionNotificationsModal.createObject(root, props).open()
-                            }
-                        }
-                    }
-                ]
-            }
         }
 
         Rectangle {
@@ -173,7 +68,6 @@ SettingsContentBase {
                 StatusBaseText {
                     Layout.preferredWidth: parent.width
                     text: qsTr("Enable notifications")
-                    font.pixelSize: d.infoFontSize
                     lineHeight: d.infoLineHeight
                     lineHeightMode: Text.FixedHeight
                     color: Theme.palette.primaryColor1
@@ -182,7 +76,6 @@ SettingsContentBase {
                 StatusBaseText {
                     Layout.preferredWidth: parent.width
                     text: qsTr("Receive notifications for incoming messages, mentions, and contact requests on your computer so you can stay up to date in real time. Customize anytime in <b>Settings → Notifications</b><br><br>Status delivers notifications directly through your operating system, with no third parties, centralized servers, or intermediaries involved.")
-                    font.pixelSize: d.infoFontSize
                     lineHeight: d.infoLineHeight
                     lineHeightMode: Text.FixedHeight
                     color: Theme.palette.baseColor1
@@ -212,7 +105,6 @@ SettingsContentBase {
 
             contentItem: StatusBaseText {
                 text: qsTr("<font color='%1'>Enable notifications in your device Settings</font><br><br>Before enabling notifications in the app below, enable them in <font color='%1'>your device settings</font> first.").arg(Theme.palette.primaryColor1)
-                font.pixelSize: d.infoFontSize
                 lineHeight: d.infoLineHeight
                 lineHeightMode: Text.FixedHeight
                 color: Theme.palette.baseColor1
@@ -369,7 +261,7 @@ SettingsContentBase {
             ColumnLayout {
                 Layout.preferredWidth: root.contentWidth - Theme.padding * 2
                 Layout.leftMargin: Theme.padding
-                Layout.rightMargin: Theme.padding 
+                Layout.rightMargin: Theme.padding
 
                 StatusBaseText {
                     Layout.fillWidth: true
@@ -387,7 +279,7 @@ SettingsContentBase {
                     notificationMessage: qsTr("Hi there! So EIP-1559 will defini...")
                     buttonGroup: messageSetting
                     checked: d.notificationsSettings.notificationMessagePreview === Constants.settingsSection.notificationsBubble.previewNameAndMessage
-                    onRadioCheckedChanged: {
+                    onRadioCheckedChanged: checked => {
                         if (checked) {
                             d.notificationsSettings.notificationMessagePreview = Constants.settingsSection.notificationsBubble.previewNameAndMessage
                         }
@@ -402,7 +294,7 @@ SettingsContentBase {
                     notificationMessage: qsTr("You have a new message")
                     buttonGroup: messageSetting
                     checked: d.notificationsSettings.notificationMessagePreview === Constants.settingsSection.notificationsBubble.previewNameOnly
-                    onRadioCheckedChanged: {
+                    onRadioCheckedChanged: checked => {
                         if (checked) {
                             d.notificationsSettings.notificationMessagePreview = Constants.settingsSection.notificationsBubble.previewNameOnly
                         }
@@ -417,7 +309,7 @@ SettingsContentBase {
                     notificationMessage: qsTr("You have a new message")
                     buttonGroup: messageSetting
                     checked: d.notificationsSettings.notificationMessagePreview === Constants.settingsSection.notificationsBubble.previewAnonymous
-                    onRadioCheckedChanged: {
+                    onRadioCheckedChanged: checked => {
                         if (checked) {
                             d.notificationsSettings.notificationMessagePreview = Constants.settingsSection.notificationsBubble.previewAnonymous
                         }
@@ -440,7 +332,7 @@ SettingsContentBase {
                 text: qsTr("Send a Test Notification")
                 onClicked: {
                     root.notificationsStore.sendTestNotification(notifNameAndMsg.notificationTitle,
-                                                                notifNameAndMsg.notificationMessage)
+                                                                 notifNameAndMsg.notificationMessage)
                 }
             }
 
@@ -471,43 +363,25 @@ SettingsContentBase {
                 color: Theme.palette.baseColor1
             }
 
-            StatusListView {
+            ExemptionsView {
                 Layout.preferredWidth: root.contentWidth
-                Layout.preferredHeight: this.isFiltering && d.unfilteredExemptionsListHeight > 0 ?
-                                            Math.max(this.contentHeight,
-                                                     Math.min(d.unfilteredExemptionsListHeight,
-                                                              root.availableHeight)) :
-                                            this.contentHeight
-                visible: root.notificationsStore.exemptionsModel.count > 0
-
-                readonly property bool isFiltering: searchBox.text.trim() !== ""
-
-                onContentHeightChanged: {
-                    if (!isFiltering)
-                        d.unfilteredExemptionsListHeight = contentHeight
-                }
+                Layout.fillHeight: true
+                Layout.preferredHeight: contentHeight
 
                 model: SortFilterProxyModel {
-                    id: exemptionsSearchModel
-
-                    readonly property string searchText: searchBox.text.trim()
-
                     sourceModel: root.notificationsStore.exemptionsModel
-                    filters: AnyOf {
-                        enabled: exemptionsSearchModel.searchText !== ""
-
-                        SQUtils.SearchFilter {
-                            roleName: "itemId"
-                            searchPhrase: exemptionsSearchModel.searchText
-                        }
-
-                        SQUtils.SearchFilter {
-                            roleName: "name"
-                            searchPhrase: exemptionsSearchModel.searchText
-                        }
+                    filters: SQUtils.SearchFilter {
+                        roleName: "name"
+                        searchPhrase: searchBox.text
+                        enabled: !!searchPhrase
+                    }
+                    sorters: RoleSorter {
+                        roleName: "joinedTimestamp"
+                        sortOrder: Qt.DescendingOrder
                     }
                 }
-                delegate: exemptionDelegateComponent
+                onSaveExemptionsRequested: (itemId, muteAllMessages, personalMentions, globalMentions, allMessages) =>
+                                           root.notificationsStore.saveExemptions(itemId, muteAllMessages, personalMentions, globalMentions, allMessages)
             }
             }
         }
@@ -622,7 +496,6 @@ SettingsContentBase {
                     Layout.preferredWidth: root.contentWidth
                     Layout.leftMargin: Theme.padding
                     text: qsTr("Volume")
-                    color: Theme.palette.directColor1
                 }
 
                 Item {
@@ -661,14 +534,12 @@ SettingsContentBase {
                         width: volumeSlider.width
 
                         StatusBaseText {
-                            font.pixelSize: Theme.primaryTextFontSize
                             text: volumeSlider.from
                             Layout.preferredWidth: volumeSlider.width/2
                             color: Theme.palette.baseColor1
                         }
 
                         StatusBaseText {
-                            font.pixelSize: Theme.primaryTextFontSize
                             text: volumeSlider.to
                             Layout.alignment: Qt.AlignRight
                             color: Theme.palette.baseColor1

--- a/ui/app/AppLayouts/Profile/views/notifications/ExemptionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/notifications/ExemptionsView.qml
@@ -1,0 +1,120 @@
+import QtQuick
+import QtQuick.Layouts
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Controls
+import StatusQ.Components
+
+import AppLayouts.Profile.popups
+
+import utils
+
+StatusListView {
+    id: root
+
+    signal saveExemptionsRequested(string itemId, bool muteAllMessages, string personalMentions, string globalMentions, string allMessages)
+
+    delegate: StatusListItem {
+        width: ListView.view.width
+        title: model.name
+        subTitle: {
+            if(model.type === Constants.settingsSection.exemptions.community)
+                return qsTr("Community")
+            if(model.type === Constants.settingsSection.exemptions.oneToOneChat)
+                return qsTr("1:1 Chat")
+            if(model.type === Constants.settingsSection.exemptions.groupChat)
+                return qsTr("Group Chat")
+            return ""
+        }
+        label: {
+            if(!model.customized)
+                return ""
+
+            let l = ""
+            if(model.muteAllMessages)
+                l += qsTr("Muted")
+            else {
+                let nbOfChanges = 0
+
+                if(model.personalMentions !== Constants.settingsSection.notifications.sendAlertsValue)
+                {
+                    nbOfChanges++
+                    let valueText = model.personalMentions === Constants.settingsSection.notifications.turnOffValue?
+                            qsTr("Off") :
+                            qsTr("Quiet")
+                    l = qsTr("Personal @ Mentions %1").arg(valueText)
+                }
+
+                if(model.globalMentions !== Constants.settingsSection.notifications.sendAlertsValue)
+                {
+                    nbOfChanges++
+                    let valueText = model.globalMentions === Constants.settingsSection.notifications.turnOffValue?
+                            qsTr("Off") :
+                            qsTr("Quiet")
+                    l = qsTr("Global @ Mentions %1").arg(valueText)
+                }
+
+                if(model.otherMessages !== Constants.settingsSection.notifications.turnOffValue)
+                {
+                    nbOfChanges++
+                    let valueText = model.otherMessages === Constants.settingsSection.notifications.sendAlertsValue?
+                            qsTr("Alerts") :
+                            qsTr("Quiet")
+                    l = qsTr("Other Messages %1").arg(valueText)
+                }
+
+                if(nbOfChanges > 1)
+                    l = qsTr("Multiple Exemptions")
+            }
+
+            return l
+        }
+
+        asset {
+            name: model.image
+            isImage: !!model.image && model.image !== ""
+            color: model.type === Constants.settingsSection.exemptions.oneToOneChat?
+                       Utils.colorForPubkey(root.Theme.palette, model.itemId) :
+                       model.color
+            charactersLen: model.type === Constants.settingsSection.exemptions.oneToOneChat? 2 : 1
+            isLetterIdenticon: !model.image || model.image === ""
+            height: 40
+            width: 40
+        }
+
+        components: [
+            StatusFlatButton {
+                id: popupBtn
+                icon.name: model.customized ? "next" : "add"
+                icon.color: model.customized ? Theme.palette.baseColor1 : Theme.palette.primaryColor1
+                size: StatusBaseButton.Size.Small
+                onClicked: {
+                    const props = {
+                        name: model.name,
+                        type: model.type,
+                        itemId: model.itemId,
+                        color: model.color,
+                        image: model.image,
+                        muteAllMessages: model.muteAllMessages,
+                        personalMentions: model.personalMentions,
+                        globalMentions: model.globalMentions,
+                        otherMessages: model.otherMessages
+                    }
+                    exemptionNotificationsModal.createObject(root, props).open()
+                }
+            }
+        ]
+        sensor.cursorShape: Qt.PointingHandCursor
+        onClicked: popupBtn.click()
+    }
+
+    Component {
+        id: exemptionNotificationsModal
+        ExemptionNotificationsModal {
+            destroyOnClose: true
+            onSaveExemptionsRequested: (itemId, muteAllMessages, personalMentions, globalMentions, allMessages) =>
+                                       root.saveExemptionsRequested(itemId, muteAllMessages, personalMentions, globalMentions, allMessages)
+        }
+    }
+}

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -7638,6 +7638,53 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
+    <name>ExemptionsView</name>
+    <message>
+        <source>Community</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1:1 Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Muted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quiet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Personal @ Mentions %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Global @ Mentions %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alerts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Other Messages %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multiple Exemptions</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExportControlNodePopup</name>
     <message>
         <source>How to move the %1 control node to another device</source>
@@ -13007,50 +13054,6 @@ to load</source>
 </context>
 <context>
     <name>NotificationsView</name>
-    <message>
-        <source>Community</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>1:1 Chat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Group Chat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Muted</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quiet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Personal @ Mentions %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Global @ Mentions %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Alerts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Other Messages %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Multiple Exemptions</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Enable notifications</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -9329,6 +9329,64 @@
     </message>
   </context>
   <context>
+    <name>ExemptionsView</name>
+    <message>
+      <source>Community</source>
+      <comment>ExemptionsView</comment>
+      <translation>Community</translation>
+    </message>
+    <message>
+      <source>1:1 Chat</source>
+      <comment>ExemptionsView</comment>
+      <translation>1:1 Chat</translation>
+    </message>
+    <message>
+      <source>Group Chat</source>
+      <comment>ExemptionsView</comment>
+      <translation>Group Chat</translation>
+    </message>
+    <message>
+      <source>Muted</source>
+      <comment>ExemptionsView</comment>
+      <translation>Muted</translation>
+    </message>
+    <message>
+      <source>Off</source>
+      <comment>ExemptionsView</comment>
+      <translation>Off</translation>
+    </message>
+    <message>
+      <source>Quiet</source>
+      <comment>ExemptionsView</comment>
+      <translation>Quiet</translation>
+    </message>
+    <message>
+      <source>Personal @ Mentions %1</source>
+      <comment>ExemptionsView</comment>
+      <translation>Personal @ Mentions %1</translation>
+    </message>
+    <message>
+      <source>Global @ Mentions %1</source>
+      <comment>ExemptionsView</comment>
+      <translation>Global @ Mentions %1</translation>
+    </message>
+    <message>
+      <source>Alerts</source>
+      <comment>ExemptionsView</comment>
+      <translation>Alerts</translation>
+    </message>
+    <message>
+      <source>Other Messages %1</source>
+      <comment>ExemptionsView</comment>
+      <translation>Other Messages %1</translation>
+    </message>
+    <message>
+      <source>Multiple Exemptions</source>
+      <comment>ExemptionsView</comment>
+      <translation>Multiple Exemptions</translation>
+    </message>
+  </context>
+  <context>
     <name>ExportControlNodePopup</name>
     <message>
       <source>How to move the %1 control node to another device</source>
@@ -15850,61 +15908,6 @@
   </context>
   <context>
     <name>NotificationsView</name>
-    <message>
-      <source>Community</source>
-      <comment>NotificationsView</comment>
-      <translation>Community</translation>
-    </message>
-    <message>
-      <source>1:1 Chat</source>
-      <comment>NotificationsView</comment>
-      <translation>1:1 Chat</translation>
-    </message>
-    <message>
-      <source>Group Chat</source>
-      <comment>NotificationsView</comment>
-      <translation>Group Chat</translation>
-    </message>
-    <message>
-      <source>Muted</source>
-      <comment>NotificationsView</comment>
-      <translation>Muted</translation>
-    </message>
-    <message>
-      <source>Off</source>
-      <comment>NotificationsView</comment>
-      <translation>Off</translation>
-    </message>
-    <message>
-      <source>Quiet</source>
-      <comment>NotificationsView</comment>
-      <translation>Quiet</translation>
-    </message>
-    <message>
-      <source>Personal @ Mentions %1</source>
-      <comment>NotificationsView</comment>
-      <translation>Personal @ Mentions %1</translation>
-    </message>
-    <message>
-      <source>Global @ Mentions %1</source>
-      <comment>NotificationsView</comment>
-      <translation>Global @ Mentions %1</translation>
-    </message>
-    <message>
-      <source>Alerts</source>
-      <comment>NotificationsView</comment>
-      <translation>Alerts</translation>
-    </message>
-    <message>
-      <source>Other Messages %1</source>
-      <comment>NotificationsView</comment>
-      <translation>Other Messages %1</translation>
-    </message>
-    <message>
-      <source>Multiple Exemptions</source>
-      <comment>NotificationsView</comment>
-      <translation>Multiple Exemptions</translation>
-    </message>
     <message>
       <source>Enable notifications</source>
       <comment>NotificationsView</comment>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -7681,6 +7681,53 @@ Prosím přidejte jej a zkuste to znovu.</translation>
     </message>
 </context>
 <context>
+    <name>ExemptionsView</name>
+    <message>
+        <source>Community</source>
+        <translation type="unfinished">Komunita</translation>
+    </message>
+    <message>
+        <source>1:1 Chat</source>
+        <translation type="unfinished">Chat 1:1</translation>
+    </message>
+    <message>
+        <source>Group Chat</source>
+        <translation type="unfinished">Skupinový chat</translation>
+    </message>
+    <message>
+        <source>Muted</source>
+        <translation type="unfinished">Ztlumeno</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished">Vypnuto</translation>
+    </message>
+    <message>
+        <source>Quiet</source>
+        <translation type="unfinished">Potichu</translation>
+    </message>
+    <message>
+        <source>Personal @ Mentions %1</source>
+        <translation type="unfinished">Osobní zmínky @ %1</translation>
+    </message>
+    <message>
+        <source>Global @ Mentions %1</source>
+        <translation type="unfinished">Globální zmínky @ %1</translation>
+    </message>
+    <message>
+        <source>Alerts</source>
+        <translation type="unfinished">Upozornění</translation>
+    </message>
+    <message>
+        <source>Other Messages %1</source>
+        <translation type="unfinished">Ostatní zprávy %1</translation>
+    </message>
+    <message>
+        <source>Multiple Exemptions</source>
+        <translation type="unfinished">Více výjimek</translation>
+    </message>
+</context>
+<context>
     <name>ExportControlNodePopup</name>
     <message>
         <source>How to move the %1 control node to another device</source>
@@ -13107,50 +13154,6 @@ selhalo</translation>
 </context>
 <context>
     <name>NotificationsView</name>
-    <message>
-        <source>Community</source>
-        <translation>Komunita</translation>
-    </message>
-    <message>
-        <source>1:1 Chat</source>
-        <translation>Chat 1:1</translation>
-    </message>
-    <message>
-        <source>Group Chat</source>
-        <translation>Skupinový chat</translation>
-    </message>
-    <message>
-        <source>Muted</source>
-        <translation>Ztlumeno</translation>
-    </message>
-    <message>
-        <source>Off</source>
-        <translation>Vypnuto</translation>
-    </message>
-    <message>
-        <source>Quiet</source>
-        <translation>Potichu</translation>
-    </message>
-    <message>
-        <source>Personal @ Mentions %1</source>
-        <translation>Osobní zmínky @ %1</translation>
-    </message>
-    <message>
-        <source>Global @ Mentions %1</source>
-        <translation>Globální zmínky @ %1</translation>
-    </message>
-    <message>
-        <source>Alerts</source>
-        <translation>Upozornění</translation>
-    </message>
-    <message>
-        <source>Other Messages %1</source>
-        <translation>Ostatní zprávy %1</translation>
-    </message>
-    <message>
-        <source>Multiple Exemptions</source>
-        <translation>Více výjimek</translation>
-    </message>
     <message>
         <source>Enable notifications</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -7652,6 +7652,53 @@ Por favor, agrégala e intenta de nuevo.</translation>
     </message>
 </context>
 <context>
+    <name>ExemptionsView</name>
+    <message>
+        <source>Community</source>
+        <translation type="unfinished">Comunidad</translation>
+    </message>
+    <message>
+        <source>1:1 Chat</source>
+        <translation type="unfinished">Chat 1:1</translation>
+    </message>
+    <message>
+        <source>Group Chat</source>
+        <translation type="unfinished">Chat grupal</translation>
+    </message>
+    <message>
+        <source>Muted</source>
+        <translation type="unfinished">Silenciado</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished">Apagado</translation>
+    </message>
+    <message>
+        <source>Quiet</source>
+        <translation type="unfinished">Silencioso</translation>
+    </message>
+    <message>
+        <source>Personal @ Mentions %1</source>
+        <translation type="unfinished">Menciones personales @ %1</translation>
+    </message>
+    <message>
+        <source>Global @ Mentions %1</source>
+        <translation type="unfinished">Menciones globales @ %1</translation>
+    </message>
+    <message>
+        <source>Alerts</source>
+        <translation type="unfinished">Alertas</translation>
+    </message>
+    <message>
+        <source>Other Messages %1</source>
+        <translation type="unfinished">Otros mensajes %1</translation>
+    </message>
+    <message>
+        <source>Multiple Exemptions</source>
+        <translation type="unfinished">Múltiples exenciones</translation>
+    </message>
+</context>
+<context>
     <name>ExportControlNodePopup</name>
     <message>
         <source>How to move the %1 control node to another device</source>
@@ -13023,50 +13070,6 @@ al cargar</translation>
 </context>
 <context>
     <name>NotificationsView</name>
-    <message>
-        <source>Community</source>
-        <translation>Comunidad</translation>
-    </message>
-    <message>
-        <source>1:1 Chat</source>
-        <translation>Chat 1:1</translation>
-    </message>
-    <message>
-        <source>Group Chat</source>
-        <translation>Chat grupal</translation>
-    </message>
-    <message>
-        <source>Muted</source>
-        <translation>Silenciado</translation>
-    </message>
-    <message>
-        <source>Off</source>
-        <translation>Apagado</translation>
-    </message>
-    <message>
-        <source>Quiet</source>
-        <translation>Silencioso</translation>
-    </message>
-    <message>
-        <source>Personal @ Mentions %1</source>
-        <translation>Menciones personales @ %1</translation>
-    </message>
-    <message>
-        <source>Global @ Mentions %1</source>
-        <translation>Menciones globales @ %1</translation>
-    </message>
-    <message>
-        <source>Alerts</source>
-        <translation>Alertas</translation>
-    </message>
-    <message>
-        <source>Other Messages %1</source>
-        <translation>Otros mensajes %1</translation>
-    </message>
-    <message>
-        <source>Multiple Exemptions</source>
-        <translation>Múltiples exenciones</translation>
-    </message>
     <message>
         <source>Enable notifications</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -7622,6 +7622,53 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
+    <name>ExemptionsView</name>
+    <message>
+        <source>Community</source>
+        <translation type="unfinished">커뮤니티</translation>
+    </message>
+    <message>
+        <source>1:1 Chat</source>
+        <translation type="unfinished">1:1 채팅</translation>
+    </message>
+    <message>
+        <source>Group Chat</source>
+        <translation type="unfinished">그룹 채팅</translation>
+    </message>
+    <message>
+        <source>Muted</source>
+        <translation type="unfinished">음소거됨</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished">끄기</translation>
+    </message>
+    <message>
+        <source>Quiet</source>
+        <translation type="unfinished">조용히</translation>
+    </message>
+    <message>
+        <source>Personal @ Mentions %1</source>
+        <translation type="unfinished">개인 @ 멘션 %1</translation>
+    </message>
+    <message>
+        <source>Global @ Mentions %1</source>
+        <translation type="unfinished">글로벌 @ 멘션 %1</translation>
+    </message>
+    <message>
+        <source>Alerts</source>
+        <translation type="unfinished">알림</translation>
+    </message>
+    <message>
+        <source>Other Messages %1</source>
+        <translation type="unfinished">기타 메시지 %1</translation>
+    </message>
+    <message>
+        <source>Multiple Exemptions</source>
+        <translation type="unfinished">다중 면제</translation>
+    </message>
+</context>
+<context>
     <name>ExportControlNodePopup</name>
     <message>
         <source>How to move the %1 control node to another device</source>
@@ -12982,50 +13029,6 @@ to load</source>
 </context>
 <context>
     <name>NotificationsView</name>
-    <message>
-        <source>Community</source>
-        <translation>커뮤니티</translation>
-    </message>
-    <message>
-        <source>1:1 Chat</source>
-        <translation>1:1 채팅</translation>
-    </message>
-    <message>
-        <source>Group Chat</source>
-        <translation>그룹 채팅</translation>
-    </message>
-    <message>
-        <source>Muted</source>
-        <translation>음소거됨</translation>
-    </message>
-    <message>
-        <source>Off</source>
-        <translation>끄기</translation>
-    </message>
-    <message>
-        <source>Quiet</source>
-        <translation>조용히</translation>
-    </message>
-    <message>
-        <source>Personal @ Mentions %1</source>
-        <translation>개인 @ 멘션 %1</translation>
-    </message>
-    <message>
-        <source>Global @ Mentions %1</source>
-        <translation>글로벌 @ 멘션 %1</translation>
-    </message>
-    <message>
-        <source>Alerts</source>
-        <translation>알림</translation>
-    </message>
-    <message>
-        <source>Other Messages %1</source>
-        <translation>기타 메시지 %1</translation>
-    </message>
-    <message>
-        <source>Multiple Exemptions</source>
-        <translation>다중 면제</translation>
-    </message>
     <message>
         <source>Enable notifications</source>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
### What does the PR do

- StatusMacNotification.qml: reduce the preview image size
- exemptions factored out into a separate view (ExemptionsView.qml), together with its respective detailed popup
(ExemptionNotificationsModal.qml)
- ExemptionNotificationsModal.qml: port from StatusModal to StatusDialog to fix problems with the bottom sheet on mobile
- NotificationSelect.qml: wrap the expensive popup menu in a component
- simplify and speedup the NIM model by not pre-sorting it upon creation; do the sorting in QML

Fixes #21012

### Affected areas

Settings/Notifications

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Settings/Notifications:
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/1fa9757c-08c5-49c4-8264-abf1b1e85b74" />

Exemptions modal:
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/53ebe0b0-9fce-4e03-af8c-5caaa78788b3" />


### Impact on end user

Faster Settings/Notifications, esp. on mobile

### How to test

- open Settings/Notifications, should take no longer than 0.5-1 sec

### Risk 

low
