### PR TITLE
ChatColumnView: preserving draf message when switching sections

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -407,12 +407,13 @@ Item {
 
                     // When `enabled` is switched true->false, `textInput.text` is cleared before d.activeChatContentModule updates.
                     // We delay the binding so that the `inputAreaModule.preservedProperties.text` doesn't get overriden with empty value.
+                    // sectionDetails is filtered by this section's own ID, so it stays stable when other sections become active.
                     Binding on enabled {
                         delayed: true
                         value: !!d.activeChatContentModule
                                  && !d.activeChatContentModule.chatDetails.blocked
-                                 && root.joined
-                                 && !root.amIBanned
+                                 && root.rootStore.sectionDetails.joined
+                                 && !root.rootStore.sectionDetails.amIBanned
                                  && root.rootStore.isUserAllowedToSendMessage
                     }
 


### PR DESCRIPTION
### What does the PR do

Fixes regression introduced in 3c9a085a1a

Closes: #21033

### Affected areas
`ChatColumnView`

### Screencapture of the functionality

[Screencast from 27.05.2026 13:57:23.webm](https://github.com/user-attachments/assets/eb7b7548-a0b9-4c86-93e8-4bb2e0e061dc)

### Impact on end user

Low

### How to test

1. Go to chat
2. Type something, no sending
3. Change section (e.g. Wallet)
4. Go back to chat, the message should be there

### Risk 
Low
