### PR TITLE
fix(browser): snaphsot stretch

### DIFF
--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -299,7 +299,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG 503977380c67b734a755642e847132c5203142e2
+      GIT_TAG 0bdd6c67c3e8520453f9ce6dfc0fc02f91e7abf1
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)


### PR DESCRIPTION
bump mobilewebview to https://github.com/status-im/mobilewebview/pull/14

* Prefer GPU rendering, fallback to software (fixes icons stretching)
* Do not stretch the snapshot image, enable clipping (fixes the whole snapshot stretching)

https://github.com/user-attachments/assets/f537306f-00e0-4753-aa50-199e8b1fa5bc

fixes #21051 