### PR TITLE
fix(emojis): fix recent emojis race condition on app start

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -918,7 +918,7 @@ Item {
         property bool enablePushNotificationsFreshInstallSeen
         property bool enablePushNotificationsDontAskAgain
         property string enablePushNotificationsLastShownVersion
-        property var recentEmojis
+        property var recentEmojis: []
         property string skinColor // NB: must be a string for the twemoji lib to work; we don't want the `#` in the name
         property int theme: ThemeUtils.Style.System
         property int fontSize: {

--- a/ui/imports/shared/status/StatusEmojiPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiPopup.qml
@@ -92,7 +92,7 @@ StatusDropdown {
         root.close()
     }
 
-    Component.onCompleted: root.emojiModel.recentEmojis = root.recentEmojis
+    onRecentEmojisChanged: root.emojiModel.recentEmojis = root.recentEmojis || []
 
     onOpened: {
         if (!StatusQUtils.Utils.isMobile)


### PR DESCRIPTION
### What does the PR do

Fixes #20990

There was a race condition where the EmojiPopup was initialized before the Settings were ready, meaning that the recent emojis were initialized as undefined.

### Affected areas

AppMain

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[recent-emojis.webm](https://github.com/user-attachments/assets/f9f14b84-8a57-45e8-bb17-18c6b0388db6)

### Impact on end user

Fixes the issue.

If you upgrade from 2.37 to 2.38, your recent emojis will be safe. However, if someone tried an RC and clicked on an emoji, they will have to "redo" their recent emojis, because they were overwritten.

### How to test

Open the app and check the emojis

### Risk 

Low
