### PR TITLE
fix(browser): fix frozen snapshot cut off

### DIFF
--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -299,7 +299,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG 0bdd6c67c3e8520453f9ce6dfc0fc02f91e7abf1
+      GIT_TAG 2dbf28dd6655cf0e534ded440134982cd588658e
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)

--- a/ui/app/mainui/panels/PrimaryNavSidebar.qml
+++ b/ui/app/mainui/panels/PrimaryNavSidebar.qml
@@ -62,6 +62,9 @@ Control {
                                                      && root.position > 0.5
                                                      && root.browserSectionActive
 
+    // Portrait mobile drawer on Browser: keep sidebar open while overlay popups are shown.
+    readonly property bool keepOpenWhenPopups: SQUtils.Utils.isMobile && !root.alwaysVisible && root.browserSectionActive
+
     required property bool acVisible // FIXME AC should not be a section
     required property bool acHasUnseenNotifications // ActivityCenterStore.hasUnseenNotifications
     required property int acUnreadNotificationsCount // ActivityCenterStore.unreadNotificationsCount
@@ -118,7 +121,7 @@ Control {
         readonly property bool hasPopups: SQUtils.Utils.hasPopups(root.Overlay.overlay.children)
 
         onHasPopupsChanged: {
-            if (d.hasPopups) {
+            if (d.hasPopups && !root.keepOpenWhenPopups) {
                 root.close()
             }
         }
@@ -307,7 +310,8 @@ Control {
 
                 onToggled: {
                     root.activityCenterRequested(checked)
-                    root.close()
+                    if (!root.keepOpenWhenPopups)
+                        root.close()
                 }
             }
         }


### PR DESCRIPTION
* The sidebar is kept open only in the Browser section to ensure the WebView snapshot has no blank areas:

https://github.com/user-attachments/assets/6a3f8c8b-ebb8-49a8-b335-73851c91bdd9



Fixes #21057 
followups #21051 