### PR TITLE
Fixes for empty community messages chart

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/chart/ChartCanvas.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/chart/ChartCanvas.qml
@@ -114,7 +114,7 @@ Canvas {
     onHeightChanged: d.resizeDebouncer()
     onWidthChanged: d.resizeDebouncer()
     onAvailableChanged: {
-        if (!d.instance) {
+        if (available) {
             rebuild()
         }
     }
@@ -125,10 +125,24 @@ Canvas {
         property var instance: null
 
         function refresh() {
+            if (!instance) {
+                return
+            }
+
             instance.config.options = canvas.options
             instance.config.plugins = canvas.plugins
             instance.data.labels = canvas.labels
-            instance.update()
+            instance.data.datasets = canvas.datasets
+            try {
+                instance.update()
+            } catch (e) {
+                const staleInstance = instance
+                instance = null
+                try {
+                    staleInstance.destroy()
+                } catch (destroyError) {}
+                canvas.rebuild()
+            }
         }
 
         function rebuild() {

--- a/ui/StatusQ/src/StatusQ/Components/private/chart/ChartCanvas.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/chart/ChartCanvas.qml
@@ -133,7 +133,14 @@ Canvas {
 
         function rebuild() {
             if (instance) {
-                instance.destroy()
+                // Guard against "Not a Context2D object" if the canvas FBO was
+                // invalidated (e.g. hidden/resized) between the rebuild() call
+                // and this deferred execution. Without the try-catch, an
+                // exception here leaves `instance` non-null, so the chart can
+                // never be recreated.
+                try {
+                    instance.destroy()
+                } catch (e) {}
                 instance = null
             }
             var ctx = canvas.getContext('2d');
@@ -159,7 +166,9 @@ Canvas {
 
     Component.onDestruction: {
         if (d.instance) {
-            d.instance.destroy()
+            try {
+                d.instance.destroy()
+            } catch (e) {}
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/private/chart/Library/Library.js
+++ b/ui/StatusQ/src/StatusQ/Components/private/chart/Library/Library.js
@@ -72,19 +72,31 @@
             }
             
             canvas._eventSource[mapped].connect(qmlHandler)
-            canvas._eventSource.connectedHandlers[listener] = qmlHandler
+            canvas._eventSource.connectedHandlers.push({
+                listener: listener,
+                mapped: mapped,
+                qmlHandler: qmlHandler
+            })
         },
 
         removeEventListener: function(chart, type, listener) {
             const canvas = chart.canvas
-            if (!canvas._eventSource.connectedHandlers[listener]) {
+            const mapped = EVENTS[type]
+            if (!mapped) {
                 return
             }
 
-            const mapped = EVENTS[type]
-            const qmlHandler = canvas._eventSource.connectedHandlers[listener]
+            const index = canvas._eventSource.connectedHandlers.findIndex(entry => {
+                return entry.listener === listener && entry.mapped === mapped
+            })
+
+            if (index === -1) {
+                return
+            }
+
+            const qmlHandler = canvas._eventSource.connectedHandlers[index].qmlHandler
             canvas._eventSource[mapped].disconnect(qmlHandler)
-            delete canvas._eventSource.connectedHandlers[listener]
+            canvas._eventSource.connectedHandlers.splice(index, 1)
         }
     })
 

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsChart.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsChart.qml
@@ -28,7 +28,12 @@ StatusChartPanel {
         d.requestCommunityMetrics()
     }
 
-    onVisibleChanged: if(visible) d.resetWithSpamProtection()
+    onVisibleChanged: {
+        if (visible) {
+            chart.rebuild()
+            d.resetWithSpamProtection()
+        }
+    }
     onTimeRangeTabBarIndexChanged: reset()
     onModelChanged: chart.refresh()
     onCollectCommunityMetricsMessagesCount: d.lastRequestModelMetadata = d.selectedTabInfo.modelItems


### PR DESCRIPTION
### What does the PR do

Fixes #21041

There were two problems:
1. The instance might have been invalidated during a rebuild, causing `destroy` to throw, meaning the `instance` never got reset to null. Wrapping it in a try/catch fixes it.
2. The chart rendered as empty when coming back after receiving a message because the chart's lifecycle was fragile. I hardened it.

<details>
<summary>Click to see the full details of the bugs</summary>

## Issue one summary

## Bug summary

The chart sometimes rendered as empty because the underlying QML `Canvas` 2D context could become invalid while the chart was being rebuilt.

The failure showed up as:

```text
Error: Not a Context2D object
```

This happened in the chart wrapper when a deferred `rebuild()` tried to destroy the existing Chart.js instance after the canvas framebuffer/context had already been recreated or invalidated.

## Root cause

A recent change added debounced resize handling in the chart canvas. That introduced a timing window:

1. The canvas resized or changed availability.
2. `rebuild()` was scheduled with `Qt.callLater(...)`.
3. By the time it ran, the old `Context2D` was no longer valid.
4. `instance.destroy()` called into Chart.js, which tried to run `clearRect()` on the dead context.
5. That exception interrupted cleanup before `instance = null` was reached.

Once that happened, the component kept a reference to a broken chart instance, so later refreshes and rebuilds did not recover correctly. The visible result was an empty chart most of the time.

## Solution

The fix was to make chart destruction resilient to invalid canvas contexts:

```qml
try {
    instance.destroy()
} catch (e) {}
instance = null
```

The same protection was added during component teardown.

## Why this fixes it

Even if Chart.js throws while destroying an instance tied to an invalid context, the wrapper now always clears its local `instance` reference. That allows the next availability/update cycle to create a fresh chart with a valid `Context2D`, instead of getting stuck with a dead instance.

## Result

The messages chart can now recover correctly from canvas invalidation during resize or visibility changes, so it renders reliably again instead of remaining empty.

## Issue two summary

There were two separate bugs in the community overview messages chart.

### 1. Chart became empty after leaving and returning

The chart could come back empty after navigating away and back to the overview panel. The underlying issue was that the QML `Canvas` / Chart.js instance lifecycle was fragile across visibility and framebuffer/context changes.

#### Changes
- Added defensive teardown and recovery in ChartCanvas.qml:
  - guard `destroy()` with `try/catch`
  - avoid updating a missing instance
  - rebuild after update failures
  - sync datasets during refresh
  - rebuild when the canvas becomes available again
- Forced a rebuild when the community overview chart becomes visible again in OverviewSettingsChart.qml

#### Result
Re-entering the overview now recreates the chart cleanly instead of leaving it attached to a stale or invalid canvas context.

---

### 2. Hovering after new messages spammed warnings

After sending a new message, hovering the chart produced repeated warnings like:

```text
TypeError: Value is undefined and could not be converted to an object
```

This turned out to be a stale event-listener bug in the QML Chart.js bridge. Mouse/hover listeners were not being tracked and removed reliably across chart rebuilds, so old handlers could keep firing against stale chart metadata.

#### Change
- Fixed listener bookkeeping in Library.js
  - replaced ad-hoc function-key storage with explicit listener records
  - remove listeners by exact `(listener, mapped event)` match

#### Result
Hover events now stay bound to the current chart instance, so moving the mouse over the chart no longer floods the log after message updates.

---

## Final outcome

The messages chart now:
- renders again after returning to the overview panel
- updates correctly after new messages
- no longer throws repeated hover warnings in the logs

</details>

### Affected areas

- ChartCanvas.qml
- Library.js
- OverviewSettingsChart.qml

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[chart-fixes.webm](https://github.com/user-attachments/assets/32429381-e471-446e-94cd-c31b648ce667)

### Impact on end user

Makes the chart visible, available and not throwing any errors/warnings at all times

### How to test

Go to community admin tab and send messages

### Risk 

Low
