### PR TITLE
fix(main): fix saving/restoring the window geometry and visibility (state)

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/NativeSwipeHandler.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/NativeSwipeHandler.qml
@@ -45,11 +45,12 @@ Item {
     Binding { target: implLoader.item; property: "visible"; value: root.visible; when: implLoader.item !== null }
     Binding { target: implLoader.item; property: "enabled"; value: root.enabled; when: implLoader.item !== null }
     Binding { target: implLoader.item; property: "openDistance"; value: root.openDistance; when: implLoader.item !== null }
-    Binding { target: implLoader.item; property: "dismissTapOverlaySceneRect"; value: root.dismissTapOverlaySceneRect; when: implLoader.item !== null }
+    Binding { target: implLoader.item; property: "dismissTapOverlaySceneRect"; value: root.dismissTapOverlaySceneRect; when: implLoader.sourceComponent === nativeComponent && implLoader.item !== null }
 
     Connections {
         target: implLoader.item ?? null
         enabled: implLoader.item !== null && implLoader.status === Loader.Ready
+        ignoreUnknownSignals: true
 
         function onSwipeStarted() {
             root.isSwipeActive = true

--- a/ui/app/mainui/sectionLoaders/NodeLoader.qml
+++ b/ui/app/mainui/sectionLoaders/NodeLoader.qml
@@ -20,6 +20,11 @@ Loader {
         })
     }
 
+    Component.onCompleted: {
+        Qt.callLater(() => QmlCompiler.precompile(QmlCompiler.nodeUrl))
+        loadSection()
+    }
+
     onActiveChanged: loadSection()
     onLoaded: item.anchors.fill = root
 }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -17,6 +17,7 @@ import StatusQ.Controls
 import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Core.Utils as SQUtils
+import StatusQ.Core.Backpressure
 import StatusQ.Platform
 import StatusQ.Popups.Dialog
 
@@ -117,15 +118,23 @@ Window {
     }
 
     function restoreAppState() {
+        if (SQUtils.Utils.isMobile && applicationWindow.visibility !== Window.Windowed) {
+            // just correct visibility on mobile
+            applicationWindow.visibility = Window.Maximized
+            return
+        }
+
         let geometry = localAppSettings.geometry;
         let visibility = localAppSettings.visibility;
 
+        // correct the visibility; we don't want to start e.g. Hidden or Minimized
         if (visibility !== Window.Windowed &&
             visibility !== Window.Maximized &&
             visibility !== Window.FullScreen) {
-            visibility = SQUtils.Utils.isMobile ? Window.Maximized : Window.Windowed
+            visibility = Window.Windowed
         }
 
+        // first set the (normal) geometry, might get overridden later with the visibility
         if (geometry === undefined ||
             // If the monitor setup of the user changed, it's possible that the old geometry now falls out of the monitor range
             // In this case, we reset to the basic geometry
@@ -133,7 +142,9 @@ Window {
             geometry.y > Screen.desktopAvailableHeight ||
             geometry.width > Screen.desktopAvailableWidth ||
             geometry.height > Screen.desktopAvailableHeight ||
-            geometry.x < 0 || geometry.y < 0)
+            geometry.x < 0 || geometry.y < 0 ||
+            visibility !== Window.Windowed
+            )
         {
             let screen = Qt.application.screens[0];
 
@@ -145,40 +156,32 @@ Window {
             geometry.y = (screen.height - geometry.height) / 2;
         }
 
-        applicationWindow.visibility = visibility;
-        if (visibility === Window.Windowed) {
-            applicationWindow.x = geometry.x;
-            applicationWindow.y = geometry.y;
-            applicationWindow.width = Math.max(geometry.width, ThemeUtils.minimumDesktopSize.width)
-            applicationWindow.height = Math.max(geometry.height, ThemeUtils.minimumDesktopSize.height)
-        }
+        // apply (the corrected) geometry to the window
+        applicationWindow.x = geometry.x
+        applicationWindow.y = geometry.y
+        applicationWindow.width = geometry.width
+        applicationWindow.height = geometry.height
+
+        // finally set the visibility; might be e.g. Maximized but we still want to restore back to normal (windowed) geometry when unmaximizing
+        applicationWindow.visibility = visibility
     }
 
     function storeAppState() {
         if (SQUtils.Utils.isMobile) // no point in storing geometry or visibility
             return
 
-        if (!applicationWindow.appIsReady)
-            return;
-
-        localAppSettings.visibility = applicationWindow.visibility;
-        if (applicationWindow.visibility === Window.Windowed) {
-            localAppSettings.geometry = Qt.rect(applicationWindow.x, applicationWindow.y,
-                                                applicationWindow.width, applicationWindow.height);
-        }
+        localAppSettings.visibility = applicationWindow.visibility
+        let newRect = Qt.rect(applicationWindow.x, applicationWindow.y,
+                              applicationWindow.width, applicationWindow.height)
+        localAppSettings.geometry = newRect
     }
 
-    onXChanged: Qt.callLater(storeAppState)
-    onYChanged: Qt.callLater(storeAppState)
     onPortraitLayoutChanged: {
         // Android looses status bar icon color when switching orientation
         if (SQUtils.Utils.isAndroid) {
             SystemUtils.setAndroidStatusBarIconColor(applicationWindow.appThemeDark)
         }
     }
-
-    onWidthChanged: Qt.callLater(storeAppState)
-    onHeightChanged: Qt.callLater(storeAppState)
 
     QtObject {
         id: d
@@ -343,6 +346,8 @@ Window {
             }
         }
         function onClosing(close) {
+            // save the geometry just before closing
+            applicationWindow.storeAppState() // noop on mobile
             // on mobile, we minimize to background (no tray icon or quitOnClose setting)
             if (SQUtils.Utils.isMobile) {
                 close.accepted = false
@@ -402,6 +407,13 @@ Window {
         }
     }
 
+    Connections {
+        target: Application
+        function onAboutToQuit() {
+            applicationWindow.storeAppState()
+        }
+    }
+
     Component.onCompleted: {
 
         console.info(">>> %1 %2 started, using Qt version %3, QPA: %4".arg(Application.name).arg(Application.version).arg(SystemUtils.qtRuntimeVersion()).arg(Qt.platform.pluginName))
@@ -430,8 +442,6 @@ Window {
             moveToAppMain()
         }
     }
-
-    signal navigateTo(string path)
 
     function makeStatusAppActive() {
         d.restoreWindowState()
@@ -578,7 +588,9 @@ Window {
                 item.biometricFlowPending = Qt.binding(() => applicationWindow.biometricFlowPending)
                 splashScreenLoader.active = false
                 applicationWindow.contentLoaded()
-                Qt.callLater(() => QmlCompiler.precompileAll()) // precompile all components after onboarding is loaded to speed up the login flow
+                Backpressure.debounce(applicationWindow, 750, () => {
+                    Qt.callLater(() => QmlCompiler.precompileAll()) // precompile all components after onboarding is loaded to speed up the login flow
+                })()
             }
         }
 


### PR DESCRIPTION
### What does the PR do

- save the state when closing the window or before quitting (there was a race between the onChanged handlers and the delayed minimum size bindings)
- fix the save sequence; it was exiting too early due to the `appIsReady` being false; we still want to save the window state from onboarding/login
- simplify the restore sequence:
  - only correct the window state on mobile, bail out early
  - correct the window geometry if we are out of bounds, or hidden/minimized
  - (always) apply the geometry, even if not Windowed
  - finally apply the visibility (window state)

Fixes #21013

### Affected areas

main

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/12dae1e1-94fe-4bb2-a2c6-8158539dcadd" />


### Impact on end user

Correct save/restore mechanism

### How to test

- start app, close app
- should get restored correctly regardless of the stage (onboarding/login/main app)

### Risk 

low
