### PR TITLE
test(e2e_appium): add 3-device group chat suite

### DIFF
--- a/test/e2e_appium/locators/messaging/chat_locators.py
+++ b/test/e2e_appium/locators/messaging/chat_locators.py
@@ -65,6 +65,12 @@ class ChatLocators(BaseLocators):
     CHAT_LOG_VIEW = BaseLocators.xpath("//*[contains(@resource-id,'chatLogView')]")
     INTRODUCE_SKIP_BUTTON = BaseLocators.tid("introduceSkipStatusFlatButton")
     BACKUP_SKIP_BUTTON = BaseLocators.tid("backupMessageSkipStatusFlatButton")
+    # QML: EnablePushNotificationsPopup.qml — "Maybe later" left footer button
+    PUSH_NOTIF_LATER_BUTTON = BaseLocators.tid("btnPushNotificationsLater")
+    # X close icon on any StatusDialog header — used to dismiss the
+    # drawer-intro dialog, which has no dedicated skip button.
+    # QML: StatusHeaderActions.qml objectName "headerActionsCloseButton"
+    DIALOG_HEADER_CLOSE_BUTTON = BaseLocators.tid("headerActionsCloseButton")
     START_CHAT_BUTTON = BaseLocators.xpath(
         "//*[contains(@resource-id,'startChatButton')]"
     )

--- a/test/e2e_appium/locators/messaging/group_chat_locators.py
+++ b/test/e2e_appium/locators/messaging/group_chat_locators.py
@@ -1,0 +1,258 @@
+"""Locators for group chat creation, management, and member list.
+
+QML sources verified against upstream/master at the time of writing:
+    ui/app/AppLayouts/Chat/views/CreateChatView.qml
+    ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+    ui/imports/shared/views/chat/ChatContextMenuView.qml
+    ui/imports/shared/popups/RenameGroupPopup.qml
+    ui/imports/shared/views/PickedContacts.qml
+    ui/imports/shared/views/ExistingContacts.qml
+
+A few UIs did not have a dedicated objectName at the time of writing — those
+locators are marked `# TODO: verify objectName` and use a fallback xpath that
+needs on-device verification. Fix these as the relevant QML gets objectName'd.
+"""
+
+from ..base_locators import BaseLocators
+
+
+class GroupChatLocators(BaseLocators):
+    """Locators for group chat flows.
+
+    This complements ``ChatLocators`` — group-specific elements only.
+    For shared elements (MESSAGE_INPUT, CHAT_SEARCH_BOX, etc.) reuse
+    ``ChatLocators``.
+    """
+
+    # ------------------------------------------------------------------
+    # Group creation (CreateChatView)
+    # ------------------------------------------------------------------
+
+    # The member-suggestion list inside CreateChatView
+    # QML: CreateChatView.qml: objectName: "createChatContactsList"
+    CREATE_CHAT_CONTACTS_LIST = BaseLocators.resource_id_contains(
+        "createChatContactsList"
+    )
+
+    # The free-text input where the user types contact names / ENS / chat keys.
+    # QML: InlineSelectorPanel.qml ~line 254 — TextInput { objectName: "chatRecipientInput" }
+    MEMBER_PICKER_INPUT = BaseLocators.resource_id_contains("chatRecipientInput")
+
+    # The confirm button in the create-chat view's footer.
+    # QML: InlineSelectorPanel.qml ~line 183 — objectName: "inlineSelectorConfirmButton"
+    CREATE_CHAT_CONFIRM_BUTTON = BaseLocators.resource_id_contains(
+        "inlineSelectorConfirmButton"
+    )
+
+    # ------------------------------------------------------------------
+    # Group chat header (ChatHeaderContentView)
+    # ------------------------------------------------------------------
+
+    # Header button that shows the current chat's title; tapping opens
+    # the group info / chat details sheet on mobile.
+    # QML: ChatHeaderContentView.qml: objectName: "chatInfoBtnInHeader"
+    CHAT_INFO_HEADER_BUTTON = BaseLocators.resource_id_contains(
+        "chatInfoBtnInHeader"
+    )
+
+    # In-chat header "Members" button → opens UserListPanel. QML
+    # ChatHeaderContentView.qml gives it no objectName (id "membersButton"
+    # only), so this best-effort locator usually misses; callers fall back
+    # to a position tap relative to chatToolbarMoreOptionsButton.
+    MEMBERS_BUTTON = BaseLocators.resource_id_contains("membersButton")
+
+    # Members list panel + remove-from-group action. UserListPanel rows
+    # (StatusMemberListItem) set Accessible.name = userName, so they're
+    # identifiable by member name — unlike the chip picker.
+    # QML: UserListPanel.qml "userListPanel"; ProfileContextMenu.qml
+    #      "removeFromGroup_StatusItem".
+    USER_LIST_PANEL = BaseLocators.resource_id_contains("userListPanel")
+    REMOVE_FROM_GROUP_ITEM = BaseLocators.resource_id_contains(
+        "removeFromGroup_StatusItem"
+    )
+    # Any member row in the UserListPanel — used to count current members.
+    MEMBER_PANEL_ROW_ANY = BaseLocators.xpath(
+        "//*[contains(@resource-id,'StatusMemberListItem')]"
+    )
+
+    # Composer placeholder shown when a removed/non-member opens a group:
+    # the input switches to this text and sending is disabled.
+    # QML: RootStore.qml chatInputPlaceHolderText (bound to
+    # isUserAllowedToSendMessage == false for privateGroupChat).
+    NOT_A_MEMBER_PLACEHOLDER = BaseLocators.xpath(
+        "//*[contains(@text,'You need to be a member of this group') or "
+        "contains(@content-desc,'You need to be a member of this group')]"
+    )
+
+    @staticmethod
+    def member_panel_row_by_name(member_identity: str) -> tuple:
+        """A UserListPanel member row, matched by identity name in
+        content-desc. ``member_identity`` is the peer's Frilledlizard
+        name (from the group name's ``&``-joined parts).
+        """
+        escaped = member_identity.replace("'", "\\'")
+        return BaseLocators.xpath(
+            "//*[contains(@resource-id,'StatusMemberListItem')]"
+            f"[contains(@content-desc,\"{escaped}\")]"
+        )
+
+    # In-chat header "More" button → opens moreOptionsContextMenu, a
+    # ChatContextMenuView with the same item objectNames as the chat-list
+    # long-press menu. Preferred on Pi: a plain tap is reliable where the
+    # long-press → right-click translation isn't.
+    # QML: ChatHeaderContentView.qml: objectName "chatToolbarMoreOptionsButton"
+    CHAT_TOOLBAR_MORE_OPTIONS_BUTTON = BaseLocators.resource_id_contains(
+        "chatToolbarMoreOptionsButton"
+    )
+    # The chat title lives on this nested Text node, not the parent
+    # button — Qt accessibility doesn't surface the button's `title:`.
+    # QML: StatusChatInfoButton.qml objectName "statusChatInfoButtonNameText"
+    CHAT_INFO_HEADER_NAME_TEXT = BaseLocators.resource_id_contains(
+        "statusChatInfoButtonNameText"
+    )
+
+    # ------------------------------------------------------------------
+    # Chat list context menu (ChatContextMenuView) — applies to the row
+    # for a group chat in the chat list.
+    # ------------------------------------------------------------------
+
+    # "Add / remove from group" context menu action.
+    # QML: ChatContextMenuView.qml: objectName: "addRemoveFromGroupStatusAction"
+    ADD_REMOVE_FROM_GROUP_ACTION = BaseLocators.resource_id_contains(
+        "addRemoveFromGroupStatusAction"
+    )
+
+    # "Edit group name and image" menu item.
+    # QML: ChatContextMenuView.qml: objectName: "editNameAndImageMenuItem"
+    EDIT_GROUP_NAME_MENU_ITEM = BaseLocators.resource_id_contains(
+        "editNameAndImageMenuItem"
+    )
+
+    # "Delete / Leave group" menu item — same objectName as 1:1 close chat;
+    # the surrounding context determines label.
+    # QML: ChatContextMenuView.qml: objectName: "deleteOrLeaveMenuItem"
+    DELETE_OR_LEAVE_MENU_ITEM = BaseLocators.resource_id_contains(
+        "deleteOrLeaveMenuItem"
+    )
+
+    # "Clear history" menu item for groups (distinct from the 1:1 variant).
+    # QML: ChatContextMenuView.qml: objectName: "clearHistoryGroupMenuItem"
+    CLEAR_GROUP_HISTORY_MENU_ITEM = BaseLocators.resource_id_contains(
+        "clearHistoryGroupMenuItem"
+    )
+
+    # Confirmation dialog's leave button.
+    # QML: ChatContextMenuView.qml's leaveGroupConfirmationDialogComponent
+    # uses confirmButtonObjectName "leaveGroupConfirmationDialogLeaveButton"
+    # for private group chats. The deleteChatConfirmationDialog (separate
+    # component) covers 1:1 / community / channel close flows and uses
+    # "deleteChatConfirmationDialogDeleteButton" — not applicable here.
+    LEAVE_CONFIRM_BUTTON = BaseLocators.resource_id_contains(
+        "leaveGroupConfirmationDialogLeaveButton"
+    )
+
+    # ------------------------------------------------------------------
+    # Rename group popup (RenameGroupPopup)
+    # ------------------------------------------------------------------
+
+    # The popup container bridges as ".../RenameGroupPopup"; the
+    # ``groupChatEdit_*`` prefix is only on its child input/save controls.
+    # QML: RenameGroupPopup.qml
+    RENAME_GROUP_POPUP = BaseLocators.resource_id_contains("RenameGroupPopup")
+    RENAME_GROUP_NAME_INPUT = BaseLocators.resource_id_contains(
+        "groupChatEdit_name"
+    )
+    RENAME_GROUP_SAVE_BUTTON = BaseLocators.resource_id_contains(
+        "groupChatEdit_save"
+    )
+
+    # ------------------------------------------------------------------
+    # Member list item (ExistingContacts / PickedContacts)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def member_list_item_by_pubkey(compressed_pubkey: str) -> tuple:
+        """Locator for a single member row in the add/remove-member list.
+
+        QML: ExistingContacts.qml / PickedContacts.qml:
+            objectName: "statusMemberListItem-%1".arg(model.compressedPubKey)
+        """
+        escaped = compressed_pubkey.replace("'", "\\'")
+        return BaseLocators.xpath(
+            f"//*[contains(@resource-id,'statusMemberListItem-{escaped}')]"
+        )
+
+    @staticmethod
+    def member_list_item_by_name(display_name: str) -> tuple:
+        """Locator for a member row found by display name anywhere in the row.
+
+        Fallback for when we don't have the compressed pubkey handy; less
+        reliable than :meth:`member_list_item_by_pubkey` because another row
+        with the same display substring can match.
+        """
+        escaped = display_name.replace("'", "\\'")
+        return BaseLocators.xpath(
+            "//*[contains(@resource-id,'statusMemberListItem')]"
+            f"[contains(@content-desc,\"{escaped}\") or contains(@text,\"{escaped}\")]"
+        )
+
+    # Generic member-list-item pattern.
+    #
+    # Two different list surfaces use this locator:
+    #
+    # 1. Create-chat picker (CreateChatView → ContactListItemDelegate over
+    #    StatusListView{objectName:"createChatContactsList"}). Each row's
+    #    resource-id is the QML-class path
+    #    "...CreateChatView_QMLTYPE_N.ContactListItemDelegate_QMLTYPE_M".
+    #    Qt's accessibility bridge marks these rows ``clickable="false"``
+    #    (onClicked is handled at the QML layer, not bridged to a11y), so
+    #    we do NOT filter by ``@clickable``; the element-tap fallback in
+    #    ``safe_click`` works regardless of the a11y flag.
+    # 2. Add/remove-members sheet (ExistingContacts.qml /
+    #    PickedContacts.qml). Rows there have objectName
+    #    "statusMemberListItem-{compressedPubKey}".
+    #
+    # The xpath alternation covers both surfaces.
+    ANY_MEMBER_LIST_ITEM = BaseLocators.xpath(
+        "//*[contains(@resource-id,'ContactListItemDelegate')]"
+        " | //*[contains(@resource-id,'statusMemberListItem-')]"
+    )
+
+    @staticmethod
+    def contact_checkbox(display_name: str) -> tuple:
+        """Locator for the tappable checkbox on a contact suggestion row.
+
+        QML: ExistingContacts.qml ~line 105:
+            objectName: "contactCheckbox-%1".arg(model.displayName)
+
+        ``displayName`` here is the local identity name Status renders for
+        the contact (e.g. "Nippy Idolized Dalmatian"), not the chat-key
+        short form. Pair this with reading the peer's identity name from
+        the open 1-1 chat header before opening the create-chat surface.
+        """
+        escaped = display_name.replace("'", "\\'")
+        return BaseLocators.xpath(
+            f"//*[contains(@resource-id,'contactCheckbox-{escaped}')]"
+        )
+
+    # ------------------------------------------------------------------
+    # Chat list entry for a group chat — reuses the 1:1 chat list row
+    # (StatusDraggableListItem) but the display name is the group name.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def group_chat_row_by_name(group_name: str) -> tuple:
+        """Locator for a group-chat row in the main chat list.
+
+        QML: ContactsColumnView.qml chat list renders each chat as a
+        StatusDraggableListItem. The chat name appears in any of:
+        the ``text`` attribute, ``content-desc``, or — for QML
+        accessibility names — embedded in the dotted ``resource-id``
+        path (e.g. ``"...<chatName>.StatusDraggableListItem_..."``).
+        """
+        escaped = group_name.replace("'", "\\'")
+        return BaseLocators.xpath(
+            "//*[contains(@resource-id,'StatusDraggableListItem')]"
+            f"[contains(@text,\"{escaped}\") or contains(@content-desc,\"{escaped}\")"
+            f" or contains(@resource-id,\"{escaped}\")]"
+        )

--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -291,12 +291,23 @@ class App(BasePage):
                 self.logger.debug("activate_app suppressed: %s", exc)
 
         # BACK closes the drawer cleanly when activate_app's foregrounding
-        # alone fails to unstick a wedged gesture handler.
+        # alone fails to unstick a wedged gesture handler. Status Mobile
+        # is a single-Activity app (StatusQtActivity), so BACK at the
+        # chat-list root with no drawer open exits the Activity to the
+        # system home screen, backgrounding Status. The subsequent
+        # activate_app doesn't always re-foreground in time before the
+        # next gesture lands on the launcher. So only press BACK when
+        # the drawer is actually open.
         def _reset_drawer_state():
-            try:
-                self.driver.press_keycode(4)  # KEYCODE_BACK
-            except Exception as exc:
-                self.logger.debug("press_keycode(BACK) suppressed: %s", exc)
+            if self.is_element_visible(self.locators.LEFT_NAV_ANY, timeout=1):
+                try:
+                    self.driver.press_keycode(4)  # KEYCODE_BACK
+                except Exception as exc:
+                    self.logger.debug("press_keycode(BACK) suppressed: %s", exc)
+            else:
+                self.logger.debug(
+                    "drawer already closed — skipping BACK to keep Status foreground"
+                )
             time.sleep(0.5)
 
         _shake_app()

--- a/test/e2e_appium/pages/messaging/chat_page.py
+++ b/test/e2e_appium/pages/messaging/chat_page.py
@@ -245,6 +245,49 @@ class ChatPage(BasePage):
                 self.logger.debug(f"dismiss_backup_prompt click also failed: {e2}")
                 return False
 
+    def dismiss_push_notification_prompt(self, timeout: int | None = 2) -> bool:
+        """Tap "Maybe later" on EnablePushNotificationsPopup if it's up.
+
+        Status shows this modal after onboarding/login on Android 13+;
+        it sits on top of the nav drawer and silently swallows clicks
+        on Settings/Messages until dismissed.
+        """
+        element = self.find_element_safe(self.locators.PUSH_NOTIF_LATER_BUTTON, timeout=timeout)
+        if not element:
+            return False
+        try:
+            element.click()
+            return True
+        except Exception as e:
+            self.logger.debug(f"dismiss_push_notification_prompt direct click failed: {e}")
+            try:
+                return self.safe_click(self.locators.PUSH_NOTIF_LATER_BUTTON, timeout=timeout)
+            except Exception as e2:
+                self.logger.debug(f"dismiss_push_notification_prompt click also failed: {e2}")
+                return False
+
+    def dismiss_drawer_intro_prompt(self, timeout: int | None = 2) -> bool:
+        """Close NavigationEducationDialog ("To open app menu") if it's up.
+
+        Status shows this dialog the first time the user reaches the main
+        app after onboarding/login. It has footer.visible: false so the
+        only dismiss is the X close button in the StatusDialog header.
+        Safe to call when no dialog is up — returns False without clicking.
+        """
+        element = self.find_element_safe(self.locators.DIALOG_HEADER_CLOSE_BUTTON, timeout=timeout)
+        if not element:
+            return False
+        try:
+            element.click()
+            return True
+        except Exception as e:
+            self.logger.debug(f"dismiss_drawer_intro_prompt direct click failed: {e}")
+            try:
+                return self.safe_click(self.locators.DIALOG_HEADER_CLOSE_BUTTON, timeout=timeout)
+            except Exception as e2:
+                self.logger.debug(f"dismiss_drawer_intro_prompt click also failed: {e2}")
+                return False
+
     def wait_for_new_chat_to_arrive(
         self,
         chat_identifier: str,

--- a/test/e2e_appium/pages/messaging/group_chat_page.py
+++ b/test/e2e_appium/pages/messaging/group_chat_page.py
@@ -1,0 +1,676 @@
+"""Page object for group chat creation, messaging, and member management.
+
+Complements :class:`ChatPage` — reuses the shared chat surface for
+composing and reading messages, and adds group-specific actions
+(create, rename, add/remove members, leave).
+
+QML sources the locators derive from are documented inline in
+``locators/messaging/group_chat_locators.py``. Every locator that could
+not be grounded to a stable ``objectName`` at the time of writing is
+tagged ``TODO: verify objectName`` — those should be revisited once
+the relevant QML gets objectName'd.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import List, Optional
+
+from locators.messaging.chat_locators import ChatLocators
+from locators.messaging.group_chat_locators import GroupChatLocators
+from utils.timeouts import CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
+
+from ..base_page import BasePage
+from .chat_page import ChatPage
+from .create_chat_page import CreateChatPage
+
+
+class GroupChatPage(BasePage):
+    """Actions for group chats on mobile.
+
+    Use :meth:`create_group_chat` from the admin/creator device; use
+    :meth:`is_group_chat_visible` / :meth:`open_group_chat_by_name` from
+    any member device once the group has propagated.
+    """
+
+    UI_TIMEOUT = 30
+    CROSS_DEVICE_TIMEOUT = CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
+    MESSAGE_DELIVERY_TIMEOUT = CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
+
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locators = GroupChatLocators()
+        self._chat_locators = ChatLocators()
+        self._chat_page = ChatPage(driver)
+        self._create_chat_page = CreateChatPage(driver)
+
+    # ------------------------------------------------------------------
+    # Group creation
+    # ------------------------------------------------------------------
+
+    def create_group_chat(
+        self,
+        group_name: str,
+        members: List[str],
+        *,
+        timeout: int = UI_TIMEOUT,
+    ) -> bool:
+        """Create a group chat with *members* and *group_name*.
+
+        The creator must already be on the chat-list screen. ``members`` is
+        a list of display names of mutual contacts to include. The group
+        name is what the desktop code computes as ``groupName.join("&")``
+        automatically from selected members; mobile lets the user override
+        it via a rename step after creation (see :meth:`set_group_name`).
+
+        Returns True on apparent success (confirm button tapped and the
+        modal closed). Delivery verification is a separate concern —
+        callers should assert against the chat list using
+        :meth:`is_group_chat_visible`.
+        """
+        self.logger.info(
+            "Creating group chat %r with members=%s", group_name, members,
+        )
+
+        if not self._chat_page.tap_start_chat(timeout=timeout):
+            self.logger.error("Could not open create-chat surface")
+            return False
+
+        for name in members:
+            if not self.add_member_to_group(name, timeout=timeout):
+                self.logger.error("Failed to add member %r", name)
+                return False
+
+        if not self.confirm_group_creation(timeout=timeout):
+            self.logger.error("Confirm failed after adding members")
+            return False
+
+        self.logger.info("Create-group confirm tapped")
+        return True
+
+    def add_member_to_group(
+        self,
+        display_name: str,
+        *,
+        timeout: int = UI_TIMEOUT,
+    ) -> bool:
+        """Pick the next available contact from the create-chat picker.
+
+        ``display_name`` is the caller's intent ("I want to add member X"),
+        recorded in logs but NOT typed into the picker. Two reasons:
+
+        1. ``CreateChatView.qml`` binds the contacts-list visibility to
+           ``edit.text === ""`` — any keystroke in the input HIDES the
+           suggestion list, leaving nothing to tap.
+        2. The picker filters by alias/displayName/ensName/localNickname.
+           Under fixture flows the contact's local display name is the
+           receiver-side auto-derived Frilledlizard identity (e.g.
+           "Unselfish Free Crocodile"), not the sender-side display_name
+           the caller passes — so a typed filter would yield zero rows
+           anyway.
+
+        We tap the first available row from ``ANY_MEMBER_LIST_ITEM``.
+        Status's ``notAMemberPredicate`` filters already-picked members
+        out of the suggestions, so successive calls to this method pick
+        distinct contacts in order.
+        """
+        self.logger.info(
+            "Picking next member (intent=%r, unfiltered first-row tap)",
+            display_name,
+        )
+        return self.safe_click(
+            self.locators.ANY_MEMBER_LIST_ITEM,
+            timeout=timeout,
+            max_attempts=2,
+        )
+
+    def confirm_group_creation(self, *, timeout: int = UI_TIMEOUT) -> bool:
+        """Tap the create-chat confirm footer button."""
+        return self.safe_click(
+            self.locators.CREATE_CHAT_CONFIRM_BUTTON,
+            timeout=timeout,
+            max_attempts=2,
+        )
+
+    def set_group_name(self, name: str, *, timeout: int = UI_TIMEOUT) -> bool:
+        """Rename the currently open group chat.
+
+        Requires the group's context menu to be opened first via
+        :meth:`open_edit_group_menu` (or equivalent). For the whole
+        rename-from-chat-list flow, use :meth:`rename_group_from_chat_list`.
+        """
+        if not self.is_element_visible(
+            self.locators.RENAME_GROUP_POPUP, timeout=timeout,
+        ):
+            self.logger.error("Rename-group popup not visible")
+            return False
+        # verify=False: the rename input's a11y value doesn't read back on Pi,
+        # and a pre-save echo wouldn't prove the rename saved anyway.
+        if not self.qt_safe_input(
+            self.locators.RENAME_GROUP_NAME_INPUT,
+            name,
+            timeout=timeout,
+            verify=False,
+        ):
+            return False
+        return self.safe_click(
+            self.locators.RENAME_GROUP_SAVE_BUTTON, timeout=timeout,
+        )
+
+    # ------------------------------------------------------------------
+    # Group management from the chat list's context menu
+    # ------------------------------------------------------------------
+
+    def open_chat_list_context_menu(
+        self,
+        group_name: str,
+        *,
+        timeout: int = UI_TIMEOUT,
+        row_locator: Optional[tuple] = None,
+    ) -> bool:
+        """Long-press the row for *group_name* to open its context menu.
+
+        Status's chat row uses a Qt clicked handler that triggers the
+        popup menu on ``mouse.button === Qt.RightButton``. Touch
+        long-press maps to right-click in Qt's touch translation layer,
+        so a long-press gesture is the right primitive on mobile. The
+        translation is timing-sensitive — too short and the press is
+        interpreted as a click; too long and Qt may interpret it as
+        a drag. We try escalating durations and verify the menu opened
+        before returning.
+
+        ``row_locator`` (preferred when caller has it) targets a row
+        located via :meth:`find_group_row_by_exclusion`, bypassing the
+        unreliable name-based ``group_chat_row_by_name`` lookup on Pi
+        (where chat list rows have empty ``text``/``content-desc`` and
+        the group name is hash-mangled in the resource-id path).
+
+        Returns True if the context menu appears (any
+        ``editNameAndImageMenuItem`` / ``deleteOrLeaveMenuItem`` /
+        ``addRemoveFromGroupStatusAction`` becomes visible).
+        """
+        from locators.messaging.group_chat_locators import (
+            GroupChatLocators as L,
+        )
+        menu_item_locators = [
+            L.EDIT_GROUP_NAME_MENU_ITEM,
+            L.DELETE_OR_LEAVE_MENU_ITEM,
+            L.ADD_REMOVE_FROM_GROUP_ACTION,
+        ]
+
+        def _menu_open() -> bool:
+            return any(
+                self.is_element_visible(loc, timeout=1)
+                for loc in menu_item_locators
+            )
+
+        row = row_locator or self.locators.group_chat_row_by_name(group_name)
+        if not self.is_element_visible(row, timeout=timeout):
+            if not self.scroll_to_element(row, max_swipes=3, timeout=3):
+                self.logger.error(
+                    "Group chat row %r not found in chat list", group_name,
+                )
+                return False
+
+        # Escalating durations: Qt's touch→right-click translation is
+        # timing-sensitive, so no single press length is reliable.
+        for duration_ms in (800, 1200, 1600):
+            element = self.find_element_safe(row, timeout=timeout)
+            if element is None:
+                self.logger.warning(
+                    "Chat row %r vanished between long-press attempts",
+                    group_name,
+                )
+                return False
+            self.long_press_element(element, duration=duration_ms)
+            if _menu_open():
+                self.logger.info(
+                    "Chat context menu opened after %dms long-press",
+                    duration_ms,
+                )
+                return True
+            self.logger.warning(
+                "Long-press %dms did not open context menu; "
+                "retrying with longer duration", duration_ms,
+            )
+        self.logger.error(
+            "Context menu did not open for %r after 3 long-press attempts",
+            group_name,
+        )
+        self.dump_page_source(f"context_menu_did_not_open_{group_name[:30]}")
+        return False
+
+    def open_group_context_menu_via_header(
+        self,
+        group_name: str,
+        *,
+        timeout: int = UI_TIMEOUT,
+        row_locator: Optional[tuple] = None,
+    ) -> bool:
+        """Open the group's context menu via the in-chat header "More"
+        button instead of the chat-list long-press.
+
+        Opens the group chat, taps ``chatToolbarMoreOptionsButton``, and
+        verifies the moreOptionsContextMenu (a ChatContextMenuView with
+        the same item objectNames as the chat-list menu) is showing.
+
+        Preferred on Pi: a plain tap is reliable where the chat-list
+        long-press is timing-sensitive (Qt long-press → right-click
+        translation intermittently auto-fires the top item or fails to
+        register).
+        """
+        from locators.messaging.group_chat_locators import (
+            GroupChatLocators as L,
+        )
+        if not self.open_group_chat_by_name(
+            group_name, timeout=timeout, row_locator=row_locator,
+        ):
+            self.logger.error(
+                "open_group_context_menu_via_header: could not open group chat"
+            )
+            return False
+        if not self.safe_click(
+            self.locators.CHAT_TOOLBAR_MORE_OPTIONS_BUTTON, timeout=timeout,
+        ):
+            self.logger.error(
+                "open_group_context_menu_via_header: could not tap More button"
+            )
+            return False
+        menu_item_locators = [
+            L.EDIT_GROUP_NAME_MENU_ITEM,
+            L.DELETE_OR_LEAVE_MENU_ITEM,
+            L.ADD_REMOVE_FROM_GROUP_ACTION,
+        ]
+        if any(self.is_element_visible(loc, timeout=2) for loc in menu_item_locators):
+            return True
+        self.logger.error(
+            "open_group_context_menu_via_header: menu did not open after tap"
+        )
+        return False
+
+    def rename_group_from_chat_list(
+        self,
+        old_name: str,
+        new_name: str,
+        *,
+        timeout: int = UI_TIMEOUT,
+        row_locator: Optional[tuple] = None,
+    ) -> bool:
+        if not self.open_group_context_menu_via_header(
+            old_name, timeout=timeout, row_locator=row_locator,
+        ):
+            return False
+        if not self.safe_click(
+            self.locators.EDIT_GROUP_NAME_MENU_ITEM, timeout=timeout,
+        ):
+            return False
+        return self.set_group_name(new_name, timeout=timeout)
+
+    def open_add_remove_members(
+        self,
+        group_name: str,
+        *,
+        timeout: int = UI_TIMEOUT,
+        row_locator: Optional[tuple] = None,
+    ) -> bool:
+        """Open the add/remove-members sheet for *group_name*."""
+        if not self.open_group_context_menu_via_header(
+            group_name, timeout=timeout, row_locator=row_locator,
+        ):
+            return False
+        return self.safe_click(
+            self.locators.ADD_REMOVE_FROM_GROUP_ACTION, timeout=timeout,
+        )
+
+    def _tap_members_button(self, *, timeout: int = UI_TIMEOUT) -> bool:
+        """Open the UserListPanel via the in-chat header Members button.
+
+        The button has no objectName, so it's targeted by position: it
+        sits immediately left of the (identifiable)
+        chatToolbarMoreOptionsButton in the header toolbar.
+
+        PI-ONLY / not cross-device robust: a relative-position tap won't
+        survive header reflow on other screen sizes or BrowserStack
+        (conditional button visibility + responsive layout). The robust
+        fix is a one-line upstream objectName on ``membersButton`` —
+        then this becomes a plain tid() tap.
+        """
+        if self.is_element_visible(self.locators.MEMBERS_BUTTON, timeout=2):
+            return self.safe_click(self.locators.MEMBERS_BUTTON, timeout=timeout)
+        more = self.find_element_safe(
+            self.locators.CHAT_TOOLBAR_MORE_OPTIONS_BUTTON, timeout=timeout,
+        )
+        if more is None:
+            self.logger.error(
+                "_tap_members_button: neither Members nor More button found"
+            )
+            return False
+        try:
+            rect = more.rect
+            gap = int(rect["width"] * 0.2)
+            x = int(rect["x"] - gap - rect["width"] / 2)
+            y = int(rect["y"] + rect["height"] / 2)
+            self.gestures.tap(x, y)
+        except Exception as exc:
+            self.logger.error("_tap_members_button position tap failed: %s", exc)
+            return False
+        # The UserListPanel container's resource-id isn't reliably
+        # exposed; its StatusMemberListItem rows are. Gate on those.
+        any_member_row = (
+            "xpath", "//*[contains(@resource-id,'StatusMemberListItem')]",
+        )
+        return self.is_element_visible(any_member_row, timeout=8)
+
+    def remove_member(
+        self,
+        group_name: str,
+        member_identity: str,
+        *,
+        timeout: int = UI_TIMEOUT,
+        row_locator: Optional[tuple] = None,
+    ) -> bool:
+        """Remove the member named *member_identity* from *group_name* (admin).
+
+        Uses the Members panel (UserListPanel), not the add/remove chip
+        picker: open group → Members button → long-press the member's row
+        (found by its content-desc identity name) → "Remove from group"
+        (``removeFromGroup_StatusItem``). The chip picker can't be used —
+        its member chips expose no per-member a11y identity.
+
+        ``member_identity`` is the peer's Frilledlizard name (the same
+        string Status shows in the panel and in the ``&``-joined
+        auto-derived group name).
+        """
+        if not self.open_group_chat_by_name(
+            group_name, timeout=timeout, row_locator=row_locator,
+        ):
+            return False
+        if not self._tap_members_button(timeout=timeout):
+            return False
+        row = self.locators.member_panel_row_by_name(member_identity)
+        for press_ms in (900, 1400):
+            element = self.find_element_safe(row, timeout=timeout)
+            if element is None:
+                self.logger.error(
+                    "remove_member: member row %r not found in panel",
+                    member_identity,
+                )
+                return False
+            # Long-press opens the member's ProfileDialog ON TOP of the
+            # ProfileContextMenu. A removeFromGroup tap while the profile
+            # covers the menu silently lands on the profile and the member
+            # is never removed. Another user's profile has no close button
+            # (ProfileDialog header is shown only for the current user), so
+            # dismiss it with a back navigation — that leaves the context
+            # menu open underneath, where removeFromGroup is reachable.
+            self.long_press_element(element, duration=press_ms)
+            time.sleep(1)
+            self.driver.back()
+            # safe_click raises (not returns False) on exhaustion, so gate on
+            # visibility first — else a missed long-press skips the retry below.
+            if self.is_element_visible(
+                self.locators.REMOVE_FROM_GROUP_ITEM, timeout=5,
+            ):
+                return self.safe_click(
+                    self.locators.REMOVE_FROM_GROUP_ITEM, timeout=timeout,
+                )
+            self.logger.warning(
+                "remove_member: removeFromGroup not actioned after %dms "
+                "long-press; retrying", press_ms,
+            )
+        return False
+
+    def add_member_to_existing_group(
+        self,
+        group_name: str,
+        member_identity: str,
+        *,
+        timeout: int = UI_TIMEOUT,
+        row_locator: Optional[tuple] = None,
+    ) -> bool:
+        """Add the contact named *member_identity* back to *group_name* (admin).
+
+        Opens the add/remove sheet (header More → add/remove from group) and
+        re-adds via the inline member picker (MembersSelectorBase →
+        InlineSelectorPanel): type into the recipient input to surface the
+        contact's suggestion row, tap it, then confirm with Save Changes.
+
+        The picker's suggestion list is hidden until the recipient input has
+        text (``visible: edit.text !== ""``) — the OPPOSITE of the new-chat
+        CreateChatView picker, which lists contacts when the input is empty.
+        Typing filters by alias/displayName, so we type a token of the
+        member's name. ``member_identity`` is the admin's local name for the
+        peer (from the group name), which is what the filter matches against.
+        ``timeout`` gates how long to wait for the suggestion: a just-removed
+        member only re-appears once the removal has settled in the membership
+        model, so a Waku-grade timeout (not a UI one) is needed.
+        """
+        if not self.open_add_remove_members(
+            group_name, timeout=self.UI_TIMEOUT, row_locator=row_locator,
+        ):
+            return False
+        token = member_identity.split()[0] if member_identity.split() else member_identity
+        self.logger.info(
+            "Re-adding member (intent=%r, search token=%r)", member_identity, token,
+        )
+        if not self.qt_safe_input(
+            self.locators.MEMBER_PICKER_INPUT, token,
+            timeout=self.UI_TIMEOUT, verify=False,
+        ):
+            return False
+        suggestion = self.locators.ANY_MEMBER_LIST_ITEM
+        if not self.is_element_visible(suggestion, timeout=timeout):
+            _dump = self.dump_page_source("add_sheet_no_suggestion")
+            self.logger.error(
+                "add_member: no suggestion for %r after typing %r (waited %ss; "
+                "dump %s)", member_identity, token, timeout, _dump,
+            )
+            return False
+        if not self.safe_click(suggestion, timeout=self.UI_TIMEOUT):
+            return False
+        return self.safe_click(
+            self.locators.CREATE_CHAT_CONFIRM_BUTTON, timeout=self.UI_TIMEOUT,
+        )
+
+    def leave_group(
+        self,
+        group_name: str,
+        *,
+        timeout: int = UI_TIMEOUT,
+        row_locator: Optional[tuple] = None,
+    ) -> bool:
+        """Leave *group_name* as a non-admin member."""
+        if not self.open_group_context_menu_via_header(
+            group_name, timeout=timeout, row_locator=row_locator,
+        ):
+            return False
+        if not self.safe_click(
+            self.locators.DELETE_OR_LEAVE_MENU_ITEM, timeout=timeout,
+        ):
+            return False
+        return self.safe_click(
+            self.locators.LEAVE_CONFIRM_BUTTON, timeout=timeout,
+        )
+
+    # ------------------------------------------------------------------
+    # Verification
+    # ------------------------------------------------------------------
+
+    def find_group_row_by_exclusion(
+        self,
+        known_one_to_one_names: List[str],
+    ) -> Optional[tuple]:
+        """Return a locator for the group row, identified by exclusion.
+
+        On Pi (Android API 35), chat list rows have empty ``text`` and
+        ``content-desc`` — the chat name lives only in the dotted
+        ``resource-id`` path. The group's name is mangled (``&`` is
+        replaced with a hash and the name is truncated), so the user-
+        visible group name doesn't substring-match. The 1:1 chats
+        expose the peer's identity name cleanly though, so we identify
+        the group as "any StatusDraggableListItem whose name-segment
+        is NOT one of the known 1:1 chat names".
+
+        Returns a (strategy, selector) locator tuple usable with
+        ``is_element_visible`` / ``safe_click`` / ``long_press_element``,
+        or None if no group row is found.
+        """
+        if not known_one_to_one_names:
+            # Nothing to exclude — the first row would always match, which is
+            # the 1:1 with admin. Refuse rather than return the wrong chat.
+            self.logger.error(
+                "find_group_row_by_exclusion called with no known 1:1 names; "
+                "cannot disambiguate the group row"
+            )
+            return None
+        from appium.webdriver.common.appiumby import AppiumBy
+        try:
+            elements = self.driver.find_elements(
+                AppiumBy.XPATH,
+                "//*[contains(@resource-id,'StatusDraggableListItem')]",
+            )
+        except Exception as exc:
+            self.logger.debug("find_group_row_by_exclusion list failed: %s", exc)
+            return None
+        excluded = set(known_one_to_one_names)
+        for el in elements:
+            try:
+                rid = el.get_attribute("resource-id") or ""
+            except Exception:
+                continue
+            if ".StatusDraggableListItem_" not in rid:
+                continue
+            prefix = rid.split(".StatusDraggableListItem_", 1)[0]
+            chat_name = prefix.rsplit(".", 1)[-1] if "." in prefix else prefix
+            if chat_name and chat_name not in excluded:
+                escaped = chat_name.replace("'", "\\'")
+                return (
+                    "xpath",
+                    "//*[contains(@resource-id,'StatusDraggableListItem')"
+                    f" and contains(@resource-id,\"{escaped}\")]",
+                )
+        return None
+
+    def is_group_chat_visible(
+        self,
+        group_name: str,
+        *,
+        timeout: int = CROSS_DEVICE_TIMEOUT,
+        row_locator: Optional[tuple] = None,
+    ) -> bool:
+        """True if *group_name* is visible in the chat list.
+
+        Uses the cross-device timeout by default — this assertion is
+        usually the cross-device half of a message-delivery check.
+        """
+        row = row_locator or self.locators.group_chat_row_by_name(group_name)
+        return self.is_element_visible(row, timeout=timeout)
+
+    def open_group_chat_by_name(
+        self,
+        group_name: str,
+        *,
+        timeout: int = CROSS_DEVICE_TIMEOUT,
+        row_locator: Optional[tuple] = None,
+    ) -> bool:
+        """Open the group chat named *group_name* from the chat list."""
+        row = row_locator or self.locators.group_chat_row_by_name(group_name)
+        if not self.is_element_visible(row, timeout=timeout):
+            if not self.scroll_to_element(row, max_swipes=3, timeout=3):
+                return False
+        return self.safe_click(row, timeout=timeout)
+
+    def get_group_name_from_header(
+        self,
+        *,
+        timeout: int = UI_TIMEOUT,
+    ) -> Optional[str]:
+        """Read the group name from the open chat's header button.
+
+        Requires the group chat to already be open. Polls until either
+        the title attribute is non-empty or ``timeout`` elapses. The
+        title (``chatContentModule.chatDetails.name``) populates
+        asynchronously after the chat is opened — empty on first read
+        is normal for ~1-2 seconds.
+        """
+        deadline = time.time() + max(1, timeout)
+        last_value: Optional[str] = None
+        # Qt accessibility surfaces the title only on the nested
+        # statusChatInfoButtonNameText node, not the parent button.
+        candidate_locators = (
+            self.locators.CHAT_INFO_HEADER_NAME_TEXT,
+            self.locators.CHAT_INFO_HEADER_BUTTON,
+        )
+        while time.time() < deadline:
+            for locator in candidate_locators:
+                element = self.find_element_safe(locator, timeout=1)
+                if element is None:
+                    continue
+                for attr in ("content-desc", "text"):
+                    try:
+                        value = element.get_attribute(attr)
+                        if value and value not in ("null", ""):
+                            # Trim Qt's "[tid:...]" debug suffix.
+                            stripped = value.strip()
+                            if " [tid:" in stripped:
+                                stripped = stripped.split(" [tid:", 1)[0].strip()
+                            if stripped:
+                                return stripped
+                    except Exception:
+                        continue
+                last_value = "<empty attributes>"
+            if last_value is None:
+                last_value = "<element not present>"
+            time.sleep(1)
+        self.logger.warning(
+            "get_group_name_from_header: gave up after %ss (last: %s)",
+            timeout, last_value,
+        )
+        return None
+
+    def count_members_in_panel(
+        self,
+        group_name: str,
+        *,
+        timeout: int = UI_TIMEOUT,
+        row_locator: Optional[tuple] = None,
+    ) -> int:
+        """Count current members shown in the group's Members panel.
+
+        Opens the group and the UserListPanel (header Members button) and
+        counts ``StatusMemberListItem`` rows — the same surface
+        :meth:`remove_member` navigates. The count includes every current
+        member (admin included), matching the desktop members-list check.
+        Returns -1 if the group or panel can't be opened, so a count
+        assertion fails with a clear value rather than 0.
+        """
+        if not self.open_group_chat_by_name(
+            group_name, timeout=timeout, row_locator=row_locator,
+        ):
+            return -1
+        if not self._tap_members_button(timeout=timeout):
+            return -1
+        by, selector = self.locators.MEMBER_PANEL_ROW_ANY
+        try:
+            return len(self.driver.find_elements(by, selector))
+        except Exception as exc:
+            self.logger.debug("count_members_in_panel failed: %s", exc)
+            return -1
+
+    def is_removed_member_lockout_shown(
+        self,
+        *,
+        timeout: int = UI_TIMEOUT,
+    ) -> bool:
+        """True if the open chat shows the not-a-member lockout.
+
+        When a removed/non-member opens a group, the composer placeholder
+        switches to "You need to be a member of this group to send
+        messages" and sending is disabled — both bound to
+        ``isUserAllowedToSendMessage == false`` in RootStore.qml. Detecting
+        the placeholder text is equivalent to asserting the lockout state.
+        Call this with the group chat already open.
+        """
+        return self.is_element_visible(
+            self.locators.NOT_A_MEMBER_PLACEHOLDER, timeout=timeout,
+        )

--- a/test/e2e_appium/tests/messaging/conftest.py
+++ b/test/e2e_appium/tests/messaging/conftest.py
@@ -19,6 +19,8 @@ serialises them so a single fixture is reused across the whole worker.
 
 from __future__ import annotations
 
+import asyncio
+import os
 import threading
 
 from dataclasses import dataclass, field
@@ -35,7 +37,10 @@ from core.stash_keys import (
     ESTABLISHED_CHAT_FAILURE_COUNT_KEY,
 )
 from utils.chat_state import ensure_chat_visible
-from utils.contact_helpers import establish_contact
+from utils.contact_helpers import (
+    establish_contact,
+    establish_contacts_admin_to_many,
+)
 from utils.timeouts import CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
 from utils.generators import generate_account_name
 
@@ -47,9 +52,11 @@ class _SessionKeepAlive:
     thread to keep idle BS sessions alive across our 300s cross-device
     waits (``appium:newCommandTimeout`` is coerced by BS).
 
-    Selenium WebDriver isn't formally thread-safe; we only fire while the
-    main thread is blocked on the OTHER device, so concurrent commands on
-    the same driver are structurally avoided.
+    Selenium WebDriver isn't thread-safe. The heartbeat can rarely collide
+    with a main-thread command on the device under test — at worst a one-off
+    flake, acceptable for a nightly. If it bites on BrowserStack, gate pings on
+    a per-driver lock. (A BS workaround; unneeded where newCommandTimeout is
+    honoured above our longest wait.)
 
     TODO(upstream): drop once BS honours ``newCommandTimeout``.
     """
@@ -170,18 +177,29 @@ async def _establish_contact(
     primary: DeviceContext,
     secondary: DeviceContext,
     timeout: int = CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS,
-) -> tuple[str, str]:
+    *,
+    verify_delivery: bool = True,
+    receiver_restart_before_accept: bool = False,
+) -> tuple[str, str, str, str]:
     """Establish contact between two devices.
 
-    Delegates to the shared ``establish_contact()`` utility.
+    Delegates to the shared ``establish_contact()`` utility. Set
+    ``verify_delivery=False`` to skip the bidirectional Waku gate when
+    the caller (e.g. a multi-device fixture) will verify delivery via a
+    later test step. Set ``receiver_restart_before_accept=True`` to
+    force a storenode history fetch on the receiver (via app restart +
+    re-login) before navigating to the pending tab.
 
     Returns:
-        Tuple of (primary_suffix, secondary_suffix).
+        Tuple of (primary_suffix, secondary_suffix, primary_chat_key,
+        secondary_chat_key). chat_keys are the compressed pub keys
+        suitable for ``member_list_item_by_pubkey`` lookups.
     """
-    sender_suffix, receiver_suffix, _, _ = await establish_contact(
+    return await establish_contact(
         primary, secondary, timeout=timeout,
+        verify_delivery=verify_delivery,
+        receiver_restart_before_accept=receiver_restart_before_accept,
     )
-    return sender_suffix, receiver_suffix
 
 
 def _report_browserstack_status(pool: SessionPool, status: str, reason: str | None = None) -> None:
@@ -265,7 +283,7 @@ async def _setup_established_chat(
         primary = contexts[device_names[0]]
         secondary = contexts[device_names[1]]
 
-        primary_suffix, secondary_suffix = await _establish_contact(
+        primary_suffix, secondary_suffix, _, _ = await _establish_contact(
             primary, secondary,
         )
 
@@ -489,3 +507,410 @@ def chat_ready(established_chat) -> EstablishedChatContext:
     ensure_chat_visible(ctx.primary, ctx.secondary_suffix, secondary_display)
     ensure_chat_visible(ctx.secondary, ctx.primary_suffix, primary_display)
     return ctx
+
+
+# ---------------------------------------------------------------------------
+# 3-device group chat fixture
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GroupChatContext:
+    """Context for 3 onboarded devices with admin-rooted contacts (admin↔B, admin↔C).
+
+    The admin creates the group; member_b and member_c are the two peers
+    needed to satisfy mobile's ``model.count >= 2`` group-creation gate
+    (see ``ui/app/AppLayouts/Chat/views/CreateChatView.qml``).
+    """
+
+    admin: DeviceContext
+    member_b: DeviceContext
+    member_c: DeviceContext
+    admin_suffix: str
+    member_b_suffix: str
+    member_c_suffix: str
+    admin_name: str
+    member_b_name: str
+    member_c_name: str
+    # compressed pub keys (chat_keys) captured during contact establishment;
+    # used by test_05/06 for member-list lookups via
+    # member_list_item_by_pubkey (Status renders member rows with
+    # Frilledlizard identity names, not onboarding display_names).
+    member_b_chat_key: str
+    member_c_chat_key: str
+    multi_ctx: MultiDeviceContext
+    # Per-device 1:1 chat names, captured after contact establishment
+    # but before group creation, keyed by device_id. Used to find the
+    # group row by exclusion: Pi mangles the group name in the QML
+    # resource-id, but the 1:1 rows keep clean identity names, so the
+    # group is the chat-list row that isn't one of these.
+    one_to_one_names_by_device: dict[str, list[str]] = field(default_factory=dict)
+    _keepalives: list["_SessionKeepAlive"] = field(default_factory=list)
+
+    @property
+    def admin_driver(self):
+        return self.admin.driver
+
+    @property
+    def member_b_driver(self):
+        return self.member_b.driver
+
+    @property
+    def member_c_driver(self):
+        return self.member_c.driver
+
+    def members(self) -> list[DeviceContext]:
+        """All three devices, admin first."""
+        return [self.admin, self.member_b, self.member_c]
+
+
+async def _exchange_contacts_admin_rooted(
+    devices: list[DeviceContext],
+    *,
+    timeout: int = CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS,
+) -> dict[tuple[str, str], tuple[str, str, str, str]]:
+    """Establish admin↔member contacts only (no member-member pair).
+
+    For mobile group chat, only the admin needs to be contacts with each
+    member — the picker shows the admin's contact list, and group chat
+    propagation is then a protocol-level concern. Skipping the B↔C pair
+    saves one ``_establish_contact`` invocation (~5-10 min on BS where
+    Settings → Contacts nav is the dominant cost).
+
+    For 3 devices ``[admin, B, C]`` this performs 2 exchanges
+    (admin↔B, admin↔C). Sequential — see prior comment about BS
+    cross-session interference on parallel profile-link capture.
+
+    Returns ``{(admin_id, member_id): (admin_suffix, member_suffix,
+    admin_chat_key, member_chat_key)}``. The chat_keys are needed for
+    member-list lookups in test_05/test_06 (member rows render with
+    Frilledlizard identity names rather than the onboarding
+    display_name, so name-based lookup is unreliable — pubkey is the
+    stable identifier).
+    """
+    if not devices:
+        return {}
+    suffixes: dict[tuple[str, str], tuple[str, str, str, str]] = {}
+    admin = devices[0]
+    receivers = devices[1:]
+
+    # Parallel admin↔[B,C] exchange (overlapped receiver accepts) is the
+    # default for 2+ receivers. Set USE_PARALLEL_CONTACT_EXCHANGE=0 to
+    # force the sequential 1:1 path (e.g. to isolate a parallel-only flake).
+    opt_out = os.getenv("USE_PARALLEL_CONTACT_EXCHANGE", "").lower() in {
+        "0", "false", "no",
+    }
+    use_parallel = (not opt_out) and len(receivers) >= 2
+    logger.info(
+        "Exchanging contacts admin↔[%s] (admin-rooted, parallel=%s)",
+        ", ".join(r.device_id for r in receivers),
+        use_parallel,
+    )
+    if use_parallel and len(receivers) >= 2:
+        results = await establish_contacts_admin_to_many(
+            admin, receivers,
+            timeout=timeout,
+            receiver_restart_before_accept=True,
+        )
+        for member, result in zip(receivers, results):
+            suffixes[(admin.device_id, member.device_id)] = result
+    else:
+        for member in receivers:
+            # verify_delivery=False: test_01's create-group step is the
+            # delivery check. receiver_restart_before_accept=True: see
+            # establish_contact — restart makes the request arrive live.
+            result = await _establish_contact(
+                admin, member, timeout=timeout,
+                verify_delivery=False,
+                receiver_restart_before_accept=True,
+            )
+            suffixes[(admin.device_id, member.device_id)] = result
+    return suffixes
+
+
+def _extract_chat_row_names(device: DeviceContext) -> list[str]:
+    """Return the chat-name portions of every StatusDraggableListItem
+    currently on *device*'s chat list.
+
+    The QML accessibility bridge encodes each row's chat name as the
+    segment immediately before ``.StatusDraggableListItem_`` in the
+    resource-id, e.g.
+    ``...StatusScrollView_QMLTYPE_X.<chat_name>.StatusDraggableListItem_QMLTYPE_Y_QML_Z``.
+    On Android API 35, ``text`` and ``content-desc`` are empty for
+    chat rows — the only on-device identifier is this resource-id
+    fragment. We surface it so callers can build exclusion-based
+    locators that survive QML name mangling (e.g. ``&`` → hash).
+    """
+    from appium.webdriver.common.appiumby import AppiumBy
+    elements = device.driver.find_elements(
+        AppiumBy.XPATH,
+        "//*[contains(@resource-id,'StatusDraggableListItem')]",
+    )
+    names: list[str] = []
+    for el in elements:
+        try:
+            rid = el.get_attribute("resource-id") or ""
+        except Exception:
+            continue
+        if ".StatusDraggableListItem_" not in rid:
+            continue
+        prefix = rid.split(".StatusDraggableListItem_", 1)[0]
+        # The chat name is the last dotted segment of the prefix.
+        chat_name = prefix.rsplit(".", 1)[-1] if "." in prefix else prefix
+        if chat_name:
+            names.append(chat_name)
+    return names
+
+
+async def _setup_group_chat_context(
+    pool: SessionPool,
+    test_nodeid: str,
+) -> GroupChatContext:
+    """Create 3 sessions, onboard 3 users, exchange admin-rooted contacts (admin↔B, admin↔C).
+
+    Mirrors ``_setup_established_chat`` but for 3 devices. Does NOT create
+    the group chat itself — that's the test's job, so the create-step
+    assertion is visible at the test level.
+    """
+    drivers = await pool.create_sessions(
+        count=3,
+        test_nodeid=f"{test_nodeid}::module_setup",
+    )
+
+    keepalives: list[_SessionKeepAlive] = []
+    for name, driver in drivers.items():
+        ka = _SessionKeepAlive(driver, label=name)
+        ka.start()
+        keepalives.append(ka)
+
+    try:
+        contexts = {
+            name: DeviceContext(driver=driver, device_id=name)
+            for name, driver in drivers.items()
+        }
+        multi_ctx = MultiDeviceContext(contexts)
+
+        display_names = [generate_account_name(12) for _ in range(3)]
+        await multi_ctx.onboard_users_parallel(
+            display_names=display_names,
+            require_all=True,
+        )
+
+        device_names = list(contexts.keys())
+        admin = contexts[device_names[0]]
+        member_b = contexts[device_names[1]]
+        member_c = contexts[device_names[2]]
+
+        suffixes = await _exchange_contacts_admin_rooted(
+            [admin, member_b, member_c],
+        )
+
+        ab_tuple = suffixes[(admin.device_id, member_b.device_id)]
+        ac_tuple = suffixes[(admin.device_id, member_c.device_id)]
+        admin_suffix = ab_tuple[0]
+        member_b_suffix = ab_tuple[1]
+        member_c_suffix = ac_tuple[1]
+        # ab_tuple = (admin_suffix, b_suffix, admin_chat_key, b_chat_key)
+        # ac_tuple = (admin_suffix, c_suffix, admin_chat_key, c_chat_key)
+        member_b_chat_key = ab_tuple[3]
+        member_c_chat_key = ac_tuple[3]
+
+        # Capture each device's 1:1 chat names before the group exists,
+        # for the exclusion-based group-row lookup (see the field docs).
+        from pages.app import App as _App
+        one_to_one_names_by_device: dict[str, list[str]] = {}
+        for ctx_dev in (admin, member_b, member_c):
+            try:
+                _App(ctx_dev.driver).click_messages_button()
+                await asyncio.sleep(0.5)
+                names = _extract_chat_row_names(ctx_dev)
+                one_to_one_names_by_device[ctx_dev.device_id] = names
+                logger.info(
+                    "Captured %s 1:1 chat names pre-group-creation: %s",
+                    ctx_dev.device_id, names,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to capture %s 1:1 chat names: %s",
+                    ctx_dev.device_id, exc,
+                )
+                one_to_one_names_by_device[ctx_dev.device_id] = []
+
+        # Empty known-names makes the exclusion lookup match the first row (the
+        # 1:1 with admin) — silently testing the wrong chat. Abort instead.
+        empty = [d for d, names in one_to_one_names_by_device.items() if not names]
+        assert not empty, (
+            f"1:1 chat-name capture is empty for device(s) {empty}; the "
+            "exclusion-based group lookup needs >=1 known 1:1 name per device "
+            "to distinguish the group from existing chats"
+        )
+
+        return GroupChatContext(
+            admin=admin,
+            member_b=member_b,
+            member_c=member_c,
+            admin_suffix=admin_suffix,
+            member_b_suffix=member_b_suffix,
+            member_c_suffix=member_c_suffix,
+            admin_name=display_names[0],
+            member_b_name=display_names[1],
+            member_c_name=display_names[2],
+            member_b_chat_key=member_b_chat_key,
+            member_c_chat_key=member_c_chat_key,
+            one_to_one_names_by_device=one_to_one_names_by_device,
+            multi_ctx=multi_ctx,
+            _keepalives=keepalives,
+        )
+    except BaseException:
+        for ka in keepalives:
+            try:
+                ka.stop()
+            except Exception:
+                pass
+        raise
+
+
+@pytest_asyncio.fixture(scope="module")
+async def group_chat_context(request, test_environment) -> GroupChatContext:
+    """Module-scoped fixture: 3 devices, admin-rooted contacts admin↔B, admin↔C (no B↔C).
+
+    Mirrors ``established_chat`` retry-once + BS status reporting +
+    module-test tracking pattern. 3-device setup is measurably more
+    expensive (~7-12 min on BrowserStack vs ~3-5 min for 2-device); the
+    module scope is doing real work — do not downgrade to function scope
+    without weighing the cost per added test method.
+
+    Does not create the group chat itself; tests own that.
+    """
+    global _module_pools
+
+    logger.info("Setting up module-scoped group_chat_context fixture")
+
+    pool = None
+    ctx = None
+    setup_failed = False
+    keepalives: list[_SessionKeepAlive] = []
+    # Single attempt under the class-level timeout. A single attempt is
+    # ~15-20 min on BS (verify_delivery=False); retrying setup would push
+    # past the budget. Test-body reruns are disabled globally (pytest.ini
+    # --reruns 0), so the suite runs once start-to-finish.
+    max_attempts = 1
+
+    # Local-mode env override: LOCAL_DEVICE_UDIDS + LOCAL_APPIUM_URLS pair
+    # each session (by index) to a distinct UDID + appium server. Without
+    # this, all 3 sessions inherit the YAML default device, which on Pi
+    # means three sessions racing for the same appium+UDID+systemPort.
+    # On BS the env vars are unset so device_overrides stays None.
+    device_overrides: list[dict] | None = None
+    udids = [v.strip() for v in os.getenv("LOCAL_DEVICE_UDIDS", "").split(",") if v.strip()]
+    urls = [v.strip() for v in os.getenv("LOCAL_APPIUM_URLS", "").split(",") if v.strip()]
+    if test_environment == "local" and len(udids) >= 3:
+        device_overrides = [
+            {
+                "capabilities": {
+                    "appium:udid": udids[i],
+                    "appium:systemPort": 8200 + i,
+                },
+                **({"server_url": urls[i]} if i < len(urls) else {}),
+            }
+            for i in range(3)
+        ]
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            pool_config = PoolConfig.from_environment(
+                test_environment,
+                parallel=True,
+                device_overrides=device_overrides,
+            )
+            pool = SessionPool(config=pool_config)
+
+            ctx = await _setup_group_chat_context(
+                pool, request.node.nodeid,
+            )
+            keepalives = ctx._keepalives
+            _module_pools.append(pool)
+            break
+
+        except Exception as e:
+            logger.error(
+                "group_chat_context setup failed (attempt %d/%d): %s",
+                attempt, max_attempts, e,
+            )
+            if pool:
+                try:
+                    _report_browserstack_status(
+                        pool, "failed", f"Setup failed (attempt {attempt}): {e}"
+                    )
+                except Exception:
+                    pass
+                try:
+                    await pool.cleanup()
+                except Exception as cleanup_err:
+                    logger.warning("Cleanup after failed attempt: %s", cleanup_err)
+                pool = None
+
+            if attempt < max_attempts:
+                logger.info("Retrying with fresh 3-device sessions")
+                continue
+
+            setup_failed = True
+            raise
+
+    try:
+        yield ctx
+    except Exception:
+        setup_failed = True
+        raise
+    finally:
+        for ka in keepalives:
+            try:
+                ka.stop()
+            except Exception:
+                pass
+        if pool:
+            if setup_failed:
+                _report_browserstack_status(
+                    pool, "failed", "group_chat_context setup failed",
+                )
+            else:
+                module_name = (
+                    request.node.module.__name__
+                    if hasattr(request.node, "module")
+                    else ""
+                )
+                failed_tests = _module_test_failures.get(module_name, [])
+                skipped_tests = _module_test_skipped.get(module_name, [])
+                passed_tests = _module_test_passed.get(module_name, [])
+
+                if failed_tests:
+                    reason = f"{len(failed_tests)} test(s) failed"
+                    _report_browserstack_status(pool, "failed", reason)
+                elif skipped_tests and not passed_tests:
+                    reason = f"All {len(skipped_tests)} test(s) skipped"
+                    _report_browserstack_status(pool, "skipped", reason)
+                else:
+                    passed_count = len(passed_tests)
+                    skipped_count = len(skipped_tests)
+                    if skipped_count > 0:
+                        reason = f"{passed_count} passed, {skipped_count} skipped"
+                    else:
+                        reason = f"All {passed_count} test(s) passed"
+                    _report_browserstack_status(pool, "passed", reason)
+
+                for tracking_dict in (
+                    _module_test_failures,
+                    _module_test_skipped,
+                    _module_test_passed,
+                ):
+                    if module_name in tracking_dict:
+                        del tracking_dict[module_name]
+
+            logger.info("Cleaning up 3-device group_chat_context sessions")
+            try:
+                await pool.cleanup()
+            except Exception as e:
+                logger.warning("Cleanup error (non-fatal): %s", e)
+
+            if pool in _module_pools:
+                _module_pools.remove(pool)

--- a/test/e2e_appium/tests/messaging/test_group_chat.py
+++ b/test/e2e_appium/tests/messaging/test_group_chat.py
@@ -1,0 +1,696 @@
+"""Group chat tests — 3 BrowserStack devices.
+
+Covers the desktop critical ``test_group_chat_add_contact_in_ac`` scope
+adapted to mobile:
+
+- creation propagation (admin + 2 members)
+- group name visibility on all three
+- message delivery from admin to both peers
+- rename propagation
+- member removal + readd
+- non-admin leave
+
+Uses the module-scoped ``group_chat_context`` fixture (in ``conftest.py``)
+which provisions 3 sessions, onboards 3 users, and exchanges admin-rooted
+contacts (admin↔B, admin↔C — no B↔C pair). The group chat itself is created in-test
+(``test_01_...``) so the creation assertion stays at the test level.
+
+Mobile's create-chat surface gates 1-1 vs group on
+``model.count >= 2`` (see ``CreateChatView.qml``) — that's why 2 devices
+isn't enough; the minimum group is admin + 2 peers.
+
+Test order is significant. The class shares state via ``cls.group_name``
+(set by test_01 from the auto-derived header name) so subsequent tests
+can find the group by its actual on-device name rather than a guess.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+
+from config.logging_config import get_logger
+from pages.app import App
+from pages.base_page import BasePage
+from pages.messaging.chat_page import ChatPage
+from pages.messaging.group_chat_page import GroupChatPage
+from utils.timeouts import CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
+
+
+def _unique_message(prefix: str = "gc") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.mark.messaging
+@pytest.mark.smoke
+@pytest.mark.device_count(3)
+@pytest.mark.timeout(3600)
+class TestGroupChat:
+    """3-device group chat lifecycle: create → message → manage → leave.
+
+    ``timeout(3600)`` (60 min) covers the full 7-test suite: fixture
+    cost is paid ONCE per pytest session (~10 min after the batched
+    admin-rooted establishment optimisation) and amortises across all
+    seven test bodies (~3-5 min each). 30-min cap was right for
+    single-test runs but too tight for the full suite.
+
+    No ``@flaky`` reruns: the tests mutate shared group state through
+    the module-scoped fixture (test_05 removes a member, test_07 has one
+    leave), so a single-test rerun would start from the already-mutated
+    state — e.g. rerunning test_05 finds the member already gone — and
+    fail spuriously while masking the real first-attempt failure. Body
+    flakes must be fixed, not retried.
+    """
+
+    UI_TIMEOUT = 30
+    CROSS_DEVICE_TIMEOUT = CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
+    MESSAGE_DELIVERY_TIMEOUT = CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
+
+    logger = get_logger("TestGroupChat")
+
+    # Set by test_01 after reading the auto-derived name from the header.
+    group_name: str | None = None
+    # Set by test_01 from the auto-derived group name's &-joined parts —
+    # the members' Frilledlizard identity names as admin sees them.
+    # Used by test_05/06 to target a specific member in the Members panel
+    # (rows are identified by content-desc = identity name).
+    member_b_identity: str | None = None
+    member_c_identity: str | None = None
+
+    @pytest.fixture(autouse=True)
+    def setup(self, group_chat_context):
+        self.ctx = group_chat_context
+        self.admin = group_chat_context.admin
+        self.member_b = group_chat_context.member_b
+        self.member_c = group_chat_context.member_c
+        self.admin_driver = group_chat_context.admin.driver
+        self.member_b_driver = group_chat_context.member_b.driver
+        self.member_c_driver = group_chat_context.member_c.driver
+
+    @asynccontextmanager
+    async def step(self, description: str):
+        self.logger.info("Step: %s", description)
+        try:
+            yield
+        finally:
+            self.logger.info("Done:  %s", description)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _group_row_locator_on(self, device) -> tuple | None:
+        """Get a locator for the group chat row on *device* via exclusion.
+
+        Identifies the group as "any StatusDraggableListItem whose
+        name-segment isn't one of the 1:1 chat names captured at
+        fixture setup". On Pi (Android API 35), chat list rows have
+        empty ``text``/``content-desc`` and the group name is hash-
+        mangled in the resource-id, so name-based lookup is brittle.
+        Exclusion is stable across renames.
+        """
+        gcp = GroupChatPage(device.driver)
+        known = self.ctx.one_to_one_names_by_device.get(device.device_id, [])
+        return gcp.find_group_row_by_exclusion(known)
+
+    async def _navigate_to_messages(self, device_driver) -> ChatPage:
+        """Bring *device_driver* to the chat list and dismiss prompts."""
+        app = App(device_driver)
+        chat_page = ChatPage(device_driver)
+
+        chat_page.dismiss_backup_prompt(timeout=2)
+        app.click_messages_button()
+        chat_page.dismiss_backup_prompt(timeout=2)
+        await asyncio.sleep(0.5)
+        return chat_page
+
+    async def _wait_for_group_on_device(
+        self,
+        device,
+        group_name: str,
+        *,
+        total_wait: int = 360,
+        poll_interval: int = 15,
+        label: str = "device",
+        use_exclusion: bool = True,
+    ) -> bool:
+        """Poll *device*'s chat list until the group appears or timeout.
+
+        Active polling — re-navigates and re-checks every ``poll_interval``
+        seconds for up to ``total_wait``. Tolerates the transient
+        BrowserStack ``urllib3.connectionpool`` "Connection pool full"
+        warnings that exit ``WebDriverWait`` early without a real
+        timeout, and gives Waku group-invite propagation real wall-clock
+        time (1-3 min nominal).
+
+        The group row locator is re-derived via exclusion AFTER each
+        navigate (when ``use_exclusion``) — deriving it once up front is
+        wrong when the device starts inside the open chat (no chat-list
+        rows are present, so exclusion yields None).
+        """
+        import time
+        gcp = GroupChatPage(device.driver)
+        deadline = time.time() + total_wait
+        attempt = 0
+        while time.time() < deadline:
+            attempt += 1
+            try:
+                await self._navigate_to_messages(device.driver)
+                row_locator = (
+                    self._group_row_locator_on(device)
+                    if use_exclusion else None
+                )
+                if gcp.is_group_chat_visible(
+                    group_name, timeout=10, row_locator=row_locator,
+                ):
+                    self.logger.info(
+                        "%s sees group %r on poll attempt %d",
+                        label, group_name, attempt,
+                    )
+                    return True
+            except Exception as exc:
+                self.logger.debug(
+                    "%s visibility poll %d raised %s — retrying",
+                    label, attempt, exc,
+                )
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                break
+            await asyncio.sleep(min(poll_interval, max(1, remaining)))
+        # Final diagnostic dump on failure
+        try:
+            BasePage(device.driver).dump_page_source(
+                f"group_not_visible_{label}_{group_name[:30]}"
+            )
+        except Exception:
+            pass
+        return False
+
+    async def _all_see_group(self, group_name: str) -> list[bool]:
+        """[admin, member_b, member_c] visibility of the group in chat list.
+
+        Resolves the row per-device via exclusion-based lookup
+        (resilient to QML resource-id hash mangling on rename and
+        empty content-desc/text on Pi). ``group_name`` is informational
+        only — used for logs and as a fallback locator if exclusion
+        finds nothing for some reason.
+        """
+        labels = ("admin", self.ctx.member_b_name, self.ctx.member_c_name)
+        results = []
+        for device, label in zip(self.ctx.members(), labels):
+            results.append(
+                await self._wait_for_group_on_device(
+                    device, group_name,
+                    total_wait=self.CROSS_DEVICE_TIMEOUT,
+                    poll_interval=15,
+                    label=label,
+                )
+            )
+        return results
+
+    # ------------------------------------------------------------------
+    # Tests (numeric ordering is intentional — state flows through the class)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.spec("SC-GRP-01")
+    async def test_01_create_group_chat_visible_to_all(self):
+        """Admin creates a group with B and C; all three see it listed.
+
+        Mobile auto-derives the group name from the picked contacts'
+        local identity names (Frilledlizard-style, e.g.
+        ``"Nippy Idolized Dalmatian"``) joined by ``&``. We read the
+        derived name from the admin's chat-list row (most recent chat
+        = the new group) rather than from the chat header, because
+        mobile may not auto-open the newly created group chat after
+        confirmation — leaving the admin on the chat list. The chat
+        list row exposes the chat name in its content-desc / text /
+        resource-id regardless of whether the chat is currently open.
+        """
+        async with self.step(
+            f"Admin creates group with {self.ctx.member_b_name}, "
+            f"{self.ctx.member_c_name}"
+        ):
+            await self._navigate_to_messages(self.admin_driver)
+            gcp_admin = GroupChatPage(self.admin_driver)
+            created = gcp_admin.create_group_chat(
+                group_name="<auto>",
+                members=[self.ctx.member_b_name, self.ctx.member_c_name],
+                timeout=self.UI_TIMEOUT,
+            )
+            assert created, "Admin could not complete create-group flow"
+
+        async with self.step("Admin reads auto-derived group name from chat list"):
+            # Mobile auto-derives the group name as "<B identity>&<C
+            # identity>" (CreateChatView.qml createChat() joins on "&").
+            # Find the group row by the "&" marker — it distinguishes the
+            # group from the pre-existing 1-1 chat rows. Chat-list order
+            # is not a reliable discriminator.
+            await self._navigate_to_messages(self.admin_driver)
+            base = BasePage(self.admin_driver)
+            group_row_locator = (
+                "xpath",
+                "//*[contains(@resource-id,'StatusDraggableListItem') and "
+                "(contains(@text,'&') or contains(@content-desc,'&') or "
+                "contains(@resource-id,'&'))]",
+            )
+            element = base.find_element_safe(
+                group_row_locator, timeout=self.CROSS_DEVICE_TIMEOUT,
+            )
+            assert element, (
+                "No '&'-containing chat-list row appeared on admin's "
+                "chat list — group chat may not be visible yet"
+            )
+            derived = None
+            for attr in ("content-desc", "text"):
+                try:
+                    value = element.get_attribute(attr)
+                    if value and value not in ("null", "") and "&" in value:
+                        derived = value.strip()
+                        if " [tid:" in derived:
+                            derived = derived.split(" [tid:")[0].strip()
+                        if derived:
+                            break
+                except Exception:
+                    continue
+            if not derived:
+                # Resource-id fallback: parse "...<name>.StatusDraggableListItem_..."
+                try:
+                    rid = element.get_attribute("resource-id") or ""
+                    if ".StatusDraggableListItem_" in rid and "&" in rid:
+                        prefix = rid.split(".StatusDraggableListItem_", 1)[0]
+                        derived = prefix.rsplit(".", 1)[-1] if "." in prefix else prefix
+                except Exception:
+                    pass
+            assert derived, (
+                "Group row found by '&' marker but name extraction "
+                "failed (content-desc, text, and resource-id all empty)"
+            )
+            type(self).group_name = derived
+            self.logger.info("Auto-derived group_name = %r", derived)
+            # The auto-derived name is "<B identity>&<C identity>" — the
+            # members in the order they were picked ([member_b, member_c]).
+            # Capture them now (before any rename in test_04) for the
+            # Members-panel member targeting in test_05/06.
+            if "&" in derived:
+                parts = [p.strip() for p in derived.split("&")]
+                type(self).member_b_identity = parts[0]
+                type(self).member_c_identity = parts[-1]
+                self.logger.info(
+                    "Member identities: B=%r C=%r",
+                    self.member_b_identity, self.member_c_identity,
+                )
+
+        async with self.step("All 3 devices see the group in the chat list"):
+            visibility = await self._all_see_group(self.group_name)
+            admin_sees, b_sees, c_sees = visibility
+            assert admin_sees, "Admin does not see their own new group"
+            assert b_sees, f"{self.ctx.member_b_name} does not see the new group"
+            assert c_sees, f"{self.ctx.member_c_name} does not see the new group"
+
+    async def test_02_group_chat_name_visible(self):
+        """Every member can open the propagated group chat and lands in it.
+
+        Originally read the group name from the chat header, but Qt
+        accessibility on Android API 35 (Pi devices) doesn't bridge
+        ``StatusChatInfoButton.title`` (or its nested
+        ``statusChatInfoButtonNameText`` Text element) to either
+        ``content-desc`` or ``text`` — both come back empty even when
+        the title is visibly rendered. The header is unreadable on
+        this surface.
+
+        So this verifies a weaker but real semantic: each device
+        locates the group row by exclusion (the non-1:1 row), opens it,
+        and lands in chat view (message input visible) — confirming the
+        group propagated and is functionally addressable on every
+        device. It does NOT assert the displayed name, which isn't
+        readable here.
+        """
+        assert self.group_name, "test_01 must run first to set group_name"
+
+        for label, device in (
+            ("admin", self.admin),
+            (self.ctx.member_b_name, self.member_b),
+            (self.ctx.member_c_name, self.member_c),
+        ):
+            async with self.step(f"{label} opens the group"):
+                await self._navigate_to_messages(device.driver)
+                gcp = GroupChatPage(device.driver)
+                row_locator = self._group_row_locator_on(device)
+                assert gcp.open_group_chat_by_name(
+                    self.group_name,
+                    timeout=self.CROSS_DEVICE_TIMEOUT,
+                    row_locator=row_locator,
+                ), f"{label} could not open group chat"
+                chat = ChatPage(device.driver)
+                assert chat.wait_for_message_input(
+                    timeout=self.UI_TIMEOUT,
+                ), f"{label} did not land in chat view after opening group"
+
+    @pytest.mark.spec("SC-GRP-02")
+    async def test_03_send_message_visible_to_all(self):
+        """Message sent by admin lands on both members' screens."""
+        assert self.group_name, "test_01 must run first to set group_name"
+        message = _unique_message("hello")
+
+        async with self.step(f"Admin opens group and sends {message!r}"):
+            chat_admin = ChatPage(self.admin_driver)
+            gcp_admin = GroupChatPage(self.admin_driver)
+            await self._navigate_to_messages(self.admin_driver)
+            admin_row = self._group_row_locator_on(self.admin)
+            assert gcp_admin.open_group_chat_by_name(
+                self.group_name,
+                timeout=self.CROSS_DEVICE_TIMEOUT,
+                row_locator=admin_row,
+            )
+            assert chat_admin.wait_for_message_input(
+                timeout=self.UI_TIMEOUT,
+            ), "Composer not ready on admin device"
+            assert chat_admin.send_message(
+                message, timeout=self.UI_TIMEOUT,
+            ), "send_message returned False on admin device"
+
+        for label, device in (
+            (self.ctx.member_b_name, self.member_b),
+            (self.ctx.member_c_name, self.member_c),
+        ):
+            async with self.step(f"Verify message delivered to {label}"):
+                chat = ChatPage(device.driver)
+                gcp = GroupChatPage(device.driver)
+                await self._navigate_to_messages(device.driver)
+                row_locator = self._group_row_locator_on(device)
+                assert gcp.open_group_chat_by_name(
+                    self.group_name,
+                    timeout=self.CROSS_DEVICE_TIMEOUT,
+                    row_locator=row_locator,
+                ), f"{label} could not open the group chat"
+                assert chat.message_exists(
+                    message, timeout=self.MESSAGE_DELIVERY_TIMEOUT,
+                ), f"Message {message!r} did not arrive on {label}"
+
+    @pytest.mark.spec("SC-GRP-03")
+    async def test_04_rename_group_propagates(self):
+        """Admin renames the group; the new name shows in the chat header.
+
+        The rename action is hard-asserted, so a broken menu/save flow fails
+        for real. Only the readback is conditional: on Pi the header title
+        doesn't bridge to a11y, so if it can't be read the test xfails at that
+        point (imperative ``pytest.xfail``). Once the QML exposes the title via
+        Accessible.name the readback passes and the test goes green — no marker
+        to remove. ``cls.group_name`` is left unchanged because the a11y tree
+        keeps exposing the original auto-derived name to later lookups.
+        """
+        assert self.group_name, "test_01 must run first to set group_name"
+        new_name = f"renamed-{uuid.uuid4().hex[:6]}"
+
+        async with self.step(f"Admin renames group to {new_name!r}"):
+            await self._navigate_to_messages(self.admin_driver)
+            gcp = GroupChatPage(self.admin_driver)
+            admin_row = self._group_row_locator_on(self.admin)
+            renamed = gcp.rename_group_from_chat_list(
+                old_name=self.group_name,
+                new_name=new_name,
+                timeout=self.UI_TIMEOUT,
+                row_locator=admin_row,
+            )
+            assert renamed, "Admin rename flow did not complete"
+
+        async with self.step("New name shows in the group header (admin)"):
+            await self._navigate_to_messages(self.admin_driver)
+            gcp = GroupChatPage(self.admin_driver)
+            admin_row = self._group_row_locator_on(self.admin)
+            assert gcp.open_group_chat_by_name(
+                self.group_name, timeout=self.UI_TIMEOUT, row_locator=admin_row,
+            )
+            actual = gcp.get_group_name_from_header(timeout=self.UI_TIMEOUT)
+            if actual != new_name:
+                pytest.xfail(
+                    f"group name not exposed via a11y on Pi (header={actual!r}); "
+                    "resolves once the QML exposes the chat title via Accessible.name"
+                )
+            assert actual == new_name
+
+    @pytest.mark.spec("SC-GRP-04")
+    @pytest.mark.spec("SC-GRP-05")
+    @pytest.mark.spec("SC-GRP-12")
+    async def test_05_remove_member_from_group(self):
+        """Admin removes member C: member count drops 3→2, the remaining
+        member still receives messages, later messages don't reach C, and
+        C's composer shows the not-a-member lockout.
+
+        A baseline message is sent BEFORE the removal and confirmed on the
+        remaining member's device. That isolates the post-removal delivery
+        check: if the baseline arrives but the post-removal message doesn't,
+        the removal disrupted delivery (a real signal) rather than it being
+        general cross-device flake.
+
+        Removal goes via the Members panel (header Members button →
+        member row by identity name → long-press → Remove from group).
+        NOTE: the Members button has no objectName, so it's tapped by
+        position — Pi-passing but not cross-device robust; the robust
+        fix is a one-line upstream objectName on membersButton.
+        """
+        assert self.group_name, "test_01 must run first to set group_name"
+        assert self.member_c_identity, "test_01 must set member_c_identity"
+        pre_remove_msg = _unique_message("pre-remove")
+        post_remove_msg = _unique_message("post-remove")
+
+        async with self.step("Admin's Members panel shows 3 members before removal"):
+            await self._navigate_to_messages(self.admin_driver)
+            gcp = GroupChatPage(self.admin_driver)
+            admin_row = self._group_row_locator_on(self.admin)
+            count_before = gcp.count_members_in_panel(
+                self.group_name, timeout=self.UI_TIMEOUT, row_locator=admin_row,
+            )
+            assert count_before == 3, (
+                "Expected 3 members (admin + B + C) before removal; "
+                f"Members panel showed {count_before}"
+            )
+
+        async with self.step(
+            f"Baseline: {self.ctx.member_b_name} receives a message before removal"
+        ):
+            await self._navigate_to_messages(self.admin_driver)
+            chat = ChatPage(self.admin_driver)
+            gcp = GroupChatPage(self.admin_driver)
+            admin_row = self._group_row_locator_on(self.admin)
+            assert gcp.open_group_chat_by_name(
+                self.group_name, timeout=self.UI_TIMEOUT, row_locator=admin_row,
+            )
+            assert chat.wait_for_message_input(timeout=self.UI_TIMEOUT)
+            assert chat.send_message(pre_remove_msg, timeout=self.UI_TIMEOUT)
+            chat_b = ChatPage(self.member_b_driver)
+            gcp_b = GroupChatPage(self.member_b_driver)
+            await self._navigate_to_messages(self.member_b_driver)
+            b_row = self._group_row_locator_on(self.member_b)
+            assert gcp_b.open_group_chat_by_name(
+                self.group_name, timeout=self.CROSS_DEVICE_TIMEOUT, row_locator=b_row,
+            )
+            assert chat_b.message_exists(
+                pre_remove_msg, timeout=self.MESSAGE_DELIVERY_TIMEOUT,
+            ), (
+                f"Baseline failed: {self.ctx.member_b_name} did not receive "
+                f"{pre_remove_msg!r} BEFORE removal (general delivery flake, "
+                "not a removal-specific failure)"
+            )
+
+        async with self.step(f"Admin removes {self.member_c_identity}"):
+            await self._navigate_to_messages(self.admin_driver)
+            gcp = GroupChatPage(self.admin_driver)
+            admin_row = self._group_row_locator_on(self.admin)
+            assert gcp.remove_member(
+                self.group_name,
+                self.member_c_identity,
+                timeout=self.UI_TIMEOUT,
+                row_locator=admin_row,
+            ), f"remove_member({self.member_c_identity}) failed"
+
+        async with self.step("Admin's Members panel shows 2 members after removal"):
+            gcp = GroupChatPage(self.admin_driver)
+            count_after = None
+            # Poll up to the Waku timeout: the removal may take time to
+            # reflect in the panel.
+            deadline = asyncio.get_running_loop().time() + self.CROSS_DEVICE_TIMEOUT
+            while asyncio.get_running_loop().time() < deadline:
+                await self._navigate_to_messages(self.admin_driver)
+                admin_row = self._group_row_locator_on(self.admin)
+                count_after = gcp.count_members_in_panel(
+                    self.group_name, timeout=self.UI_TIMEOUT, row_locator=admin_row,
+                )
+                if count_after == 2:
+                    break
+                await asyncio.sleep(10)
+            assert count_after == 2, (
+                "Expected 2 members (admin + B) after removing C; "
+                f"Members panel showed {count_after}"
+            )
+
+        async with self.step(f"Admin sends {post_remove_msg!r} post-removal"):
+            chat = ChatPage(self.admin_driver)
+            gcp = GroupChatPage(self.admin_driver)
+            # Navigate to the chat list first: after remove_member, admin
+            # is still in the Members panel, so the exclusion locator must
+            # be re-derived from the chat list (else it returns None).
+            await self._navigate_to_messages(self.admin_driver)
+            admin_row = self._group_row_locator_on(self.admin)
+            assert gcp.open_group_chat_by_name(
+                self.group_name, timeout=self.UI_TIMEOUT,
+                row_locator=admin_row,
+            )
+            assert chat.wait_for_message_input(timeout=self.UI_TIMEOUT)
+            assert chat.send_message(post_remove_msg, timeout=self.UI_TIMEOUT)
+
+        async with self.step(
+            f"{self.ctx.member_b_name} (still a member) sees the message"
+        ):
+            chat_b = ChatPage(self.member_b_driver)
+            gcp_b = GroupChatPage(self.member_b_driver)
+            await self._navigate_to_messages(self.member_b_driver)
+            b_row = self._group_row_locator_on(self.member_b)
+            assert gcp_b.open_group_chat_by_name(
+                self.group_name, timeout=self.CROSS_DEVICE_TIMEOUT,
+                row_locator=b_row,
+            )
+            assert chat_b.message_exists(
+                post_remove_msg, timeout=self.MESSAGE_DELIVERY_TIMEOUT,
+            ), (
+                f"{self.ctx.member_b_name} got the pre-removal baseline but NOT "
+                f"{post_remove_msg!r} after removal — removal disrupted delivery "
+                "to the remaining member"
+            )
+
+        async with self.step(
+            f"{self.ctx.member_c_name} (removed) does NOT see the message"
+        ):
+            chat_c = ChatPage(self.member_c_driver)
+            await self._navigate_to_messages(self.member_c_driver)
+            # Sanity check only: 30s can't rule out late delivery on its own —
+            # safe because the prior step already waited 360s for B. The lockout
+            # step below is the authoritative "C removed" proof; keep adjacent.
+            assert not chat_c.message_exists(
+                post_remove_msg, timeout=self.UI_TIMEOUT,
+            ), (
+                f"{self.ctx.member_c_name} received {post_remove_msg!r} "
+                "after being removed — removal did not propagate"
+            )
+
+        async with self.step(
+            f"{self.ctx.member_c_name} (removed) is locked out of the composer"
+        ):
+            # A removed member keeps the group in their list but can no
+            # longer post: opening it shows the not-a-member placeholder and
+            # disables sending (desktop's YOU_NEED_TO_BE_A_MEMBER check).
+            gcp_c = GroupChatPage(self.member_c_driver)
+            await self._navigate_to_messages(self.member_c_driver)
+            c_row = self._group_row_locator_on(self.member_c)
+            assert gcp_c.open_group_chat_by_name(
+                self.group_name, timeout=self.CROSS_DEVICE_TIMEOUT,
+                row_locator=c_row,
+            ), f"{self.ctx.member_c_name} could not open the group to check lockout"
+            # Removal must propagate to C before the composer locks — allow
+            # cross-device time.
+            assert gcp_c.is_removed_member_lockout_shown(
+                timeout=self.CROSS_DEVICE_TIMEOUT,
+            ), (
+                f"{self.ctx.member_c_name}'s composer did not show the "
+                "not-a-member lockout after removal"
+            )
+
+    @pytest.mark.spec("SC-GRP-06")
+    async def test_06_add_member_to_existing_group(self):
+        """Admin re-adds member C; C sees new messages again."""
+        assert self.group_name, "test_01 must run first to set group_name"
+        assert self.member_c_identity, "test_01 must set member_c_identity"
+        readd_msg = _unique_message("readd")
+
+        async with self.step(f"Admin adds {self.member_c_identity} back"):
+            await self._navigate_to_messages(self.admin_driver)
+            gcp = GroupChatPage(self.admin_driver)
+            admin_row = self._group_row_locator_on(self.admin)
+            # Waku-grade timeout: a just-removed member only re-appears as
+            # an addable contact once the removal has propagated.
+            assert gcp.add_member_to_existing_group(
+                self.group_name,
+                self.member_c_identity,
+                timeout=self.CROSS_DEVICE_TIMEOUT,
+                row_locator=admin_row,
+            ), f"Admin could not re-add {self.member_c_identity}"
+
+        async with self.step(f"Admin sends {readd_msg!r} to re-added member"):
+            chat = ChatPage(self.admin_driver)
+            gcp = GroupChatPage(self.admin_driver)
+            # Back to the chat list before re-deriving the exclusion
+            # locator (after add, admin is in the add/remove sheet).
+            await self._navigate_to_messages(self.admin_driver)
+            admin_row = self._group_row_locator_on(self.admin)
+            assert gcp.open_group_chat_by_name(
+                self.group_name, timeout=self.UI_TIMEOUT,
+                row_locator=admin_row,
+            )
+            assert chat.wait_for_message_input(timeout=self.UI_TIMEOUT)
+            assert chat.send_message(readd_msg, timeout=self.UI_TIMEOUT)
+
+        async with self.step(f"{self.ctx.member_c_name} sees the message"):
+            chat_c = ChatPage(self.member_c_driver)
+            gcp_c = GroupChatPage(self.member_c_driver)
+            await self._navigate_to_messages(self.member_c_driver)
+            c_row = self._group_row_locator_on(self.member_c)
+            assert gcp_c.open_group_chat_by_name(
+                self.group_name, timeout=self.CROSS_DEVICE_TIMEOUT,
+                row_locator=c_row,
+            )
+            assert chat_c.message_exists(
+                readd_msg, timeout=self.MESSAGE_DELIVERY_TIMEOUT,
+            ), f"Re-added member did not receive {readd_msg!r}"
+
+    @pytest.mark.spec("SC-GRP-07")
+    async def test_07_leave_group(self):
+        """Member B leaves the group; group disappears from B's chat list."""
+        assert self.group_name, "test_01 must run first to set group_name"
+
+        async with self.step(f"{self.ctx.member_b_name} leaves the group"):
+            await self._navigate_to_messages(self.member_b_driver)
+            gcp_b = GroupChatPage(self.member_b_driver)
+            b_row = self._group_row_locator_on(self.member_b)
+            assert gcp_b.leave_group(
+                self.group_name, timeout=self.UI_TIMEOUT,
+                row_locator=b_row,
+            ), f"{self.ctx.member_b_name} could not leave"
+
+        async with self.step(
+            f"{self.ctx.member_b_name}'s chat list no longer shows the group"
+        ):
+            await self._navigate_to_messages(self.member_b_driver)
+            # Confirm the chat list actually loaded (B still has the 1:1
+            # with admin) so a missing group row means the leave took
+            # effect, not that the list is empty/unrendered — otherwise
+            # the exclusion check below would pass vacuously.
+            base_b = BasePage(self.member_b_driver)
+            assert base_b.is_element_visible(
+                ("xpath", "//*[contains(@resource-id,'StatusDraggableListItem')]"),
+                timeout=self.CROSS_DEVICE_TIMEOUT,
+            ), f"{self.ctx.member_b_name}'s chat list did not load"
+            # The group row is gone when exclusion finds no non-1:1 row.
+            assert self._group_row_locator_on(self.member_b) is None, (
+                f"Group still on {self.ctx.member_b_name}'s chat list after leaving"
+            )
+
+        async with self.step(
+            f"Admin and {self.ctx.member_c_name} still see the group"
+        ):
+            admin_gcp = GroupChatPage(self.admin_driver)
+            c_gcp = GroupChatPage(self.member_c_driver)
+            await self._navigate_to_messages(self.admin_driver)
+            admin_row = self._group_row_locator_on(self.admin)
+            assert admin_gcp.is_group_chat_visible(
+                self.group_name, timeout=self.CROSS_DEVICE_TIMEOUT,
+                row_locator=admin_row,
+            ), "Admin lost the group after B left"
+            await self._navigate_to_messages(self.member_c_driver)
+            c_row = self._group_row_locator_on(self.member_c)
+            assert c_gcp.is_group_chat_visible(
+                self.group_name, timeout=self.CROSS_DEVICE_TIMEOUT,
+                row_locator=c_row,
+            ), f"{self.ctx.member_c_name} lost the group after B left"

--- a/test/e2e_appium/utils/contact_helpers.py
+++ b/test/e2e_appium/utils/contact_helpers.py
@@ -13,7 +13,9 @@ from config.logging_config import get_logger
 from core.device_context import DeviceContext
 from pages.app import App
 from pages.messaging.chat_page import ChatPage
+from pages.onboarding.welcome_back_page import WelcomeBackPage
 from pages.settings.settings_page import SettingsPage
+from utils.app_lifecycle_manager import AppLifecycleManager
 from utils.timeouts import CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS
 
 logger = get_logger("contact_helpers")
@@ -29,17 +31,93 @@ def extract_chat_suffix(link: str, length: int = 6) -> str:
     return extract_chat_key(link)[-length:]
 
 
+def _restart_and_login(device: DeviceContext, *, label: str) -> bool:
+    """Restart *device* and re-authenticate via the WelcomeBack screen.
+
+    Used as an explicit storenode-fetch trigger: per ``utils/timeouts.py``
+    docstring, app restart forces a storenode history fetch that
+    bypasses live-delivery, which is the canonical recovery path when
+    waku-mediated cross-device delivery hasn't propagated yet.
+
+    Side effect: also clears any stale drawer/QML UI state that
+    accumulates over a long session, which materially reduces the rate
+    of ``click_settings_button`` flakes on BrowserStack.
+    """
+    driver = device.driver
+    password = device.user.password if device.user else None
+    if not password:
+        logger.error("_restart_and_login(%s): no password on user", label)
+        return False
+
+    logger.info("_restart_and_login(%s): restarting app", label)
+    lifecycle = AppLifecycleManager(driver)
+    if not lifecycle.restart_app():
+        logger.error("_restart_and_login(%s): restart_app returned False", label)
+        return False
+
+    # Bring UI to a tappable state after the cold restart.
+    try:
+        lifecycle.activate_app_with_ui_ready(activation_timeout=15.0)
+    except Exception as exc:
+        logger.debug(
+            "_restart_and_login(%s): activate_app_with_ui_ready raised: %s",
+            label, exc,
+        )
+
+    welcome_back = WelcomeBackPage(driver)
+    if not welcome_back.is_welcome_back_screen_displayed(timeout=30):
+        # If the WelcomeBack screen isn't shown, the app may have
+        # auto-logged-in (Status persists the keychain across restarts on
+        # some configs). Treat as success and let the caller verify the
+        # subsequent navigation.
+        logger.info(
+            "_restart_and_login(%s): WelcomeBack screen not visible — "
+            "assuming auto-login", label,
+        )
+        return True
+
+    if not welcome_back.perform_login(password, timeout=60):
+        logger.error("_restart_and_login(%s): perform_login returned False", label)
+        return False
+
+    logger.info("_restart_and_login(%s): login complete", label)
+    return True
+
+
 async def establish_contact(
     sender: DeviceContext,
     receiver: DeviceContext,
     *,
     timeout: int = CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS,
+    verify_delivery: bool = True,
+    receiver_restart_before_accept: bool = False,
 ) -> tuple[str, str, str, str]:
     """Establish a 1:1 contact between *sender* and *receiver*.
 
     Captures profile links, sends a contact request from *sender*,
     accepts it on *receiver*, and exchanges a setup message so that both
     devices have the chat visible.
+
+    ``verify_delivery`` (default True) controls the bidirectional Waku
+    delivery gate at the end. Setting it False skips the
+    receiver→sender and sender→receiver verification messages — the
+    contacts are still established at the protocol level via the send +
+    accept flow, but the caller is responsible for any later
+    verification. Use False when the caller will assert delivery via a
+    subsequent test step (e.g. multi-device fixture setups that already
+    pay BS cost for the gate elsewhere).
+
+    ``receiver_restart_before_accept`` (default False) inserts an app
+    restart + re-login on the receiver BEFORE sender sends the
+    contact request. This is empirically better than restarting AFTER
+    sender sends: a post-send restart relies on storenode catch-up to
+    deliver the missed request, which doesn't reliably complete within
+    the 360s pending-tab wait on BrowserStack.
+    A pre-send restart instead ensures the receiver's Waku filter
+    subscription is freshly active when the contact request hits the
+    network, so the request is delivered LIVE to the receiver — no
+    storenode dependency. Also resets BS drawer/QML state so the
+    subsequent Settings nav is less likely to flake. Costs ~30-60s.
 
     Returns:
         ``(sender_suffix, receiver_suffix, sender_chat_key, receiver_chat_key)``
@@ -59,6 +137,26 @@ async def establish_contact(
     receiver_chat_key = extract_chat_key(receiver_link)
 
     logger.info("Establishing contact: %s -> %s", sender_suffix, receiver_suffix)
+
+    # Optional: restart the receiver BEFORE the sender sends, so its Waku
+    # filter subscription is freshly active when the request hits the
+    # network and the request arrives live. The alternative (restart
+    # after send, relying on storenode catch-up) doesn't reliably deliver
+    # within the 360s pending-tab wait.
+    if receiver_restart_before_accept:
+        assert _restart_and_login(receiver, label=receiver_suffix), (
+            "Receiver restart-and-login failed"
+        )
+        # Dismiss the post-login overlays — backup prompt, push-notif
+        # popup (Android 13+), and drawer-intro dialog — that otherwise
+        # eat the subsequent Settings nav click.
+        post_restart_chat = ChatPage(receiver.driver)
+        post_restart_chat.dismiss_backup_prompt(timeout=4)
+        post_restart_chat.dismiss_backup_prompt(timeout=2)
+        post_restart_chat.dismiss_push_notification_prompt(timeout=4)
+        post_restart_chat.dismiss_drawer_intro_prompt(timeout=2)
+        # Let the Waku filter subscription settle before sender publishes.
+        await asyncio.sleep(10)
 
     # Sender sends contact request
     sender_app = App(sender.driver)
@@ -168,22 +266,260 @@ async def establish_contact(
     # The Waku filter subscription race means messages sent immediately after
     # contact acceptance can be dropped in either direction.  Verify both
     # directions before yielding so tests don't run against a half-working session.
+    if verify_delivery:
+        # Direction 1: receiver → sender (setup message already sent above)
+        assert sender_chat.message_exists(setup_msg, timeout=CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS), (
+            "Delivery gate failed: setup message from receiver not visible on sender. "
+            "Waku filter subscription may not have propagated yet."
+        )
 
-    # Direction 1: receiver → sender (setup message already sent above)
-    assert sender_chat.message_exists(setup_msg, timeout=CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS), (
-        "Delivery gate failed: setup message from receiver not visible on sender. "
-        "Waku filter subscription may not have propagated yet."
-    )
-
-    # Direction 2: sender → receiver
-    ping_msg = f"Ping from {sender_suffix}"
-    assert sender_chat.send_message(ping_msg, timeout=15), (
-        "Delivery gate failed: sender could not send ping message"
-    )
-    assert receiver_chat.message_exists(ping_msg, timeout=CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS), (
-        "Delivery gate failed: ping from sender not visible on receiver. "
-        "Waku filter subscription may not have propagated yet."
-    )
+        # Direction 2: sender → receiver
+        ping_msg = f"Ping from {sender_suffix}"
+        assert sender_chat.send_message(ping_msg, timeout=15), (
+            "Delivery gate failed: sender could not send ping message"
+        )
+        assert receiver_chat.message_exists(ping_msg, timeout=CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS), (
+            "Delivery gate failed: ping from sender not visible on receiver. "
+            "Waku filter subscription may not have propagated yet."
+        )
+    else:
+        logger.info(
+            "Delivery gate skipped (verify_delivery=False) — caller "
+            "must assert delivery downstream"
+        )
 
     logger.info("Contact established: %s <-> %s", sender_suffix, receiver_suffix)
     return sender_suffix, receiver_suffix, sender_chat_key, receiver_chat_key
+
+
+async def establish_contacts_admin_to_many(
+    admin: DeviceContext,
+    receivers: list[DeviceContext],
+    *,
+    timeout: int = CROSS_DEVICE_DELIVERY_TIMEOUT_SECONDS,
+    receiver_restart_before_accept: bool = True,
+) -> list[tuple[str, str, str, str]]:
+    """Establish admin↔receiver contacts with receiver-side work overlapped.
+
+    Drop-in replacement for sequentially calling
+    :func:`establish_contact` once per receiver, when one admin is
+    pairing with multiple receivers (typical: 3-device group chat
+    setup). The win comes from overlapping the slow waku-delivery
+    waits across receivers — admin sends both requests serially
+    (because admin's UI can only navigate one place at a time), then
+    BOTH receivers accept in parallel, then BOTH receivers send their
+    setup messages in parallel.
+
+    With two receivers the overlap roughly halves contact-exchange wall
+    time (the ~6-min worst-case ``pending_request_row_exists`` waku wait
+    runs once instead of per receiver).
+
+    ``verify_delivery`` is not exposed — the bidirectional gate doesn't
+    compose across multiple receivers without doubling admin nav cost,
+    and the fixture verifies delivery downstream anyway.
+
+    Default path for 2+ receivers in the messaging conftest; set
+    ``USE_PARALLEL_CONTACT_EXCHANGE=0`` to force the sequential 1:1 path.
+
+    Returns a list of ``(admin_suffix, receiver_suffix,
+    admin_chat_key, receiver_chat_key)`` tuples in the same order as
+    *receivers*.
+    """
+    if not receivers:
+        return []
+    if len(receivers) == 1:  # nothing to overlap; use the 1:1 path
+        result = await establish_contact(
+            admin, receivers[0], timeout=timeout,
+            verify_delivery=False,
+            receiver_restart_before_accept=receiver_restart_before_accept,
+        )
+        return [result]
+
+    if receiver_restart_before_accept:
+        labels = [f"recv-{i}" for i in range(len(receivers))]
+        restart_results = await asyncio.gather(
+            *[
+                asyncio.to_thread(_restart_and_login, r, label=labels[i])
+                for i, r in enumerate(receivers)
+            ]
+        )
+        assert all(restart_results), (
+            f"Receiver restart-and-login failed: {restart_results}"
+        )
+
+        def _dismiss_overlays(receiver: DeviceContext) -> None:
+            chat = ChatPage(receiver.driver)
+            chat.dismiss_backup_prompt(timeout=4)
+            chat.dismiss_backup_prompt(timeout=2)
+            chat.dismiss_push_notification_prompt(timeout=4)
+            chat.dismiss_drawer_intro_prompt(timeout=2)
+
+        await asyncio.gather(
+            *[asyncio.to_thread(_dismiss_overlays, r) for r in receivers]
+        )
+        await asyncio.sleep(10)  # let filter subscriptions settle
+
+    captures = await asyncio.gather(
+        asyncio.to_thread(admin.capture_profile_link),
+        *[asyncio.to_thread(r.capture_profile_link) for r in receivers],
+    )
+    admin_link = captures[0]
+    receiver_links = captures[1:]
+    assert admin_link, "Admin did not return a profile link"
+    for i, link in enumerate(receiver_links):
+        assert link, f"Receiver {i} did not return a profile link"
+
+    admin_suffix = extract_chat_suffix(admin_link)
+    admin_chat_key = extract_chat_key(admin_link)
+    receiver_suffixes = [extract_chat_suffix(link) for link in receiver_links]
+    receiver_chat_keys = [extract_chat_key(link) for link in receiver_links]
+
+    # Phase C: admin sends a contact request to each receiver. Navigate
+    # Settings → Messaging → Contacts ONCE, then reopen the send-request
+    # modal per receiver from the contacts page (send() closes the modal
+    # back to it). Re-walking Settings per receiver instead leaves the
+    # settings nav in a state where open_messaging_settings fails on the
+    # second receiver.
+    sender_app = App(admin.driver)
+    sender_settings = SettingsPage(admin.driver)
+    sender_chat = ChatPage(admin.driver)
+
+    assert sender_app.click_settings_button(), "Admin Settings click failed"
+    assert sender_settings.is_loaded(timeout=12), (
+        "Admin settings page did not load"
+    )
+    messaging_page = sender_settings.open_messaging_settings()
+    assert messaging_page is not None, "Admin failed to open messaging settings"
+    contacts_page = messaging_page.open_contacts()
+    assert contacts_page is not None, "Admin failed to open contacts"
+
+    for i, (rcv_chat_key, rcv_suffix) in enumerate(
+        zip(receiver_chat_keys, receiver_suffixes)
+    ):
+        logger.info(
+            "Admin sending contact request %d/%d: %s -> %s",
+            i + 1, len(receivers), admin_suffix, rcv_suffix,
+        )
+        assert contacts_page.is_loaded(timeout=12), (
+            f"Contacts page not in view before sending to {rcv_suffix}"
+        )
+        modal = contacts_page.open_send_contact_request_modal()
+        assert modal is not None, (
+            f"Admin failed to open send modal for {rcv_suffix}"
+        )
+
+        request_message = (
+            f"Setup: {admin_suffix} connecting with {rcv_suffix}"
+        )
+        assert modal.enter_chat_key(rcv_chat_key), (
+            f"Admin enter_chat_key failed for {rcv_suffix}"
+        )
+        assert modal.enter_message(request_message), (
+            f"Admin enter_message failed for {rcv_suffix}"
+        )
+        assert modal.send(), (
+            f"Admin send failed for {rcv_suffix}"
+        )
+
+    sender_chat.dismiss_backup_prompt(timeout=4)
+    assert sender_app.click_messages_button(), (
+        "Admin failed to navigate back to messages after sending requests"
+    )
+    sender_chat.dismiss_backup_prompt(timeout=2)
+
+    # Phase D: receivers accept in parallel threads, so the slow
+    # pending-request waku wait overlaps instead of stacking.
+    def _accept_on_receiver(receiver: DeviceContext, rcv_suffix: str) -> bool:
+        rec_app = App(receiver.driver)
+        rec_settings = SettingsPage(receiver.driver)
+        assert rec_app.click_settings_button(), (
+            f"Receiver {rcv_suffix} failed to open settings"
+        )
+        assert rec_settings.is_loaded(timeout=12), (
+            f"Receiver {rcv_suffix} settings did not load"
+        )
+        rec_messaging = rec_settings.open_messaging_settings()
+        assert rec_messaging is not None, (
+            f"Receiver {rcv_suffix} failed to open messaging settings"
+        )
+        rec_contacts = rec_messaging.open_contacts()
+        assert rec_contacts is not None, (
+            f"Receiver {rcv_suffix} failed to open contacts"
+        )
+        assert rec_contacts.wait_for_pending_requests_focusable(timeout=timeout), (
+            f"Receiver {rcv_suffix} pending requests not available "
+            f"after {timeout}s"
+        )
+        assert rec_contacts.open_pending_requests_tab(timeout=12), (
+            f"Receiver {rcv_suffix} failed to open pending requests tab"
+        )
+        assert rec_contacts.pending_request_row_exists(admin_suffix, timeout=12), (
+            f"Pending request from admin not visible on {rcv_suffix}"
+        )
+        assert rec_contacts.accept_contact_request(admin_suffix), (
+            f"Receiver {rcv_suffix} failed to accept contact request"
+        )
+        return True
+
+    await asyncio.gather(*[
+        asyncio.to_thread(_accept_on_receiver, r, receiver_suffixes[i])
+        for i, r in enumerate(receivers)
+    ])
+
+    await asyncio.sleep(5)  # let filter subscriptions settle post-accept
+
+    # Phase E: each receiver sends a setup message so its chat row appears
+    # on the admin side (verifies the contact is live, in parallel).
+    def _setup_message_from_receiver(
+        receiver: DeviceContext, rcv_suffix: str,
+    ) -> str:
+        rec_app = App(receiver.driver)
+        rec_chat = ChatPage(receiver.driver)
+        rec_chat.dismiss_backup_prompt(timeout=4)
+        assert rec_app.click_messages_button(), (
+            f"Receiver {rcv_suffix} failed to navigate to messages"
+        )
+        rec_chat.dismiss_backup_prompt(timeout=2)
+
+        assert rec_chat.wait_for_new_chat_to_arrive(
+            admin_suffix, display_name=None, timeout=timeout,
+        ), f"Chat from admin did not arrive on {rcv_suffix}"
+        assert rec_chat.open_chat_by_suffix(
+            admin_suffix, display_name=None,
+        ), f"Receiver {rcv_suffix} failed to open chat with admin"
+        assert rec_chat.wait_for_message_input(timeout=15), (
+            f"Message input not ready on {rcv_suffix}"
+        )
+        setup_msg = f"Setup message from {rcv_suffix}"
+        assert rec_chat.send_message(setup_msg, timeout=15), (
+            f"Receiver {rcv_suffix} failed to send setup message"
+        )
+        return setup_msg
+
+    await asyncio.gather(*[
+        asyncio.to_thread(_setup_message_from_receiver, r, receiver_suffixes[i])
+        for i, r in enumerate(receivers)
+    ])
+
+    # Phase F: admin refreshes messages and waits for each receiver's
+    # chat row (fast — the messages already arrived during Phase E).
+    sender_chat.dismiss_backup_prompt(timeout=2)
+    assert sender_app.click_messages_button(), (
+        "Admin failed to refresh messages tab after receiver accepts"
+    )
+    sender_chat.dismiss_backup_prompt(timeout=2)
+    sender_chat.dismiss_introduce_prompt(timeout=2)
+
+    for rcv_suffix in receiver_suffixes:
+        assert sender_chat.wait_for_new_chat_to_arrive(
+            rcv_suffix, display_name=None, timeout=timeout,
+        ), f"Admin never saw chat from {rcv_suffix}"
+
+    logger.info(
+        "Contacts established admin↔[%s]",
+        ", ".join(receiver_suffixes),
+    )
+    return [
+        (admin_suffix, rs, admin_chat_key, rk)
+        for rs, rk in zip(receiver_suffixes, receiver_chat_keys)
+    ]


### PR DESCRIPTION
Adds an end-to-end test suite for group chats on mobile, run across 3 real Android devices.
  
  Covers the group chat lifecycle: create a group with two contacts and see it on every device, send and receive messages, rename the group, remove a member (member count updates, the removed member is locked out and stops
  receiving, the remaining member still receives), add the removed member back, and leave the group. 
  
  How it runs: nightly on 3 devices, not a per-PR gate — it takes ~30-40 min (mostly one-time login) and exercises real peer-to-peer delivery, which is naturally variable.
  
  Validated on 3 physical Android devices: 6 tests pass, 1 xfail (the rename test, per the known limitation below).
  
  Known limitation: the rename test is xfail on the current Android accessibility surface — the chat title isn't exposed to the accessibility tree, so the new name can't be read back. It passes automatically once the title
  is exposed via Accessible.name.