### PR TITLE
fix(login): fix sporadic crash on login because of race condition

### DIFF
--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -16,6 +16,9 @@ method onAppLoaded*(self: AccessInterface, keyUid: string) {.base.} =
 method onMainLoaded*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method cleanupAfterMainTransition*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onMainFailedToLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -88,7 +88,15 @@ method onAppLoaded*[T](self: Module[T], keyUid: string) =
   discard
 
 method onMainLoaded*[T](self: Module[T]) =
+  if self.view.isNil:
+    return
+
   self.view.appLoaded()
+
+method cleanupAfterMainTransition*[T](self: Module[T]) =
+  if self.view.isNil:
+    return
+
   singletonInstance.engine.setRootContextProperty("onboardingModule", newQVariant())
   self.view.delete
   self.view = nil

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -211,6 +211,9 @@ QtObject:
   proc requestDeleteMultiaccount(self: View, keyUid: string): string {.slot.} =
     return self.delegate.requestDeleteMultiaccount(keyUid)
 
+  proc cleanupAfterMainTransition(self: View) {.slot.} =
+    self.delegate.cleanupAfterMainTransition()
+
   proc delete*(self: View) =
     self.QObject.delete
 

--- a/test/e2e/tests/crtitical_tests_prs/test_onboarding_sync_with_code.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_onboarding_sync_with_code.py
@@ -16,7 +16,7 @@ from gui.screens.onboarding import OnboardingWelcomeToStatusView, SyncResultView
 
 
 @pytest.mark.case(703592, 738760)
-# @pytest.mark.critical # TODO: temp disable in release
+@pytest.mark.critical
 @pytest.mark.smoke
 def test_sync_devices_during_onboarding_change_settings_unpair(multiple_instances):
     user: UserAccount = RandomUser()

--- a/ui/StatusQ/src/StatusQ/Components/StatusQrCodeScanner.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusQrCodeScanner.qml
@@ -92,7 +92,7 @@ Item {
     StatusScanCorners {
         id: scanCorners
         visible: !cameraUnavailableText.visible
-        width: root.width / 1.4
+        width: Math.min(root.width, root.height) / 1.4
         height: width
         anchors.centerIn: parent
         color: {

--- a/ui/app/AppLayouts/Onboarding/pages/LoginBySyncingPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/LoginBySyncingPage.qml
@@ -29,8 +29,10 @@ OnboardingPage {
         padding: 0
 
         Item {
+
             width: scrollView.availableWidth
-            implicitHeight: Math.max(content.implicitHeight, scrollView.availableHeight)
+            implicitHeight: content.implicitHeight
+            height: Math.max(implicitHeight, scrollView.availableHeight)
 
             ColumnLayout {
                 id: content

--- a/ui/app/AppLayouts/Onboarding/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding/stores/OnboardingStore.qml
@@ -81,6 +81,10 @@ QtObject {
         d.onboardingModuleInst.requestDeleteMultiaccount(keyUid)
     }
 
+    function cleanupAfterMainTransition() {
+        d.onboardingModuleInst.cleanupAfterMainTransition()
+    }
+
     // password
     signal accountLoginError(string error, bool wrongPassword)
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -498,6 +498,10 @@ Window {
                 startupOnboardingLoader.active = false
                 splashScreenLoader.active = false
                 applicationWindow.contentLoaded()
+                if (typeof onboardingModule !== "undefined"
+                        && !!onboardingModule) {
+                    Qt.callLater(() => onboardingModule.cleanupAfterMainTransition())
+                }
                 if (d.showSkippedBiometricFlow)
                     loader.item.showEnableBiometricsFlow()
             }


### PR DESCRIPTION
### What does the PR do

Fixes #21034

The issue was that sometimes, the Nim onboardingModule was unset before the QML part was completely unloaded, meaning that we were accessing a null pointer.

This commit adds hardening to some of the context function, but more importantly, moves the module deletion after the QML main has loading and the QML onboarding has unloaded.

### Affected areas

- main.qml
- onboarding module
- DOtherSide (PR: https://github.com/status-im/dotherside/pull/110)
- nimqml (PR: https://github.com/status-im/nimqml/pull/72)

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

In the video, I enter the wrong password voluntarily, because that was how I reproduced the crash more easily.

[login-no-crash.webm](https://github.com/user-attachments/assets/51a9ffc9-08e1-4750-a7cb-d37f1d49de5f)

### Impact on end user

Fixes the crash

### How to test

Login... a lot

### Risk 

Low
