### PR TITLE
fix(login): fix wrong password switches selected profile

### DIFF
--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -1027,6 +1027,56 @@ Item {
             }
         }
 
+        function test_loginScreen_profileSelectionIsSavedAndRestoredAfterWrongPassword_data() {
+            return [{ tag: "profile selection persisted after wrong password" }] // dummy to skip global data, and run just once
+        }
+
+        function test_loginScreen_profileSelectionIsSavedAndRestoredAfterWrongPassword() {
+            verify(!!controlUnderTest)
+            controlUnderTest.onboardingStore.loginAccountsModel = loginAccountsModel
+            controlUnderTest.lastSelectedProfileKeyUid = "uid_1"
+            controlUnderTest.restartFlow()
+
+            let page = getCurrentPage(controlUnderTest.stack, LoginScreen)
+            let userSelector = findChild(page, "loginUserSelector")
+            verify(!!userSelector)
+            tryCompare(userSelector, "selectedProfileKeyId", "uid_1")
+
+            dynamicSpy.setup(controlUnderTest, "profileSelected")
+            userSelector.setSelection("uid_2")
+
+            // Validate that profile change notification is emitted so caller can persist it.
+            tryCompare(dynamicSpy, "count", 1)
+            compare(dynamicSpy.signalArguments[0][0], "uid_2")
+            tryCompare(userSelector, "selectedProfileKeyId", "uid_2")
+
+            // Simulate StartupOnboardingWrapper persisting selected profile UID.
+            controlUnderTest.lastSelectedProfileKeyUid = dynamicSpy.signalArguments[0][0]
+
+            const passwordInput = findChild(page, "loginPasswordInput")
+            verify(!!passwordInput)
+            mouseClick(passwordInput)
+            keyClickSequence("wrong-password")
+
+            const loginButton = findChild(page, "loginButton")
+            verify(!!loginButton)
+            tryCompare(loginButton, "enabled", true)
+            mouseClick(loginButton)
+
+            tryCompare(loginSpy, "count", 1)
+            tryCompare(passwordInput, "hasError", true)
+
+            // Simulate startup wrapper behavior on failed login.
+            controlUnderTest.unwindToLoginScreen()
+
+            page = getCurrentPage(controlUnderTest.stack, LoginScreen)
+            userSelector = findChild(page, "loginUserSelector")
+            verify(!!userSelector)
+            // Validate that after a failed login attempt, the previously selected profile is still selected
+            // (instead of resetting to default or first profile).
+            tryCompare(userSelector, "selectedProfileKeyId", "uid_2")
+        }
+
         function test_loginScreen_launchesExternalFlow_data() {
             return [
               { tag: "onboarding: create profile", delegateName: "createProfileDelegate", signalName: "onboardingCreateProfileFlowRequested", landingPage: CreateProfilePage },

--- a/ui/app/AppLayouts/Onboarding/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/LoginScreen.qml
@@ -220,15 +220,15 @@ OnboardingPage {
                                       root.keycardState === Onboarding.KeycardState.BlockedPUK
                 isKeycardEnabled: root.isKeycardEnabled
 
-                onSelectedProfileItemChanged: {
-                    if (!selectedProfileItem) {
+                onSelectedProfileKeyIdChanged: {
+                    if (!selectedProfileKeyId) {
                         return
                     }
 
                     root.dismissBiometricsRequested()
 
                     d.resetBiometricsResult()
-                    root.profileSelected(selectedProfileItem.keyUid)
+                    root.profileSelected(selectedProfileKeyId)
 
                     if (d.currentProfileIsKeycard) {
                         keycardBox.loginError = ""


### PR DESCRIPTION
### What does the PR do

Fixes #21072

Fixed by using onSelectedProfileKeyIdChanged rather than onSelectedProfileItemChanged. ModelEntry reuses the same QQmlPropertyMap pointer when switching between two valid profiles (updateItem vs resetItem), so the item reference never changed and onSelectedProfileItemChanged would not fire in that case.

That made the Setting never update.

### Affected areas

LoginScreen

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[profile-switch.webm](https://github.com/user-attachments/assets/ebd92d22-36f6-41ed-b8a3-82cb6a5c1d33)

### Impact on end user

Fixes the issue

### How to test

Type a bad password and see that the profile is still the right one. Switch profile and do the same

### Risk 

Low
