### PR TITLE
fix(Chat): Improve contact request action layout

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -494,21 +494,53 @@ Item {
     Component {
         id: acceptOrDeclineContactRequestComponent
 
-        RowLayout {
-            anchors.horizontalCenter: parent ? parent.horizontalCenter : undefined
+        Item {
+            id: contactRequestActions
 
-            StatusButton {
-                text: qsTr("Reject Contact Request")
-                type: StatusBaseButton.Type.Danger
-                onClicked: {
-                    root.dismissContactRequest(root.chatId, "")
+            readonly property real horizontalMargin: Theme.bigPadding + Theme.halfPadding
+            readonly property real verticalMargin: Theme.padding
+            readonly property real naturalWidth: rejectContactRequestButton.implicitWidth +
+                                                 acceptContactRequestButton.implicitWidth +
+                                                 buttonsRow.spacing
+            readonly property real availableWidth: Math.max(0, width - 2 * horizontalMargin)
+            readonly property bool compact: availableWidth < naturalWidth
+            readonly property real compactButtonWidth: Math.max(0, (availableWidth - buttonsRow.spacing) / 2)
+
+            width: parent ? parent.width : naturalWidth + 2 * horizontalMargin
+            implicitHeight: buttonsRow.implicitHeight + 2 * verticalMargin
+
+            RowLayout {
+                id: buttonsRow
+
+                anchors.centerIn: parent
+                width: Math.min(contactRequestActions.naturalWidth, contactRequestActions.availableWidth)
+                spacing: Theme.padding
+
+                StatusButton {
+                    id: rejectContactRequestButton
+
+                    Layout.fillWidth: contactRequestActions.compact
+                    Layout.preferredWidth: contactRequestActions.compact ? contactRequestActions.compactButtonWidth : implicitWidth
+                    Layout.maximumWidth: contactRequestActions.compact ? contactRequestActions.compactButtonWidth : implicitWidth
+                    textFillWidth: contactRequestActions.compact
+                    text: qsTr("Reject Contact Request")
+                    type: StatusBaseButton.Type.Danger
+                    onClicked: {
+                        root.dismissContactRequest(root.chatId, "")
+                    }
                 }
-            }
 
-            StatusButton {
-                text: qsTr("Accept Contact Request")
-                onClicked: {
-                    root.acceptContactRequest(root.chatId, "")
+                StatusButton {
+                    id: acceptContactRequestButton
+
+                    Layout.fillWidth: contactRequestActions.compact
+                    Layout.preferredWidth: contactRequestActions.compact ? contactRequestActions.compactButtonWidth : implicitWidth
+                    Layout.maximumWidth: contactRequestActions.compact ? contactRequestActions.compactButtonWidth : implicitWidth
+                    textFillWidth: contactRequestActions.compact
+                    text: qsTr("Accept Contact Request")
+                    onClicked: {
+                        root.acceptContactRequest(root.chatId, "")
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #20982

### What does the PR do

-  Add horizontal and vertical spacing around contact request action buttons and keep them in one responsive row with elided text.

### Affected areas

Chat / Contact Request buttons

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="364" height="688" alt="Screenshot 2026-06-01 at 16 28 27" src="https://github.com/user-attachments/assets/2b0ff514-d476-49d9-beea-4c4feeadc4ab" />

### Impact on end user

Better UX

### How to test

Contact request flow

### Risk 

Low
