### PR TITLE
fix(Notifications): split sound playing responsibility

### DIFF
--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -257,8 +257,8 @@ QtObject:
       debug "Add OS notification", notificationType=details.notificationType, identifier=identifier
       self.showOSNotification(data.title, data.message, identifier)
 
-    if self.settingsService.getNotificationSoundsEnabled():
-      self.events.emit(SIGNAL_PLAY_NOTIFICATION_SOUND, Args())
+      if self.settingsService.getNotificationSoundsEnabled():
+        self.events.emit(SIGNAL_PLAY_NOTIFICATION_SOUND, Args())
 
   proc processNotification(self: NotificationsManager, title: string, message: string, details: NotificationDetails) =
     ## This is the main method which need to be called to process an event according to the preferences set in the

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -76,6 +76,7 @@ import app_service/common/utils as common_utils
 import app_service/service/network/network_item
 import app_service/service/market/service as market_service
 
+import app/core/notifications/notifications_manager
 import app/core/notifications/details
 import app/core/eventemitter
 import app/core/custom_urls/urls_manager
@@ -1693,6 +1694,9 @@ method displayEphemeralNotification*[T](
     details
   )
   self.view.ephemeralNotificationModel().addItem(item)
+
+  if self.settingsService.getNotificationSoundsEnabled() and not details.isEmpty():
+    self.events.emit(SIGNAL_PLAY_NOTIFICATION_SOUND, Args())
 
 method displayEphemeralNotification*[T](self: Module[T], title: string, subTitle: string, details: NotificationDetails) =
   # Message toasts create high-frequency UI noise, so keep them disabled until their value is reassessed.

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -19655,6 +19655,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
 <context>
     <name>WalletNetworkDelegate</name>
     <message>
+        <source>%1 chain integrated. You can now view and swap &lt;br&gt;%1 assets, as well as interact with %1 dApps.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Required for some Status features</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -23920,6 +23920,11 @@
   <context>
     <name>WalletNetworkDelegate</name>
     <message>
+      <source>%1 chain integrated. You can now view and swap &lt;br&gt;%1 assets, as well as interact with %1 dApps.</source>
+      <comment>WalletNetworkDelegate</comment>
+      <translation>%1 chain integrated. You can now view and swap &lt;br&gt;%1 assets, as well as interact with %1 dApps.</translation>
+    </message>
+    <message>
       <source>Required for some Status features</source>
       <comment>WalletNetworkDelegate</comment>
       <translation>Required for some Status features</translation>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -19788,6 +19788,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
 <context>
     <name>WalletNetworkDelegate</name>
     <message>
+        <source>%1 chain integrated. You can now view and swap &lt;br&gt;%1 assets, as well as interact with %1 dApps.</source>
+        <translation type="unfinished">Řetězec %1 integrován. Nyní můžete prohlížet a směňovat &lt;br&gt;aktiva %1, stejně jako interagovat s dApps na %1.</translation>
+    </message>
+    <message>
         <source>Required for some Status features</source>
         <translation>Vyžadováno pro některé funkce Statusu</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -19686,6 +19686,10 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
 <context>
     <name>WalletNetworkDelegate</name>
     <message>
+        <source>%1 chain integrated. You can now view and swap &lt;br&gt;%1 assets, as well as interact with %1 dApps.</source>
+        <translation type="unfinished">Cadena %1 integrada. Ahora puedes ver e intercambiar &lt;br&gt;activos %1, así como interactuar con dApps %1.</translation>
+    </message>
+    <message>
         <source>Required for some Status features</source>
         <translation>Requerido para algunas funciones de Status</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -19618,6 +19618,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
 <context>
     <name>WalletNetworkDelegate</name>
     <message>
+        <source>%1 chain integrated. You can now view and swap &lt;br&gt;%1 assets, as well as interact with %1 dApps.</source>
+        <translation type="unfinished">%1 체인이 통합되었습니다. 이제 &lt;br&gt;%1 자산을 확인하고 스왑하며, %1 dApps와 상호작용할 수 있습니다.</translation>
+    </message>
+    <message>
         <source>Required for some Status features</source>
         <translation>일부 Status 기능에 필요</translation>
     </message>


### PR DESCRIPTION
### What does the PR do

- for OS notifications, always play the sound (if allowed)
- for toasts, delay the decision for until the toast is added to the model as it might get suppressed

Fixes https://github.com/status-im/status-app/issues/21040

### Affected areas

Notifications/Manager

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

N/A

### Impact on end user

Less annoying toasts, mainly on mobile

### How to test

- no unwanted sounds should be heard

### Risk 

low
