### PR TITLE
fix(main): fix crash at exit

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -260,7 +260,7 @@ proc mainProc() =
     appController.delete()
     statusFoundation.delete()
     singleInstance.delete()
-    singletonInstance.application.exit()
+    app.delete()
 
   featureGuard SINGLE_STATUS_INSTANCE_ENABLED:
     # Checks below must be always after "defer", in case anything fails destructors will freed a memory.

--- a/ui/app/mainui/StatusTrayIcon.qml
+++ b/ui/app/mainui/StatusTrayIcon.qml
@@ -1,3 +1,4 @@
+import QtQml
 import Qt.labs.platform
 
 import StatusQ.Core.Theme

--- a/ui/app/mainui/sectionLoaders/QmlCompiler.qml
+++ b/ui/app/mainui/sectionLoaders/QmlCompiler.qml
@@ -70,7 +70,8 @@ QtObject {
 
     onPrecompileFinished: function(componentUrl, success) {
         if (!success) {
-            Qt.quit()
+            console.error("Failed to precompile", componentUrl)
+            Qt.exit(-1)
         }
     }
 }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -505,7 +505,7 @@ Window {
             onStatusChanged: {
                 if (status === Loader.Error) {
                     console.error("Failed to load AppMain.qml")
-                    Qt.quit()
+                    Qt.exit(-1)
                 }
             }
         }


### PR DESCRIPTION
### What does the PR do

- use the guarded DOS quit/exit methods
- in the NIM main `defer` section, just call the `qGuiApp.delete()` destructor
- fixes the introduced memleak and also the crash because we were calling `qGuiApp.exit()` method twice; we are using the QQmlApplicationEngine which already connects and propagates the QML quit/exit signals from the engine to the global qGuiApp instance
- make sure we call `Qt.exit()` from QML when we really want to quit the app for good

Needs https://github.com/status-im/dotherside/pull/111 
Fixes #21082

### Affected areas

NIM main

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

N/A

### Impact on end user

no crash at exit/quit/logout

### How to test

- try to exit the app from various scenarios
  - onboarding/login screen
  - main app
  - systeam tray menu -> Quit
  - Ctrl+Q shortcut
  - Settings/Signout & Quit
- the above with and without the systray enabled (Settings/Advanced)

### Risk 

mid
