### PR TITLE
fix(logs): fix opening logs on Windows and actually open an explorer

### DIFF
--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -137,15 +137,9 @@ SettingsContentBase {
                             Global.openShakeToSharePopup()
                             return
                         }
-                        logsFolderDialog.open()
+                        Qt.openUrlExternally(UrlUtils.urlFromUserInput(root.advancedStore.logDir()))
                     }
                 }
-            }
-
-            StatusFolderDialog {
-                id: logsFolderDialog
-                title: qsTr("Application Logs")
-                currentFolder: root.advancedStore.logDir()
             }
 
             Item {


### PR DESCRIPTION
### What does the PR do

Fixes #21083

There were two problems.
1. The path was not Unix style, so the QT folder selector couldn't open the right place.
2. We used the Folder Dialog is actually made to select a folder, not to see what's inside. Using `openUrlExternally` actually opens a native explorer.

### Affected areas

AdvancedView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

It works on Windows too

[open-logs.webm](https://github.com/user-attachments/assets/2160a510-a0b0-4fa4-9e36-4fdf3356d0eb)

### Impact on end user

Fixes opening the logs on all Desktop OSes

### How to test

Click the logs button

### Risk 

Low
