### PR TITLE
StatusMessage: quote blocks handling improvements

### DIFF
--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -1191,7 +1191,9 @@ proc getRenderedText*(self: Service, parsedTextArray: seq[ParsedText], community
           result = result & self.renderInline(child, communityChats)
         result = result & "</p>"
       of PARSED_TEXT_TYPE_BLOCKQUOTE:
-        result = result & "<blockquote>" & escape_html(parsedText.literal) & "</blockquote>"
+        let quoted = escape_html(parsedText.literal)
+          .multiReplace(("\r\n", "<br/>"), ("\n", "<br/>"))
+        result = result & "<blockquote>" & quoted & "</blockquote>"
       of PARSED_TEXT_TYPE_CODEBLOCK:
         result = result & "<code>" & escape_html(parsedText.literal) & "</code>"
     result = result.strip()

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -1191,7 +1191,9 @@ proc getRenderedText*(self: Service, parsedTextArray: seq[ParsedText], community
           result = result & self.renderInline(child, communityChats)
         result = result & "</p>"
       of PARSED_TEXT_TYPE_BLOCKQUOTE:
-        let quoted = escape_html(parsedText.literal)
+        # strip trailing whitespace so a trailing newline doesn't become a
+        # trailing <br/> (which would add an empty line to the quote block)
+        let quoted = escape_html(parsedText.literal.strip(leading = false))
           .multiReplace(("\r\n", "<br/>"), ("\n", "<br/>"))
         result = result & "<blockquote>" & quoted & "</blockquote>"
       of PARSED_TEXT_TYPE_CODEBLOCK:

--- a/storybook/pages/StatusMessagePage.qml
+++ b/storybook/pages/StatusMessagePage.qml
@@ -241,7 +241,24 @@ SplitView {
                 senderId: "zq12345676767"
                 senderDisplayName: "Bob"
                 contentType: StatusMessage.ContentType.Text
-                message: "<blockquote>This is a block quoted text paragraph from a verified contact</blockquote>"
+                message: "<blockquote>This is a block quoted text paragraph<br />from a verified contact</blockquote><br />Some other thext there"
+                isContact: true
+                isAReply: false
+                trustIndicator: StatusContactVerificationIcons.TrustedType.Verified
+                outgoingStatus: StatusMessage.OutgoingStatus.Delivered
+                reactionsModel: []
+            }
+            ListElement {
+                timestamp: 1719769718000
+                senderId: "zq12345676767"
+                senderDisplayName: "Bob"
+                contentType: StatusMessage.ContentType.Text
+                message: `
+                    <blockquote>This is a block quoted text paragraph</blockquote>
+                    <br />Some other thext there<br />
+                    <blockquote>Another quoted text paragraph</blockquote>
+                    <br />Some other comment there
+                `
                 isContact: true
                 isAReply: false
                 trustIndicator: StatusContactVerificationIcons.TrustedType.Verified

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -181,6 +181,7 @@ add_library(StatusQ ${LIB_TYPE}
         include/StatusQ/statussyntaxhighlighter.h
         include/StatusQ/stringutilsinternal.h
         include/StatusQ/systemutilsinternal.h
+        include/StatusQ/textdocumentutilsinternal.h
         include/StatusQ/theme.h
         include/StatusQ/themepalette.h
         include/StatusQ/typesregistration.h
@@ -210,6 +211,7 @@ add_library(StatusQ ${LIB_TYPE}
         src/statussyntaxhighlighter.cpp
         src/stringutilsinternal.cpp
         src/systemutilsinternal.cpp
+        src/textdocumentutilsinternal.cpp
         src/theme.cpp
         src/themepalette.cpp
         src/typesregistration.cpp

--- a/ui/StatusQ/include/StatusQ/textdocumentutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/textdocumentutilsinternal.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QObject>
+#include <QVariantList>
+
+class QQuickTextDocument;
+
+class TextDocumentUtilsInternal : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit TextDocumentUtilsInternal(QObject* parent = nullptr);
+
+    // Returns the character ranges of every block quote in the given text
+    // document as a list of { "start": int, "end": int } maps. Each block quote
+    // (one <blockquote> element, possibly spanning multiple visual lines) yields
+    // a single range. Used to draw a vertical bar per quote block in QML.
+    Q_INVOKABLE QVariantList blockquoteRanges(QQuickTextDocument* document) const;
+};

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -40,7 +40,6 @@ Item {
         readonly property string hoveredLink: chatTextLoader.hoveredLink || root.highlightedLink
 
         property bool readMore: false
-        property bool isQuote: false
         readonly property int showMoreHeight: showMoreButtonLoader.visible ? showMoreButtonLoader.height : 0
         readonly property int maxHeight: 200
 
@@ -52,8 +51,6 @@ Item {
                 return Emoji.parse(root.messageDetails.messageText, Emoji.size.middle);
 
             let formattedMessage = Utils.linkifyAndXSS(root.messageDetails.messageText, root.linkAddressAndEnsName);
-
-            isQuote = formattedMessage.startsWith("<blockquote>") && formattedMessage.endsWith("</blockquote>")
 
             if (root.isEdited) {
                 const index = formattedMessage.endsWith("code>") ? formattedMessage.length : (formattedMessage.endsWith(">") ? formattedMessage.length - 4 : formattedMessage.length);
@@ -85,14 +82,6 @@ Item {
         }
     }
 
-    Rectangle {
-        width: 1
-        height: chatTextLoader.height
-        radius: Theme.radius
-        visible: d.isQuote
-        color: Theme.palette.baseColor1
-    }
-
     Loader {
         id: chatTextLoader
 
@@ -102,7 +91,6 @@ Item {
                                                                                           : item.implicitHeight
         height: effectiveHeight + d.showMoreHeight / 2
         anchors.left: parent.left
-        anchors.leftMargin: d.isQuote ? Theme.halfPadding : 0
         anchors.right: parent.right
 
         opacity: !showMoreOpacityMask.active && !horizontalOpacityMask.active ? 1 : 0
@@ -126,7 +114,7 @@ Item {
         StatusBaseText {
             objectName: "StatusTextMessage_chatText"
             text: d.text
-            color: d.isQuote || root.isReply ? Theme.palette.baseColor1 : Theme.palette.directColor1
+            color: root.isReply ? Theme.palette.baseColor1 : Theme.palette.directColor1
             font.pixelSize: root.isReply ? Theme.secondaryTextFontSize : Theme.primaryTextFontSize
             textFormat: Text.RichText
             wrapMode: root.convertToSingleLine ? Text.NoWrap : Text.Wrap
@@ -152,7 +140,7 @@ Item {
             bottomPadding: 0
             text: d.text
             selectedTextColor: Theme.palette.directColor1
-            color: d.isQuote || root.isReply ? Theme.palette.baseColor1 : Theme.palette.directColor1
+            color: root.isReply ? Theme.palette.baseColor1 : Theme.palette.directColor1
             font.pixelSize: root.isReply ? Theme.secondaryTextFontSize : Theme.primaryTextFontSize
             textFormat: Text.RichText
             wrapMode: root.convertToSingleLine ? Text.NoWrap : Text.Wrap

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -186,11 +186,21 @@ Item {
             // context menu handlers
             ContextMenu.menu: null // disable builtin "edit" menu; we're not an edit control
             inputMethodHints: Qt.ImhNoEditMenu
+
+            // Workaround to ignore unnecessarily triggered onPressAndHold on mobile when dragging
+            // chat content
+            property int onPressY
+
             onPressAndHold: function(event) {
+                if (onPressY !== Math.floor(mapToGlobal(0, 0).y))
+                    return
+
                 event.accepted = true
                 root.contextMenuRequested(Qt.point(event.x, event.y))
             }
             onPressed: function(event) {
+                onPressY = mapToGlobal(0, 0).y
+
                 if (event.button === Qt.RightButton) {
                     event.accepted = true
                     root.contextMenuRequested(Qt.point(event.x, event.y))

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -63,7 +63,7 @@ Item {
                 return Utils.getMessageWithStyle(root.Theme.palette, Emoji.parse(editedMessage))
             }
 
-            if (root.convertToSingleLine || isQuote)
+            if (root.convertToSingleLine)
                 formattedMessage = Utils.convertToSingleLine(formattedMessage)
 
             if (root.stripHtmlTags)

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -43,15 +43,18 @@ Item {
         readonly property int showMoreHeight: showMoreButtonLoader.visible ? showMoreButtonLoader.height : 0
         readonly property int maxHeight: 200
 
+        // Simple heuristic to check if message contains quote block.
+        readonly property bool hasBlockQuote: d.text.indexOf("<blockquote") !== -1
+
         // Character ranges ({ start, end }) of every quote block, used to draw a
-        // vertical bar per quote block (desktop only). layoutRevision is bumped on
-        // relayout to force the bars' geometry bindings (positionToRectangle calls)
-        // to re-evaluate, since method calls are not tracked by bindings.
+        // vertical bar per quote block. layoutRevision is bumped on relayout to
+        // force the bars' geometry bindings (positionToRectangle calls) to
+        // re-evaluate, since method calls are not tracked by bindings.
         property var quoteRanges: []
         property int layoutRevision: 0
         function updateQuoteRanges() {
             const item = chatTextLoader.item
-            d.quoteRanges = (!root.isMobile && item && item.textDocument)
+            d.quoteRanges = (item && item.textDocument)
                           ? TextDocumentUtils.blockquoteRanges(item.textDocument) : []
         }
 
@@ -107,7 +110,12 @@ Item {
 
         opacity: !showMoreOpacityMask.active && !horizontalOpacityMask.active ? 1 : 0
 
-        sourceComponent: root.isMobile ? chatTextMobileComp : chatTextDesktopComp
+        // Mobile uses the lightweight StatusBaseText, except for quote messages
+        // which need StatusTextArea (textDocument/positionToRectangle) to draw the
+        // quote bar. Desktop always uses StatusTextArea to allow selection by mouse.
+        sourceComponent: (root.isMobile && !d.hasBlockQuote) ? chatTextMobileComp
+                                                             : chatTextDesktopComp
+        onItemChanged: d.updateQuoteRanges()
 
         HoverHandler {
             id: hoverHandler
@@ -157,10 +165,10 @@ Item {
             textFormat: Text.RichText
             wrapMode: root.convertToSingleLine ? Text.NoWrap : Text.Wrap
             readOnly: true
-            selectByMouse: true  // applies to mouse only, not touch
+            selectByMouse: !root.isMobile  // mouse selection is desktop-only
 
-            // quote-bar overlay bookkeeping
-            Component.onCompleted: d.updateQuoteRanges()
+            // quote-bar overlay bookkeeping (initial compute handled by the
+            // loader's onItemChanged)
             onTextChanged: d.updateQuoteRanges()
             onContentHeightChanged: d.layoutRevision++
             onContentWidthChanged: d.layoutRevision++
@@ -252,7 +260,8 @@ Item {
         }
     }
 
-    // Vertical bar drawn for each quote block (desktop only).
+    // Vertical bar drawn for each quote block. Rendered whenever the text control
+    // exposes a textDocument (StatusTextArea) - desktop, and mobile quote messages.
     Item {
         anchors.fill: chatTextLoader
         clip: true
@@ -266,12 +275,14 @@ Item {
                 readonly property rect startRect: {
                     d.layoutRevision // dependency: re-evaluate on relayout
                     const item = chatTextLoader.item
-                    return item ? item.positionToRectangle(quoteBar.modelData.start) : Qt.rect(0, 0, 0, 0)
+                    return (item && item.positionToRectangle)
+                         ? item.positionToRectangle(quoteBar.modelData.start) : Qt.rect(0, 0, 0, 0)
                 }
                 readonly property rect endRect: {
                     d.layoutRevision // dependency: re-evaluate on relayout
                     const item = chatTextLoader.item
-                    return item ? item.positionToRectangle(quoteBar.modelData.end) : Qt.rect(0, 0, 0, 0)
+                    return (item && item.positionToRectangle)
+                         ? item.positionToRectangle(quoteBar.modelData.end) : Qt.rect(0, 0, 0, 0)
                 }
 
                 x: 0

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -43,6 +43,18 @@ Item {
         readonly property int showMoreHeight: showMoreButtonLoader.visible ? showMoreButtonLoader.height : 0
         readonly property int maxHeight: 200
 
+        // Character ranges ({ start, end }) of every quote block, used to draw a
+        // vertical bar per quote block (desktop only). layoutRevision is bumped on
+        // relayout to force the bars' geometry bindings (positionToRectangle calls)
+        // to re-evaluate, since method calls are not tracked by bindings.
+        property var quoteRanges: []
+        property int layoutRevision: 0
+        function updateQuoteRanges() {
+            const item = chatTextLoader.item
+            d.quoteRanges = (!root.isMobile && item && item.textDocument)
+                          ? TextDocumentUtils.blockquoteRanges(item.textDocument) : []
+        }
+
         readonly property string text: {
             if (root.messageDetails.contentType === StatusMessage.ContentType.Sticker)
                 return "";
@@ -147,6 +159,13 @@ Item {
             readOnly: true
             selectByMouse: true  // applies to mouse only, not touch
 
+            // quote-bar overlay bookkeeping
+            Component.onCompleted: d.updateQuoteRanges()
+            onTextChanged: d.updateQuoteRanges()
+            onContentHeightChanged: d.layoutRevision++
+            onContentWidthChanged: d.layoutRevision++
+            onWidthChanged: d.layoutRevision++
+
             onLinkActivated: function(link) {
                 if(d.showDisabledTooltipForAddressEnsName(link)) {
                     return
@@ -230,6 +249,38 @@ Item {
         sourceComponent: OpacityMask {
             source: chatTextLoader
             maskSource: showMoreMaskGradient
+        }
+    }
+
+    // Vertical bar drawn for each quote block (desktop only).
+    Item {
+        anchors.fill: chatTextLoader
+        clip: true
+
+        Repeater {
+            model: d.quoteRanges
+            delegate: Rectangle {
+                id: quoteBar
+                required property var modelData
+
+                readonly property rect startRect: {
+                    d.layoutRevision // dependency: re-evaluate on relayout
+                    const item = chatTextLoader.item
+                    return item ? item.positionToRectangle(quoteBar.modelData.start) : Qt.rect(0, 0, 0, 0)
+                }
+                readonly property rect endRect: {
+                    d.layoutRevision // dependency: re-evaluate on relayout
+                    const item = chatTextLoader.item
+                    return item ? item.positionToRectangle(quoteBar.modelData.end) : Qt.rect(0, 0, 0, 0)
+                }
+
+                x: 0
+                y: startRect.y
+                width: 2
+                radius: width / 2
+                height: Math.max(0, endRect.y + endRect.height - startRect.y)
+                color: Theme.palette.baseColor1
+            }
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Core/Utils/TextDocumentUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/TextDocumentUtils.qml
@@ -1,0 +1,13 @@
+pragma Singleton
+
+import QtQuick
+
+import StatusQ.Internal as Internal
+
+QtObject {
+    // Returns the character ranges ({ start, end }) of every block quote in the
+    // given text document. See TextDocumentUtilsInternal::blockquoteRanges.
+    function blockquoteRanges(textDocument) {
+        return Internal.TextDocumentUtils.blockquoteRanges(textDocument)
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -204,7 +204,11 @@ QtObject {
         const ethLinkHoverColor = ethLinkDisabled ? palette.baseColor1 : palette.primaryColor1
         const ethLinkHoverBackgroundColor = ethLinkDisabled ? palette.directColor8 : palette.primaryColor3
         return `<style type="text/css">` +
-                    `img, a, del, code, blockquote { margin: 0; padding: 0; }` +
+                    `img, a, del, code { margin: 0; padding: 0; }` +
+                    `blockquote {` +
+                        `margin: 0 0 0 8px;` +
+                        `color: ${palette.baseColor1};` +
+                    `}` +
                     `code {` +
                         `font-family: ${Fonts.codeFont.family};` +
                         `font-weight: 400;` +

--- a/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
@@ -24,4 +24,5 @@ singleton Emoji 0.1 Emoji.qml
 singleton ModelUtils 0.1 ModelUtils.qml
 singleton OperatorsUtils 0.1 OperatorsUtils.qml
 singleton StringUtils 0.1 StringUtils.qml
+singleton TextDocumentUtils 0.1 TextDocumentUtils.qml
 singleton Utils 0.1 Utils.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -215,6 +215,7 @@
         <file>StatusQ/Core/Utils/Subscription.qml</file>
         <file>StatusQ/Core/Utils/SubscriptionBroker.qml</file>
         <file>StatusQ/Core/Utils/SubscriptionBrokerCommunities.qml</file>
+        <file>StatusQ/Core/Utils/TextDocumentUtils.qml</file>
         <file>StatusQ/Core/Utils/Utils.qml</file>
         <file>StatusQ/Core/Utils/big.min.mjs</file>
         <file>StatusQ/Core/Utils/emojiList.js</file>

--- a/ui/StatusQ/src/textdocumentutilsinternal.cpp
+++ b/ui/StatusQ/src/textdocumentutilsinternal.cpp
@@ -1,0 +1,35 @@
+#include "StatusQ/textdocumentutilsinternal.h"
+
+#include <QQuickTextDocument>
+#include <QTextBlock>
+#include <QTextDocument>
+#include <QTextFormat>
+#include <QVariantMap>
+
+TextDocumentUtilsInternal::TextDocumentUtilsInternal(QObject* parent) : QObject(parent)
+{
+}
+
+QVariantList TextDocumentUtilsInternal::blockquoteRanges(QQuickTextDocument* quickDoc) const
+{
+    QVariantList result;
+    if (!quickDoc)
+        return result;
+
+    QTextDocument* doc = quickDoc->textDocument();
+    if (!doc)
+        return result;
+
+    for (QTextBlock block = doc->firstBlock(); block.isValid(); block = block.next()) {
+        if (!block.blockFormat().hasProperty(QTextFormat::BlockQuoteLevel))
+            continue;
+
+        QVariantMap range;
+        range[QStringLiteral("start")] = block.position();
+        // last valid position within the block (rectangle of the last visual line)
+        range[QStringLiteral("end")] = block.position() + block.length() - 1;
+        result.append(range);
+    }
+
+    return result;
+}

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -19,6 +19,7 @@
 #include "StatusQ/statussyntaxhighlighter.h"
 #include "StatusQ/stringutilsinternal.h"
 #include "StatusQ/systemutilsinternal.h"
+#include "StatusQ/textdocumentutilsinternal.h"
 #include "StatusQ/theme.h"
 #include "StatusQ/undefinedfilter.h"
 #include "StatusQ/urlutils.h"
@@ -109,6 +110,11 @@ void registerStatusQTypes() {
     qmlRegisterSingletonType<StringUtilsInternal>(
         "StatusQ.Internal", 0, 1, "StringUtils", [](QQmlEngine* engine, QJSEngine*) {
             return new StringUtilsInternal(engine);
+        });
+
+    qmlRegisterSingletonType<TextDocumentUtilsInternal>(
+        "StatusQ.Internal", 0, 1, "TextDocumentUtils", [](QQmlEngine* engine, QJSEngine*) {
+            return new TextDocumentUtilsInternal(engine);
         });
 
     qmlRegisterSingletonType<SystemUtilsInternal>(


### PR DESCRIPTION
### What does the PR do

This PR improves rendering of quote blocks in StatusMessage:

- ability to mix quote blocks and other content withing single message
- ability to have multiple quote blocks within single message, every block has properly rendered vertical bar decorating quote block
- new lines in quote blocks are correctly preserved

Closes: https://github.com/status-im/status-app/issues/20801

### Affected areas
`StatusTextMessage`

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[Screencast from 02.06.2026 16:14:33.webm](https://github.com/user-attachments/assets/b4f9d63c-3a5c-4baf-bede-d6aa78be3dbf)


### Impact on end user
Medium

### How to test

Go to chat, use multiple quote blocks mixed up with other content within single message.

### Risk 
Low
