### PR TITLE
fix(scodes): update SCodes to get a crash fix on Windows

### DIFF
--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -349,7 +349,7 @@ FetchContent_Declare(
   SCodes
 
   GIT_REPOSITORY https://github.com/status-im/SCodes.git
-  GIT_TAG 09f70a1c5d8a7b5facf946fdfe11f401890f45fc
+  GIT_TAG 2b46818ff46fd43f443ed80a056c01abcf927526
     SOURCE_SUBDIR src
 )
 


### PR DESCRIPTION
Fixes #21034

## Summary

This PR updates the StatusQ SCodes dependency to include a fix for a Windows crash in the **Log in by syncing** flow.

## Problem

On Windows, repeatedly entering and exiting the syncing QR flow (Continue -> Back -> Continue) could trigger an access violation during QML teardown.  
WinDbg stacks consistently pointed to `Qt6Core!QThread::terminate` in the scanner teardown path.

## Root Cause

The QR scanner worker thread in SCodes (`SBarcodeScanner`) used a Windows-specific forced thread stop (`terminate()`) in the destructor.  
During rapid view teardown/recreation, this could race with in-flight decode work and posted Qt events, causing invalid access.

## Fix

The SCodes scanner shutdown was hardened to use an orderly teardown sequence instead of forced termination:

- stop scanning and prevent new frame processing
- disconnect frame delivery
- stop/detach camera and capture session
- queue a blocking barrier on the decoder thread to drain already-queued work
- call `quit()` + `wait()` for clean thread shutdown

Also included small safety guards to avoid processing/logging against a cleared camera during teardown.

## Dependency Update

StatusQ now pins [SCodes](https://github.com/status-im/SCodes/pull/4) to:

`2b46818ff46fd43f443ed80a056c01abcf927526`

in CMakeLists.txt.

### Affected areas

SCodes (PR: https://github.com/status-im/SCodes/pull/4)

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Linux syncing:

[syncing-fix.webm](https://github.com/user-attachments/assets/b12bb2ba-97e2-4632-b0e3-5a83fc2aa147)

Linux QR Scanner:

[qr-still-works.webm](https://github.com/user-attachments/assets/daa4c695-e09b-43df-85c8-67ca01e6f69b)

Windows Syncing:


https://github.com/user-attachments/assets/4a9c0eea-6100-4df5-bd85-d6ab4fa16cf3

Windows QR scanner:


https://github.com/user-attachments/assets/1357bfee-83e7-465e-98c2-519b86d13990



### Impact on end user

It should make opening and closing the QR scanner more resilient to crashes

### How to test

Tested on Windows and Ubuntu

### Risk 

Low/Medium - We need to check that the QR scanner still works as expected on all platforms. The library was a bit "flaky" when I integrated it. It would work on one platform, but freeze on another. In theory, the build system should still be ok and the code is safe, but let's test before merging.
