### PR TITLE
fix(Wallet): Keep onchain friends tab accessible

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -51,6 +51,8 @@ Rectangle {
         property bool loaded: false
 
         readonly property string removeAccountIdentifier: "wallet-section-remove-account"
+        readonly property real bottomSafeMargin: root.SafeArea.margins.bottom
+        readonly property real footerHeight: footer.height + followingAddressesFooter.height
     }
 
     Loader {
@@ -273,7 +275,7 @@ Rectangle {
                     left: parent.left
                     right: parent.right
                 }
-                height: parent.height - footer.height
+                height: Math.max(0, parent.height - d.footerHeight)
 
                 spacing: Theme.smallPadding
                 currentIndex: -1
@@ -281,6 +283,7 @@ Rectangle {
                 preferredHighlightBegin: 0
                 preferredHighlightEnd: height
                 bottomMargin: Theme.padding
+                verticalScrollBar.implicitWidth: Math.max(Theme.halfPadding, 8)
 
                 readonly property Item firstItem: count > 0 ? itemAtIndex(0) : null
                 readonly property bool footerOverlayed: d.loaded && contentHeight > availableHeight
@@ -422,7 +425,7 @@ Rectangle {
                 anchors {
                     top: parent.top
                     // Bottom Margin is not applied to ListView if it's fully visible
-                    topMargin: Math.min(walletAccountsListView.contentHeight, parent.height - height) + (walletAccountsListView.footerOverlayed ? 0 : walletAccountsListView.bottomMargin)
+                    topMargin: Math.min(walletAccountsListView.contentHeight, parent.height - d.footerHeight) + (walletAccountsListView.footerOverlayed ? 0 : walletAccountsListView.bottomMargin)
                     left: parent.left
                     right: parent.right
                 }
@@ -481,7 +484,8 @@ Rectangle {
                 }
 
                 horizontalPadding: Theme.padding
-                verticalPadding: 0
+                topPadding: 0
+                bottomPadding: d.bottomSafeMargin
 
                 contentItem: StatusFlatButton {
                     objectName: "followingAddressesBtn"


### PR DESCRIPTION
Closes #20816

### What does the PR do

Reserve bottom space for wallet footer actions so Onchain friends stays accessible on all platforms.

### Affected areas

Wallet Left Panel

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="434" height="1009" alt="Screenshot 2026-06-03 at 14 07 01" src="https://github.com/user-attachments/assets/feaea4e7-71ee-42b0-b750-1181e2b360ab" />


### Impact on end user

Better UX

### How to test

- Have a lot of wallet accounts so that you need to scroll to reach the last ones
- See the Saved addresses and Onchain friends options are totally available

### Risk 

Low
