### PR TITLE
WIP fix(LoginScreen): don't reeval the iOS biometrics on rerun

### DIFF
--- a/ui/StatusQ/src/keychain_apple.mm
+++ b/ui/StatusQ/src/keychain_apple.mm
@@ -77,7 +77,7 @@ Keychain::Keychain(QObject *parent)
             &QGuiApplication::applicationStateChanged,
             this,
             [this](Qt::ApplicationState state) {
-                if (state == Qt::ApplicationActive) {
+                if (state == Qt::ApplicationActive && !m_future.isRunning() && !m_future.isStarted()) {
                     reevaluateAvailability();
                 }
             });

--- a/ui/app/AppLayouts/Onboarding/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingFlow.qml
@@ -254,8 +254,11 @@ OnboardingStackView {
             onKeycardRequested: root.keycardRequested()
 
             onVisibleChanged: {
-                if (!visible)
+                if (!visible) {
                     root.dismissBiometricsRequested()
+                    loginScreen.resetBiometricsResult()
+                } /*else if (loginScreen.isBiometricsLogin)
+                    root.biometricsRequested(loginScreen.selectedProfileKeyId)*/
             }
 
             Component.onDestruction: root.dismissBiometricsRequested()

--- a/ui/app/AppLayouts/Onboarding/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/LoginScreen.qml
@@ -99,6 +99,11 @@ OnboardingPage {
     signal keycardRequested()
     signal onboardingManageProfilesFlowRequested()
 
+    function resetBiometricsResult() {
+        d.biometricsSuccessful = false
+        d.biometricsFailed = false
+    }
+
     QtObject {
         id: d
 
@@ -117,12 +122,6 @@ OnboardingPage {
                 if (!d.currentProfileIsKeycard)
                     passwordBox.forceActiveFocus()
             }
-        }
-
-
-        function resetBiometricsResult() {
-            d.biometricsSuccessful = false
-            d.biometricsFailed = false
         }
 
         function doPasswordLogin(password: string) {
@@ -227,7 +226,7 @@ OnboardingPage {
 
                     root.dismissBiometricsRequested()
 
-                    d.resetBiometricsResult()
+                    root.resetBiometricsResult()
                     root.profileSelected(selectedProfileKeyId)
 
                     if (d.currentProfileIsKeycard) {
@@ -266,7 +265,7 @@ OnboardingPage {
                 onPasswordEditedManually: {
                     // reset state when typing the pass manually; not to break the bindings inside the component
                     validationError = ""
-                    d.resetBiometricsResult()
+                    root.resetBiometricsResult()
                 }
                 onDetailedErrorPopupRequested: detailedErrorPopupComp.createObject(root, {detailedError}).open()
                 onBiometricsRequested: root.biometricsRequested(loginUserSelector.selectedProfileKeyId)
@@ -290,7 +289,7 @@ OnboardingPage {
                 onPinEditedManually: {
                     // reset state when typing the PIN manually; not to break the bindings inside the component
                     loginError = ""
-                    d.resetBiometricsResult()
+                    root.resetBiometricsResult()
                 }
                 onDetailedErrorPopupRequested: detailedErrorPopupComp.createObject(root, {detailedError: loginError}).open()
                 onBiometricsRequested: root.biometricsRequested(loginUserSelector.selectedProfileKeyId)


### PR DESCRIPTION
### What does the PR do

- do not reeval the biometrics availability when woken up and when there's already an ongoing auth request being handled (which runs its own event loop)
- reset the biometrics result in the login screen; we are cancelling the active biometrics request when being hidden

Fixes #21102

### Affected areas

Login/Keychain

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

TBD

### Impact on end user

More streamlined login on iOS

### How to test

- put the app into background
- tap a notification to wake it up
- app starts, no biometrics failures

### Risk 

low
