### PR TITLE
KeycardPopup: layout improved to avoid kbd overlapping inputs

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/StatusScrollView.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusScrollView.qml
@@ -210,7 +210,7 @@ T.ScrollView {
     }
 
     function scrollEnd() {
-        flickable.contentY = flickable.contentHeight - flickable.height
+        flickable.contentY = Math.max(0, flickable.contentHeight - flickable.height)
     }
 
     function scrollPageUp() {

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -91,39 +91,42 @@ StatusDialog {
         root.sharedKeycardModule.currentState.doCancelAction();
     }
 
+    topPadding: 0
+    bottomPadding: 0
+
     contentItem: StatusScrollView {
         id: scrollView
         contentWidth: availableWidth
         padding: 0
 
         // keep content visible on mobile when keyboard activated
-        onHeightChanged: scrollView.scrollEnd()
+        onHeightChanged: {
+            Qt.callLater(() => {
+                scrollView.scrollEnd()
+            })
+        }
 
         KeycardPopupContent {
             id: content
             width: scrollView.availableWidth
-            implicitHeight: {
-                let baseHeight = Constants.keycard.general.popupHeight
-
+            height: {
                 // for all flows
                 if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
                         root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata) {
-                    if (!root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
-                        baseHeight = Constants.keycard.general.popupBiggerHeight
-                    }
+                    if (!root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown)
+                        return Constants.keycard.general.popupBiggerHeight
                 }
 
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.importFromKeycard &&
                         root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.manageKeycardAccounts &&
                         root.sharedKeycardModule.keyPairHelper.accounts.count > 1) {
-                    baseHeight = Constants.keycard.general.popupBiggerHeight
+                    return Constants.keycard.general.popupBiggerHeight
                 }
 
-                if (root.fullScreenBottomSheet) {
-                    return Math.max(baseHeight, content.implicitHeight)
-                }
+                if (root.fullScreenBottomSheet)
+                    return content.implicitHeight
 
-                return baseHeight
+                return Constants.keycard.general.popupHeight
             }
 
             sharedKeycardModule: root.sharedKeycardModule

--- a/ui/imports/shared/popups/keycard/KeycardPopupContent.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopupContent.qml
@@ -24,9 +24,8 @@ Control {
     implicitHeight: loader.implicitHeight
     implicitWidth: loader.implicitWidth
 
-    Loader {
+    contentItem: Loader {
         id: loader
-        anchors.fill: parent
         sourceComponent: {
             switch (root.sharedKeycardModule.currentState.stateType) {
             case Constants.keycardSharedState.keycardFlowStarted:


### PR DESCRIPTION
### What does the PR do

Improves popup's layout to position properly when virtual keyboard is opened.

Closes: ##21011

### Affected areas

`KeycardPopup`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screencapture of the functionality


https://github.com/user-attachments/assets/3cc0a481-5e34-4d80-882c-e5965181d064


### Impact on end user

Low

### How to test
Settings -> Password -> Enable biometrics (opens authentication popup)

### Risk 

<!-- Described potential risks and worst case scenarios. -->
