### PR TITLE
Chat input: vertical padding same as in legacy app

### DIFF
--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -720,8 +720,8 @@ Control {
 
                         Keys.forwardTo: [keyEventsFilter]
 
-                        topPadding: 9
-                        bottomPadding: 9
+                        topPadding: 22
+                        bottomPadding: 22
                         leftPadding: Theme.halfPadding // for the nav bar handle
                         rightPadding: Theme.halfPadding // for the scrollbar
 


### PR DESCRIPTION
### What does the PR do

Simply adjust the vertical padding around chat input area to match the one in legacy app

### Screencapture of the functionality

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/3ac49cb7-80ea-4e82-9c23-aa2b688c4f23" />
