### PR TITLE
ChatInput: workaround for restoring original text in edit mode

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -68,7 +68,9 @@ Item {
             let formattedMessage = Utils.linkifyAndXSS(root.messageDetails.messageText, root.linkAddressAndEnsName);
 
             if (root.isEdited) {
-                const index = formattedMessage.endsWith("code>") ? formattedMessage.length : (formattedMessage.endsWith(">") ? formattedMessage.length - 4 : formattedMessage.length);
+                // insert "(edited)" just before the last closing tag (e.g. </p>,
+                // </blockquote>); for code blocks and plain text, append at the end
+                const index = formattedMessage.endsWith("code>") ? formattedMessage.length : (formattedMessage.endsWith(">") ? formattedMessage.lastIndexOf("</") : formattedMessage.length);
                 const editedMessage = formattedMessage.slice(0, index)
                                     + ` <span class="isEdited">` + qsTr("(edited)") + `</span>`
                                     + formattedMessage.slice(index);

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -1075,7 +1075,32 @@ Loader {
                         onOpenGifPopupRequest: (params, cbOnGifSelected, cbOnClose) => root.openGifPopupRequest(params, cbOnGifSelected, cbOnClose)
 
                         Component.onCompleted: {
-                            parseMessage(root.messageText);
+                            // Workaround to restore original message to chat input.
+                            // Will be reworked later along with removal of in-place editing.
+                            //
+                            // Populate the edit field with the raw, unparsed text
+                            // (original markdown) while keeping mentions readable:
+                            //  - system mentions (e.g. "@0x00001") -> their tag
+                            //    ("@everyone"), mirroring SystemTagMapping in
+                            //    app_service/common/conversion.nim
+                            //  - user mentions ("@0x<pubkey>") -> the rendered mention
+                            //    link from root.messageText (matched in order), which
+                            //    parseMessage() then turns into a chip.
+                            // Other text is escaped/<br/>-converted so parseMessage()
+                            // treats it like the rendered message.
+                            const systemMentions = ({ "0x00001": "@everyone" })
+                            let seed = root.unparsedText
+                                .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+                                .replace(/\n/g, "<br/>")
+                            const userMentions = root.messageText.match(/<a href="\/\/0x[0-9a-fA-F]+"[^>]*class="mention"[^>]*>@[^<]*<\/a>/g) || []
+                            let u = 0
+                            seed = seed.replace(/@0x[0-9a-fA-F]+/g, function(token) {
+                                const key = token.substring(1) // drop leading '@'
+                                if (systemMentions[key] !== undefined)
+                                    return systemMentions[key]
+                                return u < userMentions.length ? userMentions[u++] : token
+                            })
+                            parseMessage(seed);
                             delegate.originalMessageText = editTextInput.textInput.text
                         }
                     }


### PR DESCRIPTION
### What does the PR do

- restores original message to the text input instead of using formatted message (with no formatting characters like *, >, `)
- fixes problem of incorrect placement of `(edited)` marker

This is workaround solution that's intended to be improved later.

Closes: #21129 

### Affected areas
`MessageView`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screencapture of the functionality

[Screencast from 04.06.2026 01:12:31.webm](https://github.com/user-attachments/assets/47846f3f-fe9a-43c2-9c2e-69daaa84182a)

### Impact on end user
Significantly improves user experience on editing messages

### How to test
- send message with some formatting (code block, quote block, *, `)
- edit message

### Risk 
Low
