### PR TITLE
fix(banners): harden online state and reset on close

### DIFF
--- a/storybook/pages/ConnectionWarningsPage.qml
+++ b/storybook/pages/ConnectionWarningsPage.qml
@@ -63,6 +63,7 @@ SplitView {
                         signal networkConnectionStatusUpdate(website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAtUnix: double)
                     }
                 }
+                isOnline: ctrlIsOnline.checked
                 websiteDown: ctrlWebsiteDown.currentValue
                 connectionState: ctrlConnectionState.currentValue
 

--- a/ui/StatusQ/src/networkchecker.cpp
+++ b/ui/StatusQ/src/networkchecker.cpp
@@ -29,12 +29,13 @@ NetworkChecker::NetworkChecker(QObject *parent)
 {
     if (!QNetworkInformation::loadDefaultBackend()) {
         qWarning() << "QNetworkInformation is not supported on this platform or backend.";
+        setActive(false);
         return;
     }
 
     m_netinfo = QNetworkInformation::instance();
 
-    // initial update (optionally delayed)
+    // initial update; app becomes active, or 10s max
     QDeadlineTimer deadline(kCheckDelay);
     while (!deadline.hasExpired() || (QGuiApplication::applicationState() & Qt::ApplicationActive)) {
         init();
@@ -123,6 +124,9 @@ void NetworkChecker::updateConnectionDetails()
 
 void NetworkChecker::checkNetwork()
 {
+    if (!m_netinfo)
+        return;
+
     setActive(false);
     setChecking(true);
     setActive(true);

--- a/ui/app/AppLayouts/Browser/controls/DownloadElement.qml
+++ b/ui/app/AppLayouts/Browser/controls/DownloadElement.qml
@@ -65,7 +65,7 @@ Rectangle {
         Component {
             id: fileImageComponent
             StatusIcon {
-                icon: "browser/file"
+                icon: "file"
                 color: downloadComplete ? StatusColors.transparent : Theme.palette.darkGrey
             }
         }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1356,8 +1356,8 @@ Item {
             Layout.fillWidth: true
 
             // apply left/right margins when we remove the window titlebar
-            Layout.leftMargin: Qt.platform.os === SQUtils.Utils.mac ? appMain.SafeArea.margins.left : 0
-            Layout.rightMargin: Qt.platform.os === SQUtils.Utils.mac ? appMain.SafeArea.margins.right : 0
+            Layout.leftMargin: SQUtils.Utils.isMacOS ? appMain.SafeArea.margins.left : 0
+            Layout.rightMargin: SQUtils.Utils.isMacOS ? appMain.SafeArea.margins.right : 0
 
             spacing: 0
 
@@ -1471,6 +1471,7 @@ Item {
                         return ""
                     }
                 }
+                isOnline: d.networkChecker.isOnline
             }
 
             ConnectionWarnings {
@@ -1522,6 +1523,7 @@ Item {
                         return ""
                     }
                 }
+                isOnline: d.networkChecker.isOnline
             }
 
             ConnectionWarnings {
@@ -1548,6 +1550,7 @@ Item {
                         return ""
                     }
                 }
+                isOnline: d.networkChecker.isOnline
             }
         }
 

--- a/ui/app/mainui/sectionLoaders/MarketLoader.qml
+++ b/ui/app/mainui/sectionLoaders/MarketLoader.qml
@@ -94,6 +94,7 @@ Loader {
 
     Connections {
         target: root.item
+        ignoreUnknownSignals: true
 
         function onRequestLaunchSwap() {
             root.popupHandler.launchSwap()

--- a/ui/imports/shared/panels/ConnectionWarnings.qml
+++ b/ui/imports/shared/panels/ConnectionWarnings.qml
@@ -24,17 +24,28 @@ Loader {
     property string toastText
 
     property bool relevantForCurrentSection: true
-    onRelevantForCurrentSectionChanged: updateBanner(false)
+    onRelevantForCurrentSectionChanged: {
+        console.debug(lc, "!!! NOT RELEVANT CHANGED, UPDATING BANNER; RELEVANT:", relevantForCurrentSection)
+        updateBanner(false)
+    }
 
-    readonly property bool isOnline: networkConnectionStore.isOnline // strict online/offline check, doesn't care about the wallet services
+    property bool isOnline: true
     onIsOnlineChanged: {
         connectionState = Constants.ConnectionStatus.Unknown // reset the state; wait for real status change from backend
+        console.debug(lc, "!!! ONLINE CHANGED, UPDATING BANNER; ONLINE:", isOnline)
         updateBanner()
+    }
+
+    LoggingCategory {
+        id: lc
+        name: "app.status.QML.ConnectionWarnings"
+        defaultLogLevel: LoggingCategory.Warning
     }
 
     function updateBanner(showOnlineBanners = true) {
         // if offline or irrelevant, hide the item
         if (!isOnline || !relevantForCurrentSection) {
+            console.debug(lc, ">>> NOT ONLINE OR RELEVANT, ABOUT TO HIDE")
             if (!!item)
                 item.hide()
             return
@@ -43,26 +54,38 @@ Loader {
         // We show error banners when there's an actual connection problem,
         // Show "Retrying" banners only when a previously working connection is being retried
         // Unknown - initial state. After the first real check completes, status changes
-        if (connectionState === Constants.ConnectionStatus.Unknown)
+        if (connectionState === Constants.ConnectionStatus.Unknown) {
+            console.debug(lc, ">>> UNKNOWN CONN, RETURN")
             return
+        }
 
+        console.debug(lc, ">>> ACTIVATING BANNER")
         root.active = true
-        if (connectionState === Constants.ConnectionStatus.Failure)
+        if (connectionState === Constants.ConnectionStatus.Failure) {
+            console.debug(lc, ">>> SHOWING BANNER")
             item.show()
-        else if (showOnlineBanners)
+        } else if (showOnlineBanners) {
+            console.debug(lc, ">>> SHOWING BANNER FOR 3s")
             item.showFor(3000)
+        }
     }
 
     sourceComponent: ModuleWarning {
         delay: false
-        onHideFinished: root.active = false
+        onHideFinished: {
+            root.connectionState = Constants.ConnectionStatus.Unknown // reset the state; wait for next real status change from backend
+            root.active = false
+        }
 
         text: root.toastText
         type: root.connectionState === Constants.ConnectionStatus.Success ? ModuleWarning.Success : ModuleWarning.Danger
         buttonText: root.connectionState === Constants.ConnectionStatus.Failure ? qsTr("Retry now") : ""
 
         onClicked: root.networkConnectionStore.retryConnection(root.websiteDown)
-        onCloseClicked: hide()
+        onCloseClicked: {
+            root.connectionState = Constants.ConnectionStatus.Unknown // reset the state; wait for next real status change from backend
+            hide()
+        }
 
         onLinkActivated: {
             toolTip.show(root.tooltipMessage, 3000)
@@ -79,11 +102,12 @@ Loader {
         enabled: root.isOnline // suspend the updates while offline; https://github.com/status-im/status-app/issues/20124
         target: root.networkConnectionStore.networkConnectionModuleInst
         function onNetworkConnectionStatusUpdate(website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAtUnix: double) {
-            if (website === websiteDown) {
+            if (website === root.websiteDown) {
                 root.connectionState = connectionState
                 root.chainIdsDown = chainIds.split(";")
                 root.completelyDown = completelyDown
                 root.lastCheckedAtUnix = lastCheckedAtUnix
+                console.debug(lc, "!!! onNetworkConnectionStatusUpdate; connectionState:", connectionState, "; UPDATING BANNER FOR WEBSITE:", website)
                 root.updateBanner()
             }
         }

--- a/ui/imports/shared/panels/ModuleWarning.qml
+++ b/ui/imports/shared/panels/ModuleWarning.qml
@@ -28,7 +28,7 @@ Item {
     property bool delay: true
 
     // extra margin that can be used to avoid overlapping with window buttons
-    property int extraInnerLeftMargin: Qt.platform.os === SQUtils.Utils.mac ? 60 : 0
+    property int extraInnerLeftMargin: SQUtils.Utils.isMacOS ? 60 : 0
 
     signal clicked()
     signal closeClicked()


### PR DESCRIPTION
### What does the PR do

- pass the online state directly from the NetworkChecker into the banner, and correctly initialize it
- reset the banner's itnernal state when closign it manually
- fixes the artificial gap created when switching between a wallet and non-wallet sections
- add a categorized logging to `ConnectionWarnings` for easier debugging in the future (doesn't log anything by default)
- some other minor fixes spotted

Fixes #21088

### Affected areas

AppMain/Banners

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

TBD

### Impact on end user

Less annoying (closed) banners

### How to test

- wait for a banner
- close it, or wait for it close automatically
- switch sections (home <--> wallet)

### Risk 

low
