### PR TITLE
fix(contacts): disable re-sending a CR if already sent in settings

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/SendContactRequestToChatKeyModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/SendContactRequestToChatKeyModal.qml
@@ -13,13 +13,16 @@ import StatusQ.Core.Backpressure
 import StatusQ.Core.Theme
 import StatusQ.Popups.Dialog
 
+import AppLayouts.Profile.helpers
 import AppLayouts.Profile.stores
 import AppLayouts.stores as AppLayoutStores
+import shared.stores as SharedStores
 
 StatusDialog {
     id: root
 
     property AppLayoutStores.ContactsStore contactsStore
+    property SharedStores.UtilsStore utilsStore
 
     title: qsTr("Send Contact Request to chat key")
     padding: d.contentMargins
@@ -37,6 +40,21 @@ StatusDialog {
         property int minChatKeyLength: 4 // ens or chat key
         property string realChatKey: ""
         property string resolvedPubKey: ""
+        readonly property string resolvedFullPubKey: {
+            if (!d.resolvedPubKey) {
+                return ""
+            }
+
+            if (!root.utilsStore) {
+                return d.resolvedPubKey
+            }
+
+            if (root.utilsStore.isCompressedPubKey(d.resolvedPubKey)) {
+                return root.utilsStore.getDecompressedPk(d.resolvedPubKey)
+            }
+
+            return d.resolvedPubKey
+        }
         property string elidedChatKey: realChatKey.length > 32?
                                            realChatKey.substring(0, 15) + "..." + realChatKey.substring(realChatKey.length - 16) :
                                            realChatKey
@@ -45,6 +63,33 @@ StatusDialog {
         property bool showPasteButton: true
         property bool showChatKeyValidationIndicator: false
         property int showChatKeyValidationIndicatorSize: 24
+
+        readonly property var lookedUpContactModelEntryLoader: Loader {
+            active: !!d.resolvedFullPubKey
+
+            sourceComponent: ContactModelEntry {
+                publicKey: d.resolvedFullPubKey
+                contactsModel: root.contactsStore.contactsModel
+                onPopulateContactDetailsRequested: {
+                    root.contactsStore.populateContactDetails(d.resolvedFullPubKey)
+                }
+            }
+        }
+        readonly property bool lookedUpContactAvailable: d.lookedUpContactModelEntryLoader.active
+                                                       && !!d.lookedUpContactModelEntryLoader.item
+                                                       && d.lookedUpContactModelEntryLoader.item.available
+        readonly property var lookedUpContact: d.lookedUpContactAvailable
+            ? d.lookedUpContactModelEntryLoader.item.contactDetails
+            : undefined
+        readonly property bool contactRequestAlreadySent: {
+            if (!d.lookedUpContactAvailable) {
+                return false
+            }
+
+            return d.lookedUpContact.contactRequestState === Constants.ContactRequestState.Mutual
+                   || d.lookedUpContact.contactRequestState === Constants.ContactRequestState.Sent
+                   || d.lookedUpContact.isBlocked === true
+        }
 
         property var lookupContact: Backpressure.debounce(root, 400, function (value) {
             root.contactsStore.resolveENS(value)
@@ -149,6 +194,27 @@ StatusDialog {
             }
         }
 
+        StatusBaseText {
+            visible: d.contactRequestAlreadySent
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.Wrap
+            text: {
+                if (d.lookedUpContact?.isBlocked) {
+                    return qsTr("This user is blocked. Unblock to send a contact request.")
+                }
+                switch (d.lookedUpContact?.contactRequestState) {
+                    case Constants.ContactRequestState.Sent:
+                        return qsTr("You already sent a contact request.")
+                    case Constants.ContactRequestState.Mutual:
+                        return qsTr("You are already contacts.")
+                    default:
+                        return ""
+                }
+            }
+            color: Theme.palette.dangerColor1
+        }
+
         StatusInput {
             id: messageInput
             input.edit.objectName: "SendContactRequestModal_SayWhoYouAre_Input"
@@ -176,11 +242,11 @@ StatusDialog {
 
         rightButtons: ObjectModel {
             StatusButton {
-                enabled: d.validChatKey && messageInput.valid
+                enabled: d.validChatKey && messageInput.valid && !d.contactRequestAlreadySent
                 objectName: "SendContactRequestModal_Send_Button"
                 text: qsTr("Send Contact Request")
                 onClicked: {
-                    root.contactsStore.sendContactRequest(d.resolvedPubKey, messageInput.text)
+                    root.contactsStore.sendContactRequest(d.resolvedFullPubKey, messageInput.text)
                     root.close()
                 }
             }

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -253,6 +253,7 @@ SettingsContentBase {
 
         SendContactRequestToChatKeyModal {
             contactsStore: root.contactsStore
+            utilsStore: root.utilsStore
             onClosed: destroy()
         }
     }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -16149,6 +16149,18 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>This user is blocked. Unblock to send a contact request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You already sent a contact request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You are already contacts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Say who you are / why you want to become a contact...</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -19683,6 +19683,21 @@
       <translation>Enter chat key here</translation>
     </message>
     <message>
+      <source>This user is blocked. Unblock to send a contact request.</source>
+      <comment>SendContactRequestToChatKeyModal</comment>
+      <translation>This user is blocked. Unblock to send a contact request.</translation>
+    </message>
+    <message>
+      <source>You already sent a contact request.</source>
+      <comment>SendContactRequestToChatKeyModal</comment>
+      <translation>You already sent a contact request.</translation>
+    </message>
+    <message>
+      <source>You are already contacts.</source>
+      <comment>SendContactRequestToChatKeyModal</comment>
+      <translation>You are already contacts.</translation>
+    </message>
+    <message>
       <source>Say who you are / why you want to become a contact...</source>
       <comment>SendContactRequestToChatKeyModal</comment>
       <translation>Say who you are / why you want to become a contact...</translation>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -16260,6 +16260,18 @@ selhalo</translation>
         <translation>Zde zadejte klíč chatu</translation>
     </message>
     <message>
+        <source>This user is blocked. Unblock to send a contact request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You already sent a contact request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You are already contacts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Say who you are / why you want to become a contact...</source>
         <translation>Řekněte, kdo jste / proč se chcete stát kontaktem...</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -16167,6 +16167,18 @@ al cargar</translation>
         <translation>Ingresa la clave de chat aquí</translation>
     </message>
     <message>
+        <source>This user is blocked. Unblock to send a contact request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You already sent a contact request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You are already contacts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Say who you are / why you want to become a contact...</source>
         <translation>Di quién eres / por qué quieres ser un contacto...</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -16117,6 +16117,18 @@ to load</source>
         <translation>여기에 채팅 키를 입력하세요</translation>
     </message>
     <message>
+        <source>This user is blocked. Unblock to send a contact request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You already sent a contact request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You are already contacts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Say who you are / why you want to become a contact...</source>
         <translation>당신이 누구인지, 왜 연락처가 되고 싶은지 말해주세요...</translation>
     </message>


### PR DESCRIPTION
### What does the PR do

Fixes #20146

Checks the contact model to see if we already sent a CR to that user before enabling the button

### Affected areas

ui/app/AppLayouts/Profile/popups/SendContactRequestToChatKeyModal.qml

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[resend-cr.webm](https://github.com/user-attachments/assets/e0fdd41b-94ec-4aca-ac0c-41e87bb6674a)

### Impact on end user

Disables resending a contact request. The receiver would just ignore the new one anyway

### How to test

- Send a contact request
- Go to settings
- Try to send a new one to the same user

### Risk 

Low
