### PR TITLE
fix(windows): fix downloading image to a specific folder

### DIFF
--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -1082,7 +1082,6 @@ QtObject {
                 property string imageSource
 
                 title: qsTr("Please choose a directory")
-                modality: Qt.NonModal
                 currentFolder: StandardPaths.writableLocation(StandardPaths.PicturesLocation)
 
                 onAccepted: {


### PR DESCRIPTION
### What does the PR do

Fixes #20537

The problem was that we still use of the NonModal property. Here are my findings:
- The non-modal setting was likely added intentionally in the original image-download folder picker to keep the app window interactive and allow dialog overlap in this specific flow.
- During the Qt5→Qt6 migration, that behavior appears to have been preserved rather than re-evaluated.
- Removing the non-modal setting fixes the Windows issue where the Openbutton can remain disabled after navigating into a folder.
- Main risk of removal is UX-only: the dialog may become modal and block interaction with the main window while open.
- Functional download behavior should remain intact; Android is not affected because this picker is bypassed there (save goes directly to gallery).
- Cross-platform risk is low to moderate and mostly around modality/focus behavior, not data correctness.

### Affected areas

Popups (download image folder dialog)

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality


https://github.com/user-attachments/assets/8cd7c92d-fed0-4ff5-9198-37386f4c0712



### Impact on end user

Enables easily changing the folder where to download the image on Windows

### How to test

Try to download an image and change the folder

### Risk 

Low, but worth testing on other OSes to be sure
