### PR TITLE
feat(image): show toast notification on result of downloading an image

### DIFF
--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -22,7 +22,7 @@ public:
     Q_INVOKABLE void restartApplication() const;
     Q_INVOKABLE void openAppSettings();
 
-    Q_INVOKABLE void downloadImageByUrl(const QUrl& url, const QString& path) const;
+    Q_INVOKABLE void downloadImageByUrl(const QUrl& url, const QString& path);
     Q_INVOKABLE void synthetizeRightClick(QQuickItem* item, qreal x, qreal y, Qt::KeyboardModifiers modifiers) const;
     Q_INVOKABLE Qt::KeyboardModifiers queryKeyboardModifiers();
     Q_INVOKABLE Qt::MouseButtons mouseButtons();
@@ -79,6 +79,8 @@ signals:
     void iosFilePickerAccepted(const QStringList& fileUrls);
     void iosFilePickerRejected();
     void shakeDetected();
+    void imageSavedToGallery(const QString& destination);
+    void imageSaveToGalleryFailed();
 
 private:
     int m_androidKeyboardHeight = 0;

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -300,10 +300,12 @@ Control {
                                 active: true
                                 sourceComponent: StatusMessageImageAlbum {
                                     objectName: "StatusMessage_imageAlbum"
+                                    readonly property int effectiveAlbumCount: Math.max(1, root.messageDetails.albumCount)
+
                                     width: messageLayout.width
                                     album: root.messageDetails.albumCount > 0 ? root.messageDetails.album : [root.messageDetails.messageContent]
-                                    albumCount: root.messageDetails.albumCount > 0 ? root.messageDetails.albumCount : 1
-                                    imageWidth: Math.min(messageLayout.width / root.messageDetails.albumCount - 9 * (root.messageDetails.albumCount - 1), 144)
+                                    albumCount: effectiveAlbumCount
+                                    imageWidth: Math.max(1, Math.min((messageLayout.width - 9 * (effectiveAlbumCount - 1)) / effectiveAlbumCount, 144))
                                     shapeType: StatusImageMessage.ShapeType.LEFT_ROUNDED
                                     onImageClicked: (image, mouse, imageSource, pos) => root.imageClicked(image, mouse, imageSource, pos)
                                 }

--- a/ui/StatusQ/src/ios_utils.h
+++ b/ui/StatusQ/src/ios_utils.h
@@ -4,6 +4,7 @@
 #include <QStringList>
 #include <QByteArray>
 #include <QUrl>
+#include <functional>
 
 
 using IOSShakeCallback = void (*)();
@@ -12,7 +13,7 @@ using IOSFilePickerRejectedCallback = void (*)();
 
 #ifdef Q_OS_IOS
 
-void saveImageToPhotosAlbum(const QByteArray& imageData);
+void saveImageToPhotosAlbumAsync(const QByteArray& imageData, const std::function<void(bool)>& completion);
 QString resolveIOSPhotoAsset(const QUrl &assetUrl);
 
 // Keyboard utilities

--- a/ui/StatusQ/src/ios_utils.mm
+++ b/ui/StatusQ/src/ios_utils.mm
@@ -317,12 +317,20 @@ void presentIOSPhotoLibraryPicker(bool selectMultiple)
 
 void saveImageToPhotosAlbumAsync(const QByteArray &data, const std::function<void(bool)>& completion)
 {
+    auto completeOnMain = [completion](bool success) {
+        if (!completion)
+            return;
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion(success);
+        });
+    };
+
     NSData *imageData = [NSData dataWithBytes:data.constData() length:data.length()];
     UIImage *image = [UIImage imageWithData:imageData];
     if (!image) {
         NSLog(@"Failed to save image");
-        if (completion)
-            completion(false);
+        completeOnMain(false);
         return;
     }
 
@@ -332,8 +340,7 @@ void saveImageToPhotosAlbumAsync(const QByteArray &data, const std::function<voi
         if (!success)
             NSLog(@"Failed to save image: %@", error);
 
-        if (completion)
-            completion(success);
+        completeOnMain(success);
     }];
 }
 QString resolveIOSPhotoAsset(const QUrl &assetUrl) {

--- a/ui/StatusQ/src/ios_utils.mm
+++ b/ui/StatusQ/src/ios_utils.mm
@@ -315,15 +315,26 @@ void presentIOSPhotoLibraryPicker(bool selectMultiple)
     });
 }
 
-void saveImageToPhotosAlbum(const QByteArray &data)
+void saveImageToPhotosAlbumAsync(const QByteArray &data, const std::function<void(bool)>& completion)
 {
     NSData *imageData = [NSData dataWithBytes:data.constData() length:data.length()];
     UIImage *image = [UIImage imageWithData:imageData];
-    if (image) {
-        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil);
-    } else {
+    if (!image) {
         NSLog(@"Failed to save image");
+        if (completion)
+            completion(false);
+        return;
     }
+
+    [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+        [PHAssetChangeRequest creationRequestForAssetFromImage:image];
+    } completionHandler:^(BOOL success, NSError *error) {
+        if (!success)
+            NSLog(@"Failed to save image: %@", error);
+
+        if (completion)
+            completion(success);
+    }];
 }
 QString resolveIOSPhotoAsset(const QUrl &assetUrl) {
     @autoreleasepool {

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -13,6 +13,7 @@
 #include <QTimer>
 #include <QDebug>
 #include <QMetaObject>
+#include <QPointer>
 #include <mutex>
 
 #ifdef Q_OS_ANDROID
@@ -142,7 +143,7 @@ void SystemUtilsInternal::restartApplication() const
     QMetaObject::invokeMethod(QCoreApplication::instance(), &QCoreApplication::exit, Qt::QueuedConnection, EXIT_SUCCESS);
 }
 
-void save(const QByteArray& imageData, const QString& targetDir)
+bool save(const QByteArray& imageData, const QString& targetDir)
 {
     // Get current Date/Time information to use in naming of the image file
     const auto dateTimeString = QDateTime::currentDateTime().toString(
@@ -162,7 +163,7 @@ void save(const QByteArray& imageData, const QString& targetDir)
         qWarning() << "SystemUtilsInternal::downloadImageByUrl: "
                       "Failed to create target directory:"
                    << targetDir;
-        return;
+        return false;
     }
 
     // Save the image in a safe way
@@ -171,19 +172,28 @@ void save(const QByteArray& imageData, const QString& targetDir)
         qWarning() << "SystemUtilsInternal::downloadImageByUrl: "
                         "Downloading image failed while opening the save file:"
                     << targetFile;
-        return;
+        return false;
     }
 
-    if (image.write(imageData) != -1)
-        image.commit();
-    else
+    if (image.write(imageData) == -1) {
         qWarning() << "SystemUtilsInternal::downloadImageByUrl: "
                         "Downloading image failed while saving to file:"
                     << targetFile;
+        return false;
+    }
+
+    if (!image.commit()) {
+        qWarning() << "SystemUtilsInternal::downloadImageByUrl: "
+                      "Downloading image failed while committing the save file:"
+                   << targetFile;
+        return false;
+    }
+
+    return true;
 }
 
 #ifdef Q_OS_ANDROID
-static void saveToAndroidGallery(const QByteArray& imageData)
+static bool saveToAndroidGallery(const QByteArray& imageData)
 {
     QMimeDatabase mimeDb;
     const auto mimeType = mimeDb.mimeTypeForData(imageData);
@@ -204,12 +214,12 @@ static void saveToAndroidGallery(const QByteArray& imageData)
         QFile tempFile(tempPath);
         if (!tempFile.open(QIODevice::WriteOnly)) {
             qWarning() << "saveToAndroidGallery: failed to open temp file:" << tempPath;
-            return;
+            return false;
         }
         if (tempFile.write(imageData) == -1) {
             qWarning() << "saveToAndroidGallery: failed to write temp file:" << tempPath;
             QFile::remove(tempPath);
-            return;
+            return false;
         }
     } // tempFile flushed and closed here before JNI reads it
 
@@ -225,14 +235,18 @@ static void saveToAndroidGallery(const QByteArray& imageData)
     );
     QFile::remove(tempPath);
 
-    if (!ok)
+    if (!ok) {
         qWarning() << "saveToAndroidGallery: MediaStore insertion failed for" << displayName;
+        return false;
+    }
+
+    return true;
 }
 
 #endif
 
 void SystemUtilsInternal::downloadImageByUrl(
-        const QUrl& url, const QString& path) const
+        const QUrl& url, const QString& path)
 {
     static thread_local QNetworkAccessManager manager;
     manager.setAutoDeleteReplies(true);
@@ -255,23 +269,53 @@ void SystemUtilsInternal::downloadImageByUrl(
     if (targetDir.isEmpty())
         targetDir = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
 
-    QObject::connect(reply, &QNetworkReply::finished, this, [reply, targetDir] {
+    QObject::connect(reply, &QNetworkReply::finished, this, [this, reply, targetDir] {
         if(reply->error() != QNetworkReply::NoError) {
             qWarning() << "SystemUtilsInternal::downloadImageByUrl: Downloading image"
                        << reply->request().url() << "failed:" << reply->errorString();
+            emit imageSaveToGalleryFailed();
             return;
         }
 
         // Extract the image data to be able to load and save it
         const auto btArray = reply->readAll();
-        Q_ASSERT(!btArray.isEmpty());
+        if (btArray.isEmpty()) {
+            qWarning() << "SystemUtilsInternal::downloadImageByUrl: Empty image data";
+            emit imageSaveToGalleryFailed();
+            return;
+        }
+
 #ifdef Q_OS_IOS
-        saveImageToPhotosAlbum(btArray);
-#elif defined(Q_OS_ANDROID)
-        saveToAndroidGallery(btArray);
-#else
-        save(btArray, targetDir);
+        QPointer<SystemUtilsInternal> self(this);
+        saveImageToPhotosAlbumAsync(btArray, [self](bool success) {
+            if (!self)
+                return;
+
+            QMetaObject::invokeMethod(self, [self, success]() {
+                if (success)
+                    emit self->imageSavedToGallery(QStringLiteral(""));
+                else
+                    emit self->imageSaveToGalleryFailed();
+            }, Qt::QueuedConnection);
+        });
+        return;
 #endif
+
+        bool success = false;
+        QString destination;
+    #ifdef Q_OS_ANDROID
+        success = saveToAndroidGallery(btArray);
+        // Android does not provide the saved file path back, so we return an empty string and show a generic success message
+        destination = QStringLiteral("");
+#else
+        success = save(btArray, targetDir);
+        destination = targetDir;
+#endif
+
+        if (success)
+            emit imageSavedToGallery(destination);
+        else
+            emit imageSaveToGalleryFailed();
     });
 }
 

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -99,6 +99,18 @@ QtObject {
     signal wcUriScanned(string uri)
     signal navigationEducationDialogSeenRequested()
 
+    readonly property Connections imageSaveConnections: Connections {
+        target: SystemUtils
+
+        function onImageSavedToGallery(destination) {
+            root.notifyImageSaveResult(true, destination)
+        }
+
+        function onImageSaveToGalleryFailed() {
+            root.notifyImageSaveResult(false)
+        }
+    }
+
     property var activePopupComponents: []
 
     property var sharedContactModelEntryLoader: Loader {
@@ -398,6 +410,25 @@ QtObject {
                       messageId,
                       messageStore
                   })
+    }
+
+    function notifyImageSaveResult(success, destination = "") {
+        if (success) {
+            Global.displayToastMessage(destination ? qsTr("Image saved to %1").arg(UrlUtils.displayPathLabel(destination))
+                                                   : qsTr("Image saved to system gallery"),
+                                         "",
+                                         "checkmark-circle",
+                                         false,
+                                         Constants.ephemeralNotificationType.success,
+                                         "")
+        } else {
+            Global.displayToastMessage(qsTr("Failed to save image"),
+                                         "",
+                                         "warning",
+                                         false,
+                                         Constants.ephemeralNotificationType.danger,
+                                         "")
+        }
     }
 
     function openDownloadImageDialog(imageSource) {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -14088,11 +14088,23 @@ to load</source>
 <context>
     <name>Popups</name>
     <message>
+        <source>Image saved to system gallery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Share addresses with %1&apos;s owner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Share addresses to rejoin %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image saved to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -17174,6 +17174,11 @@
   <context>
     <name>Popups</name>
     <message>
+      <source>Image saved to system gallery</source>
+      <comment>Popups</comment>
+      <translation>Image saved to system gallery</translation>
+    </message>
+    <message>
       <source>Share addresses with %1&#39;s owner</source>
       <comment>Popups</comment>
       <translation>Share addresses with %1&#39;s owner</translation>
@@ -17182,6 +17187,16 @@
       <source>Share addresses to rejoin %1</source>
       <comment>Popups</comment>
       <translation>Share addresses to rejoin %1</translation>
+    </message>
+    <message>
+      <source>Image saved to %1</source>
+      <comment>Popups</comment>
+      <translation>Image saved to %1</translation>
+    </message>
+    <message>
+      <source>Failed to save image</source>
+      <comment>Popups</comment>
+      <translation>Failed to save image</translation>
     </message>
     <message>
       <source>%1 removed from contacts and marked as untrusted</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -14193,12 +14193,24 @@ selhalo</translation>
 <context>
     <name>Popups</name>
     <message>
+        <source>Image saved to system gallery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Share addresses with %1&apos;s owner</source>
         <translation>Sdílet adresy s vlastníkem %1</translation>
     </message>
     <message>
         <source>Share addresses to rejoin %1</source>
         <translation>Sdílet adresy pro opětovné připojení k %1</translation>
+    </message>
+    <message>
+        <source>Image saved to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save image</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 removed from contacts and marked as untrusted</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -14113,8 +14113,20 @@ al cargar</translation>
         <translation>Compartir direcciones con el propietario de %1</translation>
     </message>
     <message>
+        <source>Image saved to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image saved to system gallery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Share addresses to rejoin %1</source>
         <translation>Compartir direcciones para volver a unirse a %1</translation>
+    </message>
+    <message>
+        <source>Failed to save image</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 removed from contacts and marked as untrusted</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -14058,12 +14058,24 @@ to load</source>
 <context>
     <name>Popups</name>
     <message>
+        <source>Image saved to system gallery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Share addresses with %1&apos;s owner</source>
         <translation>%1의 소유자와 주소 공유</translation>
     </message>
     <message>
         <source>Share addresses to rejoin %1</source>
         <translation>%1에 다시 참여하려면 주소를 공유하세요</translation>
+    </message>
+    <message>
+        <source>Image saved to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save image</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 removed from contacts and marked as untrusted</source>


### PR DESCRIPTION
### What does the PR do

Fixes #20537

On Android, downloading the image worked, but give no indication of how and where. With this change, users will now have a notification if it worked or not and know where it saved

### Affected areas

-SystemInternal
- Popupd

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Linux:

[save-image-linux.webm](https://github.com/user-attachments/assets/ec9b90f1-bc15-4806-8f66-6510cf849182)

Android:


https://github.com/user-attachments/assets/93177829-d24e-44f9-b99b-5f588c6bb4da

### Impact on end user

Makes it clearer that image downloads worked and where they were saved

### How to test

Download an image

### Risk 

Low, but should test on all OSes
