### PR TITLE
fix(rpc): remove proxy provider for katana

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1441,9 +1441,13 @@ Item {
                 Layout.fillWidth: true
                 relevantForCurrentSection: d.isWalletRelatedSectionType || d.activeSectionType === Constants.appSection.browser
                 websiteDown: Constants.walletConnections.blockchains
-                withCache: networkConnectionStore.balanceCache
+                withCache: networkConnectionStore.balanceCache && lastCheckedAtUnix > 0
                 networkConnectionStore: appMain.networkConnectionStore
-                tooltipMessage: qsTr("Pocket Network (POKT) & Infura are currently both unavailable for %1. Balances for those chains are as of %2.").arg(jointChainIdString).arg(lastCheckedAt)
+                tooltipMessage: {
+                    if (withCache)
+                        return qsTr("Pocket Network (POKT) & Infura are currently both unavailable for %1. Balances for those chains are as of %2.").arg(jointChainIdString).arg(lastCheckedAt)
+                    return qsTr("POKT & Infura down for %1. %1 token balances cannot be retrieved.").arg(jointChainIdString)
+                }
                 toastText: {
                     switch(connectionState) {
                     case Constants.ConnectionStatus.Success:

--- a/ui/imports/shared/stores/NetworkConnectionStore.qml
+++ b/ui/imports/shared/stores/NetworkConnectionStore.qml
@@ -80,9 +80,14 @@ QtObject {
                     chainIdsDown.push(chainId)
             }
             if(chainIdsDown.length > 0) {
-                return qsTr("Pocket Network (POKT) & Infura are currently both unavailable for %1. %1 balances are as of %2.")
-                .arg(getChainIdsJointString(chainIdsDown))
-                .arg(LocaleUtils.formatDateTime(new Date(networkConnectionModule.blockchainNetworkConnection.lastCheckedAt*1000)), Locale.ShortFormat)
+                const lastCheckedAt = networkConnectionModule.blockchainNetworkConnection.lastCheckedAt
+                if (lastCheckedAt > 0) {
+                    return qsTr("Pocket Network (POKT) & Infura are currently both unavailable for %1. %1 balances are as of %2.")
+                    .arg(getChainIdsJointString(chainIdsDown))
+                    .arg(LocaleUtils.formatDateTime(new Date(lastCheckedAt * 1000)), Locale.ShortFormat)
+                }
+                return qsTr("Requires POKT/Infura for %1, which is currently unavailable")
+                    .arg(getChainIdsJointString(chainIdsDown))
             }
         }
         return ""
@@ -102,9 +107,14 @@ QtObject {
                 chainIdsDown.push(chainId)
         }
         if(chainIdsDown.length > 0) {
-            return qsTr("Pocket Network (POKT) & Infura are currently both unavailable for %1. %1 balances are as of %2.")
-            .arg(getChainIdsJointString(chainIdsDown))
-            .arg(LocaleUtils.formatDateTime(new Date(networkConnectionModule.blockchainNetworkConnection.lastCheckedAt * 1000)), Locale.ShortFormat)
+            const lastCheckedAt = networkConnectionModule.blockchainNetworkConnection.lastCheckedAt
+            if (lastCheckedAt > 0) {
+                return qsTr("Pocket Network (POKT) & Infura are currently both unavailable for %1. %1 balances are as of %2.")
+                .arg(getChainIdsJointString(chainIdsDown))
+                .arg(LocaleUtils.formatDateTime(new Date(lastCheckedAt * 1000)), Locale.ShortFormat)
+            }
+            return qsTr("Requires POKT/Infura for %1, which is currently unavailable")
+                .arg(getChainIdsJointString(chainIdsDown))
         }
 
         return ""


### PR DESCRIPTION
* Katana status-proxy provider is removed: https://github.com/status-im/status-go/pull/7521
* Default status is set to unknown (instead of down)
* Fixed the date in the banner (balances are from 1970)

fixes #21143 