### PR TITLE
fix(Browser): Prevent access to Chrome extension messaging API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -592,9 +592,9 @@ ifeq ($(REBUILD_UI),true)
 endif
 
 ifeq ($(host_os),darwin)
- UI_SOURCES := $(shell find -E ui -type f -iregex '.*(qmldir|qml|qrc)$$' -not -iname 'resources.qrc')
+ UI_SOURCES := $(shell find -E ui -type f -iregex '.*(qmldir|qml|qrc|js)$$' -not -iname 'resources.qrc')
 else
- UI_SOURCES := $(shell find ui -type f -regextype egrep -iregex '.*(qmldir|qml|qrc)$$' -not -iname 'resources.qrc')
+ UI_SOURCES := $(shell find ui -type f -regextype egrep -iregex '.*(qmldir|qml|qrc|js)$$' -not -iname 'resources.qrc')
 endif
 
 UI_RESOURCES := resources.rcc

--- a/ui/app/AppLayouts/Browser/provider/js/webengine_runtime_guard.js
+++ b/ui/app/AppLayouts/Browser/provider/js/webengine_runtime_guard.js
@@ -1,0 +1,6 @@
+// Status does not implement Chrome extensions. Prevent page access to the
+// Chrome extension messaging API from causing crashes in QtWebEngine.
+if (window.chrome && window.chrome.runtime) {
+    window.chrome.runtime.sendMessage = undefined;
+    window.chrome.runtime.connect = undefined;
+}

--- a/ui/app/AppLayouts/Browser/provider/qml/BrowserConfig.qml
+++ b/ui/app/AppLayouts/Browser/provider/qml/BrowserConfig.qml
@@ -16,6 +16,7 @@ QtObject {
     property string httpUserAgent: ""
 
     readonly property var scriptPaths: root.featureEnabled ? [
+        { path: Qt.resolvedUrl("../js/webengine_runtime_guard.js"), runOnSubFrames: true },
         { path: Qt.resolvedUrl("../js/qwebchannel.js"), runOnSubFrames: true },
         { path: Qt.resolvedUrl("../js/ethereum_wrapper.js"), runOnSubFrames: true },
         { path: Qt.resolvedUrl("../js/eip6963_announcer.js"), runOnSubFrames: false },


### PR DESCRIPTION
Fix #21122

### What does the PR do

Meanwhile we don't support Chrome extensions in the embedded browser, prevent access to specific extension messaging APIs that can cause QtWebEngine crashes.

### Affected areas

App crashes when navigating to google meet link

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/83104084-e62f-4422-9928-fa75625eb026

### Impact on end user

No crash

### How to test

Click on a google meet link or navigate to a google meet page in browser

### Risk 

Low
