### PR TITLE
fix: skip blocking logout on mobile sign out and quit

### DIFF
--- a/src/app/core/tasks/qt.nim
+++ b/src/app/core/tasks/qt.nim
@@ -2,7 +2,8 @@ import # vendor libs
   nimqml, json_serialization
 
 import # status-desktop libs
-  ./common
+  ./common,
+  app/global/app_lifecycle
 
 type
   QObjectTaskArg* = ref object of TaskArg
@@ -10,7 +11,9 @@ type
     slot*: string
 
 proc finish*[T](arg: QObjectTaskArg, payload: T) =
+  if isShuttingDown(): return
   signal_handler(cast[pointer](arg.vptr), cstring(Json.encode(payload)), cstring(arg.slot))
 
 proc finish*(arg: QObjectTaskArg, payload: string) =
+  if isShuttingDown(): return
   signal_handler(cast[pointer](arg.vptr), cstring(payload), cstring(arg.slot))

--- a/src/app/global/app_lifecycle.nim
+++ b/src/app/global/app_lifecycle.nim
@@ -1,0 +1,9 @@
+import std/atomics
+
+var shuttingDown: Atomic[bool]
+
+proc markShuttingDown*() =
+  shuttingDown.store(true)
+
+proc isShuttingDown*(): bool =
+  shuttingDown.load()

--- a/src/app/global/global_singleton.nim
+++ b/src/app/global/global_singleton.nim
@@ -8,6 +8,7 @@ import utils
 import global_events
 import loader_deactivator
 import feature_flags
+import app_lifecycle
 
 export local_account_settings
 export local_account_sensitive_settings
@@ -30,6 +31,7 @@ when defined(ios) or defined(android):
   proc c_exit(code: cint) {.importc: "_exit", header: "<unistd.h>".}
 
 proc quit*(self: ApplicationHandle) =
+  markShuttingDown()
   if not self.app.isNil:
     self.app.quit()
 
@@ -37,6 +39,7 @@ proc quit*(self: ApplicationHandle) =
     c_exit(0) # terminates the process immediately without running any static destructors or atexit handlers — no cascade possible.
 
 proc exit*(self: ApplicationHandle) =
+  markShuttingDown()
   if not self.app.isNil:
     self.app.exit()
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -11,6 +11,7 @@ import app/modules/shared_modules/keycard_management/module as keycard_managemen
 import app/global/app_sections_config
 import app/global/app_signals
 import app/global/[global_singleton, feature_flags]
+import app/global/app_lifecycle
 import app/global/utils as utils
 import constants
 
@@ -2143,7 +2144,15 @@ proc runStartUsingKeycardForProfilePopup[T](self: Module[T]) =
 
 method signOutAndQuit*[T](self: Module[T]) =
   info "signOutAndQuit: logging out and quitting"
-  self.controller.logout()
+  markShuttingDown()
+  when defined(ios) or defined(android):
+    # Since on mobile devices, application.exit() ends in _exit(0), a graceful status_go.logout() is unnecessary
+    # cause it does a few other things (stops the node, closes the DBs, then re-initializes the node and restarts
+    # the media server, all synchronously on the UI thread) that are not needed on mobile devices.
+    # Desktop keeps the graceful logout (no _exit; the event loop unwinds).
+    discard
+  else:
+    self.controller.logout()
   singletonInstance.application.exit()
 
 method checkAndPerformProfileMigrationIfNeeded*[T](self: Module[T]) =

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -12,6 +12,7 @@ import statusq_bridge
 
 import app/global/global_singleton
 import app/global/local_app_settings
+import app/global/app_lifecycle
 import app/boot/app_controller
 
 featureGuard KEYCARD_ENABLED:
@@ -75,7 +76,7 @@ proc prepareLogging() =
       output.writer =
         proc (logLevel: LogLevel, msg: LogOutputStr) {.gcsafe, raises: [].} =
           try:
-            if signalsManagerQObjPointer != nil:
+            if not isShuttingDown() and signalsManagerQObjPointer != nil:
               signal_handler(signalsManagerQObjPointer, ($(%* {"type": "chronicles-log", "event": msg})).cstring, "receiveChroniclesLogEvent")
           except:
             logLoggingFailure(cstring(msg), getCurrentException())
@@ -96,12 +97,14 @@ proc setupRemoteSignalsHandling() =
   # it will be passed as a regular C function to statusgo_backend. This means that
   # we cannot capture any local variables here (we must rely on globals)
   var callbackStatusGo: status_go.SignalCallback = proc(p0: cstring) {.cdecl.} =
+    if isShuttingDown(): return
     if signalsManagerQObjPointer != nil:
       signal_handler(signalsManagerQObjPointer, p0, "receiveSignal")
   status_go.setSignalEventCallback(callbackStatusGo)
 
   featureGuard KEYCARD_ENABLED:
     var callbackKeycardGo: keycard_go.KeycardSignalCallback = proc(p0: cstring) {.cdecl.} =
+      if isShuttingDown(): return
       if keycardServiceV2QObjPointer != nil:
         signal_handler(keycardServiceV2QObjPointer, p0, "receiveKeycardSignalV2")
       if keycardServiceQObjPointer != nil:


### PR DESCRIPTION
logout() stops/re-inits the node synchronously on the UI thread and freezes the app since _exit(0) reclaims the process anyway, skip it on iOS/Android and exit immediately is safe. Desktop remains the same, since it doesn't call _exit(0).

Fixes #21146 and #21120