### PR TITLE
fix(e2e_appium): scroll seed Continue button into view before tapping

### DIFF
--- a/test/e2e_appium/pages/onboarding/seed_phrase_input_page.py
+++ b/test/e2e_appium/pages/onboarding/seed_phrase_input_page.py
@@ -73,17 +73,27 @@ class SeedPhraseInputPage(BasePage):
     def click_continue(self) -> bool:
         self.logger.info("Clicking Continue button")
 
-        # btnContinue sits BELOW the seed-input column inside SeedphrasePage's
-        # StatusScrollView. With 12+ fields above it the button is offscreen
-        # and Qt does not surface offscreen elements via accessibility — so a
-        # plain xpath search returns nothing. Scroll it into view first.
-        if not self.is_element_visible(self.locators.CONTINUE_BUTTON, timeout=2):
-            self.scroll_to_element(
-                self.locators.CONTINUE_BUTTON, max_swipes=4, timeout=2,
+        # btnContinue sits at the bottom of SeedphrasePage's StatusScrollView
+        # and is clipped at the scroll boundary until scrolled to — it is in the
+        # a11y tree but not painted, so taps miss. scroll_to_element early-returns
+        # (Qt marks the clipped button "visible"), so swipe to the bottom
+        # explicitly to render it, then tap.
+        size = self.driver.get_window_size()
+        cx = int(size["width"] * 0.5)
+        for _ in range(5):
+            self.driver.swipe(
+                cx, int(size["height"] * 0.85), cx, int(size["height"] * 0.35), 400
             )
+            time.sleep(0.3)
 
-        if self.safe_click(self.locators.CONTINUE_BUTTON):
-            self.logger.info("✅ Continue button clicked successfully")
+        button = self.find_element_safe(self.locators.CONTINUE_BUTTON, timeout=5)
+        if not button:
+            self.logger.error("❌ Failed to find Continue button")
+            return False
+
+        rect = button.rect
+        if self.tap_coordinate_relative(button, rect["width"] // 2, rect["height"] // 2):
+            self.logger.info("✅ Continue button tapped")
             return True
 
         self.logger.error("❌ Failed to click Continue button")

--- a/test/e2e_appium/tests/test_onboarding_import_seed.py
+++ b/test/e2e_appium/tests/test_onboarding_import_seed.py
@@ -122,17 +122,10 @@ class TestOnboardingImportSeed(StepMixin):
 
         return base
 
-    # Smoke-only (not gate) until the Continue-button registration issue is
-    # resolved upstream: on Pixel 8 (and CI's Android emulator) the seed-page
-    # Continue button sits at Y=2276 of a 2400px screen; gesture-tap dispatch
-    # at that edge is non-deterministic and Status sometimes ignores the
-    # click entirely. Reproducible across two consecutive runs on the same
-    # APK; passes reliably on Pi (Samsung A36, Moto G55) which have a
-    # different viewport.
+    @pytest.mark.gate
     @pytest.mark.smoke
     @pytest.mark.onboarding
     @pytest.mark.raw_devices
-    @pytest.mark.flaky(reruns=1, reruns_delay=5)
     async def test_import_seed_phrase(self):
         """First-time seed-phrase import: onboard + verify wallet address.
 


### PR DESCRIPTION
Fixes #21148

## Problem
`test_import_seed_phrase` fails on the Android nightly (BrowserStack, Pixel 8). After entering a valid 12-word recovery phrase, the test taps **Continue** but the app never reaches the Create Password step, so it times out.

## Cause
The Continue button is at the bottom of the recovery-phrase scroll view. With all 12 fields filled, the view stays scrolled to the top and the button is clipped at the scroll edge — it is in the accessibility tree (`clickable`/`enabled`) but not painted, so taps and clicks land on nothing. `scroll_to_element` skips scrolling because the clipped button is reported as "visible".

## Fix
Scroll to the bottom to render the button before tapping. Also re-enables the test as a `gate` test and drops the temporary `flaky(reruns=1)` workaround (the failure was deterministic, not flaky).

## Testing
BrowserStack Pixel 8 / Android 14: failed reliably before, passes after (two consecutive green runs, no rerun).