### PR TITLE
feat(A11YInformationTag): implement a basic warning panel component

### DIFF
--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -11,6 +11,8 @@ import android.net.Uri;
 import android.provider.Settings;
 import android.util.Log;
 import im.status.mobileui.PushNotificationHelper;
+import android.content.ActivityNotFoundException;
+import android.widget.Toast;
 
 public class StatusQtActivity extends QtActivity {
     private static final String TAG = "StatusQtActivity";
@@ -138,6 +140,19 @@ public class StatusQtActivity extends QtActivity {
             Uri uri = Uri.fromParts("package", sInstance.getPackageName(), null);
             intent.setData(uri);
             sInstance.startActivity(intent);
+        }
+    }
+
+    // Opens the system Accessibility Settings screen. Called from Qt via JNI.
+    public static void openAccessibilitySettings() {
+        if (sInstance == null) return;
+        try {
+            Intent intent = new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            sInstance.startActivity(intent);
+        } catch (ActivityNotFoundException e) {
+            // Handle the rare case where the settings activity doesn't exist
+            Toast.makeText(sInstance, "Unable to open Accessibility Settings", Toast.LENGTH_SHORT).show();
         }
     }
 }

--- a/storybook/pages/EnterSeedPhrasePage.qml
+++ b/storybook/pages/EnterSeedPhrasePage.qml
@@ -13,9 +13,6 @@ import StatusQ.Core.Theme
 import Models
 import Storybook
 
-import SortFilterProxyModel
-import QtModelsToolkit
-
 import shared
 import shared.panels
 import utils

--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -21,10 +21,16 @@ public:
     Q_INVOKABLE QString qtRuntimeVersion() const;
     Q_INVOKABLE void restartApplication() const;
     Q_INVOKABLE void openAppSettings();
+
     Q_INVOKABLE void downloadImageByUrl(const QUrl& url, const QString& path) const;
     Q_INVOKABLE void synthetizeRightClick(QQuickItem* item, qreal x, qreal y, Qt::KeyboardModifiers modifiers) const;
     Q_INVOKABLE Qt::KeyboardModifiers queryKeyboardModifiers();
     Q_INVOKABLE Qt::MouseButtons mouseButtons();
+
+    // a11y helpers
+    Q_INVOKABLE bool isScreenReaderActive() const;
+    Q_INVOKABLE bool hasAccessibilitySettings() const;
+    Q_INVOKABLE void openAccessibilitySettings();
 
     // Set Android status bar icon color (true = light/white icons, false = dark/black icons)
     Q_INVOKABLE void setAndroidStatusBarIconColor(bool lightIcons);

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -275,7 +275,6 @@ void SystemUtilsInternal::downloadImageByUrl(
     });
 }
 
-
 void SystemUtilsInternal::openAppSettings()
 {
 #ifdef Q_OS_ANDROID
@@ -291,6 +290,42 @@ void SystemUtilsInternal::openAppSettings()
 #else
     // Desktop - we shouldn't be here
     qWarning() << "openAppSettings not implemented for this platform";
+#endif
+}
+
+bool SystemUtilsInternal::isScreenReaderActive() const
+{
+#ifdef Q_OS_IOS
+    return false;
+#else
+    // TODO extend with OS native checks
+    return true;
+#endif
+}
+
+bool SystemUtilsInternal::hasAccessibilitySettings() const
+{
+    // NOTE: see also SystemUtilsInternal::openAccessibilitySettings() below
+#if defined(Q_OS_ANDROID) || defined(Q_OS_LINUX)
+    return true;
+#else
+    return false;
+#endif
+}
+
+void SystemUtilsInternal::openAccessibilitySettings()
+{
+    // NOTE: see also SystemUtilsInternal::hasAccessibilitySettings() above
+#ifdef Q_OS_ANDROID
+    QJniObject::callStaticMethod<void>(
+        "app/status/mobile/StatusQtActivity",
+        "openAccessibilitySettings",
+        "()V"
+        );
+#elif defined(Q_OS_LINUX)
+    QProcess::startDetached(QStringLiteral("gnome-control-center"), {QStringLiteral("universal-access")});
+#else
+    qWarning() << "SystemUtilsInternal::openAccessibilitySettings not implemented for this platform";
 #endif
 }
 

--- a/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
@@ -160,7 +160,7 @@ Item {
 
                     StatusBaseText {
                         Layout.alignment: Qt.AlignVCenter
-                        font.pixelSize: Theme.additionalTextFontSize
+                        font.pixelSize: Theme.additionalTextSize
                         text: pendingStateText
                         color: Theme.palette.baseColor1
                     }

--- a/ui/app/AppLayouts/Onboarding/pages/BackupSeedphraseReveal.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/BackupSeedphraseReveal.qml
@@ -11,6 +11,7 @@ import StatusQ.Core.Utils as SQUtils
 
 import AppLayouts.Onboarding.components
 
+import shared.controls
 import utils
 
 OnboardingPage {
@@ -31,111 +32,110 @@ OnboardingPage {
         readonly property var mnemonicWords: Utils.splitWords(root.mnemonic)
     }
 
-    contentItem: Item {
-        ColumnLayout {
-            anchors.centerIn: parent
-            width: Math.min(440, root.availableWidth)
-            spacing: Theme.xlPadding
+    contentItem: ColumnLayout {
+        width: Math.min(440, root.availableWidth)
+        spacing: Theme.smallPadding
 
-            StatusBaseText {
-                Layout.fillWidth: true
-                text: root.title
-                visible: !root.popupMode
-                font.pixelSize: Theme.fontSize(22)
-                font.bold: true
-                wrapMode: Text.WordWrap
-                horizontalAlignment: Text.AlignHCenter
-            }
+        StatusBaseText {
+            Layout.fillWidth: true
+            text: root.title
+            visible: !root.popupMode
+            font.pixelSize: Theme.fontSize(22)
+            font.bold: true
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+        }
 
-            StatusBaseText {
-                Layout.fillWidth: true
-                text: qsTr("A 12-word phrase that gives full access to your funds and is the only way to recover them.")
-                wrapMode: Text.WordWrap
-                horizontalAlignment: Text.AlignHCenter
-            }
+        StatusBaseText {
+            Layout.fillWidth: true
+            text: qsTr("A 12-word phrase that gives full access to your funds and is the only way to recover them. Make sure nothing can see or record your screen.")
+            wrapMode: Text.WordWrap
+        }
 
-            Item {
-                Layout.fillWidth: true
-                Layout.preferredHeight: seedGrid.height
+        A11YInformationTag {
+            Layout.fillWidth: true
+            visible: !d.seedphraseRevealed
+        }
 
-                GridLayout {
-                    objectName: "seedGrid"
-                    id: seedGrid
-                    width: parent.width
-                    columns: 2
-                    columnSpacing: Theme.halfPadding
-                    rowSpacing: columnSpacing
+        Item {
+            Layout.fillWidth: true
+            Layout.preferredHeight: seedGrid.height
 
-                    Repeater {
-                        model: d.mnemonicWords
-                        delegate: Frame {
-                            Layout.fillWidth: true
-                            Layout.fillHeight: true
-                            padding: Theme.smallPadding
-                            background: Rectangle {
-                                radius: Theme.radius
-                                color: "transparent"
-                                border.width: 1
-                                border.color: Theme.palette.baseColor2
+            GridLayout {
+                objectName: "seedGrid"
+                id: seedGrid
+                width: parent.width
+                columns: 2
+                columnSpacing: Theme.halfPadding
+                rowSpacing: columnSpacing
+
+                Repeater {
+                    model: d.mnemonicWords
+                    delegate: Frame {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        padding: Theme.smallPadding
+                        background: Rectangle {
+                            radius: Theme.radius
+                            color: "transparent"
+                            border.width: 1
+                            border.color: Theme.palette.baseColor2
+                        }
+                        contentItem: RowLayout {
+                            spacing: Theme.halfPadding
+                            StatusBaseText {
+                                Layout.preferredWidth: idxMetrics.advanceWidth
+                                horizontalAlignment: Qt.AlignHCenter
+                                text: index + 1
+                                color: Theme.palette.baseColor1
+                                font: idxMetrics.font
                             }
-                            contentItem: RowLayout {
-                                spacing: Theme.halfPadding
-                                StatusBaseText {
-                                    Layout.preferredWidth: idxMetrics.advanceWidth
-                                    horizontalAlignment: Qt.AlignHCenter
-                                    text: index + 1
-                                    color: Theme.palette.baseColor1
-                                    font: idxMetrics.font
-                                }
-                                StatusBaseText {
-                                    objectName: "seedWordText_" + (index+1)
-                                    Layout.fillWidth: true
-                                    text: modelData
-                                    Accessible.role: Accessible.StaticText
-                                    Accessible.name: SQUtils.Utils.formatAccessibleName(modelData, objectName)
-                                }
+                            StatusBaseText {
+                                objectName: "seedWordText_" + (index+1)
+                                Layout.fillWidth: true
+                                text: modelData
+                                Accessible.role: Accessible.StaticText
+                                Accessible.name: SQUtils.Utils.formatAccessibleName(modelData, objectName)
                             }
                         }
                     }
-                    layer.enabled: !d.seedphraseRevealed
-                    layer.effect: GaussianBlur {
-                        radius: 16
-                        samples: 33
-                        transparentBorder: true
-                    }
                 }
-
-                StatusButton {
-                    objectName: "btnReveal"
-                    anchors.centerIn: parent
-                    text: qsTr("Reveal recovery phrase")
-                    icon.name: "show"
-                    type: StatusBaseButton.Type.Primary
-                    visible: !d.seedphraseRevealed
-                    onClicked: {
-                        d.seedphraseRevealed = true
-                    }
+                layer.enabled: !d.seedphraseRevealed
+                layer.effect: GaussianBlur {
+                    radius: samples/2 - 1
+                    samples: 64
+                    transparentBorder: true
                 }
-            }
-
-            StatusBaseText {
-                Layout.fillWidth: true
-                text: qsTr("Never share your recovery phrase. If someone asks for it, they’re likely trying to scam you.\n\nTo backup you recovery phrase, write it down and store it securely in a safe place.")
-                font.pixelSize: Theme.additionalTextSize
-                font.weight: Font.Medium
-                wrapMode: Text.WordWrap
             }
 
             StatusButton {
-                objectName: "btnConfirm"
-                Layout.alignment: Qt.AlignHCenter
-                visible: !root.popupMode
-                text: qsTr("Confirm recovery phrase")
-                enabled: d.seedphraseRevealed
+                objectName: "btnReveal"
+                anchors.centerIn: parent
+                text: qsTr("Reveal recovery phrase")
+                icon.name: "show"
+                type: StatusBaseButton.Type.Primary
+                visible: !d.seedphraseRevealed
                 onClicked: {
-                    root.backupSeedphraseConfirmed()
-                    d.seedphraseRevealed = false
+                    d.seedphraseRevealed = true
                 }
+            }
+        }
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            text: qsTr("Never share your recovery phrase. Anyone asking for it is trying to scam you. To back up your recovery phrase, write it down and store it securely.")
+            wrapMode: Text.WordWrap
+        }
+
+        StatusButton {
+            objectName: "btnConfirm"
+            Layout.alignment: Qt.AlignHCenter
+            visible: !root.popupMode
+            text: qsTr("Confirm recovery phrase")
+            enabled: d.seedphraseRevealed
+            onClicked: {
+                root.backupSeedphraseConfirmed()
+                d.seedphraseRevealed = false
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/popups/BackupSeedModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/BackupSeedModal.qml
@@ -20,7 +20,8 @@ StatusDialog {
 
     padding: Theme.halfPadding
     implicitWidth: 480
-    implicitHeight: 640
+    implicitHeight: 700
+    fillHeightOnBottomSheet: true
 
     footer: StatusDialogFooter {
         leftButtons: ObjectModel {

--- a/ui/app/AppLayouts/Profile/views/PrivacyAndSecurityView.qml
+++ b/ui/app/AppLayouts/Profile/views/PrivacyAndSecurityView.qml
@@ -77,13 +77,12 @@ SettingsContentBase {
                 id: infoTag
 
                 Layout.preferredWidth: root.contentWidth
-                Layout.preferredHeight: 40
                 Layout.alignment: Qt.AlignHCenter
 
                 leftInset: Theme.padding
                 rightInset: Theme.padding
-                leftPadding: horizontalPadding + Theme.padding
-                rightPadding: horizontalPadding + Theme.padding
+                horizontalPadding: Theme.padding
+                spacing: 12
 
                 backgroundColor: Theme.palette.primaryColor3
                 bgBorderColor: Theme.palette.primaryColor2

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2,6 +2,29 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="en_US" sourcelanguage="en">
 <context>
+    <name>A11YInformationTag</name>
+    <message>
+        <source>Accessibility services on your device may access screen content. Check your device&apos;s %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Settings &gt; Accessibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessibility services on your computer may access screen content. Check your operating system&apos;s %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessibility services on your device may access screen content. Check your device&apos;s Accessibility settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessibility services on your computer may access screen content. Check your operating system&apos;s Accessibility settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AboutView</name>
     <message>
         <source>Check for updates</source>
@@ -2141,7 +2164,7 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>A 12-word phrase that gives full access to your funds and is the only way to recover them.</source>
+        <source>A 12-word phrase that gives full access to your funds and is the only way to recover them. Make sure nothing can see or record your screen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2149,9 +2172,7 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Never share your recovery phrase. If someone asks for it, they’re likely trying to scam you.
-
-To backup you recovery phrase, write it down and store it securely in a safe place.</source>
+        <source>Never share your recovery phrase. Anyone asking for it is trying to scam you. To back up your recovery phrase, write it down and store it securely.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -1,6 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TS language="en" sourcelanguage="en">
   <context>
+    <name>A11YInformationTag</name>
+    <message>
+      <source>Accessibility services on your device may access screen content. Check your device&#39;s %1.</source>
+      <comment>A11YInformationTag</comment>
+      <translation>Accessibility services on your device may access screen content. Check your device&#39;s %1.</translation>
+    </message>
+    <message>
+      <source>Settings &gt; Accessibility</source>
+      <comment>A11YInformationTag</comment>
+      <translation>Settings &gt; Accessibility</translation>
+    </message>
+    <message>
+      <source>Accessibility services on your computer may access screen content. Check your operating system&#39;s %1.</source>
+      <comment>A11YInformationTag</comment>
+      <translation>Accessibility services on your computer may access screen content. Check your operating system&#39;s %1.</translation>
+    </message>
+    <message>
+      <source>Accessibility services on your device may access screen content. Check your device&#39;s Accessibility settings.</source>
+      <comment>A11YInformationTag</comment>
+      <translation>Accessibility services on your device may access screen content. Check your device&#39;s Accessibility settings.</translation>
+    </message>
+    <message>
+      <source>Accessibility services on your computer may access screen content. Check your operating system&#39;s Accessibility settings.</source>
+      <comment>A11YInformationTag</comment>
+      <translation>Accessibility services on your computer may access screen content. Check your operating system&#39;s Accessibility settings.</translation>
+    </message>
+  </context>
+  <context>
     <name>AboutView</name>
     <message>
       <source>Check for updates</source>
@@ -2631,9 +2659,9 @@
       <translation>Show recovery phrase</translation>
     </message>
     <message>
-      <source>A 12-word phrase that gives full access to your funds and is the only way to recover them.</source>
+      <source>A 12-word phrase that gives full access to your funds and is the only way to recover them. Make sure nothing can see or record your screen.</source>
       <comment>BackupSeedphraseReveal</comment>
-      <translation>A 12-word phrase that gives full access to your funds and is the only way to recover them.</translation>
+      <translation>A 12-word phrase that gives full access to your funds and is the only way to recover them. Make sure nothing can see or record your screen.</translation>
     </message>
     <message>
       <source>Reveal recovery phrase</source>
@@ -2641,9 +2669,9 @@
       <translation>Reveal recovery phrase</translation>
     </message>
     <message>
-      <source>Never share your recovery phrase. If someone asks for it, they’re likely trying to scam you.&#xA;&#xA;To backup you recovery phrase, write it down and store it securely in a safe place.</source>
+      <source>Never share your recovery phrase. Anyone asking for it is trying to scam you. To back up your recovery phrase, write it down and store it securely.</source>
       <comment>BackupSeedphraseReveal</comment>
-      <translation>Never share your recovery phrase. If someone asks for it, they’re likely trying to scam you.&#xA;&#xA;To backup you recovery phrase, write it down and store it securely in a safe place.</translation>
+      <translation>Never share your recovery phrase. Anyone asking for it is trying to scam you. To back up your recovery phrase, write it down and store it securely.</translation>
     </message>
     <message>
       <source>Confirm recovery phrase</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2,6 +2,29 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="cs_CZ" sourcelanguage="en_US">
 <context>
+    <name>A11YInformationTag</name>
+    <message>
+        <source>Accessibility services on your device may access screen content. Check your device&apos;s %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Settings &gt; Accessibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessibility services on your computer may access screen content. Check your operating system&apos;s %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessibility services on your device may access screen content. Check your device&apos;s Accessibility settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessibility services on your computer may access screen content. Check your operating system&apos;s Accessibility settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AboutView</name>
     <message>
         <source>Check for updates</source>
@@ -2149,20 +2172,16 @@ z &quot;%1&quot; na &quot;%2&quot;</translation>
         <translation>Zobrazit obnovovací frázi</translation>
     </message>
     <message>
-        <source>A 12-word phrase that gives full access to your funds and is the only way to recover them.</source>
-        <translation>12slovná fráze, která dává plný přístup k vašim prostředkům a je jediným způsobem, jak je obnovit.</translation>
+        <source>A 12-word phrase that gives full access to your funds and is the only way to recover them. Make sure nothing can see or record your screen.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reveal recovery phrase</source>
         <translation>Odhalit obnovovací frázi</translation>
     </message>
     <message>
-        <source>Never share your recovery phrase. If someone asks for it, they’re likely trying to scam you.
-
-To backup you recovery phrase, write it down and store it securely in a safe place.</source>
-        <translation>Nikdy nesdílejte svou obnovovací frázi. Pokud o ni někdo požádá, pravděpodobně se vás snaží podvést.
-
-Pro zálohování obnovovací fráze si ji zapište a bezpečně uložte na bezpečné místo.</translation>
+        <source>Never share your recovery phrase. Anyone asking for it is trying to scam you. To back up your recovery phrase, write it down and store it securely.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Confirm recovery phrase</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2,6 +2,29 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="es_ES">
 <context>
+    <name>A11YInformationTag</name>
+    <message>
+        <source>Accessibility services on your device may access screen content. Check your device&apos;s %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Settings &gt; Accessibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessibility services on your computer may access screen content. Check your operating system&apos;s %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessibility services on your device may access screen content. Check your device&apos;s Accessibility settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessibility services on your computer may access screen content. Check your operating system&apos;s Accessibility settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AboutView</name>
     <message>
         <source>Check for updates</source>
@@ -2142,20 +2165,16 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
         <translation>Mostrar frase de recuperación</translation>
     </message>
     <message>
-        <source>A 12-word phrase that gives full access to your funds and is the only way to recover them.</source>
-        <translation>Una frase de 12 palabras que otorga acceso completo a tus fondos y es la única forma de recuperarlos.</translation>
+        <source>A 12-word phrase that gives full access to your funds and is the only way to recover them. Make sure nothing can see or record your screen.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reveal recovery phrase</source>
         <translation>Revelar frase de recuperación</translation>
     </message>
     <message>
-        <source>Never share your recovery phrase. If someone asks for it, they’re likely trying to scam you.
-
-To backup you recovery phrase, write it down and store it securely in a safe place.</source>
-        <translation>Nunca compartas tu frase de recuperación. Si alguien te la pide, probablemente está intentando estafarte.
-
-Para respaldar tu frase de recuperación, escríbela y guárdala de forma segura en un lugar seguro.</translation>
+        <source>Never share your recovery phrase. Anyone asking for it is trying to scam you. To back up your recovery phrase, write it down and store it securely.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Confirm recovery phrase</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2,6 +2,29 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ko_KR">
 <context>
+    <name>A11YInformationTag</name>
+    <message>
+        <source>Accessibility services on your device may access screen content. Check your device&apos;s %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Settings &gt; Accessibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessibility services on your computer may access screen content. Check your operating system&apos;s %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessibility services on your device may access screen content. Check your device&apos;s Accessibility settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accessibility services on your computer may access screen content. Check your operating system&apos;s Accessibility settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AboutView</name>
     <message>
         <source>Check for updates</source>
@@ -2134,20 +2157,16 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>복구 문구 보기</translation>
     </message>
     <message>
-        <source>A 12-word phrase that gives full access to your funds and is the only way to recover them.</source>
-        <translation>자금을 완전히 접근할 수 있게 해 주며, 복구할 수 있는 유일한 12단어 시드 구문입니다.</translation>
+        <source>A 12-word phrase that gives full access to your funds and is the only way to recover them. Make sure nothing can see or record your screen.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reveal recovery phrase</source>
         <translation>복구 구문 표시</translation>
     </message>
     <message>
-        <source>Never share your recovery phrase. If someone asks for it, they’re likely trying to scam you.
-
-To backup you recovery phrase, write it down and store it securely in a safe place.</source>
-        <translation>복구 구문은 절대 공유하지 마세요. 누군가 복구 구문을 요구한다면, 사기를 시도하는 가능성이 큽니다.
-
-복구 구문을 백업하려면, 종이에 적어 안전한 장소에 보관하세요.</translation>
+        <source>Never share your recovery phrase. Anyone asking for it is trying to scam you. To back up your recovery phrase, write it down and store it securely.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Confirm recovery phrase</source>

--- a/ui/imports/shared/controls/A11YInformationTag.qml
+++ b/ui/imports/shared/controls/A11YInformationTag.qml
@@ -1,0 +1,47 @@
+import QtQuick
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Core.Utils as SQUtils
+
+import utils
+
+InformationTag {
+    id: root
+
+    visible: SystemUtils.isScreenReaderActive()
+
+    horizontalPadding: 0
+    verticalPadding: Theme.halfPadding
+    spacing: Theme.padding
+
+    backgroundColor: Theme.palette.primaryColor3
+    bgBorderColor: Theme.palette.transparent
+    bgRadius: Theme.radius
+    asset.name: "info"
+    asset.width: 20
+    asset.height: 20
+    asset.bgWidth: 20
+    asset.bgHeight: 20
+    tagPrimaryLabel.textFormat: Text.RichText
+    tagPrimaryLabel.font.pixelSize: Theme.primaryTextFontSize
+    tagPrimaryLabel.text: {
+        if (SystemUtils.hasAccessibilitySettings()) {
+            if (SQUtils.Utils.isMobile)
+                return qsTr("Accessibility services on your device may access screen content. Check your device's %1.")
+                       .arg(Utils.getStyledLink(qsTr("Settings > Accessibility"), "#", tagPrimaryLabel.hoveredLink, Theme.palette.primaryColor1, Theme.palette.primaryColor1, false))
+            return qsTr("Accessibility services on your computer may access screen content. Check your operating system's %1.")
+                   .arg(Utils.getStyledLink(qsTr("Settings > Accessibility"), "#", tagPrimaryLabel.hoveredLink, Theme.palette.primaryColor1, Theme.palette.primaryColor1, false))
+        }
+        if (SQUtils.Utils.isMobile)
+            return qsTr("Accessibility services on your device may access screen content. Check your device's Accessibility settings.")
+        return qsTr("Accessibility services on your computer may access screen content. Check your operating system's Accessibility settings.")
+    }
+
+    HoverHandler {
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
+        cursorShape: !!tagPrimaryLabel.hoveredLink ? Qt.PointingHandCursor : undefined
+    }
+
+    tagPrimaryLabel.onLinkActivated: SystemUtils.openAccessibilitySettings()
+}

--- a/ui/imports/shared/controls/InformationTag.qml
+++ b/ui/imports/shared/controls/InformationTag.qml
@@ -54,21 +54,22 @@ Control {
         }
         StatusSmartIdenticon {
             id: smartIdenticon
-            Layout.maximumWidth: visible ? 16 : 0
-            Layout.maximumHeight: visible ? 16 : 0
+            Layout.maximumWidth: visible ? asset.bgWidth : 0
+            Layout.maximumHeight: visible ? asset.bgHeight : 0
             asset.width: visible ? 16 : 0
             asset.height: visible ? 16 : 0
-            asset.bgHeight: visible ? 16 : 0
-            asset.bgWidth: visible ? 16 : 0
+            asset.bgHeight: visible ? asset.height : 0
+            asset.bgWidth: visible ? asset.width : 0
             asset.color: Theme.palette.directColor1
             visible: !!asset.name
         }
         StatusBaseText {
             id: tagPrimaryLabel
-            Layout.maximumWidth: root.availableWidth
+            Layout.fillWidth: true
             font.pixelSize: Theme.tertiaryTextFontSize
             visible: text !== ""
             elide: Text.ElideRight
+            wrapMode: Text.Wrap
         }
         StatusBaseText {
             id: middleLabel

--- a/ui/imports/shared/controls/qmldir
+++ b/ui/imports/shared/controls/qmldir
@@ -1,3 +1,4 @@
+A11YInformationTag 1.0 A11YInformationTag.qml
 AccountSelector 1.0 AccountSelector.qml
 AccountSelectorHeader 1.0 AccountSelectorHeader.qml
 AmountInput 1.0 AmountInput.qml

--- a/ui/imports/shared/panels/EnterSeedPhrase.qml
+++ b/ui/imports/shared/panels/EnterSeedPhrase.qml
@@ -8,6 +8,8 @@ import StatusQ.Core.Theme
 import StatusQ.Core.Utils
 import StatusQ.Controls
 
+import shared.controls
+
 import QtModelsToolkit
 import SortFilterProxyModel
 
@@ -181,6 +183,11 @@ Control {
     contentItem: ColumnLayout {
         spacing: d.spacing
 
+        A11YInformationTag {
+            Layout.fillWidth: true
+            Layout.bottomMargin: Theme.bigPadding
+        }
+
         StatusSeedPhraseTabBar {
             id: lengthBar
 
@@ -196,6 +203,7 @@ Control {
         GridLayout {
             id: grid
 
+            Layout.topMargin: Theme.padding
             columnSpacing: d.spacing
             rowSpacing: d.spacing
 


### PR DESCRIPTION
### What does the PR do

- ... for any potential Accessibility (A11) services running (e.g. a screen reader)
- the warning panel is displayed when entering/revealing the seed phrase, in both Onboarding and Settings/Backupseed flows
- to be extended in 2.39 with more complete and dynamic checks (see https://github.com/status-im/status-app/pull/20971)

Fixes #21134

### Affected areas

Seedphrase screens

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2262" height="1506" alt="image" src="https://github.com/user-attachments/assets/507e633c-86ff-4c81-b6e0-98c5edc94649" />

<img width="2944" height="1832" alt="image" src="https://github.com/user-attachments/assets/fdd9017f-87b3-4b9c-8a92-48cc8d669649" />



### Impact on end user

Potentially safer seedphrase handling in the UI

### How to test

- launch any of the mentioned flows
- a warning panel should be displayed when entering/revealing the seedphrase

### Risk 

low
