### PR TITLE
fix(android): restart frontend if the backend is dead

### DIFF
--- a/mobile/android/qt6/src/app/status/mobile/StatusGoStub.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusGoStub.java
@@ -64,5 +64,10 @@ public final class StatusGoStub {
     public static void setContext(Context context) {
         sContext = context.getApplicationContext();
     }
+
+    /** Returns application context if initialized; null otherwise. */
+    public static Context getContext() {
+        return sContext;
+    }
 }
 

--- a/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoServiceClient.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoServiceClient.java
@@ -4,8 +4,10 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.os.Handler;
 import android.os.Build;
 import android.os.IBinder;
+import android.os.Looper;
 import android.os.Process;
 import android.os.RemoteException;
 import android.system.ErrnoException;
@@ -15,6 +17,7 @@ import org.json.JSONObject;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.nio.charset.StandardCharsets;
 
 import app.status.mobile.StatusGoStub;
@@ -24,8 +27,13 @@ public final class StatusGoServiceClient {
     private static final String TAG = "StatusGoServiceClient";
     private static final long CONNECT_TIMEOUT_MS = 8000;
     private static final int LARGE_SIGNAL_WARN_BYTES = 256 * 1024;
+    private static final long RESTART_KILL_DELAY_MS = 250L;
+    private static final long DISCONNECT_SUPPRESSION_WINDOW_MS = 1000L;
 
     private static volatile StatusGoServiceClient sInstance;
+    private static final AtomicBoolean restartRequested = new AtomicBoolean(false);
+    private static final AtomicBoolean suppressDisconnectRestart = new AtomicBoolean(false);
+    private static final Handler MAIN_HANDLER = new Handler(Looper.getMainLooper());
 
     /** Fire-and-forget background thread (dies when work finishes); avoids a long-lived executor. */
     private static void runUiVisibilityAsync(Runnable r) {
@@ -53,6 +61,8 @@ public final class StatusGoServiceClient {
     private volatile boolean desiredUiVisible = false;
     // Set once UI process has explicitly reported visibility at least once.
     private volatile boolean hasUiVisibilityHint = false;
+    // Tracks whether this process ever had a live Binder connection to status-go.
+    private volatile boolean everConnected = false;
 
     private final IStatusGoSignalListener signalListener = new IStatusGoSignalListener.Stub() {
         @Override
@@ -107,6 +117,7 @@ public final class StatusGoServiceClient {
                 service = IStatusGoService.Stub.asInterface(binder);
                 bindingInProgress = false;
                 bound = true;
+                everConnected = true;
                 try {
                     service.registerSignalListener(signalListener);
                 } catch (RemoteException e) {
@@ -136,6 +147,34 @@ public final class StatusGoServiceClient {
 
         @Override
         public void onServiceDisconnected(ComponentName name) {
+            final boolean suppressed = suppressDisconnectRestart.getAndSet(false);
+            synchronized (lock) {
+                service = null;
+                connectedLatch = null;
+                bindingInProgress = false;
+                bound = false;
+            }
+            if (!suppressed && everConnected && hasUiVisibilityHint && desiredUiVisible) {
+                requestFrontendRestart(StatusGoStub.getContext(), "statusgo_service_disconnected");
+            }
+        }
+
+        @Override
+        public void onBindingDied(ComponentName name) {
+            final boolean suppressed = suppressDisconnectRestart.getAndSet(false);
+            synchronized (lock) {
+                service = null;
+                connectedLatch = null;
+                bindingInProgress = false;
+                bound = false;
+            }
+            if (!suppressed && everConnected && hasUiVisibilityHint && desiredUiVisible) {
+                requestFrontendRestart(StatusGoStub.getContext(), "statusgo_binding_died");
+            }
+        }
+
+        @Override
+        public void onNullBinding(ComponentName name) {
             synchronized (lock) {
                 service = null;
                 connectedLatch = null;
@@ -147,6 +186,33 @@ public final class StatusGoServiceClient {
 
     private StatusGoServiceClient() {}
 
+    private void requestFrontendRestart(Context appContext, String reason) {
+        if (appContext == null) {
+            Log.w(TAG, "requestFrontendRestart: context is null, reason=" + reason);
+            return;
+        }
+        if (!restartRequested.compareAndSet(false, true)) return;
+
+        try {
+            Intent launch = appContext.getPackageManager()
+                    .getLaunchIntentForPackage(appContext.getPackageName());
+            if (launch != null) {
+                launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                launch.putExtra("status.recovery_reason", reason);
+                appContext.startActivity(launch);
+            } else {
+                Log.w(TAG, "requestFrontendRestart: launch intent is null, reason=" + reason);
+            }
+        } catch (Throwable t) {
+            Log.w(TAG, "requestFrontendRestart: failed to relaunch app, reason=" + reason, t);
+        }
+
+        MAIN_HANDLER.postDelayed(
+                () -> android.os.Process.killProcess(android.os.Process.myPid()),
+                RESTART_KILL_DELAY_MS
+        );
+    }
+
     private void resetConnection(Context appContext) {
         final boolean shouldUnbind;
         synchronized (lock) {
@@ -157,9 +223,16 @@ public final class StatusGoServiceClient {
         }
         try {
             if (shouldUnbind) {
+                suppressDisconnectRestart.set(true);
+                // Clear suppression even if no disconnect callback arrives for this unbind path.
+                MAIN_HANDLER.postDelayed(
+                        () -> suppressDisconnectRestart.compareAndSet(true, false),
+                        DISCONNECT_SUPPRESSION_WINDOW_MS
+                );
                 appContext.getApplicationContext().unbindService(conn);
             }
         } catch (Throwable ignored) {
+            suppressDisconnectRestart.set(false);
         } finally {
             synchronized (lock) {
                 bound = false;
@@ -256,6 +329,9 @@ public final class StatusGoServiceClient {
             s = service;
         }
         if (s == null) {
+            if (everConnected) {
+                requestFrontendRestart(app, "statusgo_service_not_connected");
+            }
             return "{\"error\":\"status-go service not connected\"}";
         }
         try {
@@ -287,6 +363,9 @@ public final class StatusGoServiceClient {
                         Log.w(TAG, "call retry failed", e2);
                     }
                 }
+            }
+            if (everConnected) {
+                requestFrontendRestart(app, "statusgo_service_call_failed");
             }
             return "{\"error\":\"status-go service call failed\"}";
         }
@@ -368,6 +447,9 @@ public final class StatusGoServiceClient {
                         s.setUiVisible(visible);
                     } catch (RemoteException e2) {
                         Log.w(TAG, "setUiVisible retry failed", e2);
+                        if (everConnected && visible) {
+                            requestFrontendRestart(app, "statusgo_set_ui_visible_failed");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### What does the PR do

Part of #21142

- Add resilient frontend recovery in StatusGoServiceClient.java when backend Binder becomes unavailable.
- Trigger one-shot app relaunch + process kill on unrecoverable backend paths:
  - disconnected/not connected after bind wait
  - call failure after dead-object retry
  - Binder disconnect/binding death while app is foregrounded
- Harden recovery behavior:
  - only restart from UI-visibility failure when app is foregrounding
  - avoid restart storms with single-shot guard
  - scope/safeguard disconnect suppression during intentional unbind
  - handle null-context safely before arming restart
- Expose application context getter in StatusGoStub.java for disconnect-driven recovery handling.

### Affected areas

StatusGoService java files

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality


https://github.com/user-attachments/assets/587fd8e9-2a4e-42e1-8294-82284fd110ef

### Impact on end user

If the backend gets killed for any reason, like memory overload, it will restart the app for the user, so that the app doesn't stay in an unusable place.

### How to test

Two options to test the restart:
1. Harder Manually use the app and open lots of app and do stuff that uses lots of memory in Status
2. Easier: Connect to the computer and use `adb shell "run-as app.status.mobile sh -c 'kill -9 PID'"` where PID is `adb shell pidof app.status.mobile:statusgo`

Otherwise, it will be good to test using the app as normal and make sure the restart doesn't trigger out of nowhere. It should only happen when the backend dies (usually the phone freezes because the OS is struggling)


### Risk 

Medium. We don't want the app to restart on its own unless necessary
