### PR TITLE
fix(messages): fix marking as read freezing the UI

### DIFF
--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -782,14 +782,30 @@ QtObject:
     read = getNewMessagesCount
     notify = countChanged
 
+  proc emitSeenDataChangedRange(self: Model, startIdx, endIdx: int) =
+    if startIdx < 0 or endIdx < startIdx:
+      return
+
+    let startIndex = self.createIndex(startIdx, 0, nil)
+    defer: startIndex.delete
+    let endIndex = self.createIndex(endIdx, 0, nil)
+    defer: endIndex.delete
+
+    self.dataChanged(startIndex, endIndex, @[ModelRole.Seen.int])
+
   proc markAllAsSeen*(self: Model) =
+    var rangeStart = -1
     for i in 0 ..< self.items.len:
-      let item = self.items[i]
-      if not item.seen:
-        item.seen = true
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index, @[ModelRole.Seen.int])
+      if not self.items[i].seen:
+        self.items[i].seen = true
+        if rangeStart == -1:
+          rangeStart = i
+      elif rangeStart != -1:
+        self.emitSeenDataChangedRange(rangeStart, i - 1)
+        rangeStart = -1
+
+    if rangeStart != -1:
+      self.emitSeenDataChangedRange(rangeStart, self.items.len - 1)
 
   proc setMessageMarker*(self: Model, messageId: string) =
     self.firstUnseenMessageId = messageId
@@ -810,20 +826,35 @@ QtObject:
 
 
   proc markAsSeen*(self: Model, messages: seq[string]) =
+    if messages.len == 0:
+      return
+
     var messagesSet = toHashSet(messages)
+    var rangeStart = -1
 
     for i in 0 ..< self.items.len:
       let currentItemID = self.items[i].id
 
       if messagesSet.contains(currentItemID):
-        self.items[i].seen = true
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index, @[ModelRole.Seen.int])
+        if not self.items[i].seen:
+          self.items[i].seen = true
+          if rangeStart == -1:
+            rangeStart = i
+        elif rangeStart != -1:
+          self.emitSeenDataChangedRange(rangeStart, i - 1)
+          rangeStart = -1
         messagesSet.excl(currentItemID)
+      elif rangeStart != -1:
+        self.emitSeenDataChangedRange(rangeStart, i - 1)
+        rangeStart = -1
 
       if messagesSet.len == 0:
+        if rangeStart != -1:
+          self.emitSeenDataChangedRange(rangeStart, i)
         return
+
+    if rangeStart != -1:
+      self.emitSeenDataChangedRange(rangeStart, self.items.len - 1)
 
   proc getFirstUnseenMentionMessageId*(self: Model): string =
     result = ""

--- a/src/app_service/common/activity_center.nim
+++ b/src/app_service/common/activity_center.nim
@@ -12,5 +12,22 @@ proc checkAndEmitACNotificationsFromResponse*(events: EventEmitter, activityCent
   if activityCenterNotifications == nil or activityCenterNotifications.kind == JNull:
     return
 
+  # Downstream consumers iterate as a JSON array. Some RPC responses wrap
+  # notifications in an object payload, so normalize before emitting.
+  if activityCenterNotifications.kind == JObject:
+    var notifications: JsonNode
+    if activityCenterNotifications.getProp("notifications", notifications):
+      if notifications.kind != JArray:
+        return
+      events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: notifications))
+      return
+
+    # No array payload available.
+    return
+
+  if activityCenterNotifications.kind != JArray:
+    return
+
   events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
     RawActivityCenterNotificationsArgs(activityCenterNotifications: activityCenterNotifications))

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -664,12 +664,19 @@ QtObject:
     var chat = self.getChatById(chatID)
     if chat.id == "":
       return
+    let previousUnreadMessagesCount = chat.unviewedMessagesCount
+    let previousUnreadMentionsCount = chat.unviewedMentionsCount
     if markAllAsRead:
       chat.unviewedMessagesCount = 0
       chat.unviewedMentionsCount = 0
     else:
       chat.unviewedMessagesCount = max(0, chat.unviewedMessagesCount - markAsReadCount)
       chat.unviewedMentionsCount = max(0, chat.unviewedMentionsCount - markAsReadMentionsCount)
+
+    if chat.unviewedMessagesCount == previousUnreadMessagesCount and
+        chat.unviewedMentionsCount == previousUnreadMentionsCount:
+      return
+
     self.updateOrAddChat(chat)
 
   proc asyncCheckChannelPermissions*(self: Service, communityId: string, chatId: string) =

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -922,7 +922,6 @@ QtObject:
       checkAndEmitACNotificationsFromResponse(self.events, responseObj{"activityCenterNotifications"})
     except Exception as e:
       error "error: ", procName="onMarkAllMessagesRead", errDesription = e.msg
-      self.events.emit(SIGNAL_SEARCH_MESSAGES_LOADED, MessagesArgs(chatId: ""))
 
   proc markAllMessagesRead*(self: Service, chatId: string) =
     if (chatId.len == 0):


### PR DESCRIPTION
### What does the PR do

Fixes #21155

- Reduced the read-marking UI hitch by batching `seen` updates in message_model.nim, so marking many messages read now emits fewer QML model updates.
- Avoided redundant unread-count churn in service.nim by skipping no-op `updateUnreadMessagesAndMentions` calls.
- Fixed the mark-as-read failure path in service.nim by removing the unrelated `searchMessagesLoaded` fallback.
- Hardened activity-center notification handling in activity_center.nim so JObject payloads are normalized before downstream iteration, preventing the `items() can not iterate a JsonNode of kind JObject` crash.

### Affected areas

- Biggest culprit: message_model
- small changes: chat service
- bug fix: activity_center.nim

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[fix-mark-as-read.webm](https://github.com/user-attachments/assets/6c94235f-29df-430d-9e81-3586be6fa12d)

### Impact on end user

Makes switching chats way faster

### How to test

- Switch to a channel with lots of unread messages
- Force it by marking a message as unread (especially an old one)

### Risk 

Low
