### PR TITLE
fix(StatusChatInput): fix pasting an image from context menu

### DIFF
--- a/ui/app/AppLayouts/Onboarding/StartupOnboardingWrapper.qml
+++ b/ui/app/AppLayouts/Onboarding/StartupOnboardingWrapper.qml
@@ -8,6 +8,7 @@ import AppLayouts.Onboarding.enums
 import AppLayouts.Onboarding.stores
 import AppLayouts.Onboarding.pages
 
+import StatusQ.Core
 import StatusQ.Core.Utils as SQUtils
 import StatusQ.Platform
 

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -16925,6 +16925,10 @@ to load</source>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusChatListCategoryItem</name>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -20615,6 +20615,11 @@
       <comment>StatusChatInputTextArea</comment>
       <translation>Paste</translation>
     </message>
+    <message>
+      <source>Select All</source>
+      <comment>StatusChatInputTextArea</comment>
+      <translation>Select All</translation>
+    </message>
   </context>
   <context>
     <name>StatusChatListCategoryItem</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -17042,6 +17042,10 @@ selhalo</translation>
         <source>Paste</source>
         <translation type="unfinished">Vložit</translation>
     </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusChatListCategoryItem</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -16941,6 +16941,10 @@ al cargar</translation>
         <source>Paste</source>
         <translation type="unfinished">Pegar</translation>
     </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusChatListCategoryItem</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -16883,6 +16883,10 @@ to load</source>
         <source>Paste</source>
         <translation type="unfinished">붙여넣기</translation>
     </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusChatListCategoryItem</name>

--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -304,15 +304,6 @@ Control {
                 emojiSuggestions.listView.decrementCurrentIndex()
                 return
             }
-
-            if (event.matches(StandardKey.Paste)) {
-                if (!ClipboardUtils.hasImage)
-                    return
-
-                const clipboardImage = ClipboardUtils.imageBase64
-                validateImagesAndShowImageArea([clipboardImage])
-                event.accepted = true
-            }
         }
     }
 
@@ -757,6 +748,8 @@ Control {
                         onAttemptToExceedHardLimit: {
                             lengthLimitTooltip.open()
                         }
+
+                        onPasteImageRequested: root.validateImagesAndShowImageArea([ClipboardUtils.imageBase64])
 
                         Shortcut {
                             enabled: messageInputField.activeFocus

--- a/ui/imports/shared/status/StatusChatInputTextArea.qml
+++ b/ui/imports/shared/status/StatusChatInputTextArea.qml
@@ -70,10 +70,12 @@ StatusQ.StatusTextArea {
     // Signal emitted when user attempts to add content exceeding hard limit.
     signal attemptToExceedHardLimit
 
+    signal pasteImageRequested()
+
     textFormat: Text.RichText
     color: Theme.palette.textColor
     background: null
-    inputMethodHints: Qt.ImhMultiLine | (StatusQUtils.Utils.isMobile ? 0 : Qt.ImhNoEditMenu)
+    inputMethodHints: Qt.ImhMultiLine | (StatusQUtils.Utils.isMobile ? Qt.ImhNone : Qt.ImhNoEditMenu)
 
     EnterKey.type: Qt.EnterKeyReturn // insert newlines hint for OSK
 
@@ -689,6 +691,14 @@ StatusQ.StatusTextArea {
         }
 
         function paste(immediateCleanup = false) {
+            // pasting images supported on desktop only
+            if (!StatusQUtils.Utils.isMobile) {
+                if (ClipboardUtils.hasImage) {
+                    root.pasteImageRequested()
+                    return true
+                }
+            }
+
             if (!ClipboardUtils.hasText)
                 return false
 
@@ -808,9 +818,8 @@ StatusQ.StatusTextArea {
         cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.IBeamCursor
     }
 
-    StatusMenu {
-        id: contextMenu
-
+    // lazy load the context menu (notice no `id` allowed/used)
+    ContextMenu.menu: StatusMenu {
         hideDisabledItems: false
         // Use the platform popup on iOS to match native text editing behavior.
         popupType: StatusQUtils.Utils.isIOS ? Popup.Native : Popup.Item
@@ -833,11 +842,14 @@ StatusQ.StatusTextArea {
         }
         StatusAction {
             text: qsTr("Paste")
-            enabled: root.canPaste
+            enabled: ClipboardUtils.hasText || ClipboardUtils.hasImage
             onTriggered: d.paste(true)
         }
+        StatusMenuSeparator{}
+        StatusAction {
+            text: qsTr("Select All")
+            enabled: length > 0
+            onTriggered: selectAll()
+        }
     }
-
-    ContextMenu.menu: StatusQUtils.Utils.isAndroid ? null
-                      : contextMenu
 }


### PR DESCRIPTION
### What does the PR do

- handle the paste action down in StatusChatInputTextArea; don't restrict the internal paste action to pasting text only, emit a signal up, and handle pasting the image as usual one level above in StatusChatInput

Fixes #21141

### Affected areas

StatusChatInput

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/165e3cb4-3f3e-43be-b226-aa7a8275423e

### Impact on end user

Can paste an image on mobile

### How to test

- copy image to clipboard (e.g. using a web browser)
- in the chat input, invoke "Paste" from the context menu

### Risk 

low
