### PR TITLE
fix(android): kill background service on sign out and quit

### DIFF
--- a/mobile/android/qt6/src/app/status/mobile/StatusGoStub.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusGoStub.java
@@ -50,6 +50,14 @@ public final class StatusGoStub {
         StatusGoServiceClient.get().setUiVisible(sContext, visible);
     }
 
+    /**
+     * Stops the separate status-go service process.
+     */
+    public static void stopService() {
+        if (sContext == null) return;
+        StatusGoServiceClient.get().stopService(sContext);
+    }
+
     private static volatile Context sContext;
 
     /** Called by Activity. Keep application context for later native calls. */

--- a/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoService.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoService.java
@@ -534,6 +534,8 @@ public final class StatusGoService extends Service {
             } catch (Throwable ignored) {}
             foregroundStarted = false;
             stopSelf();
+            // Mirrors the force-kill of the UI process in StatusQtActivity.onDestroy.
+            android.os.Process.killProcess(android.os.Process.myPid());
             return START_NOT_STICKY;
         }
         // Ensure we can be started from background components (e.g. FCM) without risking

--- a/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoServiceClient.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoServiceClient.java
@@ -217,6 +217,26 @@ public final class StatusGoServiceClient {
         }
     }
 
+    /**
+     * Stops the status-go service process.
+     *
+     * Unbinds first so our binding can't keep the service alive, then delivers ACTION_STOP via
+     * startService. startService is dispatched by the system's ActivityManager, so it is delivered
+     * even after the UI process exits immediately afterwards (_exit(0)). The service then kills its
+     * own process (see StatusGoService.onStartCommand), guaranteeing a clean login on next launch.
+     */
+    public void stopService(Context context) {
+        final Context app = context.getApplicationContext();
+        resetConnection(app);
+        Intent i = new Intent(app, StatusGoService.class);
+        i.setAction(StatusGoService.ACTION_STOP);
+        try {
+            app.startService(i);
+        } catch (Throwable t) {
+            Log.w(TAG, "stopService failed", t);
+        }
+    }
+
     public String call(Context context, String method, String argsJson) {
         final Context app = context.getApplicationContext();
         ensureStartedAndBound(app);

--- a/src/app/android/lifecycle.nim
+++ b/src/app/android/lifecycle.nim
@@ -1,0 +1,11 @@
+when defined(android):
+  {.push dynlib: "", importc.}
+  proc statusq_stopBackgroundService*() {.cdecl, importc: "statusq_stopBackgroundService".}
+  {.pop.}
+
+  proc stopBackgroundService*() =
+    statusq_stopBackgroundService()
+
+else:
+  # Stub for non-Android builds (no separate status-go service process there)
+  proc stopBackgroundService*() = discard

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -12,6 +12,7 @@ import app/global/app_sections_config
 import app/global/app_signals
 import app/global/[global_singleton, feature_flags]
 import app/global/app_lifecycle
+import app/android/lifecycle
 import app/global/utils as utils
 import constants
 
@@ -2150,7 +2151,13 @@ method signOutAndQuit*[T](self: Module[T]) =
     # cause it does a few other things (stops the node, closes the DBs, then re-initializes the node and restarts
     # the media server, all synchronously on the UI thread) that are not needed on mobile devices.
     # Desktop keeps the graceful logout (no _exit; the event loop unwinds).
-    discard
+    when defined(android):
+      # On Android status-go runs in a separate, long-lived service process. _exit(0) only reclaims
+      # the UI process, so without this the service keeps the node logged in and the next launch
+      # resumes the account instead of showing the login screen.
+      # Tell the service to stop (and kill its process); the intent is delivered by the system even
+      # after the UI process exits below.
+      stopBackgroundService()
   else:
     self.controller.logout()
   singletonInstance.application.exit()

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -282,6 +282,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Android")
     target_sources(StatusQ PRIVATE
         src/keychain_android.cpp
         src/safutils_android.cpp
+        src/lifecycleutils_android.cpp
         src/StatusQ/Controls/NativeSwipeHandlerItem_android.cpp
         src/StatusQ/Controls/NativeIndicatorItem_android.cpp
         src/shareutils_android.cpp

--- a/ui/StatusQ/include/StatusQ/lifecycleutils.h
+++ b/ui/StatusQ/include/StatusQ/lifecycleutils.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <QtGlobal>
+
+extern "C" {
+
+// Stop the separate Android status-go service process. No-op if not Android.
+Q_DECL_EXPORT void statusq_stopBackgroundService();
+
+}

--- a/ui/StatusQ/src/lifecycleutils_android.cpp
+++ b/ui/StatusQ/src/lifecycleutils_android.cpp
@@ -1,0 +1,19 @@
+#include "StatusQ/lifecycleutils.h"
+
+#ifdef Q_OS_ANDROID
+#include <QJniObject>
+
+extern "C" Q_DECL_EXPORT void statusq_stopBackgroundService()
+{
+    QJniObject::callStaticMethod<void>(
+        "app/status/mobile/StatusGoStub",
+        "stopService",
+        "()V"
+    );
+}
+
+#else // non-Android stub
+
+extern "C" Q_DECL_EXPORT void statusq_stopBackgroundService() {}
+
+#endif


### PR DESCRIPTION
On Android status-go runs in a separate, long-lived service process. After the earlier change to skip the synchronous logout on mobile, "Sign out & quit" only _exit(0) the UI process, leaving the service running with the node still logged in.

signOutAndQuit now tells the service to stop on Android, by sending an  ACTION_STOP intent.

Fixes #21170 