### PR TITLE
ci: keep less upstream jobs artifacts

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -23,9 +23,10 @@ pipeline {
     timeout(time: 1240, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
-      numToKeepStr: '30',
+      numToKeepStr: '10',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '10',
+      artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30',
     ))
     /* Allows combined build to copy */
     copyArtifactPermission('/status-app/*')

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -67,9 +67,10 @@ pipeline {
     timeout(time: 120, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
-      daysToKeepStr: '60',
       numToKeepStr: '50',
-      artifactNumToKeepStr: '50',
+      daysToKeepStr: '60',
+      artifactNumToKeepStr: '10',
+      artifactDaysToKeepStr: '30',
     ))
     disableRestartFromStage()
   }


### PR DESCRIPTION
https://ci.infra.status.im/job/status-app/job/master/
Is currently taking 10*1.7GB space.
This PR will keep only the latest.
We have artifact copies on Digital Ocean.

https://ci.infra.status.im/job/status-app/job/release/
Will keep only the latest build artifact per release branch.
But (I hope) not longer than 30 days.
We have artifact copies on Digital Ocean.

https://ci.infra.status.im/job/status-app/job/systems/job/linux/job/x86_64/job/tests-e2e/
We keep 50*500MB builds and artifacts now.
After PR we'll keep less artifacts - max 10, not older than 30 days.