### PR TITLE
fix: community channels mem-bomb

### DIFF
--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -276,7 +276,7 @@ method onSearchMessagesDone*(self: Module, messages: seq[MessageDto]) =
     # Add channels
     let communityChatItems = self.getResultItemFromChats(community.id, community.chats, SEARCH_RESULT_CHANNELS_SECTION_NAME)
     if communityChatItems.len > 0:
-      channels = channels.concat(channels, communityChatItems)
+      channels.add(communityChatItems)
 
   # Add channels in order as requested by the design
   items.add(channels)


### PR DESCRIPTION
### What does the PR do

closes https://github.com/status-im/status-app/issues/21162 https://github.com/status-im/status-app/issues/20254

`channels.concat(channels, communityChatItems)` will result in an exponential growth for this container. We'll then persist the result in the search model resulting in very high memory usage.


### Affected areas

search model (launched by ctrl+k)

### Impact on end user

Lower memory usage

### How to test

The easy way of triggering this mem bomb is to trigger the mark all messages as read flow.

1. Make sure you have lots of communities - the nb of channels is important
2. Go to a chat (or a channel), right click and choose Mark all as read (you'll know you should reproduce if you see this exception `ERR 2026-06-08 12:11:45.802Z error:                                     topics="messages-service" tid=1088271 file=service.nim:924 procName=onMarkAllMessagesRead errDesription="json.nim(834, 3) `node.kind == JArray` : items() can not iterate a JsonNode of kind JObject"`)
3. Observe the memory

### Risk 

<!-- Described potential risks and worst case scenarios. -->
