### PR TITLE
fix(android): kill the backend on restart on Android when needed

### DIFF
--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -3,6 +3,8 @@ package app.status.mobile;
 import org.qtproject.qt.android.bindings.QtActivity;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.content.pm.PackageManager;
 import androidx.core.splashscreen.SplashScreen;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -16,6 +18,7 @@ import android.widget.Toast;
 
 public class StatusQtActivity extends QtActivity {
     private static final String TAG = "StatusQtActivity";
+    private static final long RESTART_KILL_DELAY_MS = 250L;
 
     // QtActivityBase.onDestroy() can deadlock on Android during Qt/EGL teardown;
     // if it hasn't completed within this window we force-kill the UI process.
@@ -154,5 +157,44 @@ public class StatusQtActivity extends QtActivity {
             // Handle the rare case where the settings activity doesn't exist
             Toast.makeText(sInstance, "Unable to open Accessibility Settings", Toast.LENGTH_SHORT).show();
         }
+    }
+
+    /**
+     * Restarts the UI process and optionally stops the separate status-go service process.
+     *
+     * Called from Qt via JNI.
+     */
+    public static void restartApplication(boolean killBackend) {
+        final StatusQtActivity activity = sInstance;
+        final android.content.Context context = activity != null
+                ? activity
+                : StatusGoStub.getContext();
+
+        if (context == null) {
+            Log.w(TAG, "restartApplication: context is null");
+            return;
+        }
+
+        if (killBackend) {
+            StatusGoStub.stopService();
+        }
+
+        try {
+            Intent launch = context.getPackageManager()
+                    .getLaunchIntentForPackage(context.getPackageName());
+            if (launch != null) {
+                launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                context.startActivity(launch);
+            } else {
+                Log.w(TAG, "restartApplication: launch intent is null");
+            }
+        } catch (Throwable t) {
+            Log.w(TAG, "restartApplication failed", t);
+        }
+
+        new Handler(Looper.getMainLooper()).postDelayed(
+                () -> android.os.Process.killProcess(android.os.Process.myPid()),
+                RESTART_KILL_DELAY_MS
+        );
     }
 }

--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -20,6 +20,7 @@ public:
 
     Q_INVOKABLE QString qtRuntimeVersion() const;
     Q_INVOKABLE void restartApplication() const;
+    Q_INVOKABLE void restartApplication(bool killBackend) const;
     Q_INVOKABLE void openAppSettings();
 
     Q_INVOKABLE void downloadImageByUrl(const QUrl& url, const QString& path);

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -137,10 +137,26 @@ QString SystemUtilsInternal::qtRuntimeVersion() const {
 
 void SystemUtilsInternal::restartApplication() const
 {
+    restartApplication(false);
+}
+
+void SystemUtilsInternal::restartApplication(bool killBackend) const
+{
+#ifdef Q_OS_ANDROID
+    QJniObject::callStaticMethod<void>(
+        "app/status/mobile/StatusQtActivity",
+        "restartApplication",
+        "(Z)V",
+        static_cast<jboolean>(killBackend)
+    );
+    return;
+#else
+    Q_UNUSED(killBackend);
 #if QT_CONFIG(process)
     QProcess::startDetached(QCoreApplication::applicationFilePath(), {});
 #endif
     QMetaObject::invokeMethod(QCoreApplication::instance(), &QCoreApplication::exit, Qt::QueuedConnection, EXIT_SUCCESS);
+#endif
 }
 
 bool save(const QByteArray& imageData, const QString& targetDir)

--- a/ui/app/AppLayouts/Onboarding/StartupOnboardingWrapper.qml
+++ b/ui/app/AppLayouts/Onboarding/StartupOnboardingWrapper.qml
@@ -143,7 +143,7 @@ Item {
             ConvertKeycardAccountPage {
                 convertKeycardAccountState: onboardingStore.convertKeycardAccountState
                 onRestartRequested: {
-                    SystemUtils.restartApplication()
+                    SystemUtils.restartApplication(true)
                 }
                 onBackToLoginRequested: {
                     onboardingLayout.unwindToLoginScreen()

--- a/ui/app/AppLayouts/Profile/popups/ConfirmChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ConfirmChangePasswordModal.qml
@@ -175,7 +175,7 @@ StatusDialog {
                 enabled: !d.dbEncryptionInProgress
                 onClicked: {
                     if (d.passwordChanged) {
-                        SystemUtils.restartApplication();
+                        SystemUtils.restartApplication(true);
                     } else {
                         d.dbEncryptionInProgress = true
                         root.changePasswordRequested()

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -331,10 +331,14 @@ SettingsContentBase {
                 text: qsTr("Enable translations")
                 isSwitch: true
                 checked: localAppSettings.translationsEnabled
-                onToggled: {
-                    localAppSettings.translationsEnabled = !localAppSettings.translationsEnabled
-                    if (!checked)
+                onClicked: {
+                    checked = Qt.binding(() => localAppSettings.translationsEnabled)
+
+                    if (checked) {
                         Global.openPopup(disableLanguagesPopupComponent)
+                    } else {
+                        localAppSettings.translationsEnabled = true
+                    }
                 }
             }
 
@@ -343,9 +347,13 @@ SettingsContentBase {
                 ConfirmationDialog {
                     destroyOnClose: true
                     headerSettings.title: qsTr("Language reset")
-                    confirmationText: qsTr("Display language will be switched back to English. The app will restart if you confirm.")
+                    confirmationText: qsTr("Display language will be switched back to English.") + "\n" +
+                        qsTr("The app will restart if you confirm.")
                     confirmButtonLabel: qsTr("Restart")
-                    onConfirmButtonClicked: SystemUtils.restartApplication()
+                    onConfirmButtonClicked: {
+                        localAppSettings.translationsEnabled = false
+                        SystemUtils.restartApplication()
+                    }
                 }
             }
 
@@ -430,9 +438,11 @@ SettingsContentBase {
                 id: confirmDialog
                 destroyOnClose: true
                 showCancelButton: true
-                confirmationText: qsTr("Are you sure you want to %1 debug mode? The app will restart if you confirm.").arg(root.advancedStore.isDebugEnabled ?
-                    qsTr("disable") :
-                    qsTr("enable"))
+                confirmationText: (root.advancedStore.isDebugEnabled ?
+                    qsTr("Are you sure you want to disable debug mode?") :
+                    qsTr("Are you sure you want to enable debug mode?"))
+                     + "\n" +
+                    qsTr("The app will restart if you confirm.")
                 onConfirmButtonClicked: {
                     root.advancedStore.toggleDebug()
                     SystemUtils.restartApplication()

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -343,13 +343,14 @@ SettingsContentBase {
                 ConfirmationDialog {
                     destroyOnClose: true
                     headerSettings.title: qsTr("Language reset")
-                    confirmationText: qsTr("Display language will be switched back to English. You must restart the application for changes to take effect.")
+                    confirmationText: qsTr("Display language will be switched back to English. The app will restart if you confirm.")
                     confirmButtonLabel: qsTr("Restart")
                     onConfirmButtonClicked: SystemUtils.restartApplication()
                 }
             }
 
             StatusSettingsLineButton {
+                id: debugLineButton
                 width: parent.width
                 text: qsTr("Debug")
                 isSwitch: true
@@ -367,6 +368,8 @@ SettingsContentBase {
                     enabled: true
                     hoverEnabled: true
                     propagateComposedEvents: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: debugLineButton.clicked()
                 }
 
                 StatusToolTip {
@@ -427,16 +430,14 @@ SettingsContentBase {
                 id: confirmDialog
                 destroyOnClose: true
                 showCancelButton: true
-                confirmationText: qsTr("Are you sure you want to %1 debug mode? You need to restart the app for this change to take effect.").arg(root.advancedStore.isDebugEnabled ?
+                confirmationText: qsTr("Are you sure you want to %1 debug mode? The app will restart if you confirm.").arg(root.advancedStore.isDebugEnabled ?
                     qsTr("disable") :
                     qsTr("enable"))
                 onConfirmButtonClicked: {
                     root.advancedStore.toggleDebug()
-                    close()
+                    SystemUtils.restartApplication()
                 }
-                onCancelButtonClicked: {
-                    close()
-                }
+                onCancelButtonClicked: close()
             }
         }
 

--- a/ui/app/mainui/Handlers/HandlersManager.qml
+++ b/ui/app/mainui/Handlers/HandlersManager.qml
@@ -185,7 +185,7 @@ QtObject {
 
         onToggleThirdpartyServicesEnabledRequested: {
             root.privacyStore.toggleThirdpartyServicesEnabledRequested()
-            Backpressure.debounce(root, 200, () => { SystemUtils.restartApplication() })()
+            Backpressure.debounce(root, 200, () => { SystemUtils.restartApplication(true) })()
         }
         onOpenDiscussPageRequested: Global.requestOpenLink(Constants.statusDiscussPageUrl)
         onOpenThirdpartyServicesArticleRequested: Global.requestOpenLink(Constants.statusThirdpartyServicesArticle)

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1111,11 +1111,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Display language will be switched back to English. The app will restart if you confirm.</source>
+        <source>Display language will be switched back to English.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to %1 debug mode? The app will restart if you confirm.</source>
+        <source>The app will restart if you confirm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1147,11 +1147,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>disable</source>
+        <source>Are you sure you want to disable debug mode?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>enable</source>
+        <source>Are you sure you want to enable debug mode?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1111,7 +1111,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Display language will be switched back to English. You must restart the application for changes to take effect.</source>
+        <source>Display language will be switched back to English. The app will restart if you confirm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to %1 debug mode? The app will restart if you confirm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1140,10 +1144,6 @@
     </message>
     <message>
         <source>RPC statistics</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Are you sure you want to %1 debug mode? You need to restart the app for this change to take effect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -1363,9 +1363,14 @@
       <translation>Language reset</translation>
     </message>
     <message>
-      <source>Display language will be switched back to English. You must restart the application for changes to take effect.</source>
+      <source>Display language will be switched back to English. The app will restart if you confirm.</source>
       <comment>AdvancedView</comment>
-      <translation>Display language will be switched back to English. You must restart the application for changes to take effect.</translation>
+      <translation>Display language will be switched back to English. The app will restart if you confirm.</translation>
+    </message>
+    <message>
+      <source>Are you sure you want to %1 debug mode? The app will restart if you confirm.</source>
+      <comment>AdvancedView</comment>
+      <translation>Are you sure you want to %1 debug mode? The app will restart if you confirm.</translation>
     </message>
     <message>
       <source>Restart</source>
@@ -1401,11 +1406,6 @@
       <source>RPC statistics</source>
       <comment>AdvancedView</comment>
       <translation>RPC statistics</translation>
-    </message>
-    <message>
-      <source>Are you sure you want to %1 debug mode? You need to restart the app for this change to take effect.</source>
-      <comment>AdvancedView</comment>
-      <translation>Are you sure you want to %1 debug mode? You need to restart the app for this change to take effect.</translation>
     </message>
     <message>
       <source>disable</source>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -1363,14 +1363,14 @@
       <translation>Language reset</translation>
     </message>
     <message>
-      <source>Display language will be switched back to English. The app will restart if you confirm.</source>
+      <source>Display language will be switched back to English.</source>
       <comment>AdvancedView</comment>
-      <translation>Display language will be switched back to English. The app will restart if you confirm.</translation>
+      <translation>Display language will be switched back to English.</translation>
     </message>
     <message>
-      <source>Are you sure you want to %1 debug mode? The app will restart if you confirm.</source>
+      <source>The app will restart if you confirm.</source>
       <comment>AdvancedView</comment>
-      <translation>Are you sure you want to %1 debug mode? The app will restart if you confirm.</translation>
+      <translation>The app will restart if you confirm.</translation>
     </message>
     <message>
       <source>Restart</source>
@@ -1408,14 +1408,14 @@
       <translation>RPC statistics</translation>
     </message>
     <message>
-      <source>disable</source>
+      <source>Are you sure you want to disable debug mode?</source>
       <comment>AdvancedView</comment>
-      <translation>disable</translation>
+      <translation>Are you sure you want to disable debug mode?</translation>
     </message>
     <message>
-      <source>enable</source>
+      <source>Are you sure you want to enable debug mode?</source>
       <comment>AdvancedView</comment>
-      <translation>enable</translation>
+      <translation>Are you sure you want to enable debug mode?</translation>
     </message>
     <message>
       <source>How many log files do you want to keep archived?</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1114,8 +1114,12 @@
         <translation>Reset jazyka</translation>
     </message>
     <message>
-        <source>Display language will be switched back to English. You must restart the application for changes to take effect.</source>
-        <translation>Jazyk zobrazení bude přepnut zpět na angličtinu. Pro projevení změn musíte restartovat aplikaci.</translation>
+        <source>Display language will be switched back to English. The app will restart if you confirm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to %1 debug mode? The app will restart if you confirm.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restart</source>
@@ -1144,10 +1148,6 @@
     <message>
         <source>RPC statistics</source>
         <translation>Statistiky RPC</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to %1 debug mode? You need to restart the app for this change to take effect.</source>
-        <translation>Opravdu chcete %1 režim ladění? Pro projevení této změny musíte restartovat aplikaci.</translation>
     </message>
     <message>
         <source>disable</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1114,11 +1114,11 @@
         <translation>Reset jazyka</translation>
     </message>
     <message>
-        <source>Display language will be switched back to English. The app will restart if you confirm.</source>
+        <source>Display language will be switched back to English.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to %1 debug mode? The app will restart if you confirm.</source>
+        <source>The app will restart if you confirm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1150,12 +1150,12 @@
         <translation>Statistiky RPC</translation>
     </message>
     <message>
-        <source>disable</source>
-        <translation>zakázat</translation>
+        <source>Are you sure you want to disable debug mode?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>enable</source>
-        <translation>povolit</translation>
+        <source>Are you sure you want to enable debug mode?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>How many log files do you want to keep archived?</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1111,11 +1111,11 @@
         <translation>Restablecer idioma</translation>
     </message>
     <message>
-        <source>Display language will be switched back to English. The app will restart if you confirm.</source>
+        <source>Display language will be switched back to English.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to %1 debug mode? The app will restart if you confirm.</source>
+        <source>The app will restart if you confirm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1147,12 +1147,12 @@
         <translation>Estadísticas RPC</translation>
     </message>
     <message>
-        <source>disable</source>
-        <translation>deshabilitar</translation>
+        <source>Are you sure you want to disable debug mode?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>enable</source>
-        <translation>habilitar</translation>
+        <source>Are you sure you want to enable debug mode?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>How many log files do you want to keep archived?</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1111,8 +1111,12 @@
         <translation>Restablecer idioma</translation>
     </message>
     <message>
-        <source>Display language will be switched back to English. You must restart the application for changes to take effect.</source>
-        <translation>El idioma de visualización volverá a inglés. Debes reiniciar la aplicación para que los cambios surtan efecto.</translation>
+        <source>Display language will be switched back to English. The app will restart if you confirm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to %1 debug mode? The app will restart if you confirm.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restart</source>
@@ -1141,10 +1145,6 @@
     <message>
         <source>RPC statistics</source>
         <translation>Estadísticas RPC</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to %1 debug mode? You need to restart the app for this change to take effect.</source>
-        <translation>¿Estás seguro de que quieres %1 el modo de depuración? Necesitas reiniciar la aplicación para que este cambio surta efecto.</translation>
     </message>
     <message>
         <source>disable</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1108,8 +1108,12 @@
         <translation>언어 초기화</translation>
     </message>
     <message>
-        <source>Display language will be switched back to English. You must restart the application for changes to take effect.</source>
-        <translation>표시 언어가 영어로 다시 전환됩니다. 변경 사항을 적용하려면 앱을 재시작해야 합니다.</translation>
+        <source>Display language will be switched back to English. The app will restart if you confirm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to %1 debug mode? The app will restart if you confirm.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restart</source>
@@ -1138,10 +1142,6 @@
     <message>
         <source>RPC statistics</source>
         <translation>rpc 통계</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to %1 debug mode? You need to restart the app for this change to take effect.</source>
-        <translation>%1 디버그 모드를 정말로 하시겠어요? 이 변경 사항을 적용하려면 앱을 다시 시작해야 합니다.</translation>
     </message>
     <message>
         <source>disable</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1108,11 +1108,11 @@
         <translation>언어 초기화</translation>
     </message>
     <message>
-        <source>Display language will be switched back to English. The app will restart if you confirm.</source>
+        <source>Display language will be switched back to English.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to %1 debug mode? The app will restart if you confirm.</source>
+        <source>The app will restart if you confirm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1144,12 +1144,12 @@
         <translation>rpc 통계</translation>
     </message>
     <message>
-        <source>disable</source>
-        <translation>비활성화</translation>
+        <source>Are you sure you want to disable debug mode?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>enable</source>
-        <translation>활성화</translation>
+        <source>Are you sure you want to enable debug mode?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>How many log files do you want to keep archived?</source>


### PR DESCRIPTION
### What does the PR do

Fixes #21182

This fix introduces a new param in `restartApplication`. If `true`, it restarts the backend on Android and not just the front end.

It is called as `true` for the password change, the keycard path in the onboarding and the privacy mode switch.

### Affected areas

- StatusQtActivity.java
- SystemUtilsInternal
- The QML files that needed a real restart

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

The video shows that changing the language still works and only restarts the front end.
Then the password change restarts everything 


https://github.com/user-attachments/assets/45489831-6f6e-41de-8266-8ad9490677e7



### Impact on end user

Makes sure the backend is reset on Android, otherwise data could be lost or the backend would not have the right settings

### How to test

Follow the repro steps on the issue. Also test that the other restart flows still work. For example, the language restart works and only restart the front-end

### Risk 

Low
