### PR TITLE
fix(Push): Open chat list from chats deep link

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -2212,6 +2212,7 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
     return
   of DEEP_LINK_NAV_CHATS:
     self.setActiveSectionById(singletonInstance.userProfile.getPubKey())
+    self.view.navigateToMessageList()
     return
   else:
     info "No generic navigation target found in deep link"

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -468,6 +468,8 @@ QtObject:
   proc emitNavigateToMessageDetailsSignal*(self: View) =
     self.navigateToMessageDetails()
 
+  proc navigateToMessageList*(self: View) {.signal.}
+
   proc wcLinkActivated*(self: View, url: string) {.signal.}
 
   proc loadMembersForSectionId*(self: View, communityId: string) {.slot.} =

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -85,8 +85,9 @@ StackLayout {
     property var usersModel
 
     // Navigation:
-    // Internal trigger for navigating to messaging details
+    // Internal triggers for navigating between messaging panels
     property bool navToMsgDetails: false
+    property bool navToMsgList: false
 
     // Users related signals
     signal groupMembersUpdateRequested(string membersPubKeysList)
@@ -117,6 +118,7 @@ StackLayout {
     // Navigation
     signal showUsersListRequested(bool show)
     signal navToMsgDetailsRequested(bool navigate)
+    signal navToMsgListRequested(bool navigate)
 
     /*!
         \qmlproperty int StatusSectionLayoutLandscape::leftPanelWidthOverride
@@ -333,6 +335,7 @@ StackLayout {
 
             // Navigation:
             navToMsgDetails: root.navToMsgDetails
+            navToMsgList: root.navToMsgList
 
             // Layout
             leftPanelWidthOverride: root.leftPanelWidthOverride
@@ -402,6 +405,7 @@ StackLayout {
             onShowUsersListRequested: show => root.showUsersListRequested(show)
 
             onNavToMsgDetailsRequested: navigate => root.navToMsgDetailsRequested(navigate)
+            onNavToMsgListRequested: navigate => root.navToMsgListRequested(navigate)
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -126,8 +126,9 @@ StatusSectionLayout {
     property bool amIChatAdmin
 
     // Navigation:
-    // Internal trigger for navigating to messaging details
+    // Internal triggers for navigating between messaging panels
     property bool navToMsgDetails: false
+    property bool navToMsgList: false
 
     // Users related signals
     signal groupMembersUpdateRequested(string membersPubKeysList)
@@ -173,6 +174,7 @@ StatusSectionLayout {
     // Navigation
     signal showUsersListRequested(bool show)
     signal navToMsgDetailsRequested(bool navigate)
+    signal navToMsgListRequested(bool navigate)
 
     Connections {
         target: root.rootStore.stickersStore.stickersModule
@@ -224,6 +226,23 @@ StatusSectionLayout {
             root.currentIndex = StatusSectionLayout.CentralPanel
             root.navToMsgDetailsRequested(false)
         }
+    }
+
+    onNavToMsgListChanged: {
+        if (root.navToMsgList) {
+            root.navigateToMessageList()
+        }
+    }
+
+    Component.onCompleted: {
+        if (root.navToMsgList) {
+            root.navigateToMessageList()
+        }
+    }
+
+    function navigateToMessageList() {
+        root.currentIndex = StatusSectionLayout.LeftPanel
+        root.navToMsgListRequested(false)
     }
 
     rightPanel: UserListPanel {

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -32,20 +32,28 @@ QtObject {
     property bool thirdpartyServicesEnabled
 
     // TEMPORARY: Workaround to persist UI state whenever the user navigates to
-    // chat/channel detail sections from in-links (i.e. not directly via the nav bar).
+    // chat/channel lists or details from in-links (i.e. not directly via the nav bar).
     // This parameter is used to store the navigation intent so that the target component
-    // can react and move to the corresponding detail view.
+    // can react and move to the corresponding panel.
     //
     // This workaround is required due to the current Nim-based navigation architecture,
     // where UI-driven actions are intertwined in a call chain qml → nim → qml, instead of
     // being handled locally in the UI layer.
     readonly property bool navToMsgDetails: internal.forceNavToMsgDetails
+    readonly property bool navToMsgList: internal.forceNavToMsgList
     function setNavToMsgDetailsFlag(navigate) {
         internal.forceNavToMsgDetails = navigate
 
         // force actions even if the value is not changed to support deep navigation
         // within swipe view if necessary (portrait mode)
         internal.forceNavToMsgDetailsChanged()
+    }
+    function setNavToMsgListFlag(navigate) {
+        internal.forceNavToMsgList = navigate
+
+        // force actions even if the value is not changed to support deep navigation
+        // within swipe view if necessary (portrait mode)
+        internal.forceNavToMsgListChanged()
     }
 
     // Here define the needed properties that access to `Context Properties`:
@@ -55,8 +63,9 @@ QtObject {
         readonly property var mainModuleInst: mainModule
         readonly property var appSearchModuleInst: internal.mainModuleInst.appSearchModule
 
-        // TEMPORARY: Internal flag used to trigger navigation into messaging details.
+        // TEMPORARY: Internal flags used to trigger navigation into messaging lists or details.
         property bool forceNavToMsgDetails: false
+        property bool forceNavToMsgList: false
     }
 
     // Here there should be all the ContextSpecificRootStore objects creation
@@ -210,6 +219,10 @@ QtObject {
 
             function onNavigateToMessageDetails() {
                 root.setNavToMsgDetailsFlag(true)
+            }
+
+            function onNavigateToMessageList() {
+                root.setNavToMsgListFlag(true)
             }
 
             function onWcLinkActivated(url) {

--- a/ui/app/mainui/sectionLoaders/ChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ChatLoader.qml
@@ -129,6 +129,7 @@ Loader {
             usersModel:                     Qt.binding(() => d.chatRootStore.usersStore.usersModel),
             myPublicKey:                    Qt.binding(() => root.contactsStore.myPublicKey),
             navToMsgDetails:                Qt.binding(() => root.rootStore.navToMsgDetails),
+            navToMsgList:                   Qt.binding(() => root.rootStore.navToMsgList),
             leftPanelWidthOverride:         Qt.binding(() => root.leftPanelWidthOverride),
         })
     }
@@ -185,6 +186,9 @@ Loader {
         }
         function onNavToMsgDetailsRequested(navigate) {
             root.rootStore.setNavToMsgDetailsFlag(navigate)
+        }
+        function onNavToMsgListRequested(navigate) {
+            root.rootStore.setNavToMsgListFlag(navigate)
         }
     }
 


### PR DESCRIPTION

Fixes #21101

### What does the PR do

Handle `status-app://chats` push notification deep links by activating the chat section and explicitly navigating to the chat list panel.

Previously, the app could land on the central chat panel after opening this deep link on mobile. The fix adds a message-list navigation intent alongside the existing message-details intent, so the chat layout switches to the left panel when the generic chats deep link is received.

### Affected areas

Push notification navigation

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

Better UX

### How to test

Receive a chat push notification while the last page was a chat details view, open the push notification and the app navigates directly to the chat list

### Risk 

Low
