### PR TITLE
fix(push): Open contact requests from notification

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -14,6 +14,7 @@ import app/global/[global_singleton, feature_flags]
 import app/global/app_lifecycle
 import app/android/lifecycle
 import app/global/utils as utils
+import app_service/service/activity_center/dto/notification as activity_center_notification_dto
 import constants
 
 import chat_section/model as chat_model
@@ -94,10 +95,14 @@ const STATUS_EXTERNAL_DEEP_LINK_PREFIX = "https://status.app/"
 const STATUS_EXTERNAL_DEEP_LINK_PREFIX_HTTP = "http://status.app/"
 
 # Reserved, id-less navigation keywords used by generic deep links (e.g. bundled in
-# remote push notifications: `status-app://ac`, `status-app://chats`). They carry no
+# remote push notifications: `status-app://ac`, `status-app://contact-requests`,
+# `status-app://chats`). They carry no
 # chat/community id, so they map to a fixed destination rather than a specific item.
 const DEEP_LINK_NAV_ACTIVITY_CENTER = "ac"
+const DEEP_LINK_NAV_CONTACT_REQUESTS = "contact-requests"
 const DEEP_LINK_NAV_CHATS = "chats"
+const ACTIVITY_CENTER_ALL_GROUP = activity_center_notification_dto.ActivityCenterGroup.All.int
+const ACTIVITY_CENTER_CONTACT_REQUESTS_GROUP = activity_center_notification_dto.ActivityCenterGroup.ContactRequests.int
 
 type
   SpectateRequest = object
@@ -1652,7 +1657,7 @@ method displayWindowsOsNotification*[T](self: Module[T], title: string,
 method osNotificationClicked*[T](self: Module[T], details: NotificationDetails) =
   if(details.notificationType == NotificationType.NewContactRequest):
     self.controller.switchTo(details.sectionId, "", "")
-    self.view.emitOpenActivityCenterSignal()
+    self.view.openActivityCenter(ACTIVITY_CENTER_CONTACT_REQUESTS_GROUP)
   elif(details.notificationType == NotificationType.JoinCommunityRequest):
     self.controller.switchTo(details.sectionId, "", "")
     self.view.emitOpenCommunityMembershipRequestsViewSignal(details.sectionId)
@@ -2208,7 +2213,10 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
   let genericNavTarget = extractGenericNavTargetFromDeepLink(statusDeepLink)
   case genericNavTarget
   of DEEP_LINK_NAV_ACTIVITY_CENTER:
-    self.view.emitOpenActivityCenterSignal()
+    self.view.openActivityCenter(ACTIVITY_CENTER_ALL_GROUP)
+    return
+  of DEEP_LINK_NAV_CONTACT_REQUESTS:
+    self.view.openActivityCenter(ACTIVITY_CENTER_CONTACT_REQUESTS_GROUP)
     return
   of DEEP_LINK_NAV_CHATS:
     self.setActiveSectionById(singletonInstance.userProfile.getPubKey())

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -230,9 +230,7 @@ QtObject:
   proc emitResolvedENSSignal*(self: View, resolvedPubKey: string, resolvedAddress: string, uuid: string) =
     self.resolvedENS(resolvedPubKey, resolvedAddress, uuid)
 
-  proc openActivityCenter*(self: View) {.signal.}
-  proc emitOpenActivityCenterSignal*(self: View) =
-    self.openActivityCenter()
+  proc openActivityCenter*(self: View, group: int) {.signal.}
 
   proc openCommunityMembershipRequestsView*(self: View, sectionId: string) {.signal.}
   proc emitOpenCommunityMembershipRequestsViewSignal*(self: View, sectionId: string) =

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -213,7 +213,8 @@ QtObject {
                 root.openUrl(url)
             }
 
-            function onOpenActivityCenter() {
+            function onOpenActivityCenter(group) {
+                root.activityCenterStore.setActiveNotificationGroup(group)
                 root.openActivityCenter()
             }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -70,7 +70,6 @@ Item {
                                    appMain.privacyStore.thirdpartyServicesEnabled: true
         onOpenUrl: (link) => Global.requestOpenLink(link)
         onOpenActivityCenter: () => {
-            appMain.activityCenterStore.setActiveNotificationGroup(ActivityCenterTypes.ActivityCenterGroup.All)
             mainLayoutItem.openACCenterPanel = true
         }
         onWcLinkActivated: (link) => {


### PR DESCRIPTION
Fix #21188

Related status-go pr: https://github.com/status-im/status-go/pull/7536

### What does the PR do

Route contact request notification deep links to the Activity Center Contact requests group instead of the chat list.

Adds support for the `status-app://contact-requests` deep link and passes the target Activity Center group through the existing open activity center signal. RootStore now selects the requested Activity Center group before opening the panel, while AppMain only handles showing the panel.

### Affected areas

Push notifications / Contact request type

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

Better UX when using Push notifications

### How to test

Receive a Push notification / Contact Request. It opens activity center within the specific Contacts Request tab.

### Risk 

Low