### PR TITLE
Settings: my profile layout improvements

### DIFF
--- a/storybook/pages/SettingsDirtyToastMessagePage.qml
+++ b/storybook/pages/SettingsDirtyToastMessagePage.qml
@@ -1,0 +1,118 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import Storybook
+
+import shared.popups
+
+SplitView {
+    id: root
+
+    Logs { id: logs }
+
+    orientation: Qt.Vertical
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        SettingsDirtyToastMessage {
+            id: toast
+
+            anchors.centerIn: parent
+            width: ctrlWidth.value
+
+            active: ctrlActive.checked
+            loading: ctrlLoading.checked
+            cancelButtonVisible: ctrlCancelVisible.checked
+            saveForLaterButtonVisible: ctrlSaveForLaterVisible.checked
+            saveChangesButtonEnabled: ctrlSaveEnabled.checked
+            type: ctrlInfoType.checked ? SettingsDirtyToastMessage.Type.Info
+                                       : SettingsDirtyToastMessage.Type.Danger
+            saveChangesTooltipText: ctrlSaveEnabled.checked
+                                    ? "" : "Save is disabled"
+
+            additionalComponent.text: ctrlAdditional.checked
+                                       ? "Some additional information" : ""
+            additionalComponent.visible: ctrlAdditional.checked
+
+            onSaveChangesClicked: logs.logEvent("onSaveChangesClicked")
+            onSaveForLaterClicked: logs.logEvent("onSaveForLaterClicked")
+            onResetChangesClicked: logs.logEvent("onResetChangesClicked")
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 150
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            RowLayout {
+                Switch {
+                    id: ctrlActive
+                    text: "active"
+                    checked: true
+                }
+
+                Switch {
+                    id: ctrlLoading
+                    text: "loading"
+                    checked: false
+                }
+
+                Switch {
+                    id: ctrlSaveEnabled
+                    text: "saveChangesButtonEnabled"
+                    checked: true
+                }
+
+                Switch {
+                    id: ctrlCancelVisible
+                    text: "cancelButtonVisible"
+                    checked: true
+                }
+
+                Switch {
+                    id: ctrlSaveForLaterVisible
+                    text: "saveForLaterButtonVisible"
+                    checked: false
+                }
+            }
+
+            RowLayout {
+                Switch {
+                    id: ctrlInfoType
+                    text: "Info type (off = Danger)"
+                    checked: false
+                }
+
+                Switch {
+                    id: ctrlAdditional
+                    text: "additional component"
+                    checked: false
+                }
+
+                Button {
+                    text: "notifyDirty()"
+                    onClicked: toast.notifyDirty()
+                }
+
+                ToolSeparator {}
+
+                Label { text: "Width:" }
+                Slider {
+                    id: ctrlWidth
+                    from: 300
+                    to: 900
+                    value: 500
+                }
+            }
+        }
+    }
+}
+
+// category: Popups
+// status: good

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -264,7 +264,10 @@ SettingsContentBase {
         id: stackLayout
 
         width: root.contentWidth
-        height: profileTabBar.currentIndex === MyProfileView.Web ? implicitHeight : root.contentHeight
+        height: (profileTabBar.currentIndex === MyProfileView.Identity
+                 || profileTabBar.currentIndex === MyProfileView.Web)
+                ? implicitHeight : root.availableHeight
+
         currentIndex: profileTabBar.currentIndex
 
         onCurrentIndexChanged: {

--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -186,6 +186,7 @@ FocusScope {
         anchors.bottom: scrollView.bottom
         anchors.bottomMargin: d.bottomDirtyToastMargin
         anchors.horizontalCenter: parent.horizontalCenter
+        width: Math.min(implicitWidth, parent.width - 2 * Theme.padding)
 
         visible: active
         active: root.dirty

--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -8,6 +8,7 @@ import shared.popups
 import StatusQ.Core
 import StatusQ.Controls
 import StatusQ.Core.Theme
+import StatusQ.Core.Utils as SQUtils
 
 FocusScope {
     id: root
@@ -177,6 +178,29 @@ FocusScope {
                     }
                 }
             }
+        }
+    }
+
+    Connections {
+        target: scrollView.flickable
+
+        function scrollToFocusedItem() {
+            const focusedItem = root.Window.activeFocusItem
+            if (!focusedItem)
+                return
+            const contentItem = scrollView.flickable.contentItem
+            const rect = contentItem.mapFromItem(
+                focusedItem, Qt.rect(0, 0, focusedItem.width, focusedItem.height))
+            SQUtils.Utils.ensureVisible(scrollView.flickable,
+                                Qt.rect(0, rect.y, contentItem.width, rect.height))
+        }
+
+        function onContentHeightChanged() {
+            scrollToFocusedItem()
+        }
+
+        function onHeightChanged() {
+            scrollToFocusedItem()
         }
     }
 

--- a/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
+++ b/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
@@ -45,6 +45,10 @@ Control {
     signal saveForLaterClicked
     signal resetChangesClicked
 
+    // When true the available width is too small to fit the label and the
+    // buttons in a single row, so the buttons reflow onto a second row below.
+    readonly property bool compact: root.availableWidth < d.oneRowContentWidth
+
     function notifyDirty() {
         toastAlertAnimation.running = true
         saveChangesButton.forceActiveFocus()
@@ -52,7 +56,23 @@ Control {
 
     padding: Theme.padding
 
+    // Pinned to the natural one-row width so it stays constant across the
+    // compact/non-compact reflow - this keeps callers that rely on implicitWidth
+    // stable and avoids a binding loop with width-constrained call sites.
+    implicitWidth: leftPadding + rightPadding +
+                   Math.max(d.oneRowContentWidth, additionalTextComponent.implicitWidth)
+
     opacity: active ? 1 : 0
+
+    QtObject {
+        id: d
+
+        // Intrinsic (column-independent) width needed to lay out the label and
+        // the buttons side by side. Invisible buttons contribute 0.
+        readonly property real oneRowContentWidth: changesDetectedTextItem.implicitWidth
+                                                    + buttonsRow.implicitWidth
+                                                    + topGrid.columnSpacing
+    }
 
     onActiveChanged: {
         if (!active || !flickable)
@@ -90,7 +110,7 @@ Control {
         id: backgroundRect
 
         color: Theme.palette.statusToastMessage.backgroundColor
-        radius: 8
+        radius: Theme.radius
         border.color: root.type === SettingsDirtyToastMessage.Type.Danger
                       ? Theme.palette.dangerColor2 : Theme.palette.primaryColor2
         border.width: 2
@@ -98,7 +118,7 @@ Control {
         layer.enabled: true
         layer.effect: DropShadow {
             verticalOffset: 3
-            radius: 8
+            radius: Theme.radius
             samples: 15
             fast: true
             cached: true
@@ -114,21 +134,19 @@ Control {
             duration: 600
             onFinished: backgroundRect.border.width = 2
         }
-
-        StatusMouseArea {
-            anchors.fill: parent
-            visible: root.active // This is required not to change cursorShape
-            enabled: root.active
-            hoverEnabled: true
-        }
     }
 
     contentItem: ColumnLayout {
         id: toastContent
         spacing: Theme.padding
 
-        RowLayout {
-            Layout.alignment: Qt.AlignHCenter
+        GridLayout {
+            id: topGrid
+            Layout.fillWidth: true
+
+            columns: root.compact ? 1 : 2
+            columnSpacing: Theme.halfPadding
+            rowSpacing: Theme.halfPadding
 
             StatusBaseText {
                 id: changesDetectedTextItem
@@ -139,33 +157,55 @@ Control {
                 text: root.defaultChangesDetectedText
             }
 
-            StatusButton {
-                id: cancelChangesButton
-                text: root.defaultCancelChangesText
-                enabled: !root.loading && root.active
-                visible: root.cancelButtonVisible
-                type: StatusBaseButton.Type.Danger
-                onClicked: root.resetChangesClicked()
-            }
+            RowLayout {
+                id: buttonsRow
 
-            StatusFlatButton {
-                id: saveForLaterButton
-                text: root.defaultSaveForLaterText
-                loading: root.loading
-                enabled: root.active && root.saveChangesButtonEnabled
-                visible: root.saveForLaterButtonVisible
-                onClicked: root.saveForLaterClicked()
-            }
+                // Always right-aligned and packed together. The row is sized to
+                // its content when the buttons fit, so there is no extra space
+                // between them.
+                Layout.alignment: (root.compact ? Qt.AlignCenter : Qt.AlignRight) | Qt.AlignVCenter
+                // Never exceed the toast content width, so when the buttons don't
+                // fit the row is clamped and the fillWidth buttons shrink, eliding
+                // their text instead of overflowing.
+                Layout.maximumWidth: root.availableWidth
+                Layout.fillWidth: false
 
-            StatusButton {
-                id: saveChangesButton
+                spacing: Theme.bigPadding
 
-                objectName: "settingsDirtyToastMessageSaveButton"
-                loading: root.loading
-                text: root.defaultSaveChangesText
-                interactive: root.active && root.saveChangesButtonEnabled
-                tooltip.text: root.saveChangesTooltipText
-                onClicked: root.saveChangesClicked()
+                StatusButton {
+                    id: cancelChangesButton
+                    Layout.fillWidth: true
+                    Layout.maximumWidth: implicitWidth
+                    text: root.defaultCancelChangesText
+                    enabled: !root.loading && root.active
+                    visible: root.cancelButtonVisible
+                    type: StatusBaseButton.Type.Danger
+                    onClicked: root.resetChangesClicked()
+                }
+
+                StatusFlatButton {
+                    id: saveForLaterButton
+                    Layout.fillWidth: true
+                    Layout.maximumWidth: implicitWidth
+                    text: root.defaultSaveForLaterText
+                    loading: root.loading
+                    enabled: root.active && root.saveChangesButtonEnabled
+                    visible: root.saveForLaterButtonVisible
+                    onClicked: root.saveForLaterClicked()
+                }
+
+                StatusButton {
+                    id: saveChangesButton
+                    Layout.fillWidth: true
+                    Layout.maximumWidth: implicitWidth
+
+                    objectName: "settingsDirtyToastMessageSaveButton"
+                    loading: root.loading
+                    text: root.defaultSaveChangesText
+                    interactive: root.active && root.saveChangesButtonEnabled
+                    tooltip.text: root.saveChangesTooltipText
+                    onClicked: root.saveChangesClicked()
+                }
             }
         }
 

--- a/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
+++ b/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Window
 import Qt5Compat.GraphicalEffects
@@ -12,7 +13,7 @@ import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Controls
 
-Rectangle {
+Control {
     id: root
 
     property bool loading: false
@@ -49,25 +50,9 @@ Rectangle {
         saveChangesButton.forceActiveFocus()
     }
 
-    implicitHeight: toastContent.implicitHeight + toastContent.anchors.topMargin + toastContent.anchors.bottomMargin
-    implicitWidth: toastContent.implicitWidth + toastContent.anchors.leftMargin + toastContent.anchors.rightMargin
+    padding: Theme.padding
 
     opacity: active ? 1 : 0
-    color: Theme.palette.statusToastMessage.backgroundColor
-    radius: 8
-    border.color: type === SettingsDirtyToastMessage.Type.Danger ? Theme.palette.dangerColor2 : Theme.palette.primaryColor2
-    border.width: 2
-
-    layer.enabled: true
-    layer.effect: DropShadow {
-        verticalOffset: 3
-        radius: 8
-        samples: 15
-        fast: true
-        cached: true
-        color: root.border.color
-        spread: 0.1
-    }
 
     onActiveChanged: {
         if (!active || !flickable)
@@ -97,30 +82,49 @@ Rectangle {
         easing.type: Easing.InOutQuad
     }
 
-    NumberAnimation on border.width {
-        id: toastAlertAnimation
-        from: 0
-        to: 4
-        loops: 2
-        duration: 600
-        onFinished: root.border.width = 2
-    }
-
     Behavior on opacity {
         NumberAnimation {}
     }
 
-    StatusMouseArea {
-        anchors.fill: parent
-        visible: root.active // This is required not to change cursorShape
-        enabled: root.active
-        hoverEnabled: true
+    background: Rectangle {
+        id: backgroundRect
+
+        color: Theme.palette.statusToastMessage.backgroundColor
+        radius: 8
+        border.color: root.type === SettingsDirtyToastMessage.Type.Danger
+                      ? Theme.palette.dangerColor2 : Theme.palette.primaryColor2
+        border.width: 2
+
+        layer.enabled: true
+        layer.effect: DropShadow {
+            verticalOffset: 3
+            radius: 8
+            samples: 15
+            fast: true
+            cached: true
+            color: backgroundRect.border.color
+            spread: 0.1
+        }
+
+        NumberAnimation on border.width {
+            id: toastAlertAnimation
+            from: 0
+            to: 4
+            loops: 2
+            duration: 600
+            onFinished: backgroundRect.border.width = 2
+        }
+
+        StatusMouseArea {
+            anchors.fill: parent
+            visible: root.active // This is required not to change cursorShape
+            enabled: root.active
+            hoverEnabled: true
+        }
     }
 
-    ColumnLayout {
+    contentItem: ColumnLayout {
         id: toastContent
-        anchors.fill: parent
-        anchors.margins: Theme.padding
         spacing: Theme.padding
 
         RowLayout {


### PR DESCRIPTION
### What does the PR do

- refactors `SettingsDirtyToastMessage` to `Control`
- makes `SettingsDirtyToastMessage`'s layout responsive for limited width
- adds SB page for `SettingsDirtyToastMessage`
- fixes broken scrolling in `MyProfileView` - unnecessarily scrollable blank area
- Adds auto-scroll behavior for `MyProfileView` to avoid virtual keyboard overlapping inputs

Closes: #20927

### Affected areas
`SettingsContentBase`, `SettingsDirtyToastMessage`, `MyProfileView`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality


https://github.com/user-attachments/assets/0a56b29a-2ce3-4d67-a1e2-834f479ca2f7

### Impact on end user
Low

### How to test

Go to Settings  -> Profile, edit name and bio.

### Risk 

Low