### PR TITLE
fix(search): dont filter out contact requests, discord and bridge msgs

### DIFF
--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -283,7 +283,13 @@ method onSearchMessagesDone*(self: Module, messages: seq[MessageDto]) =
 
   # Add messages
   for m in messages:
-    if (m.contentType != ContentType.Message):
+    if m.contentType notin [
+        ContentType.Message,
+        ContentType.ContactRequest,
+        ContentType.DiscordMessage,
+        ContentType.BridgeMessage,
+        ContentType.Image,
+      ]:
       continue
 
     let chatDto = self.controller.getChatDetails("", m.chatId)


### PR DESCRIPTION
### What does the PR do

Fixes #21193

We were only accepting pure text messages, but contact request messages are also valid candidates, same as bridge and discord messages.

### Affected areas

Search module

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[fixed-search.webm](https://github.com/user-attachments/assets/31e843b5-b81c-42bf-9e94-2d18a1cf365b)


### Impact on end user

Enables searching every type of message

### How to test

Search the first messages of 1-1 chats

### Risk 

None
