### PR TITLE
chore: remove unused wakuV2Peers RPC wrapper

### DIFF
--- a/src/backend/general.nim
+++ b/src/backend/general.nim
@@ -47,10 +47,6 @@ proc adminPeers*(): RpcResponse[JsonNode] =
   let payload = %* []
   result = core.callPrivateRPC("admin_peers", payload)
 
-proc wakuV2Peers*(): RpcResponse[JsonNode] =
-  let payload = %* []
-  result = core.callPrivateRPC("peers".prefix, payload)
-
 proc getPasswordStrengthScore*(password: string, userInputs: seq[string]): RpcResponse[JsonNode] =
   let params = %* {"password": password, "userInputs": userInputs}
   try:


### PR DESCRIPTION
Two changes:

1. Removes the dead `wakuV2Peers` proc from `src/backend/general.nim` — it wraps the `wakuext_peers` RPC and has no callers in the app. Follow-up to #21173 (which removed the other dead `wakuext` peer wrappers).
2. Bumps the `vendor/status-go` submodule to the latest status-go `develop` branch.

Related status-go cleanup: status-im/status-go#7528.