### PR TITLE
Fix notification modes wrongly behaving

### DIFF
--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -41,6 +41,16 @@ QtObject:
   proc processNotification(self: NotificationsManager, title: string, message: string, details: NotificationDetails)
 
   proc setup(self: NotificationsManager, events: EventEmitter, settingsService: settings_service.Service)
+
+  proc highestNotifSetting(a, b: string): string =
+    ## Returns whichever of the two notification settings has the highest priority.
+    ## Priority order (highest first): SendAlerts > DeliverQuietly > TurnOff
+    if a == VALUE_NOTIF_SEND_ALERTS or b == VALUE_NOTIF_SEND_ALERTS:
+      return VALUE_NOTIF_SEND_ALERTS
+    if a == VALUE_NOTIF_DELIVER_QUIETLY or b == VALUE_NOTIF_DELIVER_QUIETLY:
+      return VALUE_NOTIF_DELIVER_QUIETLY
+    return VALUE_NOTIF_TURN_OFF
+
   proc delete*(self: NotificationsManager)
   proc newNotificationsManager*(events: EventEmitter, settingsService: settings_service.Service): NotificationsManager =
     new(result, delete)
@@ -223,27 +233,28 @@ QtObject:
 
     let appIsActive = app_isActive(singletonInstance.engine)
 
-    if details.notificationType == NotificationType.NewMessage or
+    if (details.notificationType == NotificationType.NewMessage or
         details.notificationType == NotificationType.NewMessageWithPersonalMention or
-        details.notificationType == NotificationType.NewMessageWithGlobalMention or
-        details.notificationType == NotificationType.NewContactRequest or
-        details.notificationType == NotificationType.ContactRemoved or
-        details.notificationType == NotificationType.IdentityVerificationRequest or
-        details.notificationType == NotificationType.NewsFeedMessage:
-
-      if notificationWay == VALUE_NOTIF_DELIVER_QUIETLY:
-        return
-
-      if (details.notificationType == NotificationType.NewMessage or
-          details.notificationType == NotificationType.NewMessageWithPersonalMention or
-          details.notificationType == NotificationType.NewMessageWithGlobalMention) and
-          details.sectionActive and
-          details.chatActive and appIsActive:
-        return
+        details.notificationType == NotificationType.NewMessageWithGlobalMention) and
+        details.sectionActive and
+        details.chatActive and appIsActive:
+      return
 
     if appIsActive:
       debug "Add APP notification", notificationType=details.notificationType
       self.events.emit(SIGNAL_DISPLAY_APP_NOTIFICATION, data)
+
+    if notificationWay == VALUE_NOTIF_DELIVER_QUIETLY and
+        details.notificationType in [
+          NotificationType.NewMessage,
+          NotificationType.NewMessageWithPersonalMention,
+          NotificationType.NewMessageWithGlobalMention,
+          NotificationType.NewContactRequest,
+          NotificationType.ContactRemoved,
+          NotificationType.IdentityVerificationRequest,
+          NotificationType.NewsFeedMessage
+        ]:
+      return
 
     if not appIsActive or details.notificationType == NotificationType.TestNotification:
       # Check anonymity level
@@ -297,55 +308,62 @@ QtObject:
         return
 
       let messageBelongsToCommunity = details.isCommunitySection
-      if(messageBelongsToCommunity):
+      if messageBelongsToCommunity:
         let exemptions = self.settingsService.getNotifSettingExemptions(details.sectionId)
         if(exemptions.muteAllMessages):
           return
 
-        if(details.notificationType == NotificationType.NewMessageWithPersonalMention and
-          exemptions.personalMentions != VALUE_NOTIF_TURN_OFF):
+        if details.notificationType == NotificationType.NewMessageWithPersonalMention and
+          exemptions.personalMentions != VALUE_NOTIF_TURN_OFF:
           self.notificationCheck(title, message, details, exemptions.personalMentions)
           return
 
-        if(details.notificationType == NotificationType.NewMessageWithGlobalMention and
-          exemptions.globalMentions != VALUE_NOTIF_TURN_OFF):
+        if details.notificationType == NotificationType.NewMessageWithGlobalMention and
+          exemptions.globalMentions != VALUE_NOTIF_TURN_OFF:
           self.notificationCheck(title, message, details, exemptions.globalMentions)
           return
 
-        if(details.notificationType == NotificationType.NewMessage and
-          exemptions.otherMessages != VALUE_NOTIF_TURN_OFF):
+        if details.notificationType == NotificationType.NewMessage and
+          exemptions.otherMessages != VALUE_NOTIF_TURN_OFF:
           self.notificationCheck(title, message, details, exemptions.otherMessages)
           return
 
         return
       else:
-        if(details.isOneToOne or details.isGroupChat):
+        if details.isOneToOne or details.isGroupChat:
           let exemptions = self.settingsService.getNotifSettingExemptions(details.chatId)
-          if exemptions.muteAllMessages or
-              # Don't show a notification for group messages that are NOT mentions
-              (details.isGroupChat and details.notificationType != NotificationType.NewMessageWithPersonalMention):
+          if exemptions.muteAllMessages:
+            # Chat is muted
             return
 
-        if(details.notificationType == NotificationType.NewMessageWithPersonalMention and
-          self.settingsService.getNotifSettingPersonalMentions() != VALUE_NOTIF_TURN_OFF):
+          let chatNotificationWay = if details.isOneToOne:
+              self.settingsService.getNotifSettingOneToOneChats()
+            else:
+              self.settingsService.getNotifSettingGroupChats()
+
+          if details.notificationType == NotificationType.NewMessageWithPersonalMention:
+            # A notification should be sent if either the personal mention setting or the chat-type
+            # setting allows it. Use whichever of the two is the highest priority.
+            let mentionSetting = self.settingsService.getNotifSettingPersonalMentions()
+            let effectiveSetting = highestNotifSetting(mentionSetting, chatNotificationWay)
+            if effectiveSetting != VALUE_NOTIF_TURN_OFF:
+              self.notificationCheck(title, message, details, effectiveSetting)
+          else:
+            if chatNotificationWay != VALUE_NOTIF_TURN_OFF:
+              self.notificationCheck(title, message, details, chatNotificationWay)
+          return
+
+        # Personal mentions in non-1-1/non-group-chat contexts (e.g. unnamed channels)
+        if details.notificationType == NotificationType.NewMessageWithPersonalMention and
+          self.settingsService.getNotifSettingPersonalMentions() != VALUE_NOTIF_TURN_OFF:
           self.notificationCheck(title, message, details, self.settingsService.getNotifSettingPersonalMentions())
           return
 
-        if(details.notificationType == NotificationType.NewMessageWithGlobalMention and
-          self.settingsService.getNotifSettingGlobalMentions() != VALUE_NOTIF_TURN_OFF):
+        # Global mentions in non-1-1/non-group-chat contexts
+        if details.notificationType == NotificationType.NewMessageWithGlobalMention and
+          self.settingsService.getNotifSettingGlobalMentions() != VALUE_NOTIF_TURN_OFF:
           self.notificationCheck(title, message, details, self.settingsService.getNotifSettingGlobalMentions())
           return
-
-        if(details.notificationType == NotificationType.NewMessage):
-          if(details.isOneToOne and
-            self.settingsService.getNotifSettingOneToOneChats() != VALUE_NOTIF_TURN_OFF):
-            self.notificationCheck(title, message, details, self.settingsService.getNotifSettingOneToOneChats())
-            return
-
-          if(details.isGroupChat and
-            self.settingsService.getNotifSettingGroupChats() != VALUE_NOTIF_TURN_OFF):
-            self.notificationCheck(title, message, details, self.settingsService.getNotifSettingGroupChats())
-            return
 
     # In all other cases (TestNotification, AcceptedContactRequest, ContactRemoved, JoinCommunityRequest,  MyRequestToJoinCommunityAccepted,
     # MyRequestToJoinCommunityRejected)

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1687,11 +1687,12 @@ method displayEphemeralNotification*[T](
     self.events.emit(SIGNAL_PLAY_NOTIFICATION_SOUND, Args())
 
 method displayEphemeralNotification*[T](self: Module[T], title: string, subTitle: string, details: NotificationDetails) =
-  # Message toasts create high-frequency UI noise, so keep them disabled until their value is reassessed.
-  if details.notificationType == NotificationType.NewMessage or
-      details.notificationType == NotificationType.NewMessageWithPersonalMention or
-      details.notificationType == NotificationType.NewMessageWithGlobalMention:
-    return
+  when defined(ios) or defined(android):
+    # Message toasts create high-frequency UI noise on mobile, so keep them disabled there.
+    if details.notificationType == NotificationType.NewMessage or
+        details.notificationType == NotificationType.NewMessageWithPersonalMention or
+        details.notificationType == NotificationType.NewMessageWithGlobalMention:
+      return
 
   if details.notificationType == NotificationType.CommunityTokenPermissionCreated or
       details.notificationType == NotificationType.CommunityTokenPermissionUpdated or

--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -514,16 +514,25 @@ SettingsContentBase {
                         to: 100
                         stepSize: 1
 
-                        onValueChanged: {
+                        function commitVolume() {
+                            if (d.notificationsSettings.volume === value) 
+                                return
                             d.notificationsSettings.volume = value
+                            Global.playNotificationSound()
+                        }
+
+                        onPressedChanged: {
+                            if (!pressed)
+                                commitVolume()
+                        }
+
+                        onValueChanged: {
+                            if (!pressed)
+                                commitVolume()
                         }
 
                         Component.onCompleted: {
                             value = d.notificationsSettings.volume
-                            volumeSlider.valueChanged.connect(() => {
-                                                            // play a sound preview, but not on startup
-                                                            Global.playNotificationSound()
-                                                        });
                         }
                     }
 


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-app/issues/20878

There were multiple issues with the notifications:
1. Deliver quietly didn't work most of the time, because we escaped the function too early
2. Group chat messages never sent notifications. This was per another issue, but IMO they should send notifications, since there is a setting for that. Otherwise, the setting is useless
3. 1-1 and group chats could fail to send a notification if they had a mention and the mention notification was off.
4. I re-added the toast notification for silent notifications, but only on desktop

Also fixes a small issue with the volume slider. The volume setting change and sound was fired while dragging. Now it fires only when the user stops.

### Affected areas

- notifications_manager
- main module
- NotificationsView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[notifications-fixes.webm](https://github.com/user-attachments/assets/9aae45d5-f47a-4206-ada7-d39c3b829e0a)


### Impact on end user

Makes notifications respect the settings

### How to test

Play with your settings and send message

### Risk 

Low
