### PR TITLE
fix(Wallet): unbreak the All Accounts bg color

### DIFF
--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -1243,7 +1243,7 @@ mainWallet_Saved_Addresses_Button = {"container": statusDesktop_mainWindow, "obj
 walletAccounts_StatusListView = {"container": statusDesktop_mainWindow, "objectName": "walletAccountsListView",
                                  "type": "StatusListView", "visible": True}
 mainWallet_All_Accounts_Button = {"container": walletAccounts_StatusListView, "objectName": "allAccountsBtn",
-                                  "type": "Button", "visible": True}
+                                  "type": "StatusFlatButton", "visible": True}
 mainWallet_Add_Account_Button = {"container": statusDesktop_mainWindow, "objectName": "addAccountButton",
                                  "type": "StatusRoundButton", "visible": True}
 walletAccount_StatusListItem = {"container": walletAccounts_StatusListView,

--- a/test/e2e/gui/objects_map/wallet_names.py
+++ b/test/e2e/gui/objects_map/wallet_names.py
@@ -8,7 +8,7 @@ mainWallet_LeftTab = {"container": mainWindow_WalletLayout, "objectName": "walle
 
 mainWallet_Saved_Addresses_Button = { "container": mainWallet_LeftTab, "objectName": "savedAddressesBtn", "type": "StatusFlatButton", "visible": True}
 walletAccounts_StatusListView = {"container": mainWallet_LeftTab, "objectName": "walletAccountsListView", "type": "StatusListView", "visible": True}
-mainWallet_All_Accounts_Button = {"container": walletAccounts_StatusListView, "objectName": "allAccountsBtn", "type": "Button", "visible": True}
+mainWallet_All_Accounts_Button = {"container": walletAccounts_StatusListView, "objectName": "allAccountsBtn", "type": "StatusFlatButton", "visible": True}
 mainWallet_Add_Account_Button = {"container": mainWallet_LeftTab, "objectName": "addAccountButton", "type": "StatusRoundButton", "visible": True}
 walletAccount_StatusListItem = {"container": walletAccounts_StatusListView, "objectName": "walletAccountListItem", "type": "StatusListItem", "visible": True}
 mainWallet_All_Accounts_Balance = {"container": mainWallet_All_Accounts_Button, "objectName": "walletLeftListAmountValue", "type": "StatusTextWithLoadingState", "visible": True}

--- a/test/ui-test/testSuites/global_shared/scripts/wallet_names.py
+++ b/test/ui-test/testSuites/global_shared/scripts/wallet_names.py
@@ -11,7 +11,7 @@ walletAccounts_StatusListView = {"container": statusDesktop_mainWindow, "objectN
 walletAccounts_WalletAccountItem_Placeholder = {"container": walletAccounts_StatusListView, "objectName": "walletAccount-%NAME%", "type": "StatusListItem", "visible": True}
 walletAccount_StatusListItem = {"container": walletAccounts_StatusListView, "objectName": RegularExpression("walletAccount*"), "type": "StatusListItem", "visible": True}
 mainWallet_Hide_Show_Watch_Only_Button = {"container": statusDesktop_mainWindow, "objectName": "hideShowWatchOnlyButton", "type": "StatusButton", "visible": True}
-mainWallet_All_Accounts_Button = {"container": walletAccounts_StatusListView, "objectName": "allAccountsBtn", "type": "Button", "visible": True}
+mainWallet_All_Accounts_Button = {"container": walletAccounts_StatusListView, "objectName": "allAccountsBtn", "type": "StatusFlatButton", "visible": True}
 
 # Context Menu
 mainWallet_CopyAddress_MenuItem = {"container": contextMenu_PopupItem, "enabled": True, "objectName": RegularExpression("AccountMenu-CopyAddressAction*"), "type": "StatusMenuItem"}

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -339,7 +339,7 @@ Rectangle {
                     ]
                 }
 
-                header: Button {
+                header: StatusFlatButton {
                     id: header
                     verticalPadding: Theme.padding
                     horizontalPadding: Theme.padding
@@ -357,9 +357,6 @@ Rectangle {
                         implicitWidth: parent.ListView.view.width - Theme.padding * 2
                     }
 
-                    HoverHandler {
-                        cursorShape: Qt.PointingHandCursor
-                    }
                     onClicked: root.selectAllAccounts()
 
                     contentItem: ColumnLayout {


### PR DESCRIPTION
### What does the PR do

- seems like on Windows, an unstyled plain `Button` uses the native control now; use our own StatusFlatButton

Fixes #21202

### Affected areas

Wallet

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2816" height="2008" alt="Snímek obrazovky z 2026-06-10 01-52-37" src="https://github.com/user-attachments/assets/cd674aa9-70aa-4d92-b5de-27ba1d152b19" />

### Impact on end user

Wallet UI

### How to test

- on Windows, hover the "All Accounts" left tab view button

### Risk 

low
