### PR TITLE
StatusChatInput: proper cut-off when scrolling, paddings updated

### DIFF
--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -708,7 +708,7 @@ Control {
 
                         Keys.forwardTo: [keyEventsFilter]
 
-                        readonly property int basePadding: Theme.padding + 10
+                        readonly property int basePadding: Theme.padding + 12
                         readonly property int extraHorizontalPadding: 12 // for the nav bar handle / scrollbar
 
                         // When the text area is empty, we need to use padding because textMargin is ignored

--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -696,9 +696,6 @@ Control {
                     Layout.fillWidth: true
                     Layout.maximumHeight: 200
 
-                    Layout.topMargin: Theme.padding
-                    Layout.leftMargin: 12
-                    Layout.rightMargin: 12
                     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
                     ScrollBar.vertical.implicitWidth: Theme.halfPadding
 
@@ -711,10 +708,28 @@ Control {
 
                         Keys.forwardTo: [keyEventsFilter]
 
-                        topPadding: 22
-                        bottomPadding: 22
-                        leftPadding: Theme.halfPadding // for the nav bar handle
-                        rightPadding: Theme.halfPadding // for the scrollbar
+                        readonly property int basePadding: Theme.padding + 10
+                        readonly property int extraHorizontalPadding: 12 // for the nav bar handle / scrollbar
+
+                        // When the text area is empty, we need to use padding because textMargin is ignored
+                        // when calculating size. When not empty, textMargin is used because paddings are
+                        // clipped by ScrollView.
+                        padding: 0
+                        leftPadding: (length ? -basePadding + Theme.halfPadding : Theme.halfPadding)
+                                     + extraHorizontalPadding
+                        rightPadding: (length ? -basePadding + Theme.halfPadding : Theme.halfPadding)
+                                      + extraHorizontalPadding
+                        topPadding: length ? 0 : basePadding
+                        bottomPadding: (length ? 0 : basePadding) - Theme.padding
+
+                        textMargin: length ? basePadding : 0
+
+                        onLineCountChanged: {
+                            const flickable = inputScrollView.contentItem
+
+                            if (height - (cursorRectangle.y + cursorRectangle.height) <= textMargin)
+                                flickable.contentY = height - flickable.height
+                        }
 
                         messageLimit: root.messageLimit
                         messageLimitHard: root.messageLimitHard


### PR DESCRIPTION
### What does the PR do

- fixes problems with improper selection marker clipping
- defines proper cut-off line on top when scrolling
- updates paddings

Closes: #21200
Closes: #21210

### Affected areas
`StatusChatInput`

### Screencapture of the functionality

[Screencast from 10.06.2026 18:02:53.webm](https://github.com/user-attachments/assets/bbd3d959-782a-4123-af6c-f8b8248d96aa)

### How to test

Go to chat input, write multi-line content to exceed maximum height of the chat input field. Select text, scroll using scrollbar.

<!-- How should one proceed with testing this PR. -->
<!-- What kind of user flows should be checked? -->

