### PR TITLE
Fix contact removed toast messages

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -140,7 +140,7 @@ proc init*(self: Controller) =
         self.delegate.onMutualContactChanged()
 
     self.events.on(SIGNAL_CONTACT_REMOVED) do(e: Args):
-      var args = ContactArgs(e)
+      var args = ContactRemovedArgs(e)
       if (args.contactId == self.chatId):
         self.delegate.onMutualContactChanged()
 

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -161,7 +161,7 @@ proc init*(self: Controller) =
     self.delegate.updateContactDetails(args.contactId)
 
   self.events.on(SIGNAL_CONTACT_REMOVED) do(e: Args):
-    var args = ContactArgs(e)
+    var args = ContactRemovedArgs(e)
     self.delegate.updateContactDetails(args.contactId)
 
   self.events.on(SIGNAL_CONTACT_BLOCKED) do(e: Args):

--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -82,7 +82,7 @@ proc init*(self: Controller) =
       self.delegate.contactUpdated(args.contactId)
 
     self.events.on(SIGNAL_CONTACT_REMOVED) do(e: Args):
-      let args = ContactArgs(e)
+      let args = ContactRemovedArgs(e)
       self.delegate.contactUpdated(args.contactId)
 
     self.events.on(SIGNAL_CONTACT_BLOCKED) do(e: Args):

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -144,7 +144,7 @@ proc init*(self: Controller) =
     self.delegate.onContactAdded(args.contactId, args.fromBackup)
 
   self.events.on(SIGNAL_CONTACT_REMOVED) do(e: Args):
-    var args = ContactArgs(e)
+    var args = ContactRemovedArgs(e)
     self.delegate.onContactRejected(args.contactId)
 
   self.events.on(SIGNAL_CONTACT_BLOCKED) do(e: Args):

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1197,10 +1197,17 @@ method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatI
 
   # Prepare notification
   var notificationType = notification_details.NotificationType.NewMessage
-  if(message.isPersonalMention(myPK)):
+  if message.isPersonalMention(myPK):
     notificationType = notification_details.NotificationType.NewMessageWithPersonalMention
-  elif(message.isGlobalMention()):
+  elif message.isGlobalMention():
     notificationType = notification_details.NotificationType.NewMessageWithGlobalMention
+  elif message.contentType in [SystemMessagePinnedMessage,
+                              SystemMessageMutualEventSent,
+                              SystemMessageMutualEventAccepted,
+                              SystemMessageMutualEventRemoved,
+                              SystemMessageGroup]:
+    # Don't show notifications for system messages
+    return
 
   var senderDisplayName: string =
     if message.contentType == ContentType.BridgeMessage:

--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -46,8 +46,9 @@ proc init*(self: Controller) =
     self.delegate.addOrUpdateContactItem(args.contactId)
 
   self.events.on(SIGNAL_CONTACT_REMOVED) do(e: Args):
-    var args = ContactArgs(e)
+    var args = ContactRemovedArgs(e)
     self.delegate.addOrUpdateContactItem(args.contactId)
+    self.delegate.onContactRemoved(args.contactId, args.displayName, args.theyRemovedUs)
 
   self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
     var args = ContactArgs(e)

--- a/src/app/modules/main/profile_section/contacts/io_interface.nim
+++ b/src/app/modules/main/profile_section/contacts/io_interface.nim
@@ -65,6 +65,9 @@ method removeContact*(self: AccessInterface, publicKey: string) {.base.} =
 method addOrUpdateContactItem*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onContactRemoved*(self: AccessInterface, publicKey: string, displayName: string, theyRemovedUs: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method contactNicknameChanged*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -165,6 +165,10 @@ method addOrUpdateContactItem*(self: Module, publicKey: string) =
     item.isRemoved,
   )
 
+method onContactRemoved*(self: Module, publicKey: string, displayName: string, theyRemovedUs: bool) =
+  let contactDetails = self.controller.getContactDetails(publicKey)
+  self.view.contactRemoved(displayName, theyRemovedUs)
+
 method contactsStatusUpdated*(self: Module, statusUpdates: seq[StatusUpdateDto]) =
   for s in statusUpdates:
     self.view.contactsModel().setOnlineStatus(s.publicKey, toOnlineStatus(s.statusType))

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -96,6 +96,8 @@ QtObject:
 
   proc trustStatusRemoved*(self: View, publicKey: string) {.signal.}
 
+  proc contactRemoved*(self: View, displayName: string, theyRemovedUs: bool) {.signal.}
+
   proc shareUserUrlWithData*(self: View, pubkey: string): string {.slot.} =
     return self.delegate.shareUserUrlWithData(pubkey)
 

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -37,6 +37,11 @@ type
     contactId*: string
     fromBackup*: bool
 
+  ContactRemovedArgs* = ref object of Args
+    contactId*: string
+    displayName*: string
+    theyRemovedUs*: bool
+
   TrustArgs* = ref object of Args
     publicKey*: string
     trustStatus*: TrustStatus
@@ -247,6 +252,13 @@ QtObject:
               "Contact request accepted",
               fmt "{receivedContact.displayName} accepted your contact request",
               receivedContact.id)
+          # Check if we used to be mutal and the other removed us
+          if localContact.added and localContact.hasAddedUs and not receivedContact.hasAddedUs:
+            self.events.emit(SIGNAL_CONTACT_REMOVED, ContactRemovedArgs(
+              contactId: receivedContact.id,
+              displayName: receivedContact.displayName,
+              theyRemovedUs: true)
+            )
 
           let data = ContactArgs(contactId: c.id)
           self.events.emit(SIGNAL_CONTACT_UPDATED, data)
@@ -484,19 +496,27 @@ QtObject:
   # fromBackup is used to indicate that the contact was loaded from a backup
   proc updateContact(self: Service, contact: ContactsDto, fromBackup: bool = false) =
     var signal = SIGNAL_CONTACT_ADDED
+    var alreadyEmitted = false
     let publicKey = contact.id
     if self.contacts.hasKey(publicKey):
       if self.contacts[publicKey].dto.added and not self.contacts[publicKey].dto.removed and contact.added and not contact.removed:
         signal = SIGNAL_CONTACT_UPDATED
       if contact.removed and not self.contacts[publicKey].dto.removed:
-        singletonInstance.globalEvents.showContactRemoved("Contact removed", fmt "You removed {contact.displayName} as a contact", contact.id)
-        signal = SIGNAL_CONTACT_REMOVED
+        # Removed contact emits a different signal, so mark that we have already emitted for this contact
+        # to avoid emitting two signals for the same contact
+        alreadyEmitted = true
+        self.events.emit(SIGNAL_CONTACT_REMOVED, ContactRemovedArgs(
+              contactId: contact.id,
+              displayName: contact.displayName,
+              theyRemovedUs: false)
+            )
     let merged = self.preserveCachedEnrichment(contact)
     self.contacts[publicKey] = self.constructContactDetails(
       merged,
       isCurrentUser = merged.id == singletonInstance.userProfile.getPubKey()
     )
-    self.events.emit(signal, ContactArgs(contactId: publicKey, fromBackup: fromBackup))
+    if not alreadyEmitted:
+      self.events.emit(signal, ContactArgs(contactId: publicKey, fromBackup: fromBackup))
 
   proc parseContactsResponse*(self: Service, contacts: JsonNode, fromBackup: bool = false) =
     for contactJson in contacts:

--- a/ui/app/AppLayouts/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/stores/ContactsStore.qml
@@ -23,6 +23,7 @@ QtObject {
         Component.onCompleted: {
             mainModuleInst.resolvedENS.connect(root.resolvedENS)
             contactsModuleInst.trustStatusRemoved.connect(root.trustStatusRemoved)
+            contactsModuleInst.contactRemoved.connect(root.contactRemoved)
             contactsModuleInst.contactInfoRequestFinished.connect(root.contactInfoRequestFinished)
         }
     }
@@ -72,6 +73,7 @@ QtObject {
 
     signal resolvedENS(string resolvedPubKey, string resolvedAddress, string uuid)
     signal trustStatusRemoved(string pubKey)
+    signal contactRemoved(string displayName, bool theyRemovedUs)
 
     // Sets showcasePublicKey and updates showcase models with corresponding data
     function requestContactShowcase(publicKey) {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -571,8 +571,6 @@ QtObject {
                     if (markAsUntrusted) {
                         root.contactsStore.markUntrustworthy(publicKey)
                         Global.displaySuccessToastMessage(qsTr("%1 removed from contacts and marked as untrusted").arg(mainDisplayName))
-                    } else {
-                        Global.displaySuccessToastMessage(qsTr("%1 removed from contacts").arg(mainDisplayName))
                     }
                     close()
                 }

--- a/ui/app/mainui/ToastsManager.qml
+++ b/ui/app/mainui/ToastsManager.qml
@@ -242,6 +242,20 @@ QtObject {
             const displayName = SQUtils.ModelUtils.getByKey(root.contactsStore.contactsModel, "pubKey", pubKey, "preferredDisplayName")
             Global.displaySuccessToastMessage(qsTr("Trust mark removed for %1").arg(displayName))
         }
+
+        function onContactRemoved(displayName: string, theyRemovedUs: bool) {
+            if (theyRemovedUs) {
+                Global.displayToastMessage(qsTr("Contact removed"),
+                                           qsTr("%1 removed you as a contact").arg(displayName),
+                                           root.warningAssetName,
+                                           false,
+                                            Constants.ephemeralNotificationType.danger,
+                                           "")
+            } else {
+                Global.displaySuccessToastMessage(qsTr("Contact removed"),
+                                                qsTr("You removed %1 as a contact").arg(displayName))
+            }
+        }
     }
 
     readonly property Connections _devicesStoreConnections: Connections {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -14337,10 +14337,6 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 removed from contacts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 marked as trusted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18617,6 +18613,18 @@ This action cannot be undone.</source>
     </message>
     <message>
         <source>Trust mark removed for %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contact removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 removed you as a contact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You removed %1 as a contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -17483,11 +17483,6 @@
       <translation>%1 removed from contacts and marked as untrusted</translation>
     </message>
     <message>
-      <source>%1 removed from contacts</source>
-      <comment>Popups</comment>
-      <translation>%1 removed from contacts</translation>
-    </message>
-    <message>
       <source>%1 marked as trusted</source>
       <comment>Popups</comment>
       <translation>%1 marked as trusted</translation>
@@ -22673,6 +22668,21 @@
       <source>Trust mark removed for %1</source>
       <comment>ToastsManager</comment>
       <translation>Trust mark removed for %1</translation>
+    </message>
+    <message>
+      <source>Contact removed</source>
+      <comment>ToastsManager</comment>
+      <translation>Contact removed</translation>
+    </message>
+    <message>
+      <source>%1 removed you as a contact</source>
+      <comment>ToastsManager</comment>
+      <translation>%1 removed you as a contact</translation>
+    </message>
+    <message>
+      <source>You removed %1 as a contact</source>
+      <comment>ToastsManager</comment>
+      <translation>You removed %1 as a contact</translation>
     </message>
     <message>
       <source>Your data backed up successfully</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -14443,10 +14443,6 @@ selhalo</translation>
         <translation>%1 odstraněn z kontaktů a označen jako nedůvěryhodný</translation>
     </message>
     <message>
-        <source>%1 removed from contacts</source>
-        <translation>%1 odstraněn z kontaktů</translation>
-    </message>
-    <message>
         <source>%1 marked as trusted</source>
         <translation>%1 označen jako důvěryhodný</translation>
     </message>
@@ -18743,6 +18739,18 @@ Tuto akci nelze vzít zpět.</translation>
     <message>
         <source>Trust mark removed for %1</source>
         <translation>Značka důvěry odstraněna pro %1</translation>
+    </message>
+    <message>
+        <source>Contact removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 removed you as a contact</source>
+        <translation type="unfinished">%1 si vás odebral z kontaktů</translation>
+    </message>
+    <message>
+        <source>You removed %1 as a contact</source>
+        <translation type="unfinished">Odebrali jste %1 z kontaktů</translation>
     </message>
     <message>
         <source>Your data backed up successfully</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -14358,10 +14358,6 @@ al cargar</translation>
         <translation>%1 eliminado de contactos y marcado como no confiable</translation>
     </message>
     <message>
-        <source>%1 removed from contacts</source>
-        <translation>%1 eliminado de contactos</translation>
-    </message>
-    <message>
         <source>%1 marked as trusted</source>
         <translation>%1 marcado como confiable</translation>
     </message>
@@ -18636,6 +18632,18 @@ This action cannot be undone.</source>
     <message>
         <source>Trust mark removed for %1</source>
         <translation>Marca de confianza eliminada para %1</translation>
+    </message>
+    <message>
+        <source>Contact removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 removed you as a contact</source>
+        <translation type="unfinished">%1 te eliminó como contacto</translation>
+    </message>
+    <message>
+        <source>You removed %1 as a contact</source>
+        <translation type="unfinished">Eliminaste a %1 como contacto</translation>
     </message>
     <message>
         <source>Your data backed up successfully</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -14306,10 +14306,6 @@ to load</source>
         <translation>%1 연락처에서 제거되고 신뢰하지 않는 대상으로 표시됨</translation>
     </message>
     <message>
-        <source>%1 removed from contacts</source>
-        <translation>연락처에서 %1을(를) 제거했어요</translation>
-    </message>
-    <message>
         <source>%1 marked as trusted</source>
         <translation>%1 신뢰함으로 표시됨</translation>
     </message>
@@ -18573,6 +18569,18 @@ This action cannot be undone.</source>
     <message>
         <source>Trust mark removed for %1</source>
         <translation>%1의 신뢰 표시가 제거됨</translation>
+    </message>
+    <message>
+        <source>Contact removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 removed you as a contact</source>
+        <translation type="unfinished">%1 님이 당신을 연락처에서 제거했어요</translation>
+    </message>
+    <message>
+        <source>You removed %1 as a contact</source>
+        <translation type="unfinished">%1님을 연락처에서 삭제했습니다</translation>
     </message>
     <message>
         <source>Your data backed up successfully</source>


### PR DESCRIPTION
### What does the PR do

Fixes #20875

1. [correctly display a toast message on contact removal](https://github.com/status-im/status-app/commit/1e166694991ff39d52917f925b226b8e10394f34) 

We did not use to have a toast message when we got removed as a contact, so this commit adds one.
It also standardizes the toast showing for when we remove someone to use the new one. Meaning that now it uses a QML toast message instead of a Nim one (not translateable)

2. [stop sending notifications for system messages](https://github.com/status-im/status-app/commit/9f894da1ed3a4c8b2b345b5785d6681f821cfb64) 

We were sending notifications (OS and toast) for system messages, which sometimes showed as empty, because the test isn't formatted the same.
I decided to simply disallow them, because we usually handle those manually for toast messages, which means they can get translated and also having OS level alerts for system messages is not that interesting (for example someone pinned a message in a group).

### Affected areas

- chat_section/module
- contact service
- ToastManager

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[good-notification-for-removing.webm](https://github.com/user-attachments/assets/a70bbc67-cd7b-46ca-9ae5-924f0f116300)


### Impact on end user

Notifications for removing contacts are now clearer and more useful

### How to test

- Add a contact
- Remove the contact from yourself and the other

### Risk 

Low
