### PR TITLE
fix(wallet): treat unmapped market tokens as non-critical errors

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
@@ -74,6 +74,9 @@ Item {
         readonly property string historicalDataTokenKey: {
             if (!root.tokenGroup || !root.tokenGroup.tokens)
                 return ""
+            const ethereumToken = SQUtils.ModelUtils.getByKey(root.tokenGroup.tokens, "chainId", 1)
+            if (ethereumToken && ethereumToken.key)
+                return ethereumToken.key
             const first = SQUtils.ModelUtils.get(root.tokenGroup.tokens, 0)
             return first ? first.key ?? "" : ""
         }

--- a/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
@@ -74,7 +74,7 @@ Item {
         readonly property string historicalDataTokenKey: {
             if (!root.tokenGroup || !root.tokenGroup.tokens)
                 return ""
-            const ethereumToken = SQUtils.ModelUtils.getByKey(root.tokenGroup.tokens, "chainId", 1)
+            const ethereumToken = SQUtils.ModelUtils.getByKey(root.tokenGroup.tokens, "chainId", Constants.chains.mainnetChainId)
             if (ethereumToken && ethereumToken.key)
                 return ethereumToken.key
             const first = SQUtils.ModelUtils.get(root.tokenGroup.tokens, 0)


### PR DESCRIPTION
* AssetsDetailView now prefers the Ethereum mainnet token key (chainId === 1) when picking historicalDataTokenKey, falling back to the first token. 
* Bumps status-go: unmapped tokens are non-critical errors and chart history falls back to the Ethereum sibling server-side. https://github.com/status-im/status-go/pull/7552


<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/3ac26b76-9277-454e-999e-686128a8550b" width="400" controls></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/39f8a4db-c8f5-47f4-90ee-c70d31de8847" width="400" controls></video>
    </td>
  </tr>
</table>


Fixes #21143