### PR TITLE
fix(chat): don't show the mention anchor in 1-1 chats

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -282,10 +282,13 @@ Item {
 
         ChatAnchorButtonsPanel {
             anchors.bottom: parent.bottom
+            anchors.bottomMargin: Theme.padding
             anchors.right: parent.right
             anchors.rightMargin: Theme.padding
 
-            mentionsCount: d.chatDetails ? d.chatDetails.notificationCount : 0
+            // Don't show the mention anchor in 1-1 chats, because all messages count as mentions
+            mentionsCount: d.chatDetails && d.chatDetails.type !== Constants.chatType.oneToOne ?
+                        d.chatDetails.notificationCount : 0
             recentMessagesButtonVisible: {
                 chatLogView.contentY // trigger binding on contentY change
                 return chatLogView.contentHeight - (d.scrollY + chatLogView.height) > 400


### PR DESCRIPTION
### What does the PR do

Fixes #21103

Since all messages in a 1-1 chat count as a mention, the anchor showed. We just stop showing it in 1-1 chats.

### Affected areas

ChatMessagesView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="1254" height="798" alt="image" src="https://github.com/user-attachments/assets/fe069b08-32fe-4270-9d80-da41171fa368" />

<img width="1254" height="798" alt="image" src="https://github.com/user-attachments/assets/fcab98e4-efe0-400c-9024-b8c7c01cfbcb" />


### Impact on end user

Removes the anchor when not needed

### How to test

Send 1-1 messages

### Risk 

Low
