### PR TITLE
fix(e2e_appium): verify arrival on drawer navigation, add dedicated drawer testFix/e2e nav arrival verify

### DIFF
--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -48,8 +48,12 @@ class App(BasePage):
         if self.active_section() == "messaging":
             self.logger.info("Already in Messages section — skipping nav")
             return True
-        self._ensure_main_nav_visible()
-        return self._click_nav_item(self.locators.LEFT_NAV_MESSAGES)
+        from utils.screen_identity import SCREEN_ANCHORS
+        return self._click_drawer_nav_with_verify(
+            nav_locator=self.locators.LEFT_NAV_MESSAGES,
+            landmark_locator=SCREEN_ANCHORS["messages"],
+            nav_name="Messages",
+        )
 
     def click_communities_button(self) -> bool:
         self.logger.info("Clicking Communities button")
@@ -61,8 +65,12 @@ class App(BasePage):
         if self.active_section() == "wallet":
             self.logger.info("Already in Wallet section — skipping nav")
             return True
-        self._ensure_main_nav_visible()
-        return self._click_nav_item(self.locators.LEFT_NAV_WALLET)
+        from utils.screen_identity import SCREEN_ANCHORS
+        return self._click_drawer_nav_with_verify(
+            nav_locator=self.locators.LEFT_NAV_WALLET,
+            landmark_locator=SCREEN_ANCHORS["wallet"],
+            nav_name="Wallet",
+        )
 
     def click_market_button(self) -> bool:
         self.logger.info("Clicking Market button")
@@ -276,9 +284,11 @@ class App(BasePage):
         failure mode. ``activate_app()`` between attempts unsticks the
         drawer's gesture handler.
         """
-        # Defensive armour for phone-portrait sessions; on the tablet gate
-        # device, attempt 1 (native) reliably wins and the rest is dormant.
-        strategies = ["native", "native", "w3c", "w3c"]
+        # W3C first: native clickGesture taps by elementId and inherits the
+        # a11y-bounds/rendered-rail mismatch on phone portrait, so it can
+        # mis-target a neighbouring item. The W3C pointer taps computed
+        # coordinates and survives it; native stays as the late fallback.
+        strategies = ["w3c", "w3c", "native", "native"]
         pkg = self.driver.capabilities.get("appPackage") or "app.status.mobile"
 
         # On a second call within ~1min of a successful first, the
@@ -339,6 +349,12 @@ class App(BasePage):
             # sometimes lags a frame behind the SwipeView transition.
             time.sleep(0.5)
             if self.is_element_visible(landmark_locator, timeout=15):
+                if attempt > 1:
+                    self.logger.warning(
+                        "click_%s_button: rescued on attempt %d (strategy=%s)"
+                        " — primary nav path failed",
+                        slug, attempt, strategy,
+                    )
                 return True
             self.logger.warning(
                 "click_%s_button: drawer closed but %s page not "

--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -262,11 +262,10 @@ class App(BasePage):
         if self.active_section() == "settings":
             self.logger.info("Already in Settings section — skipping nav")
             return True
-        from locators.settings.settings_locators import SettingsLocators
-        settings_locators = SettingsLocators()
+        from utils.screen_identity import SCREEN_ANCHORS
         return self._click_drawer_nav_with_verify(
             nav_locator=self.locators.LEFT_NAV_SETTINGS,
-            landmark_locator=settings_locators.PROFILE_MENU_ITEM,
+            landmark_locator=SCREEN_ANCHORS["settings"],
             nav_name="Settings",
         )
 

--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -323,6 +323,8 @@ class App(BasePage):
         _shake_app()
         time.sleep(0.6)  # let activate_app foregrounding settle
 
+        from utils.screen_identity import dismiss_backup_modal
+
         slug = nav_name.lower().replace(" ", "_")
         for attempt in range(1, len(strategies) + 1):
             if attempt > 1:
@@ -331,6 +333,13 @@ class App(BasePage):
                 time.sleep(1.0)  # longer settle on retry — the drawer
                 # state we're recovering from is already wedged
 
+            # The on-device-backup popup can appear mid-test (first Messages
+            # entry) and blocks the drawer entirely — clear it every attempt.
+            if dismiss_backup_modal(self, timeout=1):
+                self.logger.warning(
+                    "click_%s_button: dismissed backup modal on attempt %d",
+                    slug, attempt,
+                )
             self._ensure_main_nav_visible()
             # Drawer slide-in keeps animating for ~200-400ms after the
             # locator is in the AT tree; mid-animation taps land on stale

--- a/test/e2e_appium/pages/messaging/chat_page.py
+++ b/test/e2e_appium/pages/messaging/chat_page.py
@@ -333,9 +333,13 @@ class ChatPage(BasePage):
                 self.dismiss_introduce_prompt(timeout=1)
                 self.dismiss_backup_prompt(timeout=1)
                 try:
-                    app.click_wallet_button()
+                    # Bare nav both ways: this bounce only exists to force a
+                    # chat-list rebuild, so it shouldn't pay the verified-nav
+                    # cost (activate_app + modal check + landmark wait) per
+                    # poll iteration, and arrival is re-checked below anyway.
+                    app._ensure_main_nav_visible()
+                    app._click_nav_item(app.locators.LEFT_NAV_WALLET)
                     time.sleep(1)
-                    # Force nav even if already in Messages (bypass short-circuit)
                     app._ensure_main_nav_visible()
                     app._click_nav_item(app.locators.LEFT_NAV_MESSAGES)
                 except Exception as exc:

--- a/test/e2e_appium/tests/test_navigation_drawer.py
+++ b/test/e2e_appium/tests/test_navigation_drawer.py
@@ -11,16 +11,16 @@ import pytest
 
 from pages.app import App
 from utils.multi_device_helpers import StepMixin
-from utils.screen_identity import SCREEN_ANCHORS, confirm_screen, dismiss_backup_modal
+from utils.screen_identity import confirm_screen, dismiss_backup_modal
 
 
-SECTIONS = list(SCREEN_ANCHORS)
+SECTIONS = ("messages", "wallet", "settings")
 
 
 class TestNavigationDrawer(StepMixin):
     @pytest.mark.gate
     @pytest.mark.smoke
-    @pytest.mark.timeout(900)
+    @pytest.mark.timeout(1200)
     async def test_drawer_navigation_cycles(self):
         app = App(self.device.driver)
         dismiss_backup_modal(app)

--- a/test/e2e_appium/tests/test_navigation_drawer.py
+++ b/test/e2e_appium/tests/test_navigation_drawer.py
@@ -1,0 +1,45 @@
+"""Dedicated drawer-navigation coverage.
+
+Every other test treats navigation as setup plumbing and is entitled to the
+most reliable transport available. This test is the one place where drawer
+navigation is itself the behaviour under test: if tapping through the drawer
+breaks for real users, this fails — loudly and attributably — instead of
+surfacing as misleading failures scattered across unrelated suites.
+"""
+
+import pytest
+
+from pages.app import App
+from utils.multi_device_helpers import StepMixin
+from utils.screen_identity import SCREEN_ANCHORS, confirm_screen, dismiss_backup_modal
+
+
+SECTIONS = list(SCREEN_ANCHORS)
+
+
+class TestNavigationDrawer(StepMixin):
+    @pytest.mark.gate
+    @pytest.mark.smoke
+    @pytest.mark.timeout(900)
+    async def test_drawer_navigation_cycles(self):
+        app = App(self.device.driver)
+        dismiss_backup_modal(app)
+
+        nav_actions = {
+            "messages": app.click_messages_button,
+            "wallet": app.click_wallet_button,
+            "settings": app.click_settings_button,
+        }
+
+        for cycle in range(1, 4):
+            for section in SECTIONS:
+                async with self.step(
+                    self.device, f"Cycle {cycle}: navigate to {section}"
+                ):
+                    assert nav_actions[section](), (
+                        f"Drawer navigation to {section} failed (cycle {cycle})"
+                    )
+                    assert confirm_screen(app, section), (
+                        f"Navigation to {section} reported success but the "
+                        f"{section} anchor is not visible (cycle {cycle})"
+                    )

--- a/test/e2e_appium/utils/screen_identity.py
+++ b/test/e2e_appium/utils/screen_identity.py
@@ -37,12 +37,19 @@ BACKUP_MODAL_SKIP = BaseLocators.tid("backupMessageSkipStatusFlatButton")
 
 def dismiss_backup_modal(page, timeout: int = 2) -> bool:
     """Tap Skip on the on-device-backup popup if it is up. Returns True if a
-    modal was dismissed. Safe to call before or after any navigation."""
+    modal was dismissed. Safe to call before or after any navigation.
+
+    Never raises: callers use this as a guard inside nav retry loops, so a
+    failed dismissal must fall through to the caller's own retry, not abort
+    it (safe_click raises on exhaustion)."""
     if not page.is_element_visible(BACKUP_MODAL, timeout=timeout):
         return False
-    page.safe_click(BACKUP_MODAL_SKIP, timeout=5)
-    page.wait_for_invisibility(BACKUP_MODAL, timeout=5)
-    return True
+    try:
+        page.safe_click(BACKUP_MODAL_SKIP, timeout=5)
+        return page.wait_for_invisibility(BACKUP_MODAL, timeout=5)
+    except Exception as exc:
+        page.logger.warning("Backup modal present but dismissal failed: %s", exc)
+        return False
 
 
 def confirm_screen(page, expected: str, timeout: int = 15) -> bool:

--- a/test/e2e_appium/utils/screen_identity.py
+++ b/test/e2e_appium/utils/screen_identity.py
@@ -1,0 +1,52 @@
+"""Destination-identity helpers for the nav arrival check (#21086).
+
+Background: the portrait nav returns success on "drawer closed", which a missed
+tap also satisfies -- so a broken nav passes green (the masked-failure class).
+``confirm_screen`` checks a SCREEN-UNIQUE accessibility anchor instead. On this
+Qt build the a11y tree is reliable for *identity* (it correctly reflects which
+screen is shown -- a live dump on the backup modal exposed that modal's own
+test-ids and none of the screen anchors); its weakness is *timing* lag, which a
+generous post-settle timeout absorbs. So presence-of-anchor answers "am I on the
+intended screen?" -- rejecting a wrong destination (e.g. an interrupting modal)
+and accepting an already-there no-op, both of which a "changed-from-source"
+pixel check gets wrong.
+
+``dismiss_backup_modal`` clears the on-device-backup popup, which intermittently
+intercepts the Messaging nav and then blocks the nav drawer entirely -- the
+concrete cause of the nav wedges seen while building this.
+"""
+
+from locators.base_locators import BaseLocators
+from locators.wallet.accounts_locators import WalletAccountsLocators
+from locators.settings.settings_locators import SettingsLocators
+from locators.messaging.chat_locators import ChatLocators
+
+# Screen-unique landing anchor per screen. Presence == "on this screen".
+# Messages uses the new-chat header button, not the headline: a live a11y dump
+# on the Messages screen showed CHAT_HEADER's tid is stale (never resolves) while
+# startChatButton is present whether or not the chat list has conversations.
+SCREEN_ANCHORS = {
+    "wallet": WalletAccountsLocators().ADD_ACCOUNT_BUTTON,
+    "settings": SettingsLocators().PROFILE_MENU_ITEM,
+    "messages": ChatLocators().START_CHAT_BUTTON,
+}
+
+BACKUP_MODAL = BaseLocators.tid("EnableMessageBackupPopup")
+BACKUP_MODAL_SKIP = BaseLocators.tid("backupMessageSkipStatusFlatButton")
+
+
+def dismiss_backup_modal(page, timeout: int = 2) -> bool:
+    """Tap Skip on the on-device-backup popup if it is up. Returns True if a
+    modal was dismissed. Safe to call before or after any navigation."""
+    if not page.is_element_visible(BACKUP_MODAL, timeout=timeout):
+        return False
+    page.safe_click(BACKUP_MODAL_SKIP, timeout=5)
+    page.wait_for_invisibility(BACKUP_MODAL, timeout=5)
+    return True
+
+
+def confirm_screen(page, expected: str, timeout: int = 15) -> bool:
+    """Identity gate: is ``expected`` screen actually shown? Polls that screen's
+    unique a11y anchor with a lag-tolerant timeout. Raises KeyError for an
+    unknown screen name so a typo fails loudly instead of silently passing."""
+    return page.is_element_visible(SCREEN_ANCHORS[expected], timeout=timeout)


### PR DESCRIPTION
Closes #21220

  On phone portrait, a tap computed from the reported position of a drawer item can land on the neighbouring item. The framework treated "the drawer closed" as success, so a wrong-screen navigation passed

  This PR:

  1. Adds an arrival check to Wallet and Messages navigation. After every navigation, check for an element that only exists on the destination screen, instead of trusting that the drawer closed. Settings
  already did this; Wallet and Messages did not. Anchors live in the new utils/screen_identity.py.
  2. Dismisses the backup popup inside the navigation retry loop. It appears on the first Messages visit on every fresh profile, and the drawer does not respond while it is open. A start-of-test dismissal
  misses it. The dismissal never raises — on failure it logs a warning and lets the retry continue.
  3. Adds one dedicated gate test (tests/test_navigation_drawer.py) whose only purpose is to tap through the drawer and verify arrival each time. A real drawer regression now fails in one obvious place
  instead of scattering misleading failures across the suite.
  4. Tries the W3C pointer tap before the native gesture (native taps by element id and inherits the bad reported position), and logs a warning whenever navigation only succeeds on a retry — the near-miss
  rate becomes visible in logs instead of silent.

  Also: the chat-list refresh helper keeps the lightweight nav path (it only bounces sections to force a list rebuild and re-checks arrival itself).
  
  Testing — real phones, build 2.38.0-rc.8: drawer test passed 7× on Moto G55 and 2× on Samsung A36 (fresh profile each run); test_wallet_accounts_basic passed on the re-routed Wallet path. The backup
  popup fired on 7 of 7 fresh-profile runs that entered Messages and was recovered in-loop every time.

  Follow-ups (out of scope): Communities and Market still use the unverified path (same pattern applies once they have anchors). dismiss_backup_modal overlaps ChatPage.dismiss_backup_prompt; different
  layers, consolidate when next touched. The onboarding import-seed test's Wallet assertion is now stricter by design.