### PR TITLE
Keep chat at the bottom when user scrolls there

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -399,9 +399,10 @@ method onMadeActive*(self: Module) =
   # The new messages marker is reset each time the chat is made active,
   # as messages may arrive out of order and relying on the previous
   # new messages marker could yield incorrect results.
-  if not self.messagesModule.isFirstUnseenMessageInitialized() or
-     self.controller.getChatDetails().unviewedMessagesCount > 0:
+  if not self.messagesModule.isFirstUnseenMessageInitialized():
     self.messagesModule.resetAndScrollToNewMessagesMarker()
+  elif self.controller.getChatDetails().unviewedMessagesCount > 0:
+    self.messagesModule.resetNewMessagesMarker()
   self.messagesModule.reevaluateViewLoadingState()
   self.view.setActive()
 

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -86,9 +86,12 @@ Item {
         id: d
 
         readonly property real scrollY: chatLogView.visibleArea.yPosition * chatLogView.contentHeight
-        readonly property bool isMostRecentMessageInViewport: chatLogView.visibleArea.yPosition >= 0.999 - chatLogView.visibleArea.heightRatio
+        readonly property bool isMostRecentMessageInViewport: chatLogView.visibleArea.yPosition >= 0.99 - chatLogView.visibleArea.heightRatio
         readonly property var chatDetails: chatContentModule && chatContentModule.chatDetails || null
         readonly property bool keepUnread: messageStore.keepUnread
+
+        // Tracks whether the user was at the bottom of the chat to know if we must scroll back there when coming back
+        property bool isAtBottom: false
 
         readonly property var loadMoreMessagesIfScrollBelowThreshold: Backpressure.oneInTimeQueued(root, 100, function() {
             if(scrollY < 1000) messageStore.loadMoreMessages()
@@ -111,6 +114,14 @@ Item {
         function goToMessage(messageIndex) {
             chatLogView.currentIndex = -1
             chatLogView.currentIndex = messageIndex
+            // Reset isAtBottom since the new message may be up high
+            d.isAtBottom = d.isMostRecentMessageInViewport
+        }
+
+        function scrollToBottom() {
+            chatLogView.positionViewAtBeginning()
+            d.isAtBottom = true
+            markAllMessagesReadIfMostRecentMessageIsInViewport()
         }
 
         onIsMostRecentMessageInViewportChanged: markAllMessagesReadIfMostRecentMessageIsInViewport()
@@ -129,7 +140,7 @@ Item {
         target: root.messageStore.messageModule
 
         function onMessageSuccessfullySent() {
-            chatLogView.positionViewAtBeginning()
+            d.scrollToBottom()
         }
 
         function onSendingMessageFailed(error) {
@@ -151,6 +162,9 @@ Item {
 
         function onLoadingChanged() {
             d.markAllMessagesReadIfMostRecentMessageIsInViewport()
+            if (!messageStore.loading && d.isAtBottom) {
+                Qt.callLater(d.scrollToBottom)
+            }
         }
     }
 
@@ -159,6 +173,11 @@ Item {
 
         function onActiveChanged() {
             d.setKeepUnread(false)
+
+            if (active && d.isAtBottom) {
+                Qt.callLater(d.scrollToBottom)
+            }
+
             d.markAllMessagesReadIfMostRecentMessageIsInViewport()
             d.loadMoreMessagesIfScrollBelowThreshold()
         }
@@ -258,6 +277,10 @@ Item {
 
         onContentYChanged: d.loadMoreMessagesIfScrollBelowThreshold()
 
+        onMovementEnded: {
+            d.isAtBottom = d.isMostRecentMessageInViewport
+        }
+
         onCountChanged: {
             d.markAllMessagesReadIfMostRecentMessageIsInViewport()
 
@@ -265,6 +288,13 @@ Item {
             // load as much messages as the view requires
             if (!messageStore.loading) {
                 d.loadMoreMessagesIfScrollBelowThreshold()
+            }
+
+            // When a new item is added (new message or new-messages marker) and
+            // the user was already at the bottom, snap back so the few pixels of
+            // upward drift caused by the item insertion are immediately corrected.
+            if (d.isAtBottom) {
+                Qt.callLater(d.scrollToBottom)
             }
         }
 
@@ -294,7 +324,7 @@ Item {
                 return chatLogView.contentHeight - (d.scrollY + chatLogView.height) > 400
             }
 
-            onRecentMessagesButtonClicked: chatLogView.positionViewAtBeginning()
+            onRecentMessagesButtonClicked: d.scrollToBottom()
             onMentionsButtonClicked: {
                 let id = messageStore.firstUnseenMentionMessageId()
                 if (id !== "") {
@@ -456,19 +486,18 @@ Item {
             }
             return null
         }
-        onHeaderChanged: chatLogView.positionViewAtBeginning()
 
         property int prevHeight: height
 
         onHeightChanged: {
             const heightDiff = prevHeight - height
 
-            // Keep position at the end (positionViewAtBeginning must be used bc
-            // BottomToTop layout) on resize when it was at the end before.
+            // Keep position at the end on resize when it was at the end before.
             // Without this workaround, when the keyboard opens or window is
             // resized, the position is slightly changed and not at the end anymore.
-            if (contentHeight - (d.scrollY + height) <= heightDiff)
-                Qt.callLater(positionViewAtBeginning)
+            if (d.isAtBottom && contentHeight - (d.scrollY + height) <= heightDiff) {
+                Qt.callLater(d.scrollToBottom)
+            }
 
             prevHeight = height
         }

--- a/ui/app/AppLayouts/Profile/helpers/ContactModelEntry.qml
+++ b/ui/app/AppLayouts/Profile/helpers/ContactModelEntry.qml
@@ -24,35 +24,42 @@ QObject {
     }
 
     readonly property ContactDetails contactDetails: ContactDetails {
-        readonly property var entry: itemData.item
+        function fromEntry(key, defaultValue) {
+            const currentItem = itemData.item
+            if (!currentItem)
+                return defaultValue
+
+            const value = currentItem[key]
+            return value === null || value === undefined ? defaultValue : value
+        }
 
         publicKey: root.publicKey
-        compressedPubKey:  entry.compressedPubKey ?? ""
-        displayName: entry.displayName ?? ""
-        ensName: entry.ensName ?? ""
-        ensVerified: entry.isEnsVerified ?? false
-        localNickname: entry.localNickname ?? ""
-        alias: entry.alias ?? ""
-        usesDefaultName: entry.usesDefaultName ?? false
-        icon: entry.icon ?? ""
-        colorId: entry.colorId ?? 0
-        onlineStatus: entry.onlineStatus ?? Constants.onlineStatus.inactive
-        isContact: entry.isContact ?? false
-        isCurrentUser: entry.isCurrentUser ?? false
-        isVerified: entry.isVerified ?? false
-        isUntrustworthy: entry.isUntrustworthy ?? false
-        isBlocked: entry.isBlocked ?? false
-        contactRequestState: entry.contactRequest ?? Constants.ContactRequestState.None
-        preferredDisplayName: entry.preferredDisplayName ?? ""
-        lastUpdated: entry.lastUpdated ?? 0
-        lastUpdatedLocally: entry.lastUpdatedLocally ?? 0
-        thumbnailImage: entry.thumbnailImage ?? ""
-        largeImage: entry.largeImage ?? ""
-        isContactRequestReceived: entry.isContactRequestReceived ?? false
-        isContactRequestSent: entry.isContactRequestSent ?? false
-        removed: entry.isRemoved ?? false
-        trustStatus: entry.trustStatus ?? Constants.trustStatus.unknown
-        bio: entry.bio ?? ""
+        compressedPubKey: fromEntry("compressedPubKey", "")
+        displayName: fromEntry("displayName", "")
+        ensName: fromEntry("ensName", "")
+        ensVerified: fromEntry("isEnsVerified", false)
+        localNickname: fromEntry("localNickname", "")
+        alias: fromEntry("alias", "")
+        usesDefaultName: fromEntry("usesDefaultName", false)
+        icon: fromEntry("icon", "")
+        colorId: fromEntry("colorId", 0)
+        onlineStatus: fromEntry("onlineStatus", Constants.onlineStatus.inactive)
+        isContact: fromEntry("isContact", false)
+        isCurrentUser: fromEntry("isCurrentUser", false)
+        isVerified: fromEntry("isVerified", false)
+        isUntrustworthy: fromEntry("isUntrustworthy", false)
+        isBlocked: fromEntry("isBlocked", false)
+        contactRequestState: fromEntry("contactRequest", Constants.ContactRequestState.None)
+        preferredDisplayName: fromEntry("preferredDisplayName", "")
+        lastUpdated: fromEntry("lastUpdated", 0)
+        lastUpdatedLocally: fromEntry("lastUpdatedLocally", 0)
+        thumbnailImage: fromEntry("thumbnailImage", "")
+        largeImage: fromEntry("largeImage", "")
+        isContactRequestReceived: fromEntry("isContactRequestReceived", false)
+        isContactRequestSent: fromEntry("isContactRequestSent", false)
+        removed: fromEntry("isRemoved", false)
+        trustStatus: fromEntry("trustStatus", Constants.trustStatus.unknown)
+        bio: fromEntry("bio", "")
 
         // Backwards compatibility properties - Don't use in new code
         // TODO: #14965 - Try to remove these properties


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-app/issues/21044

Adds a property in the Messages view that remembers if the user scrolled to the bottom.
If so, it re-scrolls at the bottom if a new message is added or when switching back to the chat
Also fixes an issue where it sometimes always went back to the bottom even when it was not wanted.

Also fixes multiple warnings in the ContactModelEntry.

### Affected areas

ChatMessagesView
ContactModelEntry

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[keep-chat-at-bottom.webm](https://github.com/user-attachments/assets/b4080d90-8c75-4348-9db9-4f8abc2a8575)

### Impact on end user

Better UX when switching between chats

### How to test

- Go to a chat 
- Switch out
- go back
- send a message
- go back and see it being marked as read
- scroll up
- switch out 
- send another message
- go back
- not marked as read until scrolled down

### Risk 

Low
