### PR TITLE
fix: Remove unnecessary android permissions

### DIFF
--- a/mobile/android/qt6/AndroidManifest.xml
+++ b/mobile/android/qt6/AndroidManifest.xml
@@ -31,9 +31,6 @@
 
     <!-- dangerous permissions -->
     <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 


### PR DESCRIPTION
### What does the PR do

Removing images, videos and media permissions.



On android we're using the Qt's filedialog. It doesn't need these permissions.

### How to test

Areas to test: sending images, downloading images, updating profile photo, updating chat/community images

### Risk 

Low