### PR TITLE
fix(AppSearch): Fix stale app search results after closing search

### DIFF
--- a/ui/app/AppLayouts/stores/AppSearchStore.qml
+++ b/ui/app/AppLayouts/stores/AppSearchStore.qml
@@ -7,10 +7,19 @@ QtObject {
 
     property var locationMenuModel: root.appSearchModule.locationMenuModel
     property var resultModel: root.appSearchModule.resultModel
+    property bool searchInProgress: false
+
+    readonly property Connections appSearchModuleConnections: Connections {
+        target: root.appSearchModule
+        function onAppSearchCompleted() {
+            root.searchInProgress = false
+        }
+    }
 
     function searchMessages(searchTerm) {
         if(!root.appSearchModule)
             return
+        root.searchInProgress = searchTerm !== ""
         root.appSearchModule.searchMessages(searchTerm)
     }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -86,6 +86,7 @@ Item {
     readonly property AppStores.AccountSettingsStore accountSettingsStore: rootStore.accountSettingsStore
     readonly property AppStores.ContactsStore contactsStore: rootStore.contactsStore
     readonly property AppStores.ActivityCenterStore activityCenterStore: rootStore.activityCenterStore
+    readonly property AppStores.AppSearchStore appSearchStore: rootStore.appSearchStore
 
     // Settings (just references from `rootStore`)
     readonly property ProfileStores.AboutStore aboutStore: rootStore.profileSectionStore.aboutStore
@@ -1305,8 +1306,30 @@ Item {
         }
 
         sourceComponent: AppSearch {
-            store: appMain.rootStore.appSearchStore
-            utilsStore: appMain.utilsStore
+            locationMenuModel: appMain.appSearchStore.locationMenuModel
+            resultModel: appMain.appSearchStore.resultModel
+            searchInProgress: appMain.appSearchStore.searchInProgress
+            setSearchLocationFn: function(location, subLocation) {
+                appMain.appSearchStore.setSearchLocation(location, subLocation)
+            }
+            prepareLocationMenuModelFn: function() {
+                appMain.appSearchStore.prepareLocationMenuModel()
+            }
+            getSearchLocationObjectFn: function() {
+                return appMain.appSearchStore.getSearchLocationObject()
+            }
+            isChatKeyFn: function(value) {
+                return appMain.utilsStore.isChatKey(value)
+            }
+            openProfilePopupFn: function(publicKey, parentPopup) {
+                Global.openProfilePopup(publicKey, parentPopup)
+            }
+            onSearchMessages: (searchTerm) => {
+                appMain.appSearchStore.searchMessages(searchTerm)
+            }
+            onResultItemClicked: (itemId) => {
+                appMain.appSearchStore.resultItemClicked(itemId)
+            }
             onClosed: appSearch.active = false
         }
     }

--- a/ui/app/mainui/AppSearch.qml
+++ b/ui/app/mainui/AppSearch.qml
@@ -1,27 +1,36 @@
 import QtQuick
-import QtQuick.Controls
 
 import StatusQ.Core
 import StatusQ.Core.Backpressure
 import StatusQ.Popups
 
-import shared.stores
-import utils
-
-import AppLayouts.stores
-
 Item {
     id: root
 
-    property AppSearchStore store
-    property UtilsStore utilsStore
+    required property var locationMenuModel
+    required property var resultModel
+    required property bool searchInProgress
+    required property var setSearchLocationFn
+    required property var prepareLocationMenuModelFn
+    required property var getSearchLocationObjectFn
+    required property var isChatKeyFn
+    required property var openProfilePopupFn
 
-    readonly property var searchMessages: Backpressure.debounce(searchPopup, 400, function (value) {
-        root.store.searchMessages(value)
+    readonly property var searchMessagesDebounced: Backpressure.debounce(searchPopup, 400, function () {
+        if (searchPopup.searchText === "")
+            return
+
+        root.searchMessages(searchPopup.searchText)
     })
     property alias opened: searchPopup.opened
 
     signal closed()
+    signal searchMessages(string searchTerm)
+    signal resultItemClicked(string itemId)
+
+    function clearSearchResults() {
+        root.searchMessages("")
+    }
 
     function openSearchPopup(){
         searchPopup.open()
@@ -32,7 +41,7 @@ Item {
     }
 
     Connections {
-        target: root.store.locationMenuModel
+        target: root.locationMenuModel
         function onModelAboutToBeReset() {
              while (searchPopupMenu.takeItem(searchPopupMenu.numDefaultItems)) {
                 // Delete the item right after the default items
@@ -41,30 +50,23 @@ Item {
         }
     }
 
-    Connections {
-        target: root.store.appSearchModule
-        function onAppSearchCompleted() {
-            searchPopup.loading = false
-        } 
-    }
-
     StatusSearchLocationMenu {
         id: searchPopupMenu
         
-        locationModel: root.store.locationMenuModel
+        locationModel: root.locationMenuModel
 
-        onItemClicked: {
-            root.store.setSearchLocation(firstLevelItemValue, secondLevelItemValue)
+        onItemClicked: (firstLevelItemValue, secondLevelItemValue) => {
+            root.setSearchLocationFn(firstLevelItemValue, secondLevelItemValue)
             searchPopup.forceActiveFocus()
             if(searchPopup.searchText !== "")
-                searchMessages(searchPopup.searchText)
+                root.searchMessagesDebounced()
         }
 
         onResetSearchSelection: {
             searchPopup.resetSearchSelection()
         }
 
-        onSetSearchSelection: {
+        onSetSearchSelection: (text, secondaryText, imageSource, isIdenticon, iconName, iconColor, isUserIcon, colorId) => {
             searchPopup.setSearchSelection(text,
                                             secondaryText,
                                             imageSource,
@@ -82,14 +84,16 @@ Item {
         noResultsLabel: qsTr("No results")
         defaultSearchLocationText: qsTr("Anywhere")
         searchOptionsPopupMenu: searchPopupMenu
-        searchResults: root.store.resultModel
+        searchResults: root.resultModel
+        loading: root.searchInProgress
         formatTimestampFn: function (ts) {
             return LocaleUtils.formatDateTime(parseInt(ts, 10), Locale.ShortFormat)
         }
         onSearchTextChanged: {
             if (searchPopup.searchText !== "") {
-                searchPopup.loading = true
-                searchMessages(searchPopup.searchText);
+                root.searchMessagesDebounced()
+            } else {
+                root.clearSearchResults()
             }
         }
         onAboutToHide: {
@@ -99,18 +103,19 @@ Item {
         }
         onClosed: {
             searchPopupMenu.dismiss();
+            root.clearSearchResults();
             root.closed();
         }
         onResetSearchLocationClicked: {
             searchPopup.resetSearchSelection();
-            root.store.setSearchLocation("", "")
-            searchMessages(searchPopup.searchText)
+            root.setSearchLocationFn("", "")
+            root.searchMessagesDebounced()
         }
         onOpened: {
             searchPopup.resetSearchSelection();
-            root.store.prepareLocationMenuModel()
+            root.prepareLocationMenuModelFn()
 
-            const jsonObj = root.store.getSearchLocationObject()
+            const jsonObj = root.getSearchLocationObjectFn()
 
             if (!jsonObj) {
                 return
@@ -119,7 +124,7 @@ Item {
             let obj = JSON.parse(jsonObj)
             if (obj.location === "" || (obj.location !== "" && !obj.subLocation)) {
                 if(obj.subLocation === "") {
-                    root.store.setSearchLocation("", "")
+                    root.setSearchLocationFn("", "")
                 } else {
                     searchPopup.setSearchSelection(obj.subLocation.text,
                                                    "",
@@ -128,7 +133,7 @@ Item {
                                                    obj.subLocation.iconName,
                                                    obj.subLocation.identiconColor)
 
-                    root.store.setSearchLocation("", obj.subLocation.value)
+                    root.setSearchLocationFn("", obj.subLocation.value)
                 }
             } else {
                 if (obj.location.title === "Chat" && !!obj.subLocation) {
@@ -141,7 +146,7 @@ Item {
                                                    obj.subLocation.isUserIcon,
                                                    obj.subLocation.colorId)
 
-                    root.store.setSearchLocation(obj.location.value, obj.subLocation.value)
+                    root.setSearchLocationFn(obj.location.value, obj.subLocation.value)
                 } else {
                     searchPopup.setSearchSelection(obj.location.title,
                                                    obj.subLocation.text,
@@ -150,17 +155,19 @@ Item {
                                                    obj.location.iconName,
                                                    obj.location.identiconColor)
 
-                    root.store.setSearchLocation(obj.location.value, obj.subLocation.value)
+                    root.setSearchLocationFn(obj.location.value, obj.subLocation.value)
                 }
             }
         }
-        onResultItemClicked: {
+        onResultItemClicked: (itemId) => {
             searchPopup.close()
-            root.store.resultItemClicked(itemId)
+            root.resultItemClicked(itemId)
         }
         acceptsTitleClick: function (titleId) {
-            return root.utilsStore.isChatKey(titleId)
+            return root.isChatKeyFn(titleId)
         }
-        onResultItemTitleClicked: Global.openProfilePopup(titleId, searchPopup)
+        onResultItemTitleClicked: (titleId) => {
+            root.openProfilePopupFn(titleId, searchPopup)
+        }
     }
 }


### PR DESCRIPTION
Fixes #20421

### What does the PR do

- Clears app search results when the input is emptied or the popup closes, preventing old results from showing on reopen.

- Also refactors AppSearch to receive explicit models/callbacks from AppMain instead of full stores.

### Affected areas

AppSearch

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/5e925fcf-8d75-4ccd-b8e9-b710a3ee7aba


### Impact on end user

Search is correctly cleared

### How to test

Follow steps on the video

### Risk 

Low