### PR TITLE
chore(backup): skip toast message on backup success

### DIFF
--- a/ui/app/mainui/ToastsManager.qml
+++ b/ui/app/mainui/ToastsManager.qml
@@ -263,14 +263,15 @@ QtObject {
 
         function onLocalBackupExportCompleted(success: bool) {
             if (success) {
-                Global.displaySuccessToastMessage(qsTr("Your data backed up successfully"))
+                // If there is success, we don't need to draw the user attention to it, only if it's a failure
+                return
             } else {
-                Global.displayToastMessage(qsTr("Backup failed, please try again"),
-                                       "",
+                Global.displayToastMessage(qsTr("Backup failed"),
+                                       qsTr("Check Settings > Backups to see the details and try again"),
                                        root.warningAssetName,
                                        false,
                                         Constants.ephemeralNotificationType.danger,
-                                       "")
+                                       "#%1/%2".arg(Constants.appSection.profile).arg(Constants.settingsSubsection.backupSettings))
             }
         }
         function onLocalBackupImportCompleted(success: bool) {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -18628,11 +18628,11 @@ This action cannot be undone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Your data backed up successfully</source>
+        <source>Backup failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Backup failed, please try again</source>
+        <source>Check Settings &gt; Backups to see the details and try again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -22685,14 +22685,14 @@
       <translation>You removed %1 as a contact</translation>
     </message>
     <message>
-      <source>Your data backed up successfully</source>
+      <source>Backup failed</source>
       <comment>ToastsManager</comment>
-      <translation>Your data backed up successfully</translation>
+      <translation>Backup failed</translation>
     </message>
     <message>
-      <source>Backup failed, please try again</source>
+      <source>Check Settings &gt; Backups to see the details and try again</source>
       <comment>ToastsManager</comment>
-      <translation>Backup failed, please try again</translation>
+      <translation>Check Settings &gt; Backups to see the details and try again</translation>
     </message>
     <message>
       <source>Your data backup restored successfully</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -18753,12 +18753,12 @@ Tuto akci nelze vzít zpět.</translation>
         <translation type="unfinished">Odebrali jste %1 z kontaktů</translation>
     </message>
     <message>
-        <source>Your data backed up successfully</source>
-        <translation>Vaše data byla úspěšně zálohována</translation>
+        <source>Backup failed</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Backup failed, please try again</source>
-        <translation>Zálohování selhalo, zkuste to prosím znovu</translation>
+        <source>Check Settings &gt; Backups to see the details and try again</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your data backup restored successfully</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -18646,12 +18646,12 @@ This action cannot be undone.</source>
         <translation type="unfinished">Eliminaste a %1 como contacto</translation>
     </message>
     <message>
-        <source>Your data backed up successfully</source>
-        <translation>Tus datos se respaldaron exitosamente</translation>
+        <source>Backup failed</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Backup failed, please try again</source>
-        <translation>Error en el backup, por favor intenta de nuevo</translation>
+        <source>Check Settings &gt; Backups to see the details and try again</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your data backup restored successfully</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -18583,12 +18583,12 @@ This action cannot be undone.</source>
         <translation type="unfinished">%1님을 연락처에서 삭제했습니다</translation>
     </message>
     <message>
-        <source>Your data backed up successfully</source>
-        <translation>데이터가 성공적으로 백업되었습니다</translation>
+        <source>Backup failed</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Backup failed, please try again</source>
-        <translation>백업 실패, 다시 시도하세요</translation>
+        <source>Check Settings &gt; Backups to see the details and try again</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your data backup restored successfully</source>


### PR DESCRIPTION
### What does the PR do

#20361

No need to show a toast when backup succeeds, only when it fails. Also updates the toast to be more useful and now has a link to the backup settings

### Affected areas

ToastManager

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

I flipped the condition on the QML to show the toast, that's why the button still shows as a success

[backup-fail-stub.webm](https://github.com/user-attachments/assets/66ebd7dd-1fbc-42ab-9fb1-a18b727294a5)

### Impact on end user

Makes it show the toast only when necessary, so less clutter

### How to test

Hack the code or just do a normal backup and see no toast

### Risk 

Low
