### PR TITLE
fix(wallet): fix stuck balance shimmer on large token lists

### DIFF
--- a/ui/app/AppLayouts/Wallet/panels/WalletAccountHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletAccountHeader.qml
@@ -188,6 +188,8 @@ Control {
             asset.mirror: true
 
             tooltip.text: qsTr("Last refreshed %1").arg(root.lastReloadedTime)
+            tooltip.orientation: StatusToolTip.Orientation.Bottom
+            tooltip.y: height + Theme.padding
 
             loading: root.tokensLoading
             interactive: !loading && !throttleTimer.running

--- a/ui/app/AppLayouts/Wallet/panels/WalletFollowingAddressesHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFollowingAddressesHeader.qml
@@ -132,6 +132,8 @@ Control {
             asset.mirror: true
 
             tooltip.text: qsTr("Last refreshed %1").arg(root.lastReloadedTime)
+            tooltip.orientation: StatusToolTip.Orientation.Bottom
+            tooltip.y: height + Theme.padding
 
             loading: root.loading
             interactive: !loading && !throttleTimer.running

--- a/ui/app/AppLayouts/Wallet/panels/WalletSavedAddressesHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletSavedAddressesHeader.qml
@@ -108,6 +108,8 @@ Control {
             asset.mirror: true
 
             tooltip.text: qsTr("Last refreshed %1").arg(root.lastReloadedTime)
+            tooltip.orientation: StatusToolTip.Orientation.Bottom
+            tooltip.y: height + Theme.padding
 
             loading: root.loading
             interactive: !loading && !throttleTimer.running


### PR DESCRIPTION
* bump status-go, go-wallet-sdk for multicall chunk retry when RPC body or gas limits the rpc 
  * https://github.com/status-im/status-go/pull/7555
  * https://github.com/status-im/go-wallet-sdk/pull/43
* Treat fetched-but-missing ERC20 tokens as zero instead of errors

fixes #21224 
fixes #21222 

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/f2862dad-9c66-4e61-bc61-11954516838c" width="400" controls></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/37fe3f52-ba13-42a0-b6b6-e15b902d7ed5" width="400" controls></video>
    </td>
  </tr>
</table>

<img width="318" height="124" alt="image" src="https://github.com/user-attachments/assets/a88c750c-a61d-4e95-87ef-13e2b469e3f8" />

cosmetic fix #21172

Test plan:
* Wallet with many custom tokens on Optimism/Base and 10 accounts. Mandatory ETH, SNT shows balance, no infinite loader