### PR TITLE
fix(a11y): expose message text and key controls to accessibility

### DIFF
--- a/test/e2e/gui/objects_map/messaging_names.py
+++ b/test/e2e/gui/objects_map/messaging_names.py
@@ -54,7 +54,7 @@ tiny_pin_icon_StatusIcon = {"container": chatLogView_chatMessageViewDelegate_Mes
 add_remove_from_group_StatusMenuItem = {"container": mainWindow_Overlay, "enabled": True, "objectName": "addRemoveFromGroupStatusAction", "type": "StatusMenuItem", "visible": True}
 mainWindow_inputScrollView_StatusScrollView = {"container": statusDesktop_mainWindow, "id": "inputScrollView", "type": "StatusScrollView", "unnamed": 1, "visible": True}
 inputScrollView_messageInputField_TextArea = {"container": mainWindow_inputScrollView_StatusScrollView, "objectName": "messageInputField", "type": "TextArea", "visible": True}
-mainWindow_statusChatInputEmojiButton_StatusFlatRoundButton = {"container": statusDesktop_mainWindow, "id": "emojiButton", "type": "ChatIcon", "unnamed": 1, "visible": True}
+mainWindow_statusChatInputEmojiButton_StatusFlatRoundButton = {"container": statusDesktop_mainWindow, "objectName": "statusChatInputEmojiButton", "type": "ChatIcon", "visible": True}
 mainWindow_imageBtn_StatusFlatRoundButton = {"container": statusDesktop_mainWindow, "id": "imageBtn", "type": "StatusFlatRoundButton", "unnamed": 1, "visible": True}
 mainWindow_statusChatInput_StatusChatInput = {"container": statusDesktop_mainWindow, "objectName": "statusChatInput", "type": "StatusChatInputNew", "visible": True}
 mainWindow_statusChatInputSendButton = {"container": statusDesktop_mainWindow, "objectName": "statusChatInputSendButton",
@@ -91,7 +91,7 @@ chatMessageViewDelegate_inputScrollView_StatusScrollView = {"container": chatLog
 edit_inputScrollView_messageInputField_TextArea = {"container": chatMessageViewDelegate_inputScrollView_StatusScrollView, "objectName": "messageInputField", "type": "TextArea", "visible": True}
 chatMessageViewDelegate_Save_StatusButton = {"checkable": False, "container": chatLogView_chatMessageViewDelegate_MessageView, "id": "saveBtn", "type": "StatusButton", "unnamed": 1, "visible": True}
 chatMessageViewDelegate_reply_icon_StatusIcon = {"container": chatLogView_chatMessageViewDelegate_MessageView, "objectName": "reply-icon", "type": "StatusIcon", "visible": True}
-mainWindow_replyPanel_StatusChatInputReplyPanel = {"container": statusDesktop_mainWindow, "id": "replyPanel", "type": "StatusChatInputReplyPanel", "unnamed": 1, "visible": True}
+mainWindow_replyPanel_StatusChatInputReplyPanel = {"container": statusDesktop_mainWindow, "objectName": "statusChatInputReplyArea", "type": "StatusChatInputReplyPanel", "visible": True}
 layout_recentMessagesButton_AnchorButton = {"checkable": False, "container": mainWindow_chatLogView_StatusListView, "id": "recentMessagesButton", "type": "AnchorButton", "unnamed": 1, "visible": True}
 
 # Message link preview

--- a/test/e2e/gui/objects_map/settings_names.py
+++ b/test/e2e/gui/objects_map/settings_names.py
@@ -38,8 +38,8 @@ settings_StatusFlatButton = {"type": "StatusFlatButton", "unnamed": 1, "visible"
 
 # Messaging View
 mainWindow_MessagingView = {"container": statusDesktop_mainWindow, "type": "MessagingView", "unnamed": 1, "visible": True}
-allowNewContactRequestsSection = {"container": statusDesktop_mainWindow, "id": "allowNewContactRequest", "type": "StatusListItem", "unnamed": 1, "visible": True}
-allowNewContactRequestsSectionToggle = {"checkable": True, "container": allowNewContactRequestsSection, "id": "switch3", "type": "StatusSwitch", "unnamed": 1, "visible": True}
+allowNewContactRequestsSection = {"container": statusDesktop_mainWindow, "objectName": "MessagingView_ReceiveFromNonContacts_StatusListItem", "type": "StatusListItem", "visible": True}
+allowNewContactRequestsSectionToggle = {"checkable": True, "container": allowNewContactRequestsSection, "objectName": "MessagingView_ReceiveFromNonContacts_Switch", "type": "StatusSwitch", "visible": True}
 contactsListItem_btn_StatusContactRequestsIndicatorListItem = {"container": statusDesktop_mainWindow, "objectName": "MessagingView_ContactsListItem_btn", "type": "StatusContactRequestsIndicatorListItem"}
 settingsContentBase_ScrollView = {"container": statusDesktop_mainWindow, "objectName": "settingsContentBaseScrollView", "type": "StatusScrollView", "visible": True}
 always_ask_radioButton_StatusRadioButton = {"container": settingsContentBase_ScrollView, "objectName": "MessagingView_AlwaysAsk_RadioButton", "type": "SettingsRadioButton", "visible": True}

--- a/ui/StatusQ/src/StatusQ/Components/StatusTimeStampLabel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusTimeStampLabel.qml
@@ -7,6 +7,7 @@ import StatusQ.Core.Theme
 
 StatusBaseText {
     id: root
+    objectName: "messageTimestamp"
     property double timestamp: 0
     property bool showFullTimestamp
 
@@ -14,6 +15,8 @@ StatusBaseText {
     font.pixelSize: Theme.asideTextFontSize
     visible: !!text
     text: d.formattedLabel
+    Accessible.role: Accessible.StaticText
+    Accessible.name: d.formattedLabel
 
     QtObject {
         id: d

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -94,6 +94,13 @@ Item {
                                              chatTextLoader.hoveredLink, !!root.disabledTooltipText)
         }
 
+        // Plain message body for accessibility. The rendered text is RichText
+        // (HTML), which Qt's Android a11y backend does not surface, so the body
+        // is otherwise invisible to screen readers and e2e. Expose the unstyled
+        // text via Accessible.name on the text element instead.
+        readonly property string plainText:
+            Utils.stripHtmlTags(root.messageDetails.messageText)
+
         function showDisabledTooltipForAddressEnsName(link) {
             return link.startsWith('//send-via-personal-chat//') && !!root.disabledTooltipText
         }
@@ -136,6 +143,8 @@ Item {
         StatusBaseText {
             objectName: "StatusTextMessage_chatText"
             text: d.text
+            Accessible.role: Accessible.StaticText
+            Accessible.name: d.plainText
             color: root.isReply ? Theme.palette.baseColor1 : Theme.palette.directColor1
             font.pixelSize: root.isReply ? Theme.secondaryTextFontSize : Theme.primaryTextFontSize
             textFormat: Text.RichText
@@ -155,6 +164,8 @@ Item {
         id: chatTextDesktopComp
         StatusTextArea {
             objectName: "StatusTextMessage_chatText"
+            Accessible.role: Accessible.StaticText
+            Accessible.name: d.plainText
             background: null
             leftPadding: 0
             rightPadding: 0

--- a/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
@@ -124,6 +124,8 @@ Button {
                     Layout.maximumWidth: Math.ceil(implicitWidth)
                     objectName: "statusChatInfoButtonNameText"
                     text: root.title
+                    Accessible.role: Accessible.StaticText
+                    Accessible.name: root.title
                     color: root.muted ? Theme.palette.directColor5 : Theme.palette.directColor1
                     font.weight: Font.Medium
                 }

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -103,6 +103,7 @@ RowLayout {
 
         StatusFlatRoundButton {
             id: membersButton
+            objectName: "membersButton"
             visible: {
                 if(!chatContentModule)
                     return false

--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -50,6 +50,7 @@ SettingsContentBase {
         StatusListItem {
             id: allowNewContactRequest
 
+            objectName: "MessagingView_ReceiveFromNonContacts_StatusListItem"
             Layout.fillWidth: true
             implicitHeight: 64
 
@@ -58,6 +59,7 @@ SettingsContentBase {
             components: [
                 StatusSwitch {
                     id: switch3
+                    objectName: "MessagingView_ReceiveFromNonContacts_Switch"
                     checked: !root.messagingSettingsStore.messagesFromContactsOnly
                     onCheckedChanged: {
                         // messagesFromContactsOnly needs to be accessed from the module (view),

--- a/ui/imports/shared/popups/addaccount/panels/SelectOrigin.qml
+++ b/ui/imports/shared/popups/addaccount/panels/SelectOrigin.qml
@@ -13,6 +13,8 @@ import utils
 StatusSelect {
     id: root
 
+    objectName: "AddAccountPopup-OriginSelector"
+
     property string userProfilePublicKey
     property var originModel
     property var selectedOrigin

--- a/ui/imports/shared/status/StatusChatInputReplyPanel.qml
+++ b/ui/imports/shared/status/StatusChatInputReplyPanel.qml
@@ -10,6 +10,8 @@ import StatusQ.Core.Theme
 Control {
     id: root
 
+    objectName: "statusChatInputReplyArea"
+
     property string nameText
     property string messageText
     property string extraContentText

--- a/ui/imports/shared/status/StatusChatInputToolBar.qml
+++ b/ui/imports/shared/status/StatusChatInputToolBar.qml
@@ -283,6 +283,7 @@ Control {
                         ChatIcon {
                             id: emojiButton
 
+                            objectName: "statusChatInputEmojiButton"
                             icon.name: "chat/smile"
                         }
 

--- a/ui/imports/shared/status/StatusEmojiPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiPopup.qml
@@ -232,6 +232,8 @@ StatusDropdown {
 
                 StatusEmoji {
                     objectName: "statusEmoji_" + model.shortname.replace(/:/g, "")
+                    Accessible.role: Accessible.StaticText
+                    Accessible.name: model.emoji
                     anchors.centerIn: parent
                     width: d.imageWidth
                     height: d.imageWidth


### PR DESCRIPTION
Adds accessibility names to chat message text and a few UI controls, so screen readers can read message content and automated tests can find these elements reliably.

QML only, no behaviour change. The message body text was not exposed to accessibility at all (Qt renders it as rich text, which the Android accessibility layer doesn't surface); this adds a plain-text accessible name on the message text and on a handful of controls (composer emoji button, reply panel, group members button, group title, message timestamp, a settings row, and the add-account origin selector).

Draft while it's verified on a CI build.
