### PR TITLE
chore(@e2e): adapt test to landed bugfix

### DIFF
--- a/test/e2e/constants/messaging.py
+++ b/test/e2e/constants/messaging.py
@@ -4,6 +4,7 @@ from enum import Enum
 class Messaging(Enum):
     WELCOME_GROUP_MESSAGE = "Welcome to the beginning of the "
     CONTACT_REQUEST_SENT = 'Contact Request Sent'
+    CONTACT_REQUEST_ALREADY_SENT = 'You already sent a contact request.'
     NO_FRIENDS_ITEM = "You don’t have any contacts yet. Invite your friends to start chatting."
     NEW_CONTACT_REQUEST = 'New Contact Request'
     MESSAGE_NOTE_IDENTITY_REQUEST = 'Ask a question only they can answer'

--- a/test/e2e/gui/components/settings/send_contact_request_popup.py
+++ b/test/e2e/gui/components/settings/send_contact_request_popup.py
@@ -2,6 +2,8 @@ import allure
 
 import configs
 import driver
+from constants.messaging import Messaging
+from driver.objects_access import walk_children
 from gui.elements.button import Button
 from gui.elements.object import QObject
 from gui.elements.text_edit import TextEdit
@@ -17,16 +19,60 @@ class SendContactRequest(QObject):
         self._message_text_edit = TextEdit(names.sendContactRequestModal_SayWhoYouAre_Input_TextEdit)
         self._send_button = Button(names.send_Contact_Request_StatusButton)
 
-    @allure.step('Send contact request')
-    def send(self, chat_key: str, message: str):
+    @property
+    @allure.step('Check if send button is enabled')
+    def is_send_button_enabled(self) -> bool:
+        return driver.waitForObjectExists(
+            self._send_button.real_name, configs.timeouts.UI_LOAD_TIMEOUT_MSEC
+        ).enabled
+
+    def _fill_form(self, chat_key: str, message: str):
         # Inner QQuickTextEdit is inside StatusBaseInput; driver.type() cannot set focus. Use direct assignment.
         self._chat_key_text_edit.set_text_property(chat_key)
         self._message_text_edit.set_text_property(message)
+
+    @staticmethod
+    def _tree_contains_text(root, text: str) -> bool:
+        for child in walk_children(root):
+            if text in str(getattr(child, 'text', '')):
+                return True
+        return False
+
+    def _overlay_contains_text(self, text: str) -> bool:
+        overlay = driver.waitForObjectExists(names.statusDesktop_mainWindow_overlay, 200)
+        return self._tree_contains_text(overlay, text)
+
+    @allure.step('Send contact request')
+    def send(self, chat_key: str, message: str):
+        self._fill_form(chat_key, message)
         assert driver.waitFor(
             lambda: self._send_button.is_enabled,
             configs.timeouts.UI_LOAD_TIMEOUT_MSEC,
         ), 'Send Contact Request button stayed disabled after filling fields'
         self._send_button.click()
+        self.wait_until_hidden()
+
+    @allure.step('Verify resending contact request is blocked')
+    def verify_resend_blocked(self, chat_key: str, message: str):
+        self._fill_form(chat_key, message)
+        error_message = Messaging.CONTACT_REQUEST_ALREADY_SENT.value
+
+        def resend_is_blocked():
+            try:
+                return not self.is_send_button_enabled and self._overlay_contains_text(error_message)
+            except (LookupError, RuntimeError, AttributeError):
+                return False
+
+        assert driver.waitFor(
+            resend_is_blocked,
+            configs.timeouts.UI_LOAD_TIMEOUT_MSEC,
+        ), (
+            f'Send Contact Request should stay disabled with {error_message!r} shown'
+        )
+
+    @allure.step('Close contact request modal')
+    def close(self):
+        driver.type(self.contact_request_to_chat_modal.object, '<Escape>')
         self.wait_until_hidden()
 
 

--- a/test/e2e/tests/settings/settings_messaging/test_messaging_settings_reject_request.py
+++ b/test/e2e/tests/settings/settings_messaging/test_messaging_settings_reject_request.py
@@ -62,14 +62,15 @@ def test_messaging_settings_rejecting_request(multiple_instances):
             assert str(contacts_settings.no_friends_item_text) == Messaging.NO_FRIENDS_ITEM.value
             assert contacts_settings.invite_friends_button.is_visible
 
-        with step(f'User {user_one.name}, send contact request to {user_two.name} again via messaging settings'):
+        with step(f'User {user_one.name}, verify that resending contact request to {user_two.name} is blocked in messaging settings'):
             aut_one.attach()
             main_window.prepare()
             settings = main_window.left_panel.open_settings()
             messaging_settings = settings.left_panel.open_messaging_settings()
             contacts_settings = messaging_settings.open_contacts_settings()
             contact_request_popup = contacts_settings.open_contact_request_form()
-            contact_request_popup.send(chat_key, f'Hello again {user_two.name}')
+            contact_request_popup.verify_resend_blocked(chat_key, f'Hello again {user_two.name}')
+            contact_request_popup.close()
 
         with step(f'Verify that pending requests tab is not active for {user_two.name}'):
             aut_two.attach()


### PR DESCRIPTION
### What does the PR do

Fixing test that fails in nightly due to landed bug fix https://github.com/status-im/status-app/issues/20146

So if contact request is rejected, then you wont be able to send it again and now we check it in settings page as well

<img width="1833" height="863" alt="image" src="https://github.com/user-attachments/assets/fc69e540-b04e-4093-a3e4-0e98d1752eae" />
