### PR TITLE
Theme: landscape mode threashold increased to keep foldables in portrait mode

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Theme/ThemeUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/ThemeUtils.qml
@@ -38,7 +38,11 @@ QtObject {
 
     readonly property size minimumDesktopSize: Qt.size(360, 680)
     readonly property size defaultDesktopSize: Qt.size(1200, 680)
-    readonly property size portraitBreakpoint: Qt.size(640, 480) // good ol' VGA
+
+    // Threshold width increased from original 640 to keep foldable phones in portrait
+    // mode when unfolded. To be changed later along with layout improvements dedicated
+    // to foldable phones.
+    readonly property size portraitBreakpoint: Qt.size(752, 480) // good ol' VGA
     readonly property real disabledOpacity: 0.3
     readonly property real pressedOpacity: 0.7
 


### PR DESCRIPTION
### What does the PR do

To avoid some layouting problems, we keep foldables in more reliable portrait mode till fine tuning layout for foldables in landscape mode.

Closes: #21234


<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`ThemeUtils`

### Quality checklist

### Screencapture of the functionality

<img width="2268" height="2440" alt="image" src="https://github.com/user-attachments/assets/c8db6f76-13b7-4b97-bcaf-3c9cc29ee99f" />

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

<!-- How should one proceed with testing this PR. -->
<!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
