### PR TITLE
docs(roadmap): create 2026 H2 roadmap and update H1

### DIFF
--- a/docs/roadmap/2025-H2.md
+++ b/docs/roadmap/2025-H2.md
@@ -1,22 +1,18 @@
-# Status Roadmap
+# 2025 H2
 
 ## Table of Contents
-- [Status Roadmap](#status-roadmap)
+- [2025 H2](#2025-h2)
   - [Table of Contents](#table-of-contents)
-  - [2025 H2](#2025-h2)
-    - [2.35](#235)
-      - [Features](#features)
-    - [2.36](#236)
-      - [Features](#features-1)
+  - [2.35](#235)
+    - [Features](#features)
+  - [2.36](#236)
+    - [Features](#features-1)
 
-
-## 2025 H2
-
-### 2.35
+## 2.35
 
 Release Epic: https://github.com/status-im/status-app/issues/17966
 
-#### Features
+### Features
 
 - [QT6 migration](https://github.com/status-im/status-app/issues/17622)
   - No provided FURPS at the moment
@@ -32,13 +28,13 @@ Release Epic: https://github.com/status-im/status-app/issues/17966
   - [FURPS](/docs/FURPS/local-user-backups.md)
   - Done ✅ 🟩🟩🟩🟩🟩 100%
 
-### 2.36
+## 2.36
 
 Release Epic: https://github.com/status-im/status-app/issues/18029
 
 Estimated release: End of November
 
-#### Features
+### Features
 
 - [Mobile build](https://github.com/status-im/status-app/issues/18082)
   - [FURPS](/docs/FURPS/mobile-build.md)

--- a/docs/roadmap/2026-H1.md
+++ b/docs/roadmap/2026-H1.md
@@ -1,27 +1,20 @@
-# Status Roadmap
+# 2026 H1
 
 ## Table of Contents
-- [Status Roadmap](#status-roadmap)
+- [2026 H1](#2026-h1)
   - [Table of Contents](#table-of-contents)
-  - [2026 H1](#2026-h1)
-    - [2.37](#237)
-      - [Features](#features)
-    - [2.38](#238)
-      - [Features](#features-1)
-    - [2.39](#239)
-      - [Features](#features-2)
-    - [2.40](#240)
-      - [Features](#features-3)
+  - [2.37](#237)
+    - [Features](#features)
+  - [2.38](#238)
+    - [Features](#features-1)
 
-## 2026 H1
-
-### 2.37
+## 2.37
 
 Release Epic: https://github.com/status-im/status-app/issues/18528
 
 Estimated release: End of February
 
-#### Features
+### Features
 
 - ⭐ [Privacy mode](https://github.com/status-im/status-app/issues/17619)
   - [FURPS](/docs/FURPS/privacy-mode.md)
@@ -46,99 +39,25 @@ Estimated release: End of February
   - Done ✅ 🟩🟩🟩🟩🟩 100%
 
 
-### 2.38
+## 2.38
 
 Release Epic: https://github.com/status-im/status-app/issues/19509
 
-Estimated release: End of April
+Estimated release: Mid June
 
-#### Features
+### Features
 
 - ⭐ [Mobile Dapp Browser](https://github.com/status-im/status-app/issues/19535)
-  - In Progress ⏳ 🟩🟩🟩🟩⬜ 83% 
-- ⭐ [Push Notifications](https://github.com/status-im/status-app/issues/19532): In Progress ⏳ 🟩🟩🟩🟩🟨 90%
+  - Done ✅ 🟩🟩🟩🟩🟩 100%
+- ⭐ [Push Notifications](https://github.com/status-im/status-app/issues/19532): Done ✅ 🟩🟩🟩🟩🟩 100%
   - Local and server notifications for Android
   - Basic server Push notifications for iOS
 - [Chat Input Field UX Improvements](https://github.com/status-im/status-app/issues/19524)
-  - In Progress ⏳ 🟩🟩🟨⬜⬜ 50%
+  - Done ✅ 🟩🟩🟩🟩🟩 100%
 - [Activity Center revamp](https://github.com/status-im/status-app/issues/18516)
   - Done ✅ 🟩🟩🟩🟩🟩 100%
 - [Improve handling of online/offline and wallet error banners](https://github.com/status-im/status-app/issues/20325)
   - Done ✅ 🟩🟩🟩🟩🟩 100%
-- Keycard library/service alignement
-  - [Keycard new approach](https://github.com/status-im/status-app/issues/20289)
-    - In Progress ⏳ 🟩🟨⬜⬜⬜ 32%
-  - [Keycard Shell integration](https://github.com/status-im/status-app/issues/20293)
-    - In Progress ⏳ 🟩⬜⬜⬜⬜ 25% 
 - [Support Hoodi network](https://github.com/status-im/eth-rpc-proxy/pull/115):
   - Done ✅ 🟩🟩🟩🟩🟩 100%
 - Introduce new L2s
-- Status L2 mainnet
-- [SDS phase 2](https://github.com/status-im/status-go/issues/7363)
-  - Fetch missing messages when flagged as missed
-- Performance improvements
-  - Add an info banner to improve UX of loading communities in the Community portal
-  - [Improve wallet modals](https://github.com/status-im/status-app/issues/20166)
-  - [Improve community switching](https://github.com/status-im/status-app/issues/20167)
-  - [Create PoCs for improved model management](https://github.com/status-im/status-app/issues/20168)
-  - [Efficient ChatView component](https://github.com/status-im/status-app/issues/19526)
-- [Refactor popups](https://github.com/status-im/status-app/issues/20128)
-  - Might need to wait for the new design system as both require re-doing the components
-- SeaQT migration
-- Support custom RPC providers
-  - Seems to be already supported, we need to validate
-- Swap + Bridge in one (LIFI support) (get rid of the old Bridge)
-  - [Remove bridge](https://github.com/status-im/status-app/issues/20189) : Done ✅ 🟩🟩🟩🟩🟩 100%
-  - Lifi integration
-- [Nimbus Verification Proxy](https://github.com/status-im/status-app/issues/19538)
-  - By using [eth-rpc-proxy](https://github.com/erpc/erpc)
-  - In Progress ⏳
-- [New translations](https://github.com/status-im/status-app/issues/19512)
-  - In Progress ⏳ 🟩🟨⬜⬜⬜ 30%
-- [Replacing the current archive Torrent protocol with Logos Storage protocol](https://github.com/logos-storage/logos-storage-nim/issues/1304)
-  - In Progress ⏳
-
-### 2.39
-
-Release Epic: https://github.com/status-im/status-app/issues/19529
-
-Estimated release: Mid-June
-
-#### Features
-
-- ⭐ Support QR code cold wallet standard EIP -4527 (Keycard Shell)
-- ⭐ Simplify keycard flows
-- ⭐ [SDS Phase 3 (final)](https://github.com/logos-messaging/pm/issues/194)
-  - Enabling of the SDS wrapping feature flag
-  - Breaking change for people in 2.36 or lower (first supported release is 2.37)
-- [Private Transactions POC](https://github.com/status-im/status-app/issues/19539)
-- [Support custom tokens](https://github.com/status-im/status-app/issues/19691)
-- [UI Zoom setting](https://github.com/status-im/status-app/issues/18265)
-- [Color System Revamp](https://github.com/status-im/status-app/issues/19455) - Improved Dark Mode & Updated Palettes
-- [Passkey option in the Onboarding](https://github.com/status-im/status-app/issues/20172)
-- Record and send audio messages
-- Status Bots
-  - News Feed
-  - Engagement
-  - Support
-- [Ethereum Follow Protocol](https://github.com/status-im/status-app/issues/18685)
-  - In Progress ⏳ 🟨⬜⬜⬜⬜ 10%
-- Switch from `nimbus-build-system` to `Nimble`
-
-### 2.40
-
-Estimated release: End of August
-
-#### Features
-
-- Threads support
-- [Improve `New Chat Creation / Group Chats Management` Flow](https://github.com/status-im/status-app/issues/19222)
-- File sending over Codex
-  - Dependant on Codex being available in Light mode for mobile and having a C library
-- Online voice and video calls
-- [UI modularization](https://github.com/status-im/status-app/issues/17872)
-  - [FURPS](/docs/FURPS/ui-modularization.md)
-  - In Progress ⏳ 🟩⬜⬜⬜⬜ 27%
-- [New Global Search (Replace Home + CTRL + K)](https://github.com/status-im/status-app/issues/19220)
-- Refactor WalletConnect to the use the same connector service as the Browser extension
-  - This will use the same storage and reduce duplicated code.

--- a/docs/roadmap/2026-H2.md
+++ b/docs/roadmap/2026-H2.md
@@ -1,0 +1,114 @@
+# 2026 H2
+
+## Table of Contents
+- [2026 H2](#2026-h2)
+  - [Table of Contents](#table-of-contents)
+  - [2.39](#239)
+    - [Features](#features)
+  - [2.40](#240)
+    - [Features](#features-1)
+  - [2.41](#241)
+    - [Features](#features-2)
+
+
+## 2.39
+
+Release Epic: https://github.com/status-im/status-app/issues/19529
+
+Estimated release: End of July
+
+### Features
+
+- ⭐ [Keycard library/service alignment](https://github.com/status-im/status-app/issues/20289)
+  - In Progress ⏳ 🟩🟩🟩🟩⬜ 83%
+- ⭐ [SeaQT migration](https://github.com/status-im/status-app/issues/17801)
+  - In Progress ⏳ 🟩🟩🟩🟩⬜ 75%
+- ⭐ [Switch from `nimbus-build-system` to `Nimble`](https://github.com/status-im/status-app/issues/19907)
+  - In Progress ⏳ 🟩🟨⬜⬜⬜ 25%
+- ⭐ [Battery consumption improvements](https://github.com/status-im/status-go/issues/7563)
+  - In Progress ⏳ 🟩🟩🟩⬜⬜ 67%
+- ⭐ [UI Zoom setting](https://github.com/status-im/status-app/issues/20169)
+  - In Progress ⏳ 🟩🟩🟨⬜⬜ 50%
+- ⭐ Share to feature on Mobile
+- ⭐ [Standard mode in Mobile Browser (instead of incognito only)](https://github.com/status-im/status-app/issues/21274)
+  - In Progress ⏳ 🟩🟩🟨⬜⬜ 50%
+- ⭐ [Chat Input Field UX Improvements](https://github.com/status-im/status-app/issues/19524)
+  - In Progress ⏳ 🟩🟩🟨⬜⬜ 50%
+- ⭐ [SDS phase 3](https://github.com/status-im/status-go/issues/7363)
+  - Fetch missing messages when flagged as missed
+  - Enable wrapping of community messages
+  - Breaking change for people in 2.36 or lower (first supported release is 2.37)
+- Spellcheck in the Chat input
+- [Performance improvements](https://github.com/status-im/status-app/issues/20573)
+  - In Progress ⏳ 🟩🟩🟨⬜⬜ 57%
+- Fast track on the onboarding
+  - [Passkey option in the Onboarding](https://github.com/status-im/status-app/issues/20172)
+  - Investigate opening the app with zero onboarding
+- [Refactor popups](https://github.com/status-im/status-app/issues/20128)
+  - In Progress ⏳ 🟩🟨⬜⬜⬜ 25%
+- [Implement Back navigation](https://github.com/status-im/status-app/issues/20997)
+  - In Progress ⏳ 🟩🟩🟨⬜⬜ 50%
+- [Adding Logos Storage protocol as a Community Service provider](https://github.com/logos-storage/logos-storage-nim/issues/1304)
+  - Done ✅ 🟩🟩🟩🟩🟩 100%
+  -  Only missing part is adding the UI switches
+- [Threads POC](https://github.com/status-im/status-app/issues/21257)
+  - In Progress ⏳ 🟩🟩🟨⬜⬜ 50%
+- [Color System Revamp](https://github.com/status-im/status-app/issues/19455) - Improved Dark Mode & Updated Palettes
+- [New translations](https://github.com/status-im/status-app/issues/19512)
+  - In Progress ⏳ 🟩🟩🟩⬜⬜ 67%
+- Revamp main wallet view
+- Swap + Bridge in one (LIFI support) (get rid of the old Bridge)
+  - [Remove bridge](https://github.com/status-im/status-app/issues/20189): Done ✅ 🟩🟩🟩🟩🟩 100%
+  - [LIFI integration](https://github.com/status-im/status-app/issues/21246): In Progress ⏳ 🟨⬜⬜⬜⬜ 17%
+- Improve UX of sharing your profile or community
+- Improved UX for fetching a community
+- [Improve `New Chat Creation / Group Chats Management` Flow](https://github.com/status-im/status-app/issues/19222)
+- Fastlane to fetch messages on notification on iOS
+- Support custom RPC providers
+- [Support custom tokens](https://github.com/status-im/status-app/issues/19691)
+- Improve UX of Swap and Send
+- Enable making Status the default browser on Mobile
+- [Add Downloads list feature on Mobile](https://github.com/status-im/status-app/issues/21376)
+- Self note chat
+- Record and send audio messages
+
+
+## 2.40
+
+Estimated release: End of September
+
+### Features
+
+- [Keycard Shell integration](https://github.com/status-im/status-app/issues/20293)
+  - In Progress ⏳ 🟩🟨⬜⬜⬜ 25%
+- [Threads support](https://github.com/status-im/status-app/issues/21090)
+- [Nimbus Verification Proxy](https://github.com/status-im/status-app/issues/19538)
+  - By using [eth-rpc-proxy](https://github.com/erpc/erpc)
+  - In Progress ⏳
+- [Private Transactions POC](https://github.com/status-im/status-app/issues/19539)
+- Refactor Swap and Send backend
+- Mock Keycard interfaces for tests
+- Deriving from Extended pub key
+- Integrate Puzzle auth on Market proxy
+- Status Bots
+  - News Feed
+  - Engagement
+  - Support
+- [New Global Search (Replace Home + CTRL + K)](https://github.com/status-im/status-app/issues/19220)
+- Refactor WalletConnect to use the same connector service as the Browser extension
+  - This will use the same storage and reduce duplicated code.
+
+## 2.41
+
+Estimated release: Mid November
+
+### Features
+
+- File sending over Codex
+  - Dependent on Codex being available in Light mode for mobile and having a C library
+- Online voice and video calls
+- [UI modularization](https://github.com/status-im/status-app/issues/17872)
+  - [FURPS](/docs/FURPS/ui-modularization.md)
+  - In Progress ⏳ 🟩⬜⬜⬜⬜ 27%
+- [Ethereum Follow Protocol](https://github.com/status-im/status-app/issues/18685)
+  - In Progress ⏳ 🟨⬜⬜⬜⬜ 10%

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -2,6 +2,7 @@
 
 In this folder, you can find the roadmap files for the Status App.
 
+- [Second half of 2026 (H2)](2026-H2.md)
 - [First half of 2026 (H1)](2026-H1.md)
 - [Second half of 2025 (H2)](2025-H2.md) 
 


### PR DESCRIPTION
### What does the PR do

Adds the roadmap for 2026 H2.

The features/Epics are ordred from most to less important.

Clearly, the list is way too long, so we'll need to move some stuff to 2.40

Also, we'll add the links to the Epics soon.