### PR TITLE
BrowserLayout: use portrait mode condition to invert layout

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2017,6 +2017,7 @@ Item {
                         popupHandler: popupRequestsHandler
 
                         leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
+                        isPortraitMode: appMain.isPortraitMode
                     }
 
                     ProfileLoader {

--- a/ui/app/mainui/sectionLoaders/BrowserLoader.qml
+++ b/ui/app/mainui/sectionLoaders/BrowserLoader.qml
@@ -28,6 +28,7 @@ Loader {
 
     required property HandlersManagerLoader popupHandler
 
+    property bool isPortraitMode: false
     property real leftPanelWidthOverride: 0
 
     asynchronous: false
@@ -100,6 +101,7 @@ Loader {
             connectorController:        Qt.binding(() => WalletStores.RootStore.dappsConnectorController),
             isDebugEnabled:             Qt.binding(() => root.advancedStore.isDebugEnabled),
             transactionStore:           Qt.binding(() => root.transactionStore),
+            invertedLayout:             Qt.binding(() => root.isPortraitMode),
             leftPanelWidthOverride:     Qt.binding(() => root.leftPanelWidthOverride),
             "anchors.fill":             root,
         })


### PR DESCRIPTION
### What does the PR do

Instead of own condition for "inverted" layout, use the top-level `isPortraitMode` condition for that purpose.  It prevents having too narrow address bar on foldable phones.

### Affected areas
`BrowserLayout`

### Screencapture of the functionality

<img width="2440" height="2268" alt="image" src="https://github.com/user-attachments/assets/c33542a0-57ad-4268-a24b-a666bebb27be" />
<img width="2268" height="2440" alt="image" src="https://github.com/user-attachments/assets/cf80f653-9261-4922-a151-ba0c351885c7" />



### Impact on end user
Low

### How to test

Run browser on foldable phone. Tab bar should be in the bottom part of the screen.

### Risk 
Low