### PR TITLE
fix(e2e_appium): complete onboarding when the splash clears the accessibility tree

### DIFF
--- a/test/e2e_appium/pages/onboarding/loading_page.py
+++ b/test/e2e_appium/pages/onboarding/loading_page.py
@@ -16,6 +16,7 @@ from selenium.common.exceptions import (
 from ..base_page import BasePage
 from locators.onboarding.loading_screen_locators import LoadingScreenLocators
 from locators.wallet.accounts_locators import WalletAccountsLocators
+from utils.gestures import Gestures
 
 
 class SplashScreen(BasePage):
@@ -45,15 +46,28 @@ class SplashScreen(BasePage):
             )
             return False
         except WebDriverException as e:
+            # Qt's a11y tree is empty until the first input after the splash, so
+            # a stale error here means loading is completing, not a dead session.
+            # Wake the tree with a tap, then re-confirm the splash is gone.
             self.logger.warning(
                 f"WebDriver error during loading wait: {type(e).__name__}: {e}"
             )
             try:
-                _ = self.driver.current_url
-            except (WebDriverException, InvalidSessionIdException, NoSuchWindowException):
-                self.logger.error("WebDriver session appears to be dead")
+                Gestures(self.driver).activation_tap()
+            except Exception as tap_exc:
+                self.logger.warning("activation tap after stale event failed: %s", tap_exc)
+            try:
+                WebDriverWait(self.driver, 30).until(
+                    EC.invisibility_of_element_located(self.locators.SPLASH_SCREEN_PARTIAL)
+                )
+                self.logger.info("Loading completed (a11y tree woken by tap; splash gone)")
+                return True
+            except (NoSuchWindowException, InvalidSessionIdException):
+                self.logger.error("WebDriver session genuinely ended during loading wait")
                 return False
-            return False
+            except WebDriverException:
+                self.logger.warning("Splash still present after activation tap; loading not confirmed")
+                return False
         except TimeoutException:
             self.logger.warning(
                 f"Loading did not complete within {timeout} seconds; checking wallet state"

--- a/test/e2e_appium/tests/test_onboarding_import_seed.py
+++ b/test/e2e_appium/tests/test_onboarding_import_seed.py
@@ -21,6 +21,7 @@ from utils.generators import generate_seed_phrase, get_wallet_address_from_mnemo
 from utils.multi_device_helpers import StepMixin
 
 
+@pytest.mark.flaky(reruns=1, reruns_delay=5)
 class TestOnboardingImportSeed(StepMixin):
     async def _import_seed_and_verify_wallet(
         self, driver, seed_phrase: str, password: str,

--- a/test/e2e_appium/tests/test_wallet_accounts_basic.py
+++ b/test/e2e_appium/tests/test_wallet_accounts_basic.py
@@ -8,6 +8,7 @@ from utils.generators import generate_account_name
 from utils.multi_device_helpers import StepMixin
 
 
+@pytest.mark.flaky(reruns=1, reruns_delay=5)
 class TestWalletAccountsBasic(StepMixin):
     @pytest.mark.gate
     @pytest.mark.wallet


### PR DESCRIPTION
## What

The onboarding loading-completion check can wrongly conclude that onboarding
failed. Status' Qt UI leaves the Android accessibility tree empty until the
first input event after a screen transition — so when the splash screen tears
down, every element lookup returns nothing and the wait gives up, even though
onboarding actually completed.

## Fix

When the loading wait hits this empty-tree state, send one tap to wake the
accessibility tree, then re-confirm the splash is gone (the same signal the
success path already uses). A single retry is added as a backstop on the
onboarding and wallet entry tests.

## Verified

Green in the integrated gate run on physical Android (15/15) and on BrowserStack.
