### PR TITLE
fix(contact): fix signal order when removing a contact

### DIFF
--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -1,11 +1,10 @@
-import app/modules/shared_models/model_utils
 import nimqml, tables, std/strformat, sequtils, sugar
-import user_item
 
-import ../../../app_service/common/types
-import ../../../app_service/service/contacts/dto/[contacts, contact_details]
+import app_service/common/types
+import app_service/service/contacts/dto/[contacts, contact_details]
 import contacts_utils
 import model_utils
+import user_item
 
 type
   ModelRole {.pure.} = enum

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -496,26 +496,25 @@ QtObject:
   # fromBackup is used to indicate that the contact was loaded from a backup
   proc updateContact(self: Service, contact: ContactsDto, fromBackup: bool = false) =
     var signal = SIGNAL_CONTACT_ADDED
-    var alreadyEmitted = false
     let publicKey = contact.id
     if self.contacts.hasKey(publicKey):
       if self.contacts[publicKey].dto.added and not self.contacts[publicKey].dto.removed and contact.added and not contact.removed:
         signal = SIGNAL_CONTACT_UPDATED
       if contact.removed and not self.contacts[publicKey].dto.removed:
-        # Removed contact emits a different signal, so mark that we have already emitted for this contact
-        # to avoid emitting two signals for the same contact
-        alreadyEmitted = true
-        self.events.emit(SIGNAL_CONTACT_REMOVED, ContactRemovedArgs(
-              contactId: contact.id,
-              displayName: contact.displayName,
-              theyRemovedUs: false)
-            )
+        signal = SIGNAL_CONTACT_REMOVED
+
     let merged = self.preserveCachedEnrichment(contact)
     self.contacts[publicKey] = self.constructContactDetails(
       merged,
       isCurrentUser = merged.id == singletonInstance.userProfile.getPubKey()
     )
-    if not alreadyEmitted:
+    if signal == SIGNAL_CONTACT_REMOVED:
+      self.events.emit(SIGNAL_CONTACT_REMOVED, ContactRemovedArgs(
+          contactId: contact.id,
+          displayName: contact.displayName,
+          theyRemovedUs: false)
+      )
+    else:
       self.events.emit(signal, ContactArgs(contactId: publicKey, fromBackup: fromBackup))
 
   proc parseContactsResponse*(self: Service, contacts: JsonNode, fromBackup: bool = false) =


### PR DESCRIPTION
### What does the PR do

Fixes #21256

The contact's request state was not properly updated, because I moved the signal sending to be before the contact was saved, meaning that the model didn't update with the right values

### Affected areas

contact service

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[remove-contact-bug.webm](https://github.com/user-attachments/assets/b4b4bea4-986f-4667-8dae-35977c92e547)


### Impact on end user

Better UX when deleting a contact

### How to test

remove a contact and check the status

### Risk 

Low
