### PR TITLE
feat(reactions): make reaction actions async to improve performance

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -55,25 +55,25 @@ proc delete*(self: Controller) =
 proc init*(self: Controller) =
   self.events.on(SIGNAL_MESSAGES_LOADED) do(e:Args):
     let args = MessagesLoadedArgs(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.newMessagesLoaded(args.messages, args.reactions)
 
   self.events.on(SIGNAL_NEW_MESSAGE_RECEIVED) do(e: Args):
     var args = MessagesArgs(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.messagesAdded(args.messages)
 
   self.events.on(SIGNAL_SENDING_SUCCESS) do(e:Args):
     let args = MessageSendingSuccess(e)
-    if(self.chatId != args.chat.id):
+    if self.chatId != args.chat.id:
       return
     self.delegate.onSendingMessageSuccess(args.message)
 
   self.events.on(SIGNAL_SENDING_FAILED) do(e:Args):
     let args = MessageSendingFailure(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.onSendingMessageError(args.error)
 
@@ -87,51 +87,57 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_MESSAGE_DELIVERED) do(e:Args):
     let args = MessageDeliveredArgs(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.onMessageDelivered(args.messageId)
 
   self.events.on(SIGNAL_MESSAGE_PINNED) do(e:Args):
     let args = MessagePinUnpinArgs(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.onPinMessage(args.messageId, args.actionInitiatedBy)
 
   self.events.on(SIGNAL_MESSAGE_UNPINNED) do(e:Args):
     let args = MessagePinUnpinArgs(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.onUnpinMessage(args.messageId)
 
   self.events.on(SIGNAL_MESSAGE_MARKED_AS_UNREAD) do(e:Args):
     let args = MessageMarkMessageAsUnreadArgs(e)
-    if (self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.onMarkMessageAsUnread(args.messageId)
 
   self.events.on(SIGNAL_MESSAGE_REACTION_ADDED) do(e:Args):
     let args = MessageAddRemoveReactionArgs(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.onReactionAdded(args.messageId, args.emoji, args.reactionId)
 
   self.events.on(SIGNAL_MESSAGE_REACTION_REMOVED) do(e:Args):
     let args = MessageAddRemoveReactionArgs(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.onReactionRemoved(args.messageId, args.emoji, args.reactionId)
 
+  self.events.on(SIGNAL_MESSAGE_REACTION_ACTION_FAILED) do(e:Args):
+    let args = MessageReactionActionFailedArgs(e)
+    if self.chatId != args.chatId:
+      return
+    self.delegate.onReactionActionFailed(args.messageId, args.emoji, args.reactionId, args.addAction, args.error)
+
   self.events.on(SIGNAL_MESSAGE_REACTION_FROM_OTHERS) do(e:Args):
     let args = MessageAddRemoveReactionArgs(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.toggleReactionFromOthers(args.messageId, args.emoji, args.reactionId, args.reactionFrom)
 
   self.events.on(SIGNAL_MESSAGES_MARKED_AS_READ) do(e: Args):
     let args = MessagesMarkedAsReadArgs(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
-    if(args.allMessagesMarked):
+    if args.allMessagesMarked:
       self.delegate.markAllMessagesRead()
     else:
       self.delegate.markMessagesAsRead(args.messagesIds)
@@ -176,7 +182,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_MESSAGE_REMOVED) do(e: Args):
     let args = MessageRemovedArgs(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.onMessageRemoved(args.messageId, args.deletedBy)
 
@@ -187,25 +193,25 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_MESSAGE_EDITED) do(e: Args):
     let args = MessageEditedArgs(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.onMessageEdited(args.message)
 
   self.events.on(SIGNAL_CHAT_HISTORY_CLEARED) do (e: Args):
     var args = ChatArgs(e)
-    if(self.chatId != args.chatId):
+    if self.chatId != args.chatId:
       return
     self.delegate.onHistoryCleared()
 
   self.events.on(SIGNAL_CHAT_MEMBER_UPDATED) do(e: Args):
     let args = ChatMemberUpdatedArgs(e)
-    if (args.chatId != self.chatId):
+    if args.chatId != self.chatId:
       return
     self.delegate.onChatMemberUpdated(args.id, args.role, args.joined)
 
   self.events.on(SIGNAL_MAILSERVER_SYNCED) do(e: Args):
     let args = MailserverSyncedArgs(e)
-    if (args.chatId != self.chatId):
+    if args.chatId != self.chatId:
       return
     self.delegate.onMailserverSynced(args.syncedFrom)
 
@@ -216,7 +222,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_FIRST_UNSEEN_MESSAGE_LOADED) do(e: Args):
     let args = FirstUnseenMessageLoadedArgs(e)
-    if (args.chatId != self.chatId):
+    if args.chatId != self.chatId:
       return
     self.delegate.onFirstUnseenMessageLoaded(args.messageId)
 
@@ -256,10 +262,10 @@ proc loadMoreMessages*(self: Controller): bool =
   return self.messageService.asyncLoadMoreMessagesForChat(self.chatId, limit)
 
 proc addReaction*(self: Controller, messageId: string, emoji: string) =
-  self.messageService.addReaction(self.chatId, messageId, emoji)
+  self.messageService.addReactionAsync(self.chatId, messageId, emoji)
 
 proc removeReaction*(self: Controller, messageId: string, emoji: string, reactionId: string) =
-  self.messageService.removeReaction(reactionId, self.chatId, messageId, emoji)
+  self.messageService.removeReactionAsync(reactionId, self.chatId, messageId, emoji)
 
 proc pinUnpinMessage*(self: Controller, messageId: string, pin: bool) =
   self.messageService.pinUnpinMessage(self.chatId, messageId, pin)

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -34,6 +34,10 @@ method onReactionAdded*(self: AccessInterface, messageId: string, emoji: string,
 method onReactionRemoved*(self: AccessInterface, messageId: string, emoji: string, reactionId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onReactionActionFailed*(self: AccessInterface, messageId: string, emoji: string, reactionId: string,
+  addAction: bool, error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method toggleReactionFromOthers*(self: AccessInterface, messageId: string, emoji: string, reactionId: string,
   reactionFrom: string) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -325,19 +325,42 @@ method toggleReaction*(self: Module, messageId: string, emoji: string) =
     return
 
   let myPublicKey = singletonInstance.userProfile.getPubKey()
+  let myName = singletonInstance.userProfile.getName()
   if item.shouldAddReaction(emoji, myPublicKey):
+    self.view.model().addReaction(messageId, emoji, didIReactWithThisEmoji = true, myPublicKey, myName, $genUUID())
     self.controller.addReaction(messageId, emoji)
   else:
     let reactionId = item.getReactionId(emoji, myPublicKey)
+    self.view.model().removeReaction(messageId, emoji, reactionId, didIRemoveThisReaction = true)
     self.controller.removeReaction(messageId, emoji, reactionId)
 
 method onReactionAdded*(self: Module, messageId: string, emoji: string, reactionId: string) =
   let myPublicKey = singletonInstance.userProfile.getPubKey()
+  if self.view.model().updateReactionId(messageId, emoji, myPublicKey, reactionId):
+    return
+
   let myName = singletonInstance.userProfile.getName()
   self.view.model().addReaction(messageId, emoji, didIReactWithThisEmoji = true, myPublicKey, myName, reactionId)
 
 method onReactionRemoved*(self: Module, messageId: string, emoji: string, reactionId: string) =
   self.view.model().removeReaction(messageId, emoji, reactionId, didIRemoveThisReaction = true)
+
+method onReactionActionFailed*(self: Module, messageId: string, emoji: string, reactionId: string,
+  addAction: bool, error: string) =
+  let myPublicKey = singletonInstance.userProfile.getPubKey()
+
+  if addAction:
+    let item = self.view.model().getItemWithMessageId(messageId)
+    if not item.isNil:
+      let optimisticReactionId = item.getReactionId(emoji, myPublicKey)
+      if optimisticReactionId != "":
+        self.view.model().removeReaction(messageId, emoji, optimisticReactionId, didIRemoveThisReaction = true)
+  else:
+    if reactionId != "":
+      let myName = singletonInstance.userProfile.getName()
+      self.view.model().addReaction(messageId, emoji, didIReactWithThisEmoji = true, myPublicKey, myName, reactionId)
+
+  self.view.emitReactionActionFailedSignal(addAction, error)
 
 method toggleReactionFromOthers*(self: Module, messageId: string, emoji: string, reactionId: string,
   reactionFrom: string) =

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -107,6 +107,11 @@ QtObject:
   proc emitSendingMessageErrorSignal*(self: View, error: string) =
     self.sendingMessageFailed(error)
 
+  proc reactionActionFailed*(self: View, addAction: bool, error: string) {.signal.}
+
+  proc emitReactionActionFailedSignal*(self: View, addAction: bool, error: string) =
+    self.reactionActionFailed(addAction, error)
+
   proc deleteMessage*(self: View, messageId: string) {.slot.} =
     self.delegate.deleteMessage(messageId)
 

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -509,6 +509,9 @@ proc shouldAddReaction*(self: Item, emoji: string, userPublicKey: string): bool 
 proc getReactionId*(self: Item, emoji: string, userPublicKey: string): string =
   return self.reactionsModel.getReactionId(emoji, userPublicKey)
 
+proc updateReactionId*(self: Item, emoji: string, userPublicKey: string, reactionId: string): bool =
+  return self.reactionsModel.updateReactionId(emoji, userPublicKey, reactionId)
+
 proc addReaction*(self: Item, emoji: string, didIReactWithThisEmoji: bool, userPublicKey: string,
   userDisplayName: string, reactionId: string) =
   self.reactionsModel.addReaction(emoji, didIReactWithThisEmoji, userPublicKey, userDisplayName, reactionId)

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -577,6 +577,13 @@ QtObject:
 
     self.items[ind].addReaction(emoji, didIReactWithThisEmoji, userPublicKey, userDisplayName, reactionId)
 
+  proc updateReactionId*(self: Model, messageId: string, emoji: string, userPublicKey: string, reactionId: string): bool =
+    let ind = self.findIndexForMessageId(messageId)
+    if ind == -1:
+      return false
+
+    return self.items[ind].updateReactionId(emoji, userPublicKey, reactionId)
+
   proc removeReaction*(self: Model, messageId: string, emoji: string, reactionId: string, didIRemoveThisReaction: bool) =
     let ind = self.findIndexForMessageId(messageId)
     if(ind == -1):

--- a/src/app/modules/shared_models/message_reaction_item.nim
+++ b/src/app/modules/shared_models/message_reaction_item.nim
@@ -56,6 +56,15 @@ proc getReactionId*(self: MessageReactionItem, userPublicKey: string): string =
       return r.reactionId
   return ""
 
+proc updateReactionId*(self: var MessageReactionItem, userPublicKey: string, reactionId: string): bool =
+  for i in 0..<self.reactions.len:
+    if self.reactions[i].publicKey == userPublicKey:
+      if self.reactions[i].reactionId == reactionId:
+        return false
+      self.reactions[i].reactionId = reactionId
+      return true
+  return false
+
 proc addReaction*(self: var MessageReactionItem, didIReactWithThisEmoji: bool, userPublicKey: string,
   userDisplayName: string, reactionId: string) =
   if(didIReactWithThisEmoji):

--- a/src/app/modules/shared_models/message_reaction_model.nim
+++ b/src/app/modules/shared_models/message_reaction_model.nim
@@ -81,6 +81,16 @@ QtObject:
       return ""
     return self.items[ind].getReactionId(userPublicKey)
 
+  # This function is used when we optimistically have added a reaction and we received the real reactionID asyncly
+  # Returns false if it was not updated. Then we can add the reaction with the normal path
+  proc updateReactionId*(self: MessageReactionModel, emoji: string, userPublicKey: string, reactionId: string): bool =
+    let ind = self.getIndexOfTheItemWithEmoji(emoji)
+    if ind == -1:
+      return false
+
+    # Just return the result. No need to fire dataChnaged signal, because the reactionId is not used in QML side.
+    return self.items[ind].updateReactionId(userPublicKey, reactionId)
+
   proc addReaction*(self: MessageReactionModel, emoji: string, didIReactWithThisEmoji: bool, userPublicKey: string,
     userDisplayName: string, reactionId: string) =
     if self.reactionItemWithEmojiExists(emoji):

--- a/src/app/modules/shared_models/message_reaction_model.nim
+++ b/src/app/modules/shared_models/message_reaction_model.nim
@@ -88,7 +88,7 @@ QtObject:
     if ind == -1:
       return false
 
-    # Just return the result. No need to fire dataChnaged signal, because the reactionId is not used in QML side.
+    # Just return the result. No need to fire dataChanged signal, because the reactionId is not used in QML side.
     return self.items[ind].updateReactionId(userPublicKey, reactionId)
 
   proc addReaction*(self: MessageReactionModel, emoji: string, didIReactWithThisEmoji: bool, userPublicKey: string,

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -148,6 +148,91 @@ proc asyncFetchReactionsForMessageTask(argEncoded: string) {.gcsafe, nimcall.} =
 
 
 #################################################
+# Async add reaction
+#################################################
+type
+  AsyncAddReactionTaskArg = ref object of QObjectTaskArg
+    chatId: string
+    messageId: string
+    emoji: string
+
+proc asyncAddReactionTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncAddReactionTaskArg](argEncoded)
+
+  try:
+    var responseJson = %*{
+      "chatId": arg.chatId,
+      "messageId": arg.messageId,
+      "emoji": arg.emoji,
+      "error": "",
+    }
+
+    let response = status_go.addReaction(arg.chatId, arg.messageId, arg.emoji)
+    if not response.error.isNil:
+      raise newException(CatchableError, response.error.message)
+
+    let errorString = response.result{"error"}.getStr()
+    if errorString != "":
+      raise newException(CatchableError, errorString)
+
+    var reactionsArr: JsonNode
+    if response.result.getProp("emojiReactions", reactionsArr):
+      responseJson["emojiReactions"] = reactionsArr
+
+    arg.finish(responseJson)
+
+  except Exception as e:
+    arg.finish(%* {
+      "chatId": arg.chatId,
+      "messageId": arg.messageId,
+      "emoji": arg.emoji,
+      "error": e.msg,
+    })
+
+
+#################################################
+# Async remove reaction
+#################################################
+type
+  AsyncRemoveReactionTaskArg = ref object of QObjectTaskArg
+    reactionId: string
+    chatId: string
+    messageId: string
+    emoji: string
+
+proc asyncRemoveReactionTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncRemoveReactionTaskArg](argEncoded)
+
+  try:
+    var responseJson = %*{
+      "reactionId": arg.reactionId,
+      "chatId": arg.chatId,
+      "messageId": arg.messageId,
+      "emoji": arg.emoji,
+      "error": "",
+    }
+
+    let response = status_go.removeReaction(arg.reactionId)
+    if not response.error.isNil:
+      raise newException(CatchableError, response.error.message)
+
+    let errorString = response.result{"error"}.getStr()
+    if errorString != "":
+      raise newException(CatchableError, errorString)
+
+    arg.finish(responseJson)
+
+  except Exception as e:
+    arg.finish(%* {
+      "reactionId": arg.reactionId,
+      "chatId": arg.chatId,
+      "messageId": arg.messageId,
+      "emoji": arg.emoji,
+      "error": e.msg,
+    })
+
+
+#################################################
 # Async search messages
 #################################################
 

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -50,6 +50,7 @@ const SIGNAL_SEARCH_MESSAGES_LOADED* = "searchMessagesLoaded"
 const SIGNAL_MESSAGES_MARKED_AS_READ* = "messagesMarkedAsRead"
 const SIGNAL_MESSAGE_REACTION_ADDED* = "messageReactionAdded"
 const SIGNAL_MESSAGE_REACTION_REMOVED* = "messageReactionRemoved"
+const SIGNAL_MESSAGE_REACTION_ACTION_FAILED* = "messageReactionActionFailed"
 const SIGNAL_MESSAGE_REACTION_FROM_OTHERS* = "messageReactionFromOthers"
 const SIGNAL_MESSAGE_REMOVED* = "messageRemoved"
 const SIGNAL_MESSAGES_DELETED* = "messagesDeleted"
@@ -115,6 +116,14 @@ type
     emoji*: string
     reactionId*: string
     reactionFrom*: string
+
+  MessageReactionActionFailedArgs* = ref object of Args
+    chatId*: string
+    messageId*: string
+    emoji*: string
+    reactionId*: string
+    addAction*: bool
+    error*: string
 
   MessageRemovedArgs* =  ref object of Args
     chatId*: string
@@ -693,17 +702,24 @@ QtObject:
     except Exception as e:
       error "error: ", procName="onAsyncLoadCommunityMemberAllMessages", errName = e.name, errDesription = e.msg
 
-  proc addReaction*(self: Service, chatId: string, messageId: string, emoji: string) =
+  proc onAsyncAddReaction*(self: Service, response: string) {.slot.} =
+    var chatId, messageId, emoji: string
     try:
-      let response = status_go.addReaction(chatId, messageId, emoji)
+      let responseObj = response.parseJson
+      if responseObj.kind != JObject:
+        raise newException(CatchableError, "add reaction response is not a json object")
 
-      let errorString = response.result{"error"}.getStr()
+      discard responseObj.getProp("chatId", chatId)
+      discard responseObj.getProp("messageId", messageId)
+      discard responseObj.getProp("emoji", emoji)
+
+      let errorString = responseObj{"error"}.getStr()
       if errorString != "":
         raise newException(CatchableError, errorString)
 
       var reactionsArr: JsonNode
       var reactions: seq[ReactionDto]
-      if response.result.getProp("emojiReactions", reactionsArr):
+      if responseObj.getProp("emojiReactions", reactionsArr):
         reactions = map(reactionsArr.getElems(), proc(x: JsonNode): ReactionDto = x.toReactionDto())
 
       var reactionId: string
@@ -715,13 +731,45 @@ QtObject:
       self.events.emit(SIGNAL_MESSAGE_REACTION_ADDED, data)
 
     except Exception as e:
-      error "error: ", procName="addReaction", errName = e.name, errDesription = e.msg
+      error "error: ", procName="onAsyncAddReaction", errName = e.name, errDesription = e.msg
+      let data = MessageReactionActionFailedArgs(
+        chatId: chatId,
+        messageId: messageId,
+        emoji: emoji,
+        addAction: true,
+        error: e.msg
+      )
+      self.events.emit(SIGNAL_MESSAGE_REACTION_ACTION_FAILED, data)
 
-  proc removeReaction*(self: Service, reactionId: string, chatId: string, messageId: string, emoji: string) =
+  proc addReactionAsync*(self: Service, chatId: string, messageId: string, emoji: string) =
+    if chatId.len == 0 or messageId.len == 0 or emoji.len == 0:
+      error "empty chat id, message id or emoji", procName="addReactionAsync"
+      return
+
+    let arg = AsyncAddReactionTaskArg(
+      tptr: asyncAddReactionTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onAsyncAddReaction",
+      chatId: chatId,
+      messageId: messageId,
+      emoji: emoji
+    )
+
+    self.threadpool.start(arg)
+
+  proc onAsyncRemoveReaction*(self: Service, response: string) {.slot.} =
+    var reactionId, chatId, messageId, emoji: string
     try:
-      let response = status_go.removeReaction(reactionId)
+      let responseObj = response.parseJson
+      if responseObj.kind != JObject:
+        raise newException(CatchableError, "remove reaction response is not a json object")
 
-      let errorString = response.result{"error"}.getStr()
+      discard responseObj.getProp("reactionId", reactionId)
+      discard responseObj.getProp("chatId", chatId)
+      discard responseObj.getProp("messageId", messageId)
+      discard responseObj.getProp("emoji", emoji)
+
+      let errorString = responseObj{"error"}.getStr()
       if errorString != "":
         raise newException(CatchableError, errorString)
 
@@ -730,7 +778,33 @@ QtObject:
       self.events.emit(SIGNAL_MESSAGE_REACTION_REMOVED, data)
 
     except Exception as e:
-      error "error: ", procName="removeReaction", errName = e.name, errDesription = e.msg
+      error "error: ", procName="onAsyncRemoveReaction", errName = e.name, errDesription = e.msg
+      let data = MessageReactionActionFailedArgs(
+        chatId: chatId,
+        messageId: messageId,
+        emoji: emoji,
+        reactionId: reactionId,
+        addAction: false,
+        error: e.msg
+      )
+      self.events.emit(SIGNAL_MESSAGE_REACTION_ACTION_FAILED, data)
+
+  proc removeReactionAsync*(self: Service, reactionId: string, chatId: string, messageId: string, emoji: string) =
+    if reactionId.len == 0 or chatId.len == 0 or messageId.len == 0 or emoji.len == 0:
+      error "empty reaction id, chat id, message id or emoji", procName="removeReactionAsync"
+      return
+
+    let arg = AsyncRemoveReactionTaskArg(
+      tptr: asyncRemoveReactionTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onAsyncRemoveReaction",
+      reactionId: reactionId,
+      chatId: chatId,
+      messageId: messageId,
+      emoji: emoji
+    )
+
+    self.threadpool.start(arg)
 
   proc pinUnpinMessage*(self: Service, chatId: string, messageId: string, pin: bool) =
     try:

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -743,7 +743,12 @@ QtObject:
 
   proc addReactionAsync*(self: Service, chatId: string, messageId: string, emoji: string) =
     if chatId.len == 0 or messageId.len == 0 or emoji.len == 0:
-      error "empty chat id, message id or emoji", procName="addReactionAsync"
+      let err = "empty chat id, message id or emoji"
+      error "error adding a reaction", err, procName="addReactionAsync"
+      self.events.emit(
+        SIGNAL_MESSAGE_REACTION_ACTION_FAILED,
+        MessageReactionActionFailedArgs(chatId: chatId, messageId: messageId, emoji: emoji, addAction: true, error: err)
+      )
       return
 
     let arg = AsyncAddReactionTaskArg(
@@ -791,7 +796,19 @@ QtObject:
 
   proc removeReactionAsync*(self: Service, reactionId: string, chatId: string, messageId: string, emoji: string) =
     if reactionId.len == 0 or chatId.len == 0 or messageId.len == 0 or emoji.len == 0:
-      error "empty reaction id, chat id, message id or emoji", procName="removeReactionAsync"
+      let err = "empty reaction id, chat id, message id or emoji"
+      error "error removing a reaction", err, procName="removeReactionAsync"
+      self.events.emit(
+        SIGNAL_MESSAGE_REACTION_ACTION_FAILED,
+        MessageReactionActionFailedArgs(
+          chatId: chatId,
+          messageId: messageId,
+          emoji: emoji,
+          reactionId: reactionId,
+          addAction: false,
+          error: err
+        )
+      )
       return
 
     let arg = AsyncRemoveReactionTaskArg(

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -151,7 +151,7 @@ Item {
         function onReactionActionFailed(addAction, error) {
             Global.displayToastMessage(
                         addAction ? qsTr("Couldn't add reaction") : qsTr("Couldn't remove reaction"),
-                        error,
+                        qsTr("Please try again later"),
                         "warning",
                         false,
                         Constants.ephemeralNotificationType.danger,

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -148,6 +148,16 @@ Item {
             sendingMsgFailedPopup.open()
         }
 
+        function onReactionActionFailed(addAction, error) {
+            Global.displayToastMessage(
+                        addAction ? qsTr("Couldn't add reaction") : qsTr("Couldn't remove reaction"),
+                        error,
+                        "warning",
+                        false,
+                        Constants.ephemeralNotificationType.danger,
+                        "")
+        }
+
         function onScrollToMessage(messageIndex) {
             d.goToMessage(messageIndex)
         }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -3048,6 +3048,10 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Please try again later</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Send Contact Request</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -3040,6 +3040,14 @@ Do you wish to override the security check and continue?</source>
 <context>
     <name>ChatMessagesView</name>
     <message>
+        <source>Couldn&apos;t add reaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t remove reaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Send Contact Request</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -11436,7 +11436,7 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Token balances are fetched from Pocket Network (POKT) and Infura which are both curently unavailable</source>
+        <source>Token balances are fetched from Pocket Network (POKT) and Infura which are both currently unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -13953,9 +13953,9 @@
       <translation>Internet connection lost. Data could not be retrieved.</translation>
     </message>
     <message>
-      <source>Token balances are fetched from Pocket Network (POKT) and Infura which are both curently unavailable</source>
+      <source>Token balances are fetched from Pocket Network (POKT) and Infura which are both currently unavailable</source>
       <comment>NetworkConnectionStore</comment>
-      <translation>Token balances are fetched from Pocket Network (POKT) and Infura which are both curently unavailable</translation>
+      <translation>Token balances are fetched from Pocket Network (POKT) and Infura which are both currently unavailable</translation>
     </message>
     <message>
       <source>Market values are fetched from CoinGecko which is currently unavailable</source>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -3733,6 +3733,11 @@
       <translation>Couldn&#39;t remove reaction</translation>
     </message>
     <message>
+      <source>Please try again later</source>
+      <comment>ChatMessagesView</comment>
+      <translation>Please try again later</translation>
+    </message>
+    <message>
       <source>Send Contact Request</source>
       <comment>ChatMessagesView</comment>
       <translation>Send Contact Request</translation>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -3723,6 +3723,16 @@
   <context>
     <name>ChatMessagesView</name>
     <message>
+      <source>Couldn&#39;t add reaction</source>
+      <comment>ChatMessagesView</comment>
+      <translation>Couldn&#39;t add reaction</translation>
+    </message>
+    <message>
+      <source>Couldn&#39;t remove reaction</source>
+      <comment>ChatMessagesView</comment>
+      <translation>Couldn&#39;t remove reaction</translation>
+    </message>
+    <message>
       <source>Send Contact Request</source>
       <comment>ChatMessagesView</comment>
       <translation>Send Contact Request</translation>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -11505,8 +11505,8 @@ selhalo</translation>
         <translation>Připojení k internetu ztraceno. Data nelze načíst.</translation>
     </message>
     <message>
-        <source>Token balances are fetched from Pocket Network (POKT) and Infura which are both curently unavailable</source>
-        <translation>Zůstatky tokenů jsou načítány z Pocket Network (POKT) a Infura, které jsou momentálně nedostupné</translation>
+        <source>Token balances are fetched from Pocket Network (POKT) and Infura which are both currently unavailable</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Market values are fetched from CoinGecko which is currently unavailable</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -3051,6 +3051,14 @@ Přejete si obejít bezpečnostní kontrolu a pokračovat?</translation>
 <context>
     <name>ChatMessagesView</name>
     <message>
+        <source>Couldn&apos;t add reaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t remove reaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Send Contact Request</source>
         <translation>Odeslat žádost o kontakt</translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -3059,6 +3059,10 @@ Přejete si obejít bezpečnostní kontrolu a pokračovat?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Please try again later</source>
+        <translation type="unfinished">Prosím zkuste znovu později</translation>
+    </message>
+    <message>
         <source>Send Contact Request</source>
         <translation>Odeslat žádost o kontakt</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -11449,8 +11449,8 @@ al cargar</translation>
         <translation>Se perdió la conexión a internet. No se pudieron recuperar los datos.</translation>
     </message>
     <message>
-        <source>Token balances are fetched from Pocket Network (POKT) and Infura which are both curently unavailable</source>
-        <translation>Los balances de tokens se obtienen de Pocket Network (POKT) e Infura, ambos no están disponibles actualmente</translation>
+        <source>Token balances are fetched from Pocket Network (POKT) and Infura which are both currently unavailable</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Market values are fetched from CoinGecko which is currently unavailable</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -3042,6 +3042,14 @@ Do you wish to override the security check and continue?</source>
 <context>
     <name>ChatMessagesView</name>
     <message>
+        <source>Couldn&apos;t add reaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t remove reaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Send Contact Request</source>
         <translation>Enviar solicitud de contacto</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -3050,6 +3050,10 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Please try again later</source>
+        <translation type="unfinished">Por favor, intenta de nuevo más tarde</translation>
+    </message>
+    <message>
         <source>Send Contact Request</source>
         <translation>Enviar solicitud de contacto</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -3040,6 +3040,10 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Please try again later</source>
+        <translation type="unfinished">나중에 다시 시도해 주세요</translation>
+    </message>
+    <message>
         <source>Send Contact Request</source>
         <translation>연락처 요청 보내기</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -3032,6 +3032,14 @@ Do you wish to override the security check and continue?</source>
 <context>
     <name>ChatMessagesView</name>
     <message>
+        <source>Couldn&apos;t add reaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t remove reaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Send Contact Request</source>
         <translation>연락처 요청 보내기</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -11394,8 +11394,8 @@ to load</source>
         <translation>인터넷 연결이 끊겼습니다. 데이터를 가져올 수 없습니다.</translation>
     </message>
     <message>
-        <source>Token balances are fetched from Pocket Network (POKT) and Infura which are both curently unavailable</source>
-        <translation>토큰 잔액은 Pocket Network (POKT)와 Infura에서 가져오는데, 현재 두 서비스 모두 이용할 수 없습니다</translation>
+        <source>Token balances are fetched from Pocket Network (POKT) and Infura which are both currently unavailable</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Market values are fetched from CoinGecko which is currently unavailable</source>

--- a/ui/imports/shared/stores/NetworkConnectionStore.qml
+++ b/ui/imports/shared/stores/NetworkConnectionStore.qml
@@ -48,7 +48,7 @@ QtObject {
     readonly property string notOnlineWithNoCacheText: qsTr("Internet connection lost. Data could not be retrieved.")
 
     readonly property bool noBlockchainConnectionAndNoCache: networkConnectionModule.blockchainNetworkConnection.completelyDown && !balanceCache
-    readonly property string noBlockchainConnectionAndNoCacheText: qsTr("Token balances are fetched from Pocket Network (POKT) and Infura which are both curently unavailable")
+    readonly property string noBlockchainConnectionAndNoCacheText: qsTr("Token balances are fetched from Pocket Network (POKT) and Infura which are both currently unavailable")
 
     readonly property bool noMarketConnectionAndNoCache: networkConnectionModule.marketValuesNetworkConnection.completelyDown && !marketValuesCache
     readonly property string noMarketConnectionAndNoCacheText: qsTr("Market values are fetched from CoinGecko which is currently unavailable")


### PR DESCRIPTION
### What does the PR do

Fixes #21269

I converted chat reactions to an async, optimistic flow across the message stack. On the backend-facing side, both add and remove reaction actions now run asynchronously, and their success paths continue to emit the existing reaction signals used by the chat layer. On the UI-facing side, `toggleReaction` was updated to mutate the local model immediately (add/remove) so users see instant feedback, while add-success reconciles the temporary client UUID to the server-provided reaction ID instead of duplicating entries.

To support ID reconciliation cleanly, I added reaction-ID update helpers in the shared reaction models and exposed them up through the message item/model APIs. This allows the module to replace the optimistic reaction ID in place for the current user when the add-reaction success event arrives, with a safe fallback to normal insertion if no optimistic item is present.

I also added full rollback-on-error handling for optimistic reactions. A new reaction-action-failed signal is emitted from message service catch paths (for both add and remove), forwarded by the messages controller, and handled in the messages module to undo the optimistic model change. Finally, the view propagates that failure to QML, where a t` toast is shown ("Couldn't add reaction" / "Couldn't remove reaction") with the error details.

### Affected areas

message service and module mostly

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[reactions-async.webm](https://github.com/user-attachments/assets/dba2acae-5f2c-44a6-a1af-e1cfb98d7dac)


### Impact on end user

For users on a performant device, none, but for someone on a low end device or unlucky and the DB is busy, it will make interacting with reactions feel instantaneous

### How to test

Send and retract reactions

Testing failing reactions probably requires changing the code to fake an error, because there is no scenario where it wouldn't work in a normal app

### Risk 

Low
