### PR TITLE
fix(profile): fix changing profile showcase with no display name

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -309,6 +309,9 @@ SettingsContentBase {
                 displayName.input.edit.readOnly: isEnsName
                 displayName.text: profileStore.displayName
                 displayName.placeholderText: profileStore.compressedPubKey
+                // Set to Always even if there are no validators
+                // otherwise valid is false and it blocks the user if they want to change something else
+                displayName.validationMode: StatusInput.ValidationMode.Always
                 displayName.validators: []
                 bio.text: profileStore.bio
 


### PR DESCRIPTION
### What does the PR do

Fixes #21275

The regression was introduced because I removed the validation mode so that it was validated only when dirty, but I didn't know it would mean `valid` would default to `false` in that case. In that situation, it meant that modifying anything else than the display name didn't let the user save, because it counted the display name as invalid.

Setting `Always` on the validation mode means the validity in calculated from the get go, setting it to `true`.

### Affected areas

MyProfileView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[fix-saving-profile-showcase-no-display-name.webm](https://github.com/user-attachments/assets/1baa9636-3446-4c7c-a495-62ea622005ca)

### Impact on end user

The user can keep the empty display name if they want and still update their showcase. Mostly fixed e2e test (nightlies)

### How to test

Follow repro steps in the issue. Test also changing the description, that was broken before too

### Risk 

Low
