### PR TITLE
feat(new-keycard-approach): integration of a new keycard approach into the wallet settings part

### DIFF
--- a/src/app/modules/shared_modules/add_account/controller.nim
+++ b/src/app/modules/shared_modules/add_account/controller.nim
@@ -20,7 +20,6 @@ type
     savedAddressService: saved_address_service.Service
     connectionIds: seq[UUID]
     tmpAuthenticatedKeyUid: string
-    tmpPin: string
     tmpPassword: string
     tmpSeedPhrase: string
     tmpGeneratedAccount: GeneratedAccountDto
@@ -86,12 +85,6 @@ proc setAuthenticatedKeyUid*(self: Controller, value: string) =
 proc getAuthenticatedKeyUid*(self: Controller): string =
   return self.tmpAuthenticatedKeyUid
 
-proc setPin*(self: Controller, value: string) =
-  self.tmpPin = value
-
-proc getPin*(self: Controller): string =
-  return self.tmpPin
-
 proc setPassword*(self: Controller, value: string) =
   self.tmpPassword = value
 
@@ -125,11 +118,8 @@ proc deleteSavedAddress*(self: Controller, address: string) =
 proc finalizeAction*(self: Controller) =
   self.delegate.finalizeAction()
 
-proc fetchDerivedAddresses*(self: Controller, derivedFrom: string, paths: seq[string])=
-  var hashPassword = true
-  if self.getPin().len > 0:
-    hashPassword = false
-  self.walletAccountService.fetchDerivedAddresses(self.getPassword(), derivedFrom, paths, hashPassword)
+proc fetchDerivedAddresses*(self: Controller, derivedFrom: string, paths: seq[string], doPasswordHashing: bool)=
+  self.walletAccountService.fetchDerivedAddresses(self.getPassword(), derivedFrom, paths, doPasswordHashing)
 
 proc getRandomMnemonic*(self: Controller): string =
   return self.walletAccountService.getRandomMnemonic()

--- a/src/app/modules/shared_modules/add_account/module.nim
+++ b/src/app/modules/shared_modules/add_account/module.nim
@@ -311,7 +311,8 @@ proc fetchAddressForDerivationPath[T](self: Module[T]) =
       if selectedOrigin.getMigratedToColdWallet():
         self.fetchDerivedAddressesFromColdWalletKeypair(selectedOrigin.getKeyUid(), paths)
         return
-      self.controller.fetchDerivedAddresses(selectedOrigin.getDerivedFrom(), paths)
+      let doPasswordHashing = not singletonInstance.userProfile.getMigratedToColdWallet()
+      self.controller.fetchDerivedAddresses(selectedOrigin.getDerivedFrom(), paths, doPasswordHashing)
       return
   error "derivation is not supported for other than profile and seed imported keypairs for origin"
 
@@ -329,7 +330,6 @@ method onUserAuthenticated*[T](self: Module[T], pin: string, password: string, k
   if password.len == 0:
     info "unsuccessful authentication"
     return
-  self.controller.setPin(pin)
   self.controller.setPassword(password)
   self.controller.setAuthenticatedKeyUid(keyUid)
   if self.authenticationReason == AuthenticationReason.AddingAccount:
@@ -354,7 +354,9 @@ proc isAuthenticationNeededForSelectedOrigin[T](self: Module[T]): bool =
       return false
   if selectedOrigin.getKeyUid() == self.controller.getAuthenticatedKeyUid():
     return false
-  if not selectedOrigin.getMigratedToColdWallet() and self.controller.getAuthenticatedKeyUid() == singletonInstance.userProfile.getKeyUid():
+  if not selectedOrigin.getMigratedToColdWallet() and
+    self.controller.getAuthenticatedKeyUid() == singletonInstance.userProfile.getKeyUid() and
+    self.controller.getPassword().len > 0: # need this condition because cold wallet migrated profile does derive from xpub, without password
     return false
   return true
 
@@ -394,7 +396,6 @@ proc setItemForSelectedOrigin[T](self: Module[T], item: KeyPairItem) =
 
   if self.isAuthenticationNeededForSelectedOrigin():
     self.controller.setAuthenticatedKeyUid("")
-    self.controller.setPin("")
     self.controller.setPassword("")
     self.view.setActionAuthenticated(false)
   else:

--- a/src/app/modules/shared_modules/keycard_management/controller.nim
+++ b/src/app/modules/shared_modules/keycard_management/controller.nim
@@ -61,8 +61,8 @@ proc init*(self: Controller) =
   self.connectionIds.add(handlerId)
 
   handlerId = self.events.onWithUUID(SIGNAL_KEYCARD_LOAD_FINISHED) do(e: Args):
-    let args = KeycardErrorArg(e)
-    self.delegate.onKeycardLoadSeedPhraseFinished(args.error)
+    let args = KeycardLoginArgs(e)
+    self.delegate.onKeycardLoadSeedPhraseFinished(args.exportedKeys, args.error)
   self.connectionIds.add(handlerId)
 
   handlerId = self.events.onWithUUID(SIGNAL_CONVERTING_PROFILE_KEYPAIR) do(e: Args):
@@ -72,12 +72,18 @@ proc init*(self: Controller) =
 
   handlerId = self.events.onWithUUID(SIGNAL_KEYCARD_EXPORT_EXTENDED_PUBLIC_KEYS_FINISHED) do(e: Args):
     let args = KeycardExportedExtendedPublicKeyArgs(e)
-    self.delegate.onKeycardExportExtendedPublicKeyFinished(args.exportedExtendedPublicKey.xpub, args.error)
+    self.delegate.onKeycardExportExtendedPublicKeyFinished(args.exportResult.extendedPublicKey.xpub,
+      args.exportResult.masterKeyAddress, args.error)
   self.connectionIds.add(handlerId)
 
   handlerId = self.events.onWithUUID(SIGNAL_ALL_KEYCARDS_DELETED) do(e: Args):
     let args = KeycardArgs(e)
     self.delegate.onStopUsingKeycardForKeyPairFinished(args.keycard.keyUid, args.success)
+  self.connectionIds.add(handlerId)
+
+  handlerId = self.events.onWithUUID(SIGNAL_NEW_KEYCARD_SET) do(e: Args):
+    let args = KeycardArgs(e)
+    self.delegate.onNonProfileKeypairMigratedToColdWalletFinished(args.keycard.keyUid, args.success)
   self.connectionIds.add(handlerId)
 
   handlerId = self.events.onWithUUID(SIGNAL_KEYCARD_CHANGE_PIN_FINISHED) do(e: Args):
@@ -120,8 +126,8 @@ proc startLoadSeedPhrase*(self: Controller, pin: string, puk: string, seedPhrase
     metadataPaths: seq[string]) =
   self.keycardServiceV2.asyncLoadSeedPhrase(pin, puk, seedPhrase, metadataName, metadataPaths)
 
-proc startExportExtendedPublicKey*(self: Controller, keyUid: string, path: string, pin: string) =
-  self.keycardServiceV2.asyncExportExtendedPublicKey(keyUid, path, pin)
+proc startExportExtendedPublicKey*(self: Controller, keyUid: string, path: string, exportMasterAddr: bool, pin: string) =
+  self.keycardServiceV2.asyncExportExtendedPublicKey(keyUid, path, exportMasterAddr, pin)
 
 proc stopKeycardAction*(self: Controller) =
   self.keycardServiceV2.asyncStop()
@@ -139,15 +145,10 @@ proc getKeypairByKeyUid*(self: Controller, keyUid: string): KeypairDto =
     return
   return self.walletAccountService.getKeypairByKeyUid(keyUid)
 
-proc addNewColdWalletStoredKeypair*(self: Controller, keyUid, keypairName, xpub, coldWallet: string, accounts: seq[wallet_account_service.WalletAccountDto]): string =
+proc addNewColdWalletStoredKeypair*(self: Controller, keyUid, keypairName, xpub, coldWallet, masterAddress: string, accounts: seq[wallet_account_service.WalletAccountDto]): string =
   if not serviceApplicable(self.walletAccountService):
     return
-  return self.walletAccountService.addNewColdWalletStoredKeypair(keyUid, keypairName, xpub, coldWallet,
-    rootWalletMasterKey = "", accounts)
-
-proc addKeycardOrAccounts*(self: Controller, keyPair: KeycardDto, password: string) =
-  # TODO: re-implement when integrating new keycard approach
-  discard
+  return self.walletAccountService.addNewColdWalletStoredKeypair(keyUid, keypairName, xpub, coldWallet, masterAddress, accounts)
 
 proc deriveAccountsPublicInfoFromExtendedPublicKeyForPaths*(self: Controller, extendedPublicKey: string, paths: seq[string]): DerivedAccounts =
   if not serviceApplicable(self.accountsService):
@@ -197,10 +198,15 @@ proc convertKeycardProfileKeypairToRegular*(self: Controller, mnemonic, currentP
 proc setStoreToKeychainValueNotNow*(self: Controller) =
   singletonInstance.localAccountSettings.setStoreToKeychainValue(LS_VALUE_NOT_NOW)
 
-proc startStopUsingKeycardForKeyPair*(self: Controller, keyUid, seedPhrase, newPassword: string) =
+proc startStopUsingKeycardForKeyPair*(self: Controller, keyUid, seedPhrase, newPassword: string, doPasswordHashing: bool) =
   if not serviceApplicable(self.walletAccountService):
     return
-  self.walletAccountService.migrateNonProfileColdWalletKeypairToAppAsync(keyUid, seedPhrase, newPassword, doPasswordHashing = true)
+  self.walletAccountService.migrateNonProfileColdWalletKeypairToAppAsync(keyUid, seedPhrase, newPassword, doPasswordHashing)
+
+proc migrateNonProfileKeypairToColdWallet*(self: Controller, keyUid, password, coldWallet: string, doPasswordHashing: bool) =
+  if not serviceApplicable(self.walletAccountService):
+    return
+  self.walletAccountService.migrateNonProfileKeypairToColdWalletAsync(keyUid, password, coldWallet, doPasswordHashing)
 
 proc startChangeKeycardPIN*(self: Controller, keyUid, currentPin, newPin, keycardUid: string) =
   self.keycardServiceV2.asyncChangeKeycardPIN(keyUid, currentPin, newPin, keycardUid)
@@ -219,10 +225,6 @@ proc startRecover*(self: Controller, pin, puk, mnemonic, metadataName: string, m
 
 proc startAsyncLogin*(self: Controller, keyUid, pin, xPubPath: string) =
   self.keycardServiceV2.asyncLogin(keyUid, pin, xPubPath)
-
-proc updateKeycardUid*(self: Controller, oldKeycardUid, newKeycardUid: string) =
-  # TODO: re-implement when integrating new keycard approach
-  discard
 
 proc remainingKeypairCapacity*(self: Controller): int =
   if not serviceApplicable(self.walletAccountService):

--- a/src/app/modules/shared_modules/keycard_management/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_management/io_interface.nim
@@ -57,10 +57,10 @@ method startAddingKeyPairToStatusFromKeycard*(self: AccessInterface, pin: string
     metadataName: string, metadataAccounts: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onKeycardExportExtendedPublicKeyFinished*(self: AccessInterface, xpub: string, error: string) {.base.} =
+method onKeycardExportExtendedPublicKeyFinished*(self: AccessInterface, xpub: string, rootWalletMasterKey: string, error: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onKeycardLoadSeedPhraseFinished*(self: AccessInterface, error: string) {.base.} =
+method onKeycardLoadSeedPhraseFinished*(self: AccessInterface, exportedKeys: KeycardExportedKeysDto, error: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method generateMnemonic*(self: AccessInterface): string {.base.} =
@@ -86,6 +86,9 @@ method startStopUsingKeycardForKeyPair*(self: AccessInterface, keyUid, seedPhras
   raise newException(ValueError, "No implementation available")
 
 method onStopUsingKeycardForKeyPairFinished*(self: AccessInterface, keyUid: string, success: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onNonProfileKeypairMigratedToColdWalletFinished*(self: AccessInterface, keyUid: string, success: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method startStopUsingKeycardForProfileKeyPair*(self: AccessInterface, seedPhrase, newPassword: string) {.base.} =

--- a/src/app/modules/shared_modules/keycard_management/module.nim
+++ b/src/app/modules/shared_modules/keycard_management/module.nim
@@ -2,6 +2,7 @@ import nimqml, sugar, strutils, sequtils, chronicles, json, marshal, json_serial
 
 import io_interface
 import view, controller
+import app/global/global_singleton
 import app/core/eventemitter
 import app/modules/shared/keypairs
 
@@ -52,6 +53,7 @@ type
     tmpKeycardUid: string
     tmpKeypairName: string
     tmpXpub: string
+    masterAddress: string
     tmpAccountsData: seq[AccountData]
     tmpSeedPhrase: string
     tmpMetadataAccountsJson: string
@@ -254,7 +256,7 @@ method startImportingKeyPair*[T](self: Module[T], pin: string, seedPhrase: strin
 
 method startMigratingNonProfileKeypairToKeycard*[T](self: Module[T], password: string, pin: string, seedPhrase: string) =
   self.tmpFlowType = FlowType.MigratingNonProfileKeypairToKeycard
-  self.tmpPassword = utils.hashPassword(password)
+  self.tmpPassword = password
   let keyUid = self.controller.getKeyUidForSeedPhrase(seedPhrase)
   let metadataName = self.getKeyPairNameForKeyUid(keyUid)
   let metadataAccounts = self.getKeyPairAccountPathsJsonForKeyUid(keyUid)
@@ -268,7 +270,7 @@ method getMnemonic*[T](self: Module[T]): string =
 
 method startMigratingProfileKeypairToKeycard*[T](self: Module[T], password: string, pin: string, seedPhrase: string) =
   self.tmpFlowType = FlowType.MigratingProfileKeypairToKeycard
-  self.tmpPassword = password # don't hash it here, cause it's hashed in the service (TODO: change that and use hashPassword instead, from this line)
+  self.tmpPassword = password
   self.tmpSeedPhrase = seedPhrase
   let keyUid = self.controller.getKeyUidForSeedPhrase(seedPhrase)
   let metadataName = self.getKeyPairNameForKeyUid(keyUid)
@@ -303,21 +305,7 @@ proc addNewKeycardKeypair*[T](self: Module[T]): string =
       emoji: account.emoji,
     ))
   return self.controller.addNewColdWalletStoredKeypair(self.tmpKeyUid, self.tmpKeypairName, self.tmpXpub,
-    wallet_account_service.ColdWalletTypeStatusKeycard, walletAccounts)
-
-## #########################################################
-## TODO: remove the part below once we remove the keycard management on the status-go side
-## For now, we just add a new keycard and don't care (listen for signal) about the result of that operation
-proc saveKeypairToKeycard[T](self: Module[T]) =
-  let keyPair = KeycardDto(
-    keycardUid: self.view.getKeycardUid(),
-    keyUid: self.tmpKeyUid,
-    keycardName: self.tmpKeypairName,
-    keycardLocked: false,
-    accountsAddresses: self.tmpAccountsData.map(a => a.address),
-  )
-  self.controller.addKeycardOrAccounts(keyPair, self.tmpPassword) # this call is removing local keystore files, we will need a new function for this, once we remove the keycard management on the status-go side
-## #########################################################
+    wallet_account_service.ColdWalletTypeStatusKeycard, self.masterAddress, walletAccounts)
 
 method generateMnemonic*[T](self: Module[T]): string =
   return self.controller.generateMnemonic()
@@ -343,8 +331,9 @@ method startStopUsingKeycardForKeyPair*[T](self: Module[T], keyUid, seedPhrase, 
   self.tmpFlowType = FlowType.StoppingKeycardForKeyPair
   self.tmpKeyUid = keyUid
   self.tmpSeedPhrase = seedPhrase
-  self.tmpPassword = newPassword # it is hashed in the service
-  self.controller.startStopUsingKeycardForKeyPair(keyUid, seedPhrase, newPassword)
+  self.tmpPassword = newPassword
+  let doPasswordHashing = not singletonInstance.userProfile.getMigratedToColdWallet()
+  self.controller.startStopUsingKeycardForKeyPair(keyUid, seedPhrase, newPassword, doPasswordHashing)
 
 method onStopUsingKeycardForKeyPairFinished*[T](self: Module[T], keyUid: string, success: bool) =
   if self.tmpFlowType != FlowType.StoppingKeycardForKeyPair:
@@ -353,6 +342,14 @@ method onStopUsingKeycardForKeyPairFinished*[T](self: Module[T], keyUid: string,
     self.emitError("failed to stop using Keycard for key pair")
     return
   self.view.stopUsingKeycardForKeyPairSuccess()
+
+method onNonProfileKeypairMigratedToColdWalletFinished*[T](self: Module[T], keyUid: string, success: bool) =
+  if self.tmpFlowType != FlowType.MigratingNonProfileKeypairToKeycard:
+    return
+  if not success or keyUid != self.tmpKeyUid:
+    self.emitError("failed to migrate key pair to keycard")
+    return
+  self.view.keycardMoveKeyPairSuccess()
 
 method startChangeKeycardPIN*[T](self: Module[T], currentPin, newPin: string) =
   self.tmpFlowType = FlowType.ChangingKeycardPIN
@@ -431,13 +428,6 @@ method onKeycardRecoverFinished*[T](self: Module[T], error: string) =
   if error.len > 0:
     self.emitError("keycard recover error: " & error)
     return
-  ## #########################################################
-  ## TODO: remove the part below once we remove the keycard management on the status-go side
-  ## For now, we just update the keycard uid in the db and don't care (listen for signal) about the result of that operation
-  let newKeycardUid = self.view.getKeycardUid()
-  if self.tmpKeycardUid.len > 0 and newKeycardUid.len > 0 and self.tmpKeycardUid != newKeycardUid:
-    self.controller.updateKeycardUid(self.tmpKeycardUid, newKeycardUid)
-  ## #########################################################
   self.view.keycardUnblockSuccess()
 
 method startAsyncLogin*[T](self: Module[T], keyUid, pin: string, generateXPub: bool) =
@@ -484,7 +474,7 @@ method onKeycardAsyncLoginFinished*[T](self: Module[T], exportedKeys: KeycardExp
 method startStopUsingKeycardForProfileKeyPair*[T](self: Module[T], seedPhrase, newPassword: string) =
   self.tmpFlowType = FlowType.StoppingKeycardForProfileKeyPair
   self.tmpSeedPhrase = seedPhrase
-  self.tmpPassword = newPassword # don't hash it here, cause it's hashed in the service
+  self.tmpPassword = newPassword
   let acc = self.controller.createAccountFromMnemonic(seedPhrase, includeEncryption = true)
   let currentPassword = acc.derivedAccounts.encryption.publicKey
   if currentPassword.len == 0:
@@ -499,9 +489,9 @@ method startAddingKeyPairToStatusFromKeycard*[T](self: Module[T], pin: string, k
   self.tmpKeyUid = keyUid
   self.tmpKeypairName = metadataName
   self.tmpMetadataAccountsJson = metadataAccounts
-  self.controller.startExportExtendedPublicKey(self.tmpKeyUid, PATH_WALLET_XPUB, pin)
+  self.controller.startExportExtendedPublicKey(self.tmpKeyUid, PATH_WALLET_XPUB, exportMasterAddr = true, pin)
 
-method onKeycardExportExtendedPublicKeyFinished*[T](self: Module[T], xpub: string, error: string) =
+method onKeycardExportExtendedPublicKeyFinished*[T](self: Module[T], xpub: string, masterAddress: string, error: string) =
   if self.tmpFlowType != FlowType.AddingKeyPairFromKeycard:
     return
   if error.len > 0:
@@ -517,6 +507,7 @@ method onKeycardExportExtendedPublicKeyFinished*[T](self: Module[T], xpub: strin
     return
 
   self.tmpXpub = xpub
+  self.masterAddress = masterAddress
 
   if not self.prepareAccountsData(self.tmpXpub, self.tmpMetadataAccountsJson):
     self.emitError("failed to prepare accounts data")
@@ -529,10 +520,9 @@ method onKeycardExportExtendedPublicKeyFinished*[T](self: Module[T], xpub: strin
     self.emitError("failed to add new keycard stored keypair: " & err)
     return
 
-  self.saveKeypairToKeycard()
   self.view.keycardAddKeyPairSuccess()
 
-method onKeycardLoadSeedPhraseFinished*[T](self: Module[T], error: string) =
+method onKeycardLoadSeedPhraseFinished*[T](self: Module[T], exportedKeys: KeycardExportedKeysDto, error: string) =
   if error.len > 0:
     self.emitError("keycard load key pair error: " & error)
     return
@@ -541,20 +531,18 @@ method onKeycardLoadSeedPhraseFinished*[T](self: Module[T], error: string) =
 
   if self.tmpFlowType == FlowType.ImportingKeyPair:
     if not self.isKnownKeyUid(self.tmpKeyUid):
+      self.masterAddress = exportedKeys.masterKey.address
       let err = self.addNewKeycardKeypair()
       if err.len > 0:
         self.emitError("failed to add new keycard stored keypair: " & err)
         return
-      self.saveKeypairToKeycard() # this is just to add keycard to db and remove keystore files
     elif not self.isKeypairMigratedToColdWallet(self.tmpKeyUid):
       self.emitError("key pair is not migrated to keycard, cannot be imported to keycard, keyUid: " & self.tmpKeyUid)
       return
     self.view.keycardImportKeyPairSuccess()
   elif self.tmpFlowType == FlowType.MigratingNonProfileKeypairToKeycard:
-    # TODO: updating xpub explicitly (via updateKeypairXPub) is removed, cause once the key pair is added the xpub is always the same
-    # regardless if the key pair is migrated to a cold wallet device or not, just need to ensure that every (old - already added) key pair has xpub set
-    self.saveKeypairToKeycard() # this is just to add keycard to db and remove keystore files
-    self.view.keycardMoveKeyPairSuccess()
+    let doPasswordHashing = not singletonInstance.userProfile.getMigratedToColdWallet()
+    self.controller.migrateNonProfileKeypairToColdWallet(self.tmpKeyUid, self.tmpPassword, wallet_account_service.ColdWalletTypeStatusKeycard, doPasswordHashing)
   elif self.tmpFlowType == FlowType.MigratingProfileKeypairToKeycard:
     let acc = self.controller.createAccountFromMnemonic(self.tmpSeedPhrase, includeEncryption = true)
     let newPassword = acc.derivedAccounts.encryption.publicKey

--- a/src/app_service/service/keycardV2/dto.nim
+++ b/src/app_service/service/keycardV2/dto.nim
@@ -82,6 +82,10 @@ type KeycardExportedExtendedPublicKeyDto* = object
   chainCode*: string
   xpub*: string
 
+type KeycardExportExtendedPublicKeyResultDto* = object
+  extendedPublicKey*: KeycardExportedExtendedPublicKeyDto
+  masterKeyAddress*: string
+
 type KeycardExportedKeysDto* = object
   eip1581Key*: KeyDetailsV2
   encryptionKey*: KeyDetailsV2
@@ -203,6 +207,13 @@ proc toKeycardExportedExtendedPublicKeyDto*(jsonObj: JsonNode): KeycardExportedE
   discard jsonObj.getProp("publicKey", result.publicKey)
   discard jsonObj.getProp("chainCode", result.chainCode)
   discard jsonObj.getProp("xpub", result.xpub)
+
+proc toKeycardExportExtendedPublicKeyResultDto*(jsonObj: JsonNode): KeycardExportExtendedPublicKeyResultDto =
+  result = KeycardExportExtendedPublicKeyResultDto()
+  var obj: JsonNode
+  if jsonObj.getProp("extendedPublicKey", obj):
+    result.extendedPublicKey = toKeycardExportedExtendedPublicKeyDto(obj)
+  discard jsonObj.getProp("masterKeyAddress", result.masterKeyAddress)
 
 proc toKeycardExportedKeysDto*(jsonObj: JsonNode): KeycardExportedKeysDto =
   result = KeycardExportedKeysDto()

--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -102,7 +102,7 @@ type
     exportedPublicKeys*: KeycardExportedPublicKeysDto
 
   KeycardExportedExtendedPublicKeyArgs* = ref object of KeycardErrorArg
-    exportedExtendedPublicKey*: KeycardExportedExtendedPublicKeyDto
+    exportResult*: KeycardExportExtendedPublicKeyResultDto
 
   KeycardGetKeycardMetadataArgs* = ref object of KeycardErrorArg
     metadata*: CardMetadataDto

--- a/src/app_service/service/keycardV2/service_composite_methods.nim
+++ b/src/app_service/service/keycardV2/service_composite_methods.nim
@@ -91,10 +91,11 @@ proc asyncExportPublicKey*(self: Service, keyUid: string, paths: seq[string], ex
     self.events.emit(SIGNAL_KEYCARD_EXPORT_PUBLIC_KEYS_FINISHED, data)
   )
 
-proc asyncExportExtendedPublicKey*(self: Service, keyUid: string, path: string, pin: string) {.featureGuard(KEYCARD_ENABLED).} =
+proc asyncExportExtendedPublicKey*(self: Service, keyUid: string, path: string, exportMasterAddr: bool, pin: string) {.featureGuard(KEYCARD_ENABLED).} =
   let params = %*{
     "keyUid": keyUid,
     "path": path,
+    "exportMasterAddr": exportMasterAddr,
     "pin": pin,
     "storageFilePath": status_const.KEYCARDPAIRINGDATAFILE,
     "logEnabled": status_const.KEYCARD_LOGS_ENABLED,
@@ -110,7 +111,7 @@ proc asyncExportExtendedPublicKey*(self: Service, keyUid: string, path: string, 
         if errorObj.hasKey("message"):
           raise newException(CatchableError, "exporting extended public keys keycard response error: " & errorObj["message"].getStr())
         raise newException(CatchableError, "exporting extended public keys keycard response unknown error")
-      data.exportedExtendedPublicKey = responseObj["result"].toKeycardExportedExtendedPublicKeyDto()
+      data.exportResult = responseObj["result"].toKeycardExportExtendedPublicKeyResultDto()
     except Exception as e:
       error "exporting extended public keys error", err=e.msg
       data.error = e.msg
@@ -308,7 +309,7 @@ proc asyncLoadSeedPhrase*(self: Service, pin: string, puk: string, seedPhrase: s
     "logFilePath": status_const.KEYCARD_LOG_FILE_PATH,
   }
   self.asyncCallRPC(KeycardAction.Load, params, proc (responseObj: JsonNode, err: string) =
-    var data = KeycardErrorArg()
+    var data = KeycardLoginArgs()
     try:
       if err.len > 0:
         raise newException(CatchableError, "load key pair parsing response error: " & err)
@@ -317,6 +318,10 @@ proc asyncLoadSeedPhrase*(self: Service, pin: string, puk: string, seedPhrase: s
         if errorObj.hasKey("message"):
           raise newException(CatchableError, "load key pair response error: " & errorObj["message"].getStr())
         raise newException(CatchableError, "load key pair response unknown error")
+      let resultObj = responseObj["result"]
+      if not resultObj.hasKey("keys"):
+        raise newException(CatchableError, "recover action keycard response missing keys")
+      data.exportedKeys = resultObj["keys"].toKeycardExportedKeysDto()
     except Exception as e:
       error "load key pair error", err=e.msg
       data.error = e.msg

--- a/src/app_service/service/wallet_account/service_account.nim
+++ b/src/app_service/service/wallet_account/service_account.nim
@@ -26,6 +26,8 @@ proc replaceKeypair(self: Service, keypair: KeypairDto) =
   localKp.lastUsedDerivationIndex = keypair.lastUsedDerivationIndex
   localKp.syncedFrom = keypair.syncedFrom
   localKp.removed = keypair.removed
+  localKp.extendedPublicKey = keypair.extendedPublicKey
+  localKp.coldWalletType = keypair.coldWalletType
   for locAcc in localKp.accounts:
     for acc in keypair.accounts:
       if cmpIgnoreCase(locAcc.address, acc.address) != 0:
@@ -418,11 +420,10 @@ proc addNewSeedPhraseKeypair*(self: Service, seedPhrase, password: string, doPas
     error "error: ", procName="addNewSeedPhraseKeypair", errName=e.name, errDesription=e.msg
     return e.msg
 
-proc addNewColdWalletStoredKeypair*(self: Service, keyUid, keypairName, walletXPub, coldWallet, rootWalletMasterKey: string,
+proc addNewColdWalletStoredKeypair*(self: Service, keyUid, keypairName, walletXPub, coldWallet, masterAddress: string,
   accounts: seq[WalletAccountDto]): string =
   try:
-    var response = status_go_accounts.addKeypairStoredToColdWallet(keyUid, rootWalletMasterKey, keypairName, walletXPub,
-      coldWallet, accounts)
+    var response = status_go_accounts.addKeypairStoredToColdWallet(keyUid, masterAddress, keypairName, walletXPub, coldWallet, accounts)
     if not response.error.isNil:
       error "status-go error adding keypair", procName="addNewColdWalletStoredKeypair", errCode=response.error.code, errDesription=response.error.message
       return response.error.message
@@ -497,6 +498,12 @@ proc onNonProfileColdWalletKeypairMigratedToApp*(self: Service, response: string
     let kp = self.getKeypairByKeyUid(data.keycard.keyUid)
     if kp.isNil:
       data.success = false
+    elif data.success:
+      let dbKp = self.getKeypairByKeyUidFromDb(data.keycard.keyUid)
+      if dbKp.isNil:
+        data.success = false
+      else:
+        self.replaceKeypair(dbKp)
   except Exception as e:
     error "error handling migrated cold-wallet keypair response", errDesription=e.msg
   self.events.emit(SIGNAL_ALL_KEYCARDS_DELETED, data)
@@ -524,6 +531,12 @@ proc onNonProfileKeypairMigratedToColdWallet*(self: Service, response: string) {
     let responseObj = response.parseJson
     discard responseObj.getProp("success", data.success)
     discard responseObj.getProp("keyUid", data.keycard.keyUid)
+    if data.success:
+      let dbKp = self.getKeypairByKeyUidFromDb(data.keycard.keyUid)
+      if dbKp.isNil:
+        data.success = false
+      else:
+        self.replaceKeypair(dbKp)
   except Exception as e:
     error "error handling cold-wallet flip response", errDesription=e.msg
   self.events.emit(SIGNAL_NEW_KEYCARD_SET, data)

--- a/storybook/pages/KeycardManagementPopupPage.qml
+++ b/storybook/pages/KeycardManagementPopupPage.qml
@@ -87,6 +87,7 @@ SplitView {
         property var keyPairItem: keyPairItemMock
         property string userProfileKeyUid: root.userProfile.keyUid
         property string userProfilePubKey: root.userProfile.pubKey
+        property bool isProfileMigratedToColdWallet: root.userProfile.migratedToColdWallet
 
         readonly property string _mnemonic: "abandon ability able about above absent absorb abstract absurd abuse access accident"
 

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -290,11 +290,19 @@ SettingsContentBase {
                 removeKeypairPopup.active = true
             }
             onRunMoveKeypairToKeycardFlow: (model) => {
-                console.log("TODO: add when integrate new keycard approach")
-            }
+                                               Global.openKeycardManagementPopup(Constants.keycard.flow.moveKeyPair,
+                                                                                 model.keyPair.keyUid,
+                                                                                 "",
+                                                                                 "",
+                                                                                 "[]")
+                                           }
             onRunStopUsingKeycardFlow: (model) => {
-                console.log("TODO: add when integrate new keycard approach")
-            }
+                                           Global.openKeycardManagementPopup(Constants.keycard.flow.stopUsingKeycard,
+                                                                             model.keyPair.keyUid,
+                                                                             "",
+                                                                             "",
+                                                                             "[]")
+                                       }
             onGoToManageTokensView: priv.navigateToDetails(root.manageTokensViewIndex)
             onGoToSavedAddressesView: priv.navigateToDetails(root.savedAddressesViewIndex)
         }
@@ -371,10 +379,18 @@ SettingsContentBase {
                 root.walletStore.runKeypairImportPopup(keyPair.keyUid, Constants.keypairImportPopup.mode.selectImportMethod)
             }
             onRunMoveKeypairToKeycardFlow: {
-                console.log("TODO: add when integrate new keycard approach")
+                Global.openKeycardManagementPopup(Constants.keycard.flow.moveKeyPair,
+                                                  keyPair.keyUid,
+                                                  "",
+                                                  "",
+                                                  "[]")
             }
             onRunStopUsingKeycardFlow: {
-                console.log("TODO: add when integrate new keycard approach")
+                Global.openKeycardManagementPopup(Constants.keycard.flow.stopUsingKeycard,
+                                                  keyPair.keyUid,
+                                                  "",
+                                                  "",
+                                                  "[]")
             }
             onUpdateWatchAccountHiddenFromTotalBalance: (address, hideFromTotalBalance) => {
                 root.walletStore.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -254,7 +254,7 @@ QtObject {
                 break
             case Constants.keycard.flow.moveProfileKeyPair:
                 if (finalKeyUid !== root.keycardManagementStore.userProfileKeyUid) {
-                    finalFlow = Constants.keycard.flow.stopUsingKeycard
+                    finalFlow = Constants.keycard.flow.moveKeyPair
                 }
                 break
             case Constants.keycard.flow.stopUsingKeycardForProfile:

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -8707,6 +8707,17 @@ Are you sure you want to do this?</source>
     </message>
 </context>
 <context>
+    <name>InsertEmptyKeycardState</name>
+    <message>
+        <source>Insert an empty Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert an empty Keycard you want to migrate your key pair to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>IntroMessageInput</name>
     <message>
         <source>Dialog for new members</source>
@@ -9913,6 +9924,14 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
     <message>
         <source>It&apos;s a different Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keycard is not empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Try again with an empty keycard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14851,6 +14870,10 @@ to load</source>
     </message>
     <message>
         <source>Profile key pair</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Key pair</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -10632,6 +10632,19 @@
     </message>
   </context>
   <context>
+    <name>InsertEmptyKeycardState</name>
+    <message>
+      <source>Insert an empty Keycard</source>
+      <comment>InsertEmptyKeycardState</comment>
+      <translation>Insert an empty Keycard</translation>
+    </message>
+    <message>
+      <source>Insert an empty Keycard you want to migrate your key pair to.</source>
+      <comment>InsertEmptyKeycardState</comment>
+      <translation>Insert an empty Keycard you want to migrate your key pair to.</translation>
+    </message>
+  </context>
+  <context>
     <name>IntroMessageInput</name>
     <message>
       <source>Dialog for new members</source>
@@ -12111,6 +12124,16 @@
       <source>It&#39;s a different Keycard</source>
       <comment>KeycardProgressState</comment>
       <translation>It&#39;s a different Keycard</translation>
+    </message>
+    <message>
+      <source>Keycard is not empty</source>
+      <comment>KeycardProgressState</comment>
+      <translation>Keycard is not empty</translation>
+    </message>
+    <message>
+      <source>Try again with an empty keycard</source>
+      <comment>KeycardProgressState</comment>
+      <translation>Try again with an empty keycard</translation>
     </message>
     <message>
       <source>The card is not a Keycard, try again with Keycard</source>
@@ -18113,6 +18136,11 @@
       <source>Profile key pair</source>
       <comment>SelectKeyPairState</comment>
       <translation>Profile key pair</translation>
+    </message>
+    <message>
+      <source>Key pair</source>
+      <comment>SelectKeyPairState</comment>
+      <translation>Key pair</translation>
     </message>
     <message>
       <source>I understand that moving this key pair will require using Keycard to log in and sign</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -8751,6 +8751,17 @@ Opravdu to chcete udělat?</translation>
     </message>
 </context>
 <context>
+    <name>InsertEmptyKeycardState</name>
+    <message>
+        <source>Insert an empty Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert an empty Keycard you want to migrate your key pair to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>IntroMessageInput</name>
     <message>
         <source>Dialog for new members</source>
@@ -9967,6 +9978,14 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
     <message>
         <source>It&apos;s a different Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keycard is not empty</source>
+        <translation type="unfinished">Keycard není prázdná</translation>
+    </message>
+    <message>
+        <source>Try again with an empty keycard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14936,6 +14955,10 @@ selhalo</translation>
     <message>
         <source>Profile key pair</source>
         <translation type="unfinished">Pár klíčů profilu</translation>
+    </message>
+    <message>
+        <source>Key pair</source>
+        <translation type="unfinished">Pár klíčů</translation>
     </message>
     <message>
         <source>I understand that moving this key pair will require using Keycard to log in and sign</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -8719,6 +8719,17 @@ Are you sure you want to do this?</source>
     </message>
 </context>
 <context>
+    <name>InsertEmptyKeycardState</name>
+    <message>
+        <source>Insert an empty Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert an empty Keycard you want to migrate your key pair to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>IntroMessageInput</name>
     <message>
         <source>Dialog for new members</source>
@@ -9925,6 +9936,14 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
     <message>
         <source>It&apos;s a different Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keycard is not empty</source>
+        <translation type="unfinished">La Keycard no está vacía</translation>
+    </message>
+    <message>
+        <source>Try again with an empty keycard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14867,6 +14886,10 @@ al cargar</translation>
     <message>
         <source>Profile key pair</source>
         <translation type="unfinished">Par de claves del perfil</translation>
+    </message>
+    <message>
+        <source>Key pair</source>
+        <translation type="unfinished">Par de claves</translation>
     </message>
     <message>
         <source>I understand that moving this key pair will require using Keycard to log in and sign</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -8688,6 +8688,17 @@ Are you sure you want to do this?</source>
     </message>
 </context>
 <context>
+    <name>InsertEmptyKeycardState</name>
+    <message>
+        <source>Insert an empty Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert an empty Keycard you want to migrate your key pair to.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>IntroMessageInput</name>
     <message>
         <source>Dialog for new members</source>
@@ -9884,6 +9895,14 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
     <message>
         <source>It&apos;s a different Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keycard is not empty</source>
+        <translation type="unfinished">Keycard가 비어 있지 않습니다</translation>
+    </message>
+    <message>
+        <source>Try again with an empty keycard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14799,6 +14818,10 @@ to load</source>
     <message>
         <source>Profile key pair</source>
         <translation type="unfinished">프로필 키 페어</translation>
+    </message>
+    <message>
+        <source>Key pair</source>
+        <translation type="unfinished">키 쌍</translation>
     </message>
     <message>
         <source>I understand that moving this key pair will require using Keycard to log in and sign</source>

--- a/ui/imports/shared/popups/addaccount/panels/DerivationPathSection.qml
+++ b/ui/imports/shared/popups/addaccount/panels/DerivationPathSection.qml
@@ -61,9 +61,12 @@ Column {
                     return ""
                 }
 
-                if (root.store.selectedOrigin.keyUid === root.store.userProfileKeyUid &&
-                        root.store.userProfileUsingBiometricLogin) {
+                if (root.store.userProfileUsingBiometricLogin) {
                     return "touch-id"
+                }
+
+                if (root.store.userProfileMigratedToColdWallet) {
+                    return "keycard"
                 }
 
                 return "password"

--- a/ui/imports/shared/popups/addaccount/states/SelectMasterKey.qml
+++ b/ui/imports/shared/popups/addaccount/states/SelectMasterKey.qml
@@ -115,9 +115,7 @@ Item {
                     text: qsTr("Continue in Keycard settings")
                     onClicked: {
                         root.continueOnKeycard()
-                        console.log("TODO: add when integrate new keycard approach")
-                        // TODO: enable the line below
-                        // Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.keycardNew)
+                        Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.keycardNew)
                     }
                 }
             ]

--- a/ui/imports/shared/popups/auth_sign_base/ErrorsHandler.qml
+++ b/ui/imports/shared/popups/auth_sign_base/ErrorsHandler.qml
@@ -9,6 +9,7 @@ QtObject {
 
     readonly property QtObject errKeyword: QtObject {
         readonly property string internalError: "Keycard info not found"
+        readonly property string notEmptyKeycardError: "Card is not empty"
         readonly property string wrongKeycardProfile: "profile does not match"
         readonly property string wrongKeycard: "Keycard instance UID does not match"
         readonly property string wrongPin1: "Wrong PIN"
@@ -25,6 +26,7 @@ QtObject {
     }
 
     readonly property bool internalError: root.errorText.toLowerCase().indexOf(errKeyword.internalError.toLowerCase()) > -1
+    readonly property bool notEmptyKeycardError: root.errorText.toLowerCase().indexOf(errKeyword.notEmptyKeycardError.toLowerCase()) > -1
     readonly property bool wrongKeycardProfileError: root.errorText.toLowerCase().indexOf(errKeyword.wrongKeycardProfile.toLowerCase()) > -1
     readonly property bool wrongKeycardError: root.errorText.toLowerCase().indexOf(errKeyword.wrongKeycard.toLowerCase()) > -1
     readonly property bool wrongPinError1: root.errorText.toLowerCase().indexOf(errKeyword.wrongPin1.toLowerCase()) > -1

--- a/ui/imports/shared/popups/keycard_new/KeycardManagementPopup.qml
+++ b/ui/imports/shared/popups/keycard_new/KeycardManagementPopup.qml
@@ -97,6 +97,7 @@ StatusDialog {
         DisplaySeedPhrase,
         ConfirmSeedPhraseWords,
         SelectKeyPair,
+        InsertEmptyKeycard,
         ConfirmKeyPair,
         CreatePassword,
         ConfirmPassword,
@@ -218,6 +219,8 @@ StatusDialog {
                 return root.flow === Constants.keycard.flow.moveProfileKeyPair
                     ? selectProfileKeyPairComponent
                     : selectKeyPairComponent
+            case KeycardManagementPopup.FlowStep.InsertEmptyKeycard:
+                return insertEmptyKeycardComponent
             case KeycardManagementPopup.FlowStep.ConfirmKeyPair:
                 return confirmKeyPairForStopUsingComponent
             case KeycardManagementPopup.FlowStep.CreatePassword:
@@ -299,7 +302,7 @@ StatusDialog {
             Backpressure.setTimeout(this, 500, () => {
                                         root.store.startStopUsingKeycardForKeyPair(root.keyUid,
                                                                                    d.seedPhrase,
-                                                                                   d.newStatusPassword)
+                                                                                   d.authenticationPassword)
                                     })
         }
 
@@ -381,6 +384,10 @@ StatusDialog {
         }
 
         function nextStep() {
+            if (d.currentStep === KeycardManagementPopup.FlowStep.InsertEmptyKeycard) {
+                d.startMigratingNonProfileKeypairToKeycard()
+                return
+            }
             if (d.currentStep === KeycardManagementPopup.FlowStep.SelectKeyPair) {
                 d.currentStep = d.keycardHasOnlyPinSet
                     ? KeycardManagementPopup.FlowStep.EnterPin
@@ -506,8 +513,11 @@ StatusDialog {
                     Global.openAuthenticationPopup(Constants.keycard.flow.moveProfileKeyPair, root.store.userProfileKeyUid, false)
                     return
                 }
-                if (root.flow === Constants.keycard.flow.stopUsingKeycard
-                        || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile
+                if (root.flow === Constants.keycard.flow.stopUsingKeycard) {
+                    Global.openAuthenticationPopup(Constants.keycard.flow.stopUsingKeycard, root.store.userProfileKeyUid, false)
+                    return
+                }
+                if (root.flow === Constants.keycard.flow.stopUsingKeycardForProfile
                         || root.flow === Constants.keycard.flow.startUsingProfileWithoutKeycard) {
                     d.currentStep = KeycardManagementPopup.FlowStep.CreatePassword
                     return
@@ -898,6 +908,7 @@ StatusDialog {
         target: Global
         enabled: root.flow === Constants.keycard.flow.moveKeyPair
                  || root.flow === Constants.keycard.flow.moveProfileKeyPair
+                 || root.flow === Constants.keycard.flow.stopUsingKeycard
 
         function onAuthenticationResult(reason, password, pin, keyUid) {
             if (!password) {
@@ -908,10 +919,16 @@ StatusDialog {
 
             switch(reason) {
             case Constants.keycard.flow.moveKeyPair:
-                d.startMigratingNonProfileKeypairToKeycard()
+                if (root.store.isProfileMigratedToColdWallet)
+                    d.currentStep = KeycardManagementPopup.FlowStep.InsertEmptyKeycard
+                else
+                    d.startMigratingNonProfileKeypairToKeycard()
                 break
             case Constants.keycard.flow.moveProfileKeyPair:
                 d.startMigratingProfileKeypairToKeycard()
+                break
+            case Constants.keycard.flow.stopUsingKeycard:
+                d.startStopUsingKeycardForKeyPair()
                 break
             default:
                 console.warn("unknown authentication reason received in keycard popup", reason)
@@ -1149,7 +1166,8 @@ StatusDialog {
                              || (root.flow === Constants.keycard.flow.moveKeyPair
                                  && (d.currentStep === KeycardManagementPopup.FlowStep.SelectKeyPair
                                      || d.currentStep === KeycardManagementPopup.FlowStep.RepeatPin
-                                     || d.currentStep === KeycardManagementPopup.FlowStep.EnterSeedPhrase))
+                                     || d.currentStep === KeycardManagementPopup.FlowStep.EnterSeedPhrase
+                                     || d.currentStep === KeycardManagementPopup.FlowStep.InsertEmptyKeycard))
                              || (root.flow === Constants.keycard.flow.moveProfileKeyPair
                                  && (d.currentStep === KeycardManagementPopup.FlowStep.SelectKeyPair
                                      || d.currentStep === KeycardManagementPopup.FlowStep.RepeatPin
@@ -1194,7 +1212,8 @@ StatusDialog {
                                  && (d.currentStep === KeycardManagementPopup.FlowStep.RepeatPin
                                      || d.currentStep === KeycardManagementPopup.FlowStep.EnterSeedPhrase)))
                 enabled: visible
-                         && ((d.currentStep === KeycardManagementPopup.FlowStep.RepeatPin && d.pinMismatch)
+                         && ((d.currentStep === KeycardManagementPopup.FlowStep.InsertEmptyKeycard)
+                             || (d.currentStep === KeycardManagementPopup.FlowStep.RepeatPin && d.pinMismatch)
                              || (d.currentStep === KeycardManagementPopup.FlowStep.EnterSeedPhrase && contentLoader.item.seedPhraseValid)
                              || (d.currentStep === KeycardManagementPopup.FlowStep.DisplaySeedPhrase && contentLoader.item.seedPhraseRevealed)
                              || (d.currentStep === KeycardManagementPopup.FlowStep.ConfirmSeedPhraseWords && contentLoader.item.allEntriesValid)
@@ -1237,6 +1256,10 @@ StatusDialog {
                     return qsTr("Next")
                 }
                 onClicked: {
+                    if (d.currentStep === KeycardManagementPopup.FlowStep.InsertEmptyKeycard) {
+                        d.nextStep()
+                        return
+                    }
                     if (d.currentStep === KeycardManagementPopup.FlowStep.SelectKeyPair) {
                         d.moveKeyPairSelectedKeyUid = contentLoader.item.selectedKeyUid
                         d.moveKeyPairSelectedKeyPairName = contentLoader.item.selectedKeyPairName
@@ -1267,6 +1290,7 @@ StatusDialog {
                                 || root.flow === Constants.keycard.flow.moveProfileKeyPair
                                 || root.flow === Constants.keycard.flow.unblockWithRecoveryPhrase
                                 || root.flow === Constants.keycard.flow.onboardingImportSeedPhrase
+                                || root.flow === Constants.keycard.flow.stopUsingKeycard
                                 || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile
                                 || root.flow === Constants.keycard.flow.startUsingProfileWithoutKeycard) {
                             d.nextStep()
@@ -1376,6 +1400,7 @@ StatusDialog {
         id: keycardProgressComponent
         KeycardProgressState {
             keycardInternalError: keycardErrors.internalError
+            keycardNotEmptyError: keycardErrors.notEmptyKeycardError
             wrongKeycard: keycardErrors.wrongKeycardError
             wrongKeycardProfile: keycardErrors.wrongKeycardProfileError
             wrongPin: keycardErrors.wrongPinError1
@@ -1759,12 +1784,18 @@ StatusDialog {
     }
 
     Component {
+        id: insertEmptyKeycardComponent
+        InsertEmptyKeycardState {}
+    }
+
+    Component {
         id: selectKeyPairComponent
         SelectKeyPairState {
             userProfilePublicKey: root.store.userProfilePubKey
 
             keypairsModel: root.store.keypairsModel
-            initialSelectedKeyUid: d.moveKeyPairSelectedKeyUid
+            fixedKeyUid: root.keyUid
+            initialSelectedKeyUid: root.keyUid.length > 0 ? root.keyUid : d.moveKeyPairSelectedKeyUid
             initialUnderstandChecked: d.moveKeyPairUnderstandChecked
         }
     }

--- a/ui/imports/shared/popups/keycard_new/states/InsertEmptyKeycardState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/InsertEmptyKeycardState.qml
@@ -1,0 +1,54 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+
+import utils
+
+Control {
+    id: root
+
+    topPadding: Theme.xlPadding
+    bottomPadding: Theme.halfPadding
+    leftPadding: Theme.xlPadding
+    rightPadding: Theme.xlPadding
+
+    contentItem: ColumnLayout {
+        spacing: Theme.padding
+
+        Image {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredHeight: Constants.keycard.shared.imageHeight
+            Layout.preferredWidth: Constants.keycard.shared.imageWidth
+            fillMode: Image.PreserveAspectFit
+            mipmap: true
+            source: Assets.png("keycard/card_insert/insert")
+        }
+
+        StatusBaseText {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            font.weight: Font.Bold
+            font.pixelSize: Theme.fontSize(22)
+            color: Theme.palette.directColor1
+            text: qsTr("Insert an empty Keycard")
+        }
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            color: Theme.palette.directColor1
+            text: qsTr("Insert an empty Keycard you want to migrate your key pair to.")
+        }
+
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+    }
+}

--- a/ui/imports/shared/popups/keycard_new/states/KeycardProgressState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/KeycardProgressState.qml
@@ -14,6 +14,7 @@ Control {
 
     required property string keycardState
     required property bool keycardInternalError
+    required property bool keycardNotEmptyError
     required property bool wrongKeycard
     required property bool wrongKeycardProfile
     required property bool wrongPin
@@ -188,6 +189,7 @@ Control {
                 when: !root.failure
                       && !root.keycardInteractionCompleted
                       && !root.keycardInternalError
+                      && !root.keycardNotEmptyError
                       && !root.wrongKeycard
                       && !root.wrongKeycardProfile
                       && (root.keycardState === Constants.keycard.state.connectingCard
@@ -368,6 +370,25 @@ Control {
                 PropertyChanges {
                     target: message
                     text: qsTr("Keycard is blocked due to three failed PIN input attempts")
+                    color: Theme.palette.dangerColor1
+                }
+            },
+            State {
+                name: "keycard-not-empty-error"
+                when: root.failure
+                      && root.keycardNotEmptyError
+                PropertyChanges {
+                    target: image
+                    source: Assets.png("keycard/wrong_card/something-went-wrong")
+                }
+                PropertyChanges {
+                    target: title
+                    text: qsTr("Keycard is not empty")
+                    color: Theme.palette.dangerColor1
+                }
+                PropertyChanges {
+                    target: message
+                    text: qsTr("Try again with an empty keycard")
                     color: Theme.palette.dangerColor1
                 }
             },

--- a/ui/imports/shared/popups/keycard_new/states/SelectKeyPairState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/SelectKeyPairState.qml
@@ -21,8 +21,11 @@ Control {
     required property string userProfilePublicKey
 
     property bool profileOnly: false
+    property string fixedKeyUid: ""
     property string initialSelectedKeyUid: ""
     property bool initialUnderstandChecked: false
+
+    readonly property bool singleKeyPairMode: root.profileOnly || root.fixedKeyUid.length > 0
 
     property string selectedKeyUid: initialSelectedKeyUid
     property string selectedKeyPairName: ""
@@ -45,13 +48,16 @@ Control {
         Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            visible: root.profileOnly
+            visible: root.singleKeyPairMode
         }
 
         StatusBaseText {
             Layout.fillWidth: true
             wrapMode: Text.WordWrap
-            text: root.profileOnly ? qsTr("Profile key pair") : qsTr("Select key pair")
+            text: root.profileOnly ? qsTr("Profile key pair")
+                                   : root.fixedKeyUid.length > 0
+                                     ? qsTr("Key pair")
+                                     : qsTr("Select key pair")
             color: Theme.palette.baseColor1
         }
 
@@ -64,16 +70,18 @@ Control {
             sourceModel: root.keypairsModel ?? null
             filters: ExpressionFilter {
                 expression: root.profileOnly
-                            ? (model.keyPair.pairType === d.profileKeyPairTypeValue && !model.keyPair.migratedToColdWallet)
-                            : (model.keyPair.pairType === d.seedKeyPairTypeValue && !model.keyPair.migratedToColdWallet)
+                            ? model.keyPair.pairType === d.profileKeyPairTypeValue && !model.keyPair.migratedToColdWallet
+                            : root.fixedKeyUid.length > 0
+                              ? model.keyPair.keyUid === root.fixedKeyUid && !model.keyPair.migratedToColdWallet
+                              : model.keyPair.pairType === d.seedKeyPairTypeValue && !model.keyPair.migratedToColdWallet
             }
         }
 
         ListView {
             id: keypairsList
             Layout.fillWidth: true
-            Layout.fillHeight: !root.profileOnly
-            Layout.preferredHeight: root.profileOnly ? contentHeight : -1
+            Layout.fillHeight: !root.singleKeyPairMode
+            Layout.preferredHeight: root.singleKeyPairMode ? contentHeight : -1
             clip: true
             spacing: Theme.halfPadding
             model: filteredModel
@@ -88,7 +96,7 @@ Control {
 
                 userProfilePublicKey: root.userProfilePublicKey
 
-                usedAsSelectOption: !root.profileOnly
+                usedAsSelectOption: !root.singleKeyPairMode
                 buttonGroup: keyPairsButtonGroup
                 checked: model.keyPair.keyUid === root.initialSelectedKeyUid
 
@@ -109,7 +117,7 @@ Control {
         Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            visible: root.profileOnly
+            visible: root.singleKeyPairMode
         }
 
         Item {

--- a/ui/imports/shared/popups/keycard_new/states/qmldir
+++ b/ui/imports/shared/popups/keycard_new/states/qmldir
@@ -8,6 +8,7 @@ ManageKeyPairAccountsState 1.0 ManageKeyPairAccountsState.qml
 SeedPhraseDisplayState 1.0 SeedPhraseDisplayState.qml
 ConfirmSeedPhraseWordsState 1.0 ConfirmSeedPhraseWordsState.qml
 SelectKeyPairState 1.0 SelectKeyPairState.qml
+InsertEmptyKeycardState 1.0 InsertEmptyKeycardState.qml
 ConfirmKeyPairForStopUsingState 1.0 ConfirmKeyPairForStopUsingState.qml
 CreatePasswordState 1.0 CreatePasswordState.qml
 ConfirmPasswordState 1.0 ConfirmPasswordState.qml

--- a/ui/imports/shared/popups/keycard_new/stores/KeycardManagementStore.qml
+++ b/ui/imports/shared/popups/keycard_new/stores/KeycardManagementStore.qml
@@ -9,6 +9,7 @@ BaseKeycardManagementStore {
 
     readonly property string userProfileKeyUid: userProfile.keyUid
     readonly property string userProfilePubKey: userProfile.pubKey
+    readonly property bool isProfileMigratedToColdWallet: userProfile.migratedToColdWallet
 
     readonly property var keypairsModel: backend ? backend.keyPairModel : null
     readonly property var keyPairItem: backend ? backend.keyPairItem : null


### PR DESCRIPTION
Corresponding `status-keycard-qt` PR:
- https://github.com/status-im/status-keycard-qt/pull/26


When migrating a non-profile key pair to a keycard, while the profile key pair is already keycard migrated,
in the middle of that flow an authentication of the profile has to be conducted (in order to get current password
for keystore files) using one keycard and as soon as that is finished another, an empty, keycard has to be
provided to which a non-profile key pair needs to be migrated. That all happens pretty fast, and these changes
introduce a new `InsertEmptyKeycardState.qml` where the flow stops after authentication (reminding that an
empty keycard has to be provided) and the user needs to explicitly click "Next" button in order to continue
with the flow.

There was an issue with double-hashing the password, which is fixed now.

These changes also integrate a new keycard approach into the wallet settings part.

Partially closes https://github.com/status-im/status-app/issues/20303