### PR TITLE
fix(BackupSeedphraseReveal): set minimum width and add scrolling

### DIFF
--- a/ui/app/AppLayouts/Onboarding/pages/BackupSeedphraseReveal.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/BackupSeedphraseReveal.qml
@@ -32,118 +32,131 @@ OnboardingPage {
         readonly property var mnemonicWords: Utils.splitWords(root.mnemonic)
     }
 
-    contentItem: ColumnLayout {
-        width: Math.min(440, root.availableWidth)
-        spacing: Theme.smallPadding
+    padding: 0
 
-        StatusBaseText {
-            Layout.fillWidth: true
-            text: root.title
-            visible: !root.popupMode
-            font.pixelSize: Theme.fontSize(22)
-            font.bold: true
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-        }
+    StackView.onActivated: scrollView.scrollHome()
 
-        StatusBaseText {
-            Layout.fillWidth: true
-            text: qsTr("A 12-word phrase that gives full access to your funds and is the only way to recover them. Make sure nothing can see or record your screen.")
-            wrapMode: Text.WordWrap
-        }
+    StatusScrollView {
+        id: scrollView
+        anchors.fill: parent
+        contentWidth: availableWidth
+        flickable.topMargin: Math.max(0, flickable.height - contentHeight) / 2 // centering the content vertically
 
-        A11YInformationTag {
-            Layout.fillWidth: true
-            visible: !d.seedphraseRevealed
-        }
+        ColumnLayout {
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: Math.min(440, scrollView.availableWidth) // don't take full width if not needed
+            spacing: Theme.smallPadding
 
-        Item {
-            Layout.fillWidth: true
-            Layout.preferredHeight: seedGrid.height
+            StatusBaseText {
+                Layout.fillWidth: true
+                text: root.title
+                visible: !root.popupMode
+                font.pixelSize: Theme.fontSize(22)
+                font.bold: true
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+            }
 
-            GridLayout {
-                objectName: "seedGrid"
-                id: seedGrid
-                width: parent.width
-                columns: 2
-                columnSpacing: Theme.halfPadding
-                rowSpacing: columnSpacing
+            StatusBaseText {
+                Layout.fillWidth: true
+                text: qsTr("A 12-word phrase that gives full access to your funds and is the only way to recover them. Make sure nothing can see or record your screen.")
+                wrapMode: Text.WordWrap
+            }
 
-                Repeater {
-                    model: d.mnemonicWords
-                    delegate: Frame {
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
-                        padding: Theme.smallPadding
-                        background: Rectangle {
-                            radius: Theme.radius
-                            color: "transparent"
-                            border.width: 1
-                            border.color: Theme.palette.baseColor2
-                        }
-                        contentItem: RowLayout {
-                            spacing: Theme.halfPadding
-                            StatusBaseText {
-                                Layout.preferredWidth: idxMetrics.advanceWidth
-                                horizontalAlignment: Qt.AlignHCenter
-                                text: index + 1
-                                color: Theme.palette.baseColor1
-                                font: idxMetrics.font
+            A11YInformationTag {
+                Layout.fillWidth: true
+                visible: !d.seedphraseRevealed
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: seedGrid.height
+
+                GridLayout {
+                    objectName: "seedGrid"
+                    id: seedGrid
+                    width: parent.width
+                    columns: 2
+                    columnSpacing: Theme.halfPadding
+                    rowSpacing: columnSpacing
+
+                    Repeater {
+                        model: d.mnemonicWords
+                        delegate: Frame {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            padding: Theme.smallPadding
+                            background: Rectangle {
+                                radius: Theme.radius
+                                color: "transparent"
+                                border.width: 1
+                                border.color: Theme.palette.baseColor2
                             }
-                            StatusBaseText {
-                                objectName: "seedWordText_" + (index+1)
-                                Layout.fillWidth: true
-                                text: modelData
-                                Accessible.role: Accessible.StaticText
-                                Accessible.name: SQUtils.Utils.formatAccessibleName(modelData, objectName)
+                            contentItem: RowLayout {
+                                spacing: Theme.halfPadding
+                                StatusBaseText {
+                                    Layout.preferredWidth: idxMetrics.advanceWidth
+                                    horizontalAlignment: Qt.AlignHCenter
+                                    text: index + 1
+                                    color: Theme.palette.baseColor1
+                                    font: idxMetrics.font
+                                }
+                                StatusBaseText {
+                                    objectName: "seedWordText_" + (index+1)
+                                    Layout.fillWidth: true
+                                    text: modelData
+                                    Accessible.role: Accessible.StaticText
+                                    Accessible.name: SQUtils.Utils.formatAccessibleName(modelData, objectName)
+                                }
                             }
                         }
                     }
+                    layer.enabled: !d.seedphraseRevealed
+                    layer.effect: GaussianBlur {
+                        radius: samples/2 - 1
+                        samples: 64
+                        transparentBorder: true
+                    }
                 }
-                layer.enabled: !d.seedphraseRevealed
-                layer.effect: GaussianBlur {
-                    radius: samples/2 - 1
-                    samples: 64
-                    transparentBorder: true
+
+                StatusButton {
+                    objectName: "btnReveal"
+                    anchors.centerIn: parent
+                    text: qsTr("Reveal recovery phrase")
+                    icon.name: "show"
+                    type: StatusBaseButton.Type.Primary
+                    visible: !d.seedphraseRevealed
+                    onClicked: {
+                        d.seedphraseRevealed = true
+                    }
                 }
+            }
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                text: qsTr("Never share your recovery phrase. Anyone asking for it is trying to scam you. To back up your recovery phrase, write it down and store it securely.")
+                wrapMode: Text.WordWrap
             }
 
             StatusButton {
-                objectName: "btnReveal"
-                anchors.centerIn: parent
-                text: qsTr("Reveal recovery phrase")
-                icon.name: "show"
-                type: StatusBaseButton.Type.Primary
-                visible: !d.seedphraseRevealed
+                objectName: "btnConfirm"
+                Layout.topMargin: Theme.padding
+                Layout.alignment: Qt.AlignHCenter
+                visible: !root.popupMode
+                text: qsTr("Confirm recovery phrase")
+                enabled: d.seedphraseRevealed
                 onClicked: {
-                    d.seedphraseRevealed = true
+                    root.backupSeedphraseConfirmed()
+                    d.seedphraseRevealed = false
                 }
             }
         }
 
-        StatusBaseText {
-            Layout.fillWidth: true
-            text: qsTr("Never share your recovery phrase. Anyone asking for it is trying to scam you. To back up your recovery phrase, write it down and store it securely.")
-            wrapMode: Text.WordWrap
+        TextMetrics {
+            id: idxMetrics
+            font.family: Fonts.monoFont.family
+            font.pixelSize: Theme.primaryTextFontSize
+            text: "99"
         }
-
-        StatusButton {
-            objectName: "btnConfirm"
-            Layout.alignment: Qt.AlignHCenter
-            visible: !root.popupMode
-            text: qsTr("Confirm recovery phrase")
-            enabled: d.seedphraseRevealed
-            onClicked: {
-                root.backupSeedphraseConfirmed()
-                d.seedphraseRevealed = false
-            }
-        }
-    }
-
-    TextMetrics {
-        id: idxMetrics
-        font.family: Fonts.monoFont.family
-        font.pixelSize: Theme.primaryTextFontSize
-        text: "99"
     }
 }

--- a/ui/app/AppLayouts/Profile/popups/BackupSeedModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/BackupSeedModal.qml
@@ -21,7 +21,6 @@ StatusDialog {
     padding: Theme.halfPadding
     implicitWidth: 480
     implicitHeight: 700
-    fillHeightOnBottomSheet: true
 
     footer: StatusDialogFooter {
         leftButtons: ObjectModel {


### PR DESCRIPTION
### What does the PR do

- restore the minimum width of 440 (as other Backup seed pages)
- wrap it into a ScrollView

Fixes #21235

### Affected areas

Backup seed

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

As part of Onboarding:
<img width="2960" height="2474" alt="Snímek obrazovky z 2026-06-18 11-35-41" src="https://github.com/user-attachments/assets/4145da82-69ff-40e0-8131-e2411f57d090" />

Standalone (Backup seed modal) with scrollbars:
<img width="768" height="1800" alt="image" src="https://github.com/user-attachments/assets/488ea686-395a-45a0-abab-18c584403b35" />


### Impact on end user

Better UI/UX

### How to test

- onboarding
- backup seed modal

### Risk 

low
