### PR TITLE
fix(android): deep links on warm start-up

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -391,6 +391,7 @@ proc start*(self: AppController) =
   else:
     self.initializeQmlContext()
     self.finishAppLoading()
+    self.appReady()
 
 proc load(self: AppController) =
   self.settingsService.init()


### PR DESCRIPTION
### What does the PR do

Closes #21270

We need to call the url manager `appReady` on warm start-up as well. It will make sure to forward the deep link

### Affected areas

Android warm start-up

### Impact on end user

Deep link will work with warm start-up.

### How to test

Open the app, go to wallet, close the app.
Send a message from another device, tap the PN. The app will launch in a logged-in state.
The user lands in the proper chat.

### Risk 

low