### PR TITLE
Theme: landscape/portrait threshold dependent on screen orientation

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Theme/ThemeUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/ThemeUtils.qml
@@ -42,7 +42,12 @@ QtObject {
     // Threshold width increased from original 640 to keep foldable phones in portrait
     // mode when unfolded. To be changed later along with layout improvements dedicated
     // to foldable phones.
-    readonly property size portraitBreakpoint: Qt.size(752, 480) // good ol' VGA
+    // Moreover the threshold is set higher for portrait orientation to keep portrait layout on foldable
+    // phones but keep landscape mode on mobile phones in a horizontal position.
+    readonly property size portraitBreakpoint: Qt.size(
+                                                   (Screen.orientation  === Qt.PortraitOrientation
+                                                    || Screen.orientation  === Qt.InvertedPortraitOrientation)
+                                                   ? 900 : 752, 480)
     readonly property real disabledOpacity: 0.3
     readonly property real pressedOpacity: 0.7
 


### PR DESCRIPTION
### What does the PR do

Threshold used so far was not enough to keep portrait layout on foldable phones configured to use "small" display size option. By simply increasing the threshold we would force portrait mode in horizontal orientation on some mobile devices. To avoid that there are two separate thresholds for Portrait/Landscape orientations.

Closes: #21254

### Affected areas
`ThemeUtils`


### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user
Low

### How to test

Use the app on foldable phones, in both standard and small display size configuration (Settings -> Display & brightness -> Display size).
Use the app on regular phone in both horizontal and vertical orientation.

### Risk 
Low