### PR TITLE
Fixes to the token minting

### DIFF
--- a/src/app/modules/main/communities/tokens/module.nim
+++ b/src/app/modules/main/communities/tokens/module.nim
@@ -360,6 +360,7 @@ method computeDeployCollectiblesFee*(self: Module, uuid: string, communityId: st
 
   let croppedImage = imageCropInfoJson.parseJson
   let base65Image = singletonInstance.utils.fromPathUri(croppedImage["imagePath"].getStr)
+  self.tempDeploymentParams.croppedImageJson = imageCropInfoJson
   self.tempDeploymentParams.base64image = base65Image
 
   self.tempDeploymentParams.communityId = communityId
@@ -416,6 +417,7 @@ method computeDeployAssetsFee*(self: Module, uuid: string, communityId: string, 
 
   let croppedImage = imageCropInfoJson.parseJson
   let base65Image = singletonInstance.utils.fromPathUri(croppedImage["imagePath"].getStr)
+  self.tempDeploymentParams.croppedImageJson = imageCropInfoJson
   self.tempDeploymentParams.base64image = base65Image
 
   self.tempDeploymentParams.communityId = communityId

--- a/ui/imports/shared/panels/EditCroppedImagePanel.qml
+++ b/ui/imports/shared/panels/EditCroppedImagePanel.qml
@@ -166,24 +166,10 @@ Item {
                 width: 40
                 height: 40
 
-                readonly property real rotationRadius: root.roundedImage ? parent.width/2 : imageCropEditor.radius
-
-                transform: [
-                    Translate {
-                        x: -addButton.width/2 - d.buttonsInsideOffset
-                        y: -addButton.height/2 + d.buttonsInsideOffset
-                    },
-                    Rotation { angle: -addRotationTransform.angle },
-                    Rotation {
-                        id: addRotationTransform
-                        angle: 135
-                        origin.x: addButton.rotationRadius
-                    },
-                    Translate {
-                        x: root.roundedImage ? 0 : addButton.parent.width - 2 * addButton.rotationRadius
-                        y: addButton.rotationRadius
-                    }
-                ]
+                parent: root
+                visible: imageCropEditor.visible
+                x: imageCropEditor.x + imageCropEditor.width - width/2 - d.buttonsInsideOffset
+                y: imageCropEditor.y - height/2 + d.buttonsInsideOffset
 
                 type: StatusRoundButton.Type.Secondary
 


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-app/issues/19184

1. [fix(EditCroppedImagePanel): choose image button was half unclickable](https://github.com/status-im/status-app/commit/225d123218eba4a3ba602db06d173c13c86f3f53)
    - The top right button to choose an image was only half clickable

2. [fix(tokens): correctly pass image crop info from minting tokens](https://github.com/status-im/status-app/commit/f87f6f1cb8c6d4c9698d26287a16b34a5a96c65c)
    - Fixes the issue linked above. It was just missing the params in the module

### Affected areas

- tokens module
- EditCroppedImagePanel

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="336" height="313" alt="image" src="https://github.com/user-attachments/assets/e6ba9118-7d70-4c7d-94c1-786f066a79eb" />

### Impact on end user

Makes the crop actually work plus the button is easier to click, for better UX

### How to test

Mint a new token

### Risk 

Low
