### PR TITLE
fix(ActivityCenter): Close panel on escape

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1835,6 +1835,12 @@ Item {
                                     }
             }
 
+            Shortcut {
+                enabled: mainLayoutItem.openACCenterPanel
+                sequence: StandardKey.Cancel
+                onActivated: mainLayoutItem.openACCenterPanel = false
+            }
+
             Item {
                 id: sectionLayout
                 anchors.fill: parent


### PR DESCRIPTION
Fix #20835

### What does the PR do

Add an Escape shortcut that closes the Activity Center panel when it is open.

### Affected areas

Activity Center Panel

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/f133d451-097b-48b8-9312-74b3f2d8c313

### Impact on end user

Better UX

### How to test

Open Activity Center and press ESC key. It must close the panel.

### Risk 

Low
