### PR TITLE
fix(SavedAddresses): Typing a whitespace in the Name field shows an error

### DIFF
--- a/storybook/pages/AddEditSavedAddressPopupPage.qml
+++ b/storybook/pages/AddEditSavedAddressPopupPage.qml
@@ -2,17 +2,10 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-import StatusQ.Core.Utils
-import SortFilterProxyModel
-
 import Storybook
-import Models
-import AppLayouts.stores
 import AppLayouts.Wallet.popups
-import AppLayouts.Wallet.stores as WalletStores
 
 import utils
-import shared.stores as SharedStores
 
 SplitView {
     orientation: Qt.Horizontal
@@ -24,6 +17,48 @@ SplitView {
 
         SplitView.fillWidth: true
         SplitView.fillHeight: true
+
+        QtObject {
+            id: mockStore
+
+            function isChecksumValidForAddress(address) {
+                return true
+            }
+
+            function getWalletAccount(address) {
+                if (address.toLowerCase() === "0x1234567890123456789012345678901234567892") {
+                    return {
+                        name: "Wallet account",
+                        mixedcaseAddress: address,
+                        emoji: ":)",
+                        colorId: "blue"
+                    }
+                }
+
+                return {}
+            }
+
+            function getSavedAddress(address) {
+                if (address.toLowerCase() === "0x1234567890123456789012345678901234567893") {
+                    return {
+                        address: address,
+                        ens: "",
+                        name: "Existing saved address",
+                        colorId: "magenta"
+                    }
+                }
+
+                return {}
+            }
+
+            function remainingCapacityForSavedAddresses() {
+                return 10
+            }
+
+            function savedAddressNameExists(name) {
+                return name.toLowerCase() === "taken"
+            }
+        }
 
         Button {
             id: reopenButton
@@ -47,8 +82,11 @@ SplitView {
                 modal: false
                 closePolicy: Popup.NoAutoClose               
 
-                store: WalletStores.RootStore
-                sharedRootStore: SharedStores.RootStore {}
+                isChecksumValidForAddress: mockStore.isChecksumValidForAddress
+                getWalletAccount: mockStore.getWalletAccount
+                getSavedAddress: mockStore.getSavedAddress
+                remainingCapacityForSavedAddresses: mockStore.remainingCapacityForSavedAddresses
+                savedAddressNameExists: mockStore.savedAddressNameExists
 
                 // Emulate resolving ENS by simple validation
                 QtObject {
@@ -64,6 +102,14 @@ SplitView {
                     }
 
                     signal resolvedENS(string pubkey, string address, string uuid)
+                }
+
+                onFetchProfileShowcaseAccountsByAddressRequested: {
+                    profileShowcaseAccountsByAddressFetched("[]")
+                }
+
+                onCreateOrUpdateSavedAddressRequested: (name, address, ens, colorId) => {
+                    logs.logEvent("createOrUpdateSavedAddressRequested: name=%1 address=%2 ens=%3 colorId=%4".arg(name).arg(address).arg(ens).arg(colorId))
                 }
 
                 Component.onCompleted: initWithParams({edit: ctrlIsEdit.checked,

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -10,13 +10,11 @@ import StatusQ.Core.Theme
 import StatusQ.Popups.Dialog
 
 import utils
-import shared.stores as SharedStores
 import AppLayouts.Profile.helpers
 
 StatusDialog {
     id: root
 
-    required property SharedStores.RootStore sharedRootStore
     required property var isChecksumValidForAddress
     required property var getWalletAccount
     required property var getSavedAddress
@@ -25,6 +23,7 @@ StatusDialog {
     property var contactsModel
 
     signal populateContactDetails(string publicKey)
+    signal fetchProfileShowcaseAccountsByAddressRequested(string address)
     signal createOrUpdateSavedAddressRequested(string name, string address, string ens, string colorId)
 
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
@@ -63,6 +62,35 @@ StatusDialog {
             addressInput.setPlainText("%1".arg(d.address == Constants.zeroAddress? "" : d.address))
 
         nameInput.input.edit.forceActiveFocus()
+    }
+
+    function profileShowcaseAccountsByAddressFetched(accounts) {
+        d.cardsModel.clear()
+        d.checkingContactsAddressInProgress = false
+        try {
+            let accountsJson = JSON.parse(accounts)
+            d.contactsWithSameAddress = accountsJson.length
+            addressInput.errorMessageCmp.visible = d.contactsWithSameAddress > 0
+            addressInput.errorMessageCmp.color = root.Theme.palette.warningColor1
+            addressInput.errorMessageCmp.text = ""
+            if (d.contactsWithSameAddress === 1)
+                addressInput.errorMessageCmp.text = qsTr("This address belongs to a contact")
+            if (d.contactsWithSameAddress > 1)
+                addressInput.errorMessageCmp.text = qsTr("This address belongs to the following contacts")
+
+            d.contactsToProcess = accountsJson.map(account => account.contactId)
+            for (let i = 0; i < accountsJson.length; ++i) {
+                const contactEntry = d.getContactModelEntry(accountsJson[i].contactId)
+                if (!contactEntry.available) {
+                    // Waiting for contact details to be populated
+                    continue
+                }
+                d.processContactDetails(contactEntry.contactDetails)
+            }
+        }
+        catch (e) {
+            console.warn("error parsing fetched accounts for contact: ", e.message)
+        }
     }
 
     enum CardType {
@@ -189,8 +217,6 @@ StatusDialog {
             mainModule.resolveENS(name, d.uuid)
         });
 
-        property var contactsModuleInst: root.sharedRootStore.profileSectionModuleInst.contactsModule
-
         /// Ensures that the \c root.address is not reset when the initial text is set
         property bool initialized: false
 
@@ -225,7 +251,7 @@ StatusDialog {
 
                 d.checkingContactsAddressInProgress = true
                 d.contactsWithSameAddress = 0
-                d.contactsModuleInst.fetchProfileShowcaseAccountsByAddress(d.address)
+                root.fetchProfileShowcaseAccountsByAddressRequested(d.address)
                 return
             }
 
@@ -327,38 +353,6 @@ StatusDialog {
                 d.checkForAddressInputOwningErrorsWarnings()
             }
             catch (e) {
-            }
-        }
-    }
-
-    Connections {
-        target: d.contactsModuleInst
-        function onProfileShowcaseAccountsByAddressFetched(accounts: string) {
-            d.cardsModel.clear()
-            d.checkingContactsAddressInProgress = false
-            try {
-                let accountsJson = JSON.parse(accounts)
-                d.contactsWithSameAddress = accountsJson.length
-                addressInput.errorMessageCmp.visible = d.contactsWithSameAddress > 0
-                addressInput.errorMessageCmp.color = root.Theme.palette.warningColor1
-                addressInput.errorMessageCmp.text = ""
-                if (d.contactsWithSameAddress === 1)
-                    addressInput.errorMessageCmp.text = qsTr("This address belongs to a contact")
-                if (d.contactsWithSameAddress > 1)
-                    addressInput.errorMessageCmp.text = qsTr("This address belongs to the following contacts")
-
-                d.contactsToProcess = accountsJson.map(account => account.contactId)
-                for (let i = 0; i < accountsJson.length; ++i) {
-                    const contactEntry = d.getContactModelEntry(accountsJson[i].contactId)
-                    if (!contactEntry.available) {
-                        // Waiting for contact details to be populated
-                        continue
-                    }
-                    d.processContactDetails(contactEntry.contactDetails)
-                }
-            }
-            catch (e) {
-                console.warn("error parsing fetched accounts for contact: ", e.message)
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -11,17 +11,21 @@ import StatusQ.Popups.Dialog
 
 import utils
 import shared.stores as SharedStores
-import AppLayouts.Wallet.stores as WalletStores
 import AppLayouts.Profile.helpers
 
 StatusDialog {
     id: root
 
-    required property WalletStores.RootStore store
     required property SharedStores.RootStore sharedRootStore
+    required property var isChecksumValidForAddress
+    required property var getWalletAccount
+    required property var getSavedAddress
+    required property var remainingCapacityForSavedAddresses
+    required property var savedAddressNameExists
     property var contactsModel
 
     signal populateContactDetails(string publicKey)
+    signal createOrUpdateSavedAddressRequested(string name, string address, string ens, string colorId)
 
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
@@ -94,7 +98,7 @@ StatusDialog {
 
         property bool incorrectChecksum: {
             if (d.addressInputIsAddress) {
-                return !root.store.isChecksumValidForAddress(d.address)
+                return !root.isChecksumValidForAddress(d.address)
             }
             return false
         }
@@ -145,7 +149,7 @@ StatusDialog {
         }
 
         function checkIfAddressIsAlreadyAddedToWallet(address) {
-            let account = root.store.getWalletAccount(address)
+            let account = root.getWalletAccount(address)
             d.cardsModel.clear()
             d.addressAlreadyAddedToWalletError = !!account.name
             if (!d.addressAlreadyAddedToWalletError) {
@@ -162,7 +166,7 @@ StatusDialog {
         }
 
         function checkIfAddressIsAlreadyAddedToSavedAddresses(address) {
-            let savedAddress = root.store.getSavedAddress(address)
+            let savedAddress = root.getSavedAddress(address)
             d.cardsModel.clear()
             d.addressAlreadyAddedToSavedAddressesError = !!savedAddress.address
             if (!d.addressAlreadyAddedToSavedAddressesError) {
@@ -271,12 +275,12 @@ StatusDialog {
                     || event !== undefined && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter)
                 return
 
-            if (!d.editMode && root.store.remainingCapacityForSavedAddresses() === 0) {
+            if (!d.editMode && root.remainingCapacityForSavedAddresses() === 0) {
                 Global.openLimitReachedPopup(Constants.LimitWarning.SavedAddresses)
                 return
             }
 
-            root.store.createOrUpdateSavedAddress(d.normalizedName, d.address, d.ens, d.colorId)
+            root.createOrUpdateSavedAddressRequested(d.normalizedName, d.address, d.ens, d.colorId)
             root.close()
         }
 
@@ -416,7 +420,7 @@ StatusDialog {
                         name: "check-saved-address-existence"
                         validate: (value) => {
                                       const normalizedValue = value.trim()
-                                      return !root.store.savedAddressNameExists(normalizedValue)
+                                      return !root.savedAddressNameExists(normalizedValue)
                                       || d.editMode && d.storedName == normalizedValue
                                   }
                         errorMessage: qsTr("Name already in use")

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -73,6 +73,7 @@ StatusDialog {
         property bool editMode: false
         property bool addAddress: false
         property alias name: nameInput.text
+        readonly property string normalizedName: d.name.trim()
         property string address: Constants.zeroAddress // Setting as zero address since we don't have the address yet
         property string ens: ""
         property string colorId: ""
@@ -87,7 +88,7 @@ StatusDialog {
                                          !d.addressAlreadyAddedToWalletError &&
                                          !d.addressAlreadyAddedToSavedAddressesError
         readonly property bool valid: d.addressInputValid && nameInput.valid
-        readonly property bool dirty: nameInput.input.dirty && (!d.editMode || d.storedName !== d.name)
+        readonly property bool dirty: nameInput.input.dirty && (!d.editMode || d.storedName !== d.normalizedName)
                                       || !d.editMode
                                       || d.colorId.toUpperCase() !== d.storedColorId.toUpperCase()
 
@@ -275,7 +276,7 @@ StatusDialog {
                 return
             }
 
-            root.store.createOrUpdateSavedAddress(d.name, d.address, d.ens, d.colorId)
+            root.store.createOrUpdateSavedAddress(d.normalizedName, d.address, d.ens, d.colorId)
             root.close()
         }
 
@@ -383,8 +384,11 @@ StatusDialog {
                 placeholderText: qsTr("Address name")
                 label: qsTr("Name")
                 validators: [
-                    StatusMinLengthValidator {
-                        minLength: 1
+                    StatusValidator {
+                        name: "check-name-not-empty"
+                        validate: (value) => {
+                                      return value.trim().length > 0
+                                  }
                         errorMessage: qsTr("Please name your saved address")
                     },
                     StatusValidator {
@@ -392,16 +396,17 @@ StatusDialog {
 
                         name: "check-for-no-emojis"
                         validate: (value) => {
-                                      if (!value) {
+                                      const normalizedValue = value.trim()
+                                      if (!normalizedValue) {
                                           return true
                                       }
 
-                                      isEmoji = Constants.regularExpressions.emoji.test(value)
+                                      isEmoji = Constants.regularExpressions.emoji.test(normalizedValue)
                                       if (isEmoji){
                                           return false
                                       }
 
-                                      return Constants.regularExpressions.alphanumericalExpanded1.test(value)
+                                      return Constants.regularExpressions.alphanumericalExpanded1.test(normalizedValue)
                                   }
                         errorMessage: isEmoji?
                                           Constants.errorMessages.emojRegExp
@@ -410,8 +415,9 @@ StatusDialog {
                     StatusValidator {
                         name: "check-saved-address-existence"
                         validate: (value) => {
-                                      return !root.store.savedAddressNameExists(value)
-                                      || d.editMode && d.storedName == value
+                                      const normalizedValue = value.trim()
+                                      return !root.store.savedAddressNameExists(normalizedValue)
+                                      || d.editMode && d.storedName == normalizedValue
                                   }
                         errorMessage: qsTr("Name already in use")
                     }

--- a/ui/app/AppLayouts/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/stores/ContactsStore.qml
@@ -10,6 +10,7 @@ QtObject {
     id: root
 
     signal contactInfoRequestFinished(string publicKey, bool ok)
+    signal profileShowcaseAccountsByAddressFetched(string accounts)
 
     readonly property QtObject _d: QtObject {
         id: d
@@ -25,6 +26,9 @@ QtObject {
             contactsModuleInst.trustStatusRemoved.connect(root.trustStatusRemoved)
             contactsModuleInst.contactRemoved.connect(root.contactRemoved)
             contactsModuleInst.contactInfoRequestFinished.connect(root.contactInfoRequestFinished)
+            contactsModuleInst.profileShowcaseAccountsByAddressFetched.connect((accounts) => {
+                root.profileShowcaseAccountsByAddressFetched(accounts)
+            })
         }
     }
 
@@ -166,5 +170,9 @@ QtObject {
 
     function populateContactDetails(publicKey) {
         return d.contactsModuleInst.populateContactDetails(publicKey)
+    }
+
+    function fetchProfileShowcaseAccountsByAddress(address) {
+        d.contactsModuleInst.fetchProfileShowcaseAccountsByAddress(address)
     }
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2537,11 +2537,18 @@ Item {
         }
 
         sourceComponent: WalletPopups.AddEditSavedAddressPopup {
-            store: WalletStores.RootStore
             sharedRootStore: appMain.sharedRootStore
             contactsModel: appMain.contactsStore.contactsModel
+            isChecksumValidForAddress: (address) => WalletStores.RootStore.isChecksumValidForAddress(address)
+            getWalletAccount: (address) => WalletStores.RootStore.getWalletAccount(address)
+            getSavedAddress: (address) => WalletStores.RootStore.getSavedAddress(address)
+            remainingCapacityForSavedAddresses: () => WalletStores.RootStore.remainingCapacityForSavedAddresses()
+            savedAddressNameExists: (name) => WalletStores.RootStore.savedAddressNameExists(name)
 
             onPopulateContactDetails: (publicKey) => appMain.contactsStore.populateContactDetails(publicKey)
+            onCreateOrUpdateSavedAddressRequested: (name, address, ens, colorId) => {
+                WalletStores.RootStore.createOrUpdateSavedAddress(name, address, ens, colorId)
+            }
             onClosed: {
                 addEditSavedAddress.close()
             }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -127,9 +127,12 @@ Item {
         currencyStore: appMain.currencyStore
     }
     property CommunitiesStore communitiesStore: CommunitiesStore {}
-    readonly property WalletStores.TokensStore tokensStore: WalletStores.RootStore.tokensStore
-    readonly property WalletStores.WalletAssetsStore walletAssetsStore: WalletStores.RootStore.walletAssetsStore
-    readonly property WalletStores.CollectiblesStore walletCollectiblesStore: WalletStores.RootStore.collectiblesStore
+    // Main wallet root store. It is currently a singleton, but should be refactored to be an instance
+    // created only by AppStores.RootStore rootStore. Until then, access it through this single property.
+    readonly property WalletStores.RootStore walletRootStore: WalletStores.RootStore
+    readonly property WalletStores.TokensStore tokensStore: appMain.walletRootStore.tokensStore
+    readonly property WalletStores.WalletAssetsStore walletAssetsStore: appMain.walletRootStore.walletAssetsStore
+    readonly property WalletStores.CollectiblesStore walletCollectiblesStore: appMain.walletRootStore.collectiblesStore
     readonly property SharedStores.CurrenciesStore currencyStore: SharedStores.CurrenciesStore {}
     readonly property TransactionStore transactionStore: TransactionStore {
         walletAssetStore: appMain.walletAssetsStore
@@ -995,7 +998,7 @@ Item {
         currencyStore: appMain.currencyStore
         networksStore: appMain.networksStore
         networkConnectionStore: appMain.networkConnectionStore
-        walletRootStore: WalletStores.RootStore
+        walletRootStore: appMain.walletRootStore
         walletAssetsStore: appMain.walletAssetsStore
         transactionStore: appMain.transactionStore
         walletCollectiblesStore: appMain.walletCollectiblesStore
@@ -2538,18 +2541,18 @@ Item {
 
         sourceComponent: WalletPopups.AddEditSavedAddressPopup {
             contactsModel: appMain.contactsStore.contactsModel
-            isChecksumValidForAddress: (address) => WalletStores.RootStore.isChecksumValidForAddress(address)
-            getWalletAccount: (address) => WalletStores.RootStore.getWalletAccount(address)
-            getSavedAddress: (address) => WalletStores.RootStore.getSavedAddress(address)
-            remainingCapacityForSavedAddresses: () => WalletStores.RootStore.remainingCapacityForSavedAddresses()
-            savedAddressNameExists: (name) => WalletStores.RootStore.savedAddressNameExists(name)
+            isChecksumValidForAddress: (address) => appMain.walletRootStore.isChecksumValidForAddress(address)
+            getWalletAccount: (address) => appMain.walletRootStore.getWalletAccount(address)
+            getSavedAddress: (address) => appMain.walletRootStore.getSavedAddress(address)
+            remainingCapacityForSavedAddresses: () => appMain.walletRootStore.remainingCapacityForSavedAddresses()
+            savedAddressNameExists: (name) => appMain.walletRootStore.savedAddressNameExists(name)
 
             onPopulateContactDetails: (publicKey) => appMain.contactsStore.populateContactDetails(publicKey)
             onFetchProfileShowcaseAccountsByAddressRequested: (address) => {
                 appMain.contactsStore.fetchProfileShowcaseAccountsByAddress(address)
             }
             onCreateOrUpdateSavedAddressRequested: (name, address, ens, colorId) => {
-                WalletStores.RootStore.createOrUpdateSavedAddress(name, address, ens, colorId)
+                appMain.walletRootStore.createOrUpdateSavedAddress(name, address, ens, colorId)
             }
             onClosed: {
                 addEditSavedAddress.close()
@@ -2570,12 +2573,12 @@ Item {
     }
 
     Connections {
-        target: WalletStores.RootStore
+        target: appMain.walletRootStore
 
         function onSavedAddressAddedOrUpdated(added: bool, name: string, address: string, errorMsg: string) {
             console.warn("[saved-address] onSavedAddressAddedOrUpdated added=", added, "name=", name, "address=", address, "errorMsg=", errorMsg)
-            WalletStores.RootStore.addingSavedAddress = false
-            WalletStores.RootStore.lastCreatedSavedAddress = { address: address, error: errorMsg }
+            appMain.walletRootStore.addingSavedAddress = false
+            appMain.walletRootStore.lastCreatedSavedAddress = { address: address, error: errorMsg }
 
             if (!!errorMsg) {
                 let mode = qsTr("adding")
@@ -2638,18 +2641,18 @@ Item {
             }
 
             onRemoveSavedAddress: {
-                WalletStores.RootStore.deleteSavedAddress(address)
+                appMain.walletRootStore.deleteSavedAddress(address)
                 close()
             }
         }
     }
 
     Connections {
-        target: WalletStores.RootStore
+        target: appMain.walletRootStore
 
         function onSavedAddressDeleted(name: string, address: string, errorMsg: string) {
             console.warn("[saved-address] onSavedAddressDeleted name=", name, "address=", address, "errorMsg=", errorMsg)
-            WalletStores.RootStore.deletingSavedAddress = false
+            appMain.walletRootStore.deletingSavedAddress = false
 
             if (!!errorMsg) {
 
@@ -2728,7 +2731,7 @@ Item {
                 if (showQR.showSingleAccount || showQR.showForSavedAddress) {
                     return null
                 }
-                return WalletStores.RootStore.accounts
+                return appMain.walletRootStore.accounts
             }
 
             selectedAccount: {
@@ -2776,7 +2779,7 @@ Item {
         sourceComponent: WalletPopups.SavedAddressActivityPopup {
             networkConnectionStore: appMain.networkConnectionStore
             networksStore: appMain.networksStore
-            walletRootStore: WalletStores.RootStore
+            walletRootStore: appMain.walletRootStore
 
             onSendToAddressRequested: {
                 Global.sendToRecipientRequested(address)
@@ -2819,9 +2822,9 @@ Item {
                 enabled: dAppsService.isServiceOnline
                 visualParent: appMain
                 loginType: appMain.rootStore.getLoginType()
-                selectedAccountAddress: WalletStores.RootStore.selectedAddress
+                selectedAccountAddress: appMain.walletRootStore.selectedAddress
                 dAppsModel: dAppsService.dappsModel
-                accountsModel: WalletStores.RootStore.nonWatchAccounts
+                accountsModel: appMain.walletRootStore.nonWatchAccounts
                 networksModel: appMain.networksStore.activeNetworks
                 sessionRequestsModel: dAppsService.sessionRequestsModel
                 walletConnectEnabled: featureFlagsStore.dappsEnabled
@@ -2868,7 +2871,7 @@ Item {
                 sourceComponent: DAppsModule {
                     currenciesStore: appMain.currencyStore
                     groupedAccountAssetsModel: appMain.walletAssetsStore.groupedAccountAssetsModel
-                    accountsModel: WalletStores.RootStore.nonWatchAccounts
+                    accountsModel: appMain.walletRootStore.nonWatchAccounts
                     networksModel: SortFilterProxyModel {
                         sourceModel: appMain.networksStore.activeNetworks
                         proxyRoles: [
@@ -2880,27 +2883,27 @@ Item {
                         ]
                     }
                     wcSdk: ConnectorWCSDK {
-                        enabled: featureFlagsStore.dappsEnabled && WalletStores.RootStore.walletSectionInst.walletReady
-                        connectorController: WalletStores.RootStore.dappsConnectorController
+                        enabled: featureFlagsStore.dappsEnabled && appMain.walletRootStore.walletSectionInst.walletReady
+                        connectorController: appMain.walletRootStore.dappsConnectorController
                         networksModel: appMain.networksStore.activeNetworks
-                        accountsModel: WalletStores.RootStore.nonWatchAccounts
+                        accountsModel: appMain.walletRootStore.nonWatchAccounts
                     }
                     bcSdk: DappsConnectorSDK {
-                        enabled: featureFlagsStore.dappsEnabled && WalletStores.RootStore.walletSectionInst.walletReady
+                        enabled: featureFlagsStore.dappsEnabled && appMain.walletRootStore.walletSectionInst.walletReady
                         excludeClientIds: ["walletconnect"]
                         store: SharedStores.BrowserConnectStore {
-                            controller: WalletStores.RootStore.dappsConnectorController
+                            controller: appMain.walletRootStore.dappsConnectorController
                         }
                         networksModel: appMain.networksStore.activeNetworks
-                        accountsModel: WalletStores.RootStore.nonWatchAccounts
+                        accountsModel: appMain.walletRootStore.nonWatchAccounts
                     }
                     store: SharedStores.DAppsStore {
-                        controller: WalletStores.RootStore.walletConnectController
+                        controller: appMain.walletRootStore.walletConnectController
                     }
                 }
             }
-            selectedAddress: WalletStores.RootStore.selectedAddress
-            accountsModel: WalletStores.RootStore.nonWatchAccounts
+            selectedAddress: appMain.walletRootStore.selectedAddress
+            accountsModel: appMain.walletRootStore.nonWatchAccounts
             connectorFeatureEnabled: featureFlagsStore.connectorEnabled
             walletConnectFeatureEnabled: featureFlagsStore.dappsEnabled
 
@@ -2939,15 +2942,15 @@ Item {
                 return
 
             const isAddress = SQUtils.ModelUtils.contains(
-                              WalletStores.RootStore.accounts, "address",
+                              appMain.walletRootStore.accounts, "address",
                               text, Qt.CaseInsensitive)
             if (isAddress)
-                WalletStores.RootStore.addressWasShown(text)
+                appMain.walletRootStore.addressWasShown(text)
         }
     }
 
     Binding {
-        target: WalletStores.RootStore
+        target: appMain.walletRootStore
         property: "palette"
         value: appMain.Theme.palette
     }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2537,7 +2537,6 @@ Item {
         }
 
         sourceComponent: WalletPopups.AddEditSavedAddressPopup {
-            sharedRootStore: appMain.sharedRootStore
             contactsModel: appMain.contactsStore.contactsModel
             isChecksumValidForAddress: (address) => WalletStores.RootStore.isChecksumValidForAddress(address)
             getWalletAccount: (address) => WalletStores.RootStore.getWalletAccount(address)
@@ -2546,12 +2545,27 @@ Item {
             savedAddressNameExists: (name) => WalletStores.RootStore.savedAddressNameExists(name)
 
             onPopulateContactDetails: (publicKey) => appMain.contactsStore.populateContactDetails(publicKey)
+            onFetchProfileShowcaseAccountsByAddressRequested: (address) => {
+                appMain.contactsStore.fetchProfileShowcaseAccountsByAddress(address)
+            }
             onCreateOrUpdateSavedAddressRequested: (name, address, ens, colorId) => {
                 WalletStores.RootStore.createOrUpdateSavedAddress(name, address, ens, colorId)
             }
             onClosed: {
                 addEditSavedAddress.close()
             }
+        }
+    }
+
+    Connections {
+        target: appMain.contactsStore
+
+        function onProfileShowcaseAccountsByAddressFetched(accounts: string) {
+            if (!addEditSavedAddress.active || !addEditSavedAddress.item) {
+                return
+            }
+
+            addEditSavedAddress.item.profileShowcaseAccountsByAddressFetched(accounts)
         }
     }
 


### PR DESCRIPTION
Fixes #21165 

### What does the PR do

- Validate and save saved address names using the trimmed value so leading/trailing spaces do not trigger invalid input or create inconsistent names.

Takes profit of the task to do some cleanup / refactor:
- Decouple saved address popup from wallet root store / shared store
- Centralize wallet root store access in `AppMain`

### Affected areas

Wallet Shared Addresses

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/a2ed53be-22e5-491a-bcc9-6ae8d7db9f28

### Impact on end user

Better UX / Improved code base

### How to test

Add a white space in the name of a new Shared Address in Wallet

### Risk 

Low
