### PR TITLE
fix(async): escaped strings in async tasks

### DIFF
--- a/src/app_service/service/devices/async_tasks.nim
+++ b/src/app_service/service/devices/async_tasks.nim
@@ -7,7 +7,7 @@ type
 type
   AsyncInputConnectionStringArg = ref object of QObjectTaskArg
     connectionString: string
-    configJSON: string
+    configJSON: JsonNode
 
 proc asyncLoadDevicesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncLoadDevicesTaskArg](argEncoded)
@@ -26,7 +26,7 @@ proc asyncLoadDevicesTask(argEncoded: string) {.gcsafe, nimcall.} =
 proc asyncInputConnectionStringTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncInputConnectionStringArg](argEncoded)
   try:
-    let response = status_go.inputConnectionStringForBootstrapping(arg.connectionString, arg.configJSON.replace("\\", "\\\\"))
+    let response = status_go.inputConnectionStringForBootstrapping(arg.connectionString, $arg.configJSON)
     arg.finish(response)
   except Exception as e:
     arg.finish(%* {
@@ -36,7 +36,7 @@ proc asyncInputConnectionStringTask(argEncoded: string) {.gcsafe, nimcall.} =
 proc asyncInputConnectionStringForImportingKeystoreTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncInputConnectionStringArg](argEncoded)
   try:
-    let response = status_go.inputConnectionStringForImportingKeypairsKeystores(arg.connectionString, arg.configJSON)
+    let response = status_go.inputConnectionStringForImportingKeypairsKeystores(arg.connectionString, $arg.configJSON)
     arg.finish(response)
   except Exception as e:
     arg.finish(%* {

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -278,7 +278,7 @@ QtObject:
       vptr: cast[uint](self.vptr),
       slot: "inputConnectionStringForBootstrappingFinished",
       connectionString: connectionString,
-      configJSON: $configJSON
+      configJSON: configJSON
     )
     self.threadpool.start(arg)
 
@@ -401,7 +401,7 @@ QtObject:
       vptr: cast[uint](self.vptr),
       slot: "inputConnectionStringForImportingKeystoreFinished",
       connectionString: connectionString,
-      configJSON: $configJSON
+      configJSON: configJSON
     )
     self.threadpool.start(arg)
 

--- a/src/app_service/service/wallet_connect/async_tasks.nim
+++ b/src/app_service/service/wallet_connect/async_tasks.nim
@@ -14,7 +14,7 @@ type
   AsyncEstimateGasArgs = ref object of QObjectTaskArg
     topic: string
     chainId: int
-    txJson: string
+    txJson: JsonNode
 
 proc asyncGetEstimatedTimeTask(argsEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetEstimatedTimeArgs](argsEncoded)
@@ -74,7 +74,7 @@ proc asyncEstimateGasTask(argsEncoded: string) {.gcsafe, nimcall.} =
         "estimatedGas": "",
     }
     try:
-        let tx = parseJson(arg.txJson)
+        let tx = arg.txJson
         let transaction = %*{
             "from": tx["from"].getStr,
             "to": tx["to"].getStr

--- a/src/app_service/service/wallet_connect/service.nim
+++ b/src/app_service/service/wallet_connect/service.nim
@@ -194,7 +194,7 @@ QtObject:
       slot: "estimatedGasResponse",
       topic: topic,
       chainId: chainId,
-      txJson: $tx
+      txJson: tx
     )
     self.threadpool.start(request)
 


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-app/issues/19153

The escaping bug came from passing pre-stringified JSON documents through the async task transport as `string` fields. That meant the payload was serialized, deserialized, and then stringified again before reaching status-go, which was enough to collapse the backslash escaping in Windows paths and break the nested JSON structure. I verified that the async task serializer itself handles structured values correctly, so the problem was the shape of the data being transported, not the serializer.

The fix was to change the affected async task arguments to carry `JsonNode` instead of `string`, and only stringify at the final status-go call site. I updated both device pairing paths and the wallet_connect gas estimation path, which removed the brittle backslash workaround and kept JSON intact across the thread boundary.

### Affected areas

- devices async task
- wallet connect async task

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

None. Just improves code quality and reduces the chance of regression

### How to test

- Import an account using Sync (I tested on Windows and Linux)
- Do a TX using WalletConnect (I tested Uniswap on Sepolia)

### Risk 

Low
