### PR TITLE
Fix/issue 20919

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
@@ -165,7 +165,7 @@ Item {
         id: scrollView
         anchors.top: tokenDetailsHeader.bottom
         anchors.bottom: parent.bottom
-        anchors.topMargin: 47
+        anchors.topMargin: Theme.padding
 
         width: parent.width
         contentWidth: availableWidth

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -296,6 +296,7 @@ RightTabBaseView {
                 id: mainViewLoader
                 Layout.fillWidth: true
                 Layout.fillHeight: true
+                Layout.topMargin: Theme.padding
                 sourceComponent: d.walletViewsMap[walletTabBar.currentIndex]
 
                 Component {


### PR DESCRIPTION
Fixes #20919
Fixes #20911

### What does the PR do

- Add spacing below active tab indicator
- Asset detail - reduce gap above price chart

### Affected areas

Wallet Main Layout and Wallet Assets Details

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="806" height="418" alt="Screenshot 2026-06-22 at 16 37 29" src="https://github.com/user-attachments/assets/e48da63a-d4cb-4768-836c-e7b782d4ae85" />

<img width="1221" height="523" alt="Screenshot 2026-06-22 at 16 42 19" src="https://github.com/user-attachments/assets/86ed7734-388b-4ebe-9bbd-d70127a9b7f4" />

### Impact on end user

Better UX

### How to test

See the layout in main wallet page and assets details

### Risk 

Low
