### PR TITLE
fix(StatusChatInfoButton): fix hover color under Windows

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusChatInfoToolBar.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatInfoToolBar.qml
@@ -86,7 +86,7 @@ Item {
             }
         ]
 
-        onClicked: {
+        onClicked: function (mouse) {
             statusChatInfoToolBar.addButtonClicked(mouse)
             statusMenuButton.state = "pressed"
             popupMenuSlot.item.popup(statusMenuButton.width-popupMenuSlot.item.width, statusMenuButton.height + 4)

--- a/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Controls.Universal
 
 import StatusQ.Core
 import StatusQ.Core.Theme
@@ -97,7 +98,7 @@ Button {
                 spacing: 2
 
                 StatusIcon {
-                    visible: root.type !== StatusChatInfoButton.Type.OneToOneChat && !forceHideTypeIcon && icon
+                    visible: root.type !== StatusChatInfoButton.Type.OneToOneChat && !root.forceHideTypeIcon && icon
                     Layout.preferredWidth: 14
                     Layout.preferredHeight: 14
                     color: root.muted ? Theme.palette.baseColor1 : Theme.palette.directColor1


### PR DESCRIPTION
### What does the PR do

- explicitely import the base Universal theme

Fixes #21168

### Affected areas

Chat/Header

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

N/A need a Windows screenshot

### Impact on end user

Better UI

### How to test

- on Windows, hover over a chat info toolbar button

### Risk 

low
