### PR TITLE
fix(StatusBaseInput): reduce horizontal padding

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -160,12 +160,12 @@ Item {
         \qmlproperty real StatusBaseInput::leftPadding
         This property sets the left padding.
     */
-    property real leftPadding: leftComponentLoader.status === Loader.Ready && leftComponentLoader.item ? 6 : 16
+    property real leftPadding: leftComponentLoader.status === Loader.Ready && leftComponentLoader.item ? 6 : Theme.halfPadding
     /*!
         \qmlproperty real StatusBaseInput::rightPadding
         This property sets the right padding.
     */
-    property real rightPadding: rightComponentLoader.status === Loader.Ready && rightComponentLoader.item ? 6 : 16
+    property real rightPadding: rightComponentLoader.status === Loader.Ready && rightComponentLoader.item ? 6 : Theme.halfPadding
     /*!
         \qmlproperty real StatusBaseInput::topPadding
         This property sets the top padding.
@@ -333,7 +333,7 @@ Item {
             }
             RowLayout {
                 id: contentLayout
-                spacing: 8
+                spacing: Theme.halfPadding
                 anchors {
                     fill: parent
                     leftMargin: root.leftPadding
@@ -498,7 +498,7 @@ Item {
         id: clearButton
 
         StatusClearButton {
-            visible: edit.length != 0 && root.clearable && !root.multiline
+            visible: edit.length !== 0 && root.clearable && !root.multiline
                      && edit.activeFocus
             onClicked: {
                 edit.clear()


### PR DESCRIPTION
### What does the PR do

- 16px is indeed too much; halve it

Fixes #20824

### Affected areas

Status(Base)Input

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2732" height="2062" alt="image" src="https://github.com/user-attachments/assets/59491c36-1a3e-4e18-9432-33f244d64903" />

### Impact on end user

Smoother UI

### How to test

- check various (multi/single) line inputs

### Risk 

low
