### PR TITLE
fix(StatusDialog): set a standard padding

### DIFF
--- a/storybook/pages/StatusDialogPage.qml
+++ b/storybook/pages/StatusDialogPage.qml
@@ -38,7 +38,10 @@ SplitView {
             subtitle: ctrlSubTitle.text
             backgroundColor: !!ctrlBgColor.text ? ctrlBgColor.text : Theme.palette.statusModal.backgroundColor
 
-            padding: ctrlPadding.text
+            Binding on padding {
+                value: parseInt(ctrlPadding.text)
+                when: !!ctrlPadding.text
+            }
 
             contentItem: ColumnLayout {
                 spacing: 16
@@ -192,7 +195,7 @@ SplitView {
                 TextField {
                     Layout.fillWidth: true
                     id: ctrlPadding
-                    text: "32"
+                    text: ""
                 }
             }
 

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -65,6 +65,8 @@ Dialog {
     */
     property alias showHeaderDivider: dialogHeader.showDivider
 
+    padding: Theme.defaultPadding // keep in sync with StatusDialogHeader/Footer
+
     QtObject {
         id: d
 
@@ -206,7 +208,8 @@ Dialog {
                                                | Dialog.SaveAll | Dialog.Retry | Dialog.Ignore
         readonly property int yesRoleFlags: Dialog.Yes | Dialog.YesToAll
 
-        bottomPadding: Theme.padding + root.parent.SafeArea.margins.bottom
+        padding: root.padding
+        bottomPadding: root.padding + root.parent.SafeArea.margins.bottom
         visible: rightButtons
                  && root.standardButtons & (rejectRoleFlags | noRoleFlags | acceptRoleFlags
                                             | yesRoleFlags | Dialog.ApplyRole)


### PR DESCRIPTION
### What does the PR do

- set the `padding` to a uniform value, one that matches the same padding that we use in header/footer
- problem is that the base Dialog already sets its own padding value which differs across OS/platforms

Fixes #20673

### Affected areas

StatusDialog

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2732" height="2062" alt="Snímek obrazovky z 2026-06-23 12-00-36" src="https://github.com/user-attachments/assets/797e102e-8125-43f7-a0d7-637dd9bb86ee" />


### Impact on end user

Aligned dialog UI

### How to test

- open various dialogs/popups
- the content should ideally align vertically with the header/footer

### Risk 

low
