### PR TITLE
fix(StatusUserImage): enlarge the online badge

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
@@ -131,8 +131,8 @@ Loader {
         visible: false
         anchors.bottom: root.bottom
         anchors.right: root.right
-        anchors.rightMargin: -border.width
-        anchors.bottomMargin: -border.width
+        anchors.rightMargin: Math.ceil(-border.width)
+        anchors.bottomMargin: Math.ceil(-border.width)
         border.width: 3
         height: 15
         width: 15

--- a/ui/StatusQ/src/StatusQ/Components/StatusUserImage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusUserImage.qml
@@ -49,8 +49,8 @@ Loader {
         loading: root.loading
 
         badge.visible: root.onlineStatus !== -1 && !root.isBridgedAccount
-        badge.width: root.imageWidth/4
-        badge.height: root.imageWidth/4
+        badge.width: root.imageWidth/3
+        badge.height: root.imageWidth/3
         badge.border.width: 0.05 * root.imageWidth
         badge.border.color: Theme.palette.statusBadge.foregroundColor
         badge.color: {
@@ -58,8 +58,6 @@ Loader {
                 return Theme.palette.successColor1
             return Theme.palette.baseColor1
         }
-        badge.anchors.rightMargin: badge.border.width/2
-        badge.anchors.bottomMargin: badge.border.width/2
 
         bridgeBadge.visible: root.isBridgedAccount
         bridgeBadge.image.source: Assets.svg("discord-bridge")

--- a/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
@@ -95,7 +95,6 @@ ContactListItemDelegate {
         },
         StatusBaseText {
             text: root.contactText
-            anchors.verticalCenter: parent.verticalCenter
             color: Theme.palette.baseColor1
         },
         StatusFlatRoundButton {


### PR DESCRIPTION
### What does the PR do

- make the online status indicator badge bigger, and center it more appropriately

Fixes #20692

### Affected areas

StatusUserImage

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

User list:
<img width="2708" height="2062" alt="image" src="https://github.com/user-attachments/assets/f5c35566-8821-411b-ba80-dd1345ec66b3" />

Contacts view:
<img width="2708" height="2062" alt="image" src="https://github.com/user-attachments/assets/7c2f00d5-6637-40e1-9e55-8f188b892861" />

### Impact on end user

Smoother UI

### How to test

- observe the User list side panel or Settings/Messaging/Contacts list item delegates

### Risk 

low
