### PR TITLE
fix: fixed signing joining community request issues

### DIFF
--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -220,9 +220,6 @@ method prepareKeypairsForSigning*(self: AccessInterface, communityId: string, en
   airdropAddress: string, editMode: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method signProfileKeypairAndAllNonKeycardKeypairs*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method signSharedAddressesForKeypair*(self: AccessInterface, keyUid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -651,10 +651,6 @@ method shareCommunityChannelUrlWithChatKey*(self: Module, communityId: string, c
 method shareCommunityChannelUrlWithData*(self: Module, communityId: string, chatId: string): string =
   return self.controller.shareCommunityChannelUrlWithData(communityId, chatId)
 
-proc isColdWalletKeypair(self: Module, keyUid: string): bool =
-  let keypair = self.controller.getKeypairByKeyUid(keyUid)
-  return (not keypair.isNil) and keypair.migratedToColdWallet()
-
 proc emitSignAllSignedIfDone(self: Module) =
   if self.joiningCommunityDetails.allSigned():
     self.view.sendAllSharedAddressesSignedSignal()
@@ -671,18 +667,11 @@ proc requestNextSignatureForKeypair(self: Module, keyUid: string) =
       return
   self.emitSignAllSignedIfDone()
 
-proc requestNextNonColdWalletSignature(self: Module) =
-  for address, details in self.joiningCommunityDetails.addressesToShare.pairs:
-    if details.signature.len == 0 and not self.isColdWalletKeypair(details.keyUid):
-      self.requestSignature(address)
-      return
-  self.emitSignAllSignedIfDone()
-
 method onSigningResult*(self: Module, signature: string, address: string) =
   if not self.joiningCommunityDetails.addressesToShare.hasKey(address):
     return
   if signature.len == 0:
-    self.communityAccessFailed(self.joiningCommunityDetails.communityId, "signing was cancelled or failed")
+    warn "community shared addresses signing returned an empty signature", address
     return
   self.joiningCommunityDetails.addressesToShare[address].signature = signature
   let keyUid = self.joiningCommunityDetails.addressesToShare[address].keyUid
@@ -693,10 +682,7 @@ method onSigningResult*(self: Module, signature: string, address: string) =
       break
   if allForKeypairSigned:
     self.view.keypairsSigningModel().setOwnershipVerified(keyUid, true)
-  if self.isColdWalletKeypair(keyUid):
-    self.requestNextSignatureForKeypair(keyUid)
-  else:
-    self.requestNextNonColdWalletSignature()
+  self.requestNextSignatureForKeypair(keyUid)
 
 method prepareKeypairsForSigning*(self: Module, communityId, ensName: string, addresses: string,
   airdropAddress: string, editMode: bool) =
@@ -738,6 +724,8 @@ method prepareKeypairsForSigning*(self: Module, communityId, ensName: string, ad
           return (it.getKeyUid(), acc.getPath())
     return ("", "")
 
+  self.joiningCommunityDetails.addressesToShare.clear()
+
   for param in signingParams:
     let (keyUid, path) = findKeyUidAndPathForAddress(keypairsForSigning, param.address)
     let details = AddressToShareDetails(
@@ -748,9 +736,6 @@ method prepareKeypairsForSigning*(self: Module, communityId, ensName: string, ad
       messageToBeSigned: param.data
     )
     self.joiningCommunityDetails.addressesToShare[param.address] = details
-
-method signProfileKeypairAndAllNonKeycardKeypairs*(self: Module) =
-  self.requestNextNonColdWalletSignature()
 
 method signSharedAddressesForKeypair*(self: Module, keyUid: string) =
   self.requestNextSignatureForKeypair(keyUid)

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -326,9 +326,6 @@ QtObject:
   proc prepareTokenModelForCommunityChat(self: View, communityId: string, chatId: string) {.slot.} =
     self.delegate.prepareTokenModelForCommunityChat(communityId, chatId)
 
-  proc signProfileKeypairAndAllNonKeycardKeypairs*(self: View) {.slot.} =
-    self.delegate.signProfileKeypairAndAllNonKeycardKeypairs()
-
   proc signSharedAddressesForKeypair*(self: View, keyUid: string) {.slot.} =
     self.delegate.signSharedAddressesForKeypair(keyUid)
 

--- a/storybook/pages/CommunityMembershipSetupDialogPage.qml
+++ b/storybook/pages/CommunityMembershipSetupDialogPage.qml
@@ -72,7 +72,6 @@ SplitView {
                 onPrepareForSigning: logs.logEvent("CommunityMembershipSetupDialog::onPrepareForSigning", ["airdropAddress", "sharedAddresses"], arguments)
                 onJoinCommunity: logs.logEvent("CommunityMembershipSetupDialog::onJoinCommunity")
                 onEditRevealedAddresses: logs.logEvent("CommunityMembershipSetupDialog::editRevealedAddresses")
-                onSignProfileKeypairAndAllNonKeycardKeypairs: logs.logEvent("CommunityMembershipSetupDialog::onSignProfileKeypairAndAllNonKeycardKeypairs")
                 onSignSharedAddressesForKeypair: logs.logEvent("CommunityMembershipSetupDialog::onSignSharedAddressesForKeypair", ["keyUid"], arguments)
                 onSharedAddressesUpdated: logs.logEvent("CommunityMembershipSetupDialog::onSharedAddressesUpdated", ["sharedAddresses"], arguments)
                 getCurrencyAmount: function (balance, symbol) {

--- a/test/e2e/gui/components/community/welcome_community.py
+++ b/test/e2e/gui/components/community/welcome_community.py
@@ -9,6 +9,17 @@ from gui.objects_map import names
 from scripts.tools.image import Image
 
 
+class CommunityJoinAuthenticatePopup(AuthenticatePopup):
+    def __init__(self):
+        super().__init__()
+        self._submit_button = Button(names.submit_shared_addresses_to_join_StatusButton)
+
+    @allure.step('Authenticate and submit the join request with password {0}')
+    def authenticate(self, password: str):
+        super().authenticate(password)
+        self._submit_button.click()
+
+
 class WelcomeCommunityPopup(QObject):
 
     def __init__(self):
@@ -17,9 +28,8 @@ class WelcomeCommunityPopup(QObject):
         self._community_icon = QObject(names.image_StatusImage)
         self._intro_text_label = TextLabel(names.intro_StatusBaseText)
         self._select_address_button = Button(names.select_addresses_to_share_StatusFlatButton)
-        self._join_button = Button(names.join_StatusButton)
-        self._authenticate_button = Button(names.welcome_authenticate_StatusButton)
         self._share_address_button = Button(names.share_your_addresses_to_join_StatusButton)
+        self._sign_keypair_button = Button(names.sign_keypair_StatusButton)
 
     @property
     @allure.step('Get title')
@@ -36,12 +46,12 @@ class WelcomeCommunityPopup(QObject):
     def intro(self) -> str:
         return self._intro_text_label.text
 
-    @allure.step('Join community')
-    def join(self) -> AuthenticatePopup:
-        self._join_button.click()
-        self._authenticate_button.click()
-        return AuthenticatePopup().wait_until_appears()
-
-    def join_with_sharing_all_addresses(self):
+    @allure.step('Join community sharing all addresses')
+    def join(self) -> CommunityJoinAuthenticatePopup:
         self._share_address_button.click()
-        return AuthenticatePopup().wait_until_appears()
+        self._sign_keypair_button.click()
+        return CommunityJoinAuthenticatePopup().wait_until_appears()
+
+    @allure.step('Join community sharing all addresses')
+    def join_with_sharing_all_addresses(self) -> CommunityJoinAuthenticatePopup:
+        return self.join()

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -382,7 +382,12 @@ join_StatusButton = {"container": statusDesktop_mainWindow_overlay, "type": "Sta
 welcome_authenticate_StatusButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusButton",
                                      "unnamed": 1, "visible": True}
 share_your_addresses_to_join_StatusButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusButton",
-                                             "unnamed": 1, "visible": True}
+                                             "objectName": "membershipShareAllAddressesButton", "visible": True}
+sign_keypair_StatusButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusButton",
+                             "objectName": "signKeyPairButton", "visible": True}
+submit_shared_addresses_to_join_StatusButton = {"container": statusDesktop_mainWindow_overlay, "type": "StatusButton",
+                                                "objectName": "membershipSubmitSharedAddressesButton", "visible": True,
+                                                "enabled": True}
 
 # Pinned messages
 pinnedMessagesPopup = {"container": statusDesktop_mainWindow_overlay, "objectName": "PinnedMessagesPopup",

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
@@ -28,8 +28,6 @@ Control {
     required property var selectedSharedAddressesMap // Map[address, [keyUid, selected, isAirdrop]
     property var currentSharedAddressesMap // Map[address, [keyUid, selected, isAirdrop]
     required property int totalNumOfAddressesForSharing
-    required property bool profileProvesOwnershipOfSelectedAddresses
-    required property bool allAddressesToRevealBelongToSingleNonProfileKeypair
     required property int /*PermissionTypes.Type*/ eligibleToJoinAs
 
     property bool requirementsCheckPending
@@ -136,27 +134,6 @@ Control {
                 return qsTr("Reveal %n address(s)", "", d.selectedSharedAddressesCount)
             }
 
-            icon.name: {
-                if (!d.lostCommunityPermission
-                        && !d.lostChannelPermissions
-                        && root.profileProvesOwnershipOfSelectedAddresses) {
-                    if (userProfile.usingBiometricLogin) {
-                        return "touch-id"
-                    }
-
-                    if (userProfile.migratedToColdWallet) {
-                        return "keycard"
-                    }
-
-                    return "password"
-                }
-                if (root.allAddressesToRevealBelongToSingleNonProfileKeypair) {
-                    return "keycard"
-                }
-
-                return ""
-            }
-
             onClicked: {
                 root.shareSelectedAddressesClicked()
             }
@@ -177,25 +154,6 @@ Control {
                     return qsTr("Share all addresses to join")
                 }
                 return qsTr("Share %n address(s) to join", "", d.selectedSharedAddressesCount)
-            }
-
-            icon.name: {
-                if (root.profileProvesOwnershipOfSelectedAddresses) {
-                    if (userProfile.usingBiometricLogin) {
-                        return "touch-id"
-                    }
-
-                    if (userProfile.migratedToColdWallet) {
-                        return "keycard"
-                    }
-
-                    return "password"
-                }
-                if (root.allAddressesToRevealBelongToSingleNonProfileKeypair) {
-                    return "keycard"
-                }
-
-                return ""
             }
 
             onClicked: {

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesSigningPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesSigningPanel.qml
@@ -27,7 +27,6 @@ ColumnLayout {
     readonly property var rightButtons: [d.rightBtn]
 
     signal joinCommunity()
-    signal signProfileKeypairAndAllNonKeycardKeypairs()
     signal signSharedAddressesForKeypair(string keyUid)
 
     function allSigned() {
@@ -41,28 +40,8 @@ ColumnLayout {
 
         property bool allSigned: false
 
-        readonly property bool anyOfSelectedAddressesToRevealBelongToProfileKeypair: {
-            for (const [key, value] of root.selectedSharedAddressesMap) {
-                if (value.keyUid === userProfile.keyUid) {
-                    return true
-                }
-            }
-            return false
-        }
-
-        readonly property bool thereAreMoreThanOneNonProfileRegularKeypairs: nonProfileRegularKeypairs.count > 1
-
-        readonly property bool allNonProfileRegularKeypairsSigned: {
-            for (let i = 0; i < nonProfileRegularKeypairs.model.count; ++i) {
-                const item = nonProfileRegularKeypairs.model.get(i)
-                if (!!item && !item.keyPair.ownershipVerified) {
-                    return false
-                }
-            }
-            return true
-        }
-
         readonly property var rightBtn: StatusButton {
+            objectName: "membershipSubmitSharedAddressesButton"
             enabled: d.allSigned
             text: {
                 if (d.selectedSharedAddressesCount === root.totalNumOfAddressesForSharing) {
@@ -76,6 +55,73 @@ ColumnLayout {
         }
     }
 
+    Component {
+        id: keypairDelegate
+
+        KeyPairItem {
+            id: kpDelegate
+            width: ListView.view.width
+            sensor.hoverEnabled: !model.keyPair.ownershipVerified
+            additionalInfoForProfileKeypair: ""
+
+            keyPairType: model.keyPair.pairType
+            keyPairKeyUid: model.keyPair.keyUid
+            keyPairName: model.keyPair.name
+            keyPairIcon: model.keyPair.icon
+            keyPairImage: model.keyPair.image
+            keyPairDerivedFrom: model.keyPair.derivedFrom
+            keyPairAccounts: model.keyPair.accounts
+
+            readonly property bool migratedToColdWallet: model.keyPair.migratedToColdWallet
+
+            components: [
+                StatusButton {
+                    objectName: "signKeyPairButton"
+                    text: qsTr("Sign")
+                    visible: !model.keyPair.ownershipVerified
+                    icon.name: {
+                        if (userProfile.keyUid !== kpDelegate.keyPairKeyUid && kpDelegate.migratedToColdWallet)
+                            return "keycard"
+                        if (userProfile.usingBiometricLogin)
+                            return "touch-id"
+                        if (userProfile.migratedToColdWallet)
+                            return "keycard"
+                        return "password"
+                    }
+
+                    onClicked: {
+                        root.signSharedAddressesForKeypair(model.keyPair.keyUid)
+                    }
+                },
+                StatusButton {
+                    text: qsTr("Signed")
+                    visible: model.keyPair.ownershipVerified
+                    enabled: false
+                    normalColor: "transparent"
+                    disabledColor: "transparent"
+                    disabledTextColor: Theme.palette.successColor1
+                    icon.name: "checkmark-circle"
+                }
+            ]
+
+            SequentialAnimation {
+                running: model.keyPair.ownershipVerified
+                PropertyAnimation {
+                    target: kpDelegate
+                    property: "color"
+                    to: Theme.palette.successColor3
+                    duration: 500
+                }
+                PropertyAnimation {
+                    target: kpDelegate
+                    property: "color"
+                    to: Theme.palette.baseColor2
+                    duration: 1500
+                }
+            }
+        }
+    }
+
     ColumnLayout {
         Layout.fillWidth: true
         Layout.margins: Theme.xlPadding
@@ -85,106 +131,46 @@ ColumnLayout {
         StatusBaseText {
             Layout.preferredWidth: parent.width
             elide: Text.ElideRight
-            text: qsTr("To share %n address(s) with <b>%1</b>, authenticate the associated key pairs...", "", d.selectedSharedAddressesCount).arg(root.communityName)
+            text: qsTr("To share %n address(s) with <b>%1</b>, sign with the associated key pairs...", "", d.selectedSharedAddressesCount).arg(root.communityName)
         }
 
         RowLayout {
             Layout.fillWidth: true
-
-            visible: nonKeycardProfileKeypair.visible
+            visible: storedOnDeviceList.visible
 
             StatusBaseText {
                 Layout.fillWidth: true
                 text: qsTr("Stored on device")
+                color: Theme.palette.baseColor1
                 wrapMode: Text.WordWrap
             }
         }
 
         StatusListView {
-            id: nonKeycardProfileKeypair
+            id: storedOnDeviceList
             Layout.fillWidth: true
-            Layout.preferredHeight: nonKeycardProfileKeypair.contentHeight
-            visible: nonKeycardProfileKeypair.model.count > 0
+            Layout.preferredHeight: contentHeight
+            visible: count > 0
             spacing: Theme.padding
             model: SortFilterProxyModel {
                 sourceModel: root.keypairSigningModel
                 filters: ExpressionFilter {
-                    expression: model.keyPair.keyUid === userProfile.keyUid && !userProfile.migratedToColdWallet
+                    expression: !model.keyPair.migratedToColdWallet
                 }
             }
-            delegate: KeyPairItem {
-                id: kpOnDeviceDelegate
-                width: ListView.view.width
-                sensor.hoverEnabled: false
-                additionalInfoForProfileKeypair: ""
-
-                keyPairType: model.keyPair.pairType
-                keyPairKeyUid: model.keyPair.keyUid
-                keyPairName: model.keyPair.name
-                keyPairIcon: model.keyPair.icon
-                keyPairImage: model.keyPair.image
-                keyPairDerivedFrom: model.keyPair.derivedFrom
-                keyPairAccounts: model.keyPair.accounts
-
-                components: [
-                    StatusButton {
-                        text: qsTr("Authenticate")
-                        visible: !model.keyPair.ownershipVerified
-                        icon.name: {
-                            if (userProfile.usingBiometricLogin) {
-                                return "touch-id"
-                            }
-
-                            if (userProfile.migratedToColdWallet) {
-                                return "keycard"
-                            }
-
-                            return "password"
-                        }
-
-                        onClicked: {
-                            root.signProfileKeypairAndAllNonKeycardKeypairs()
-                        }
-                    },
-                    StatusButton {
-                        text: qsTr("Authenticated")
-                        visible: model.keyPair.ownershipVerified
-                        enabled: false
-                        normalColor: "transparent"
-                        disabledColor: "transparent"
-                        disabledTextColor: Theme.palette.successColor1
-                        icon.name: "checkmark-circle"
-                    }
-                ]
-
-                SequentialAnimation {
-                    running: model.keyPair.ownershipVerified
-                    PropertyAnimation {
-                        target: kpOnDeviceDelegate
-                        property: "color"
-                        to: Theme.palette.successColor3
-                        duration: 500
-                    }
-                    PropertyAnimation {
-                        target: kpOnDeviceDelegate
-                        property: "color"
-                        to: Theme.palette.baseColor2
-                        duration: 1500
-                    }
-                }
-            }
+            delegate: keypairDelegate
         }
 
         Item {
-            visible: nonKeycardProfileKeypair.visible
+            visible: storedOnDeviceList.visible && storedOnKeycardList.visible
             Layout.fillWidth: true
             Layout.preferredHeight: Theme.xlPadding
         }
 
         RowLayout {
             Layout.fillWidth: true
-
-            visible: keycardKeypairs.visible
+            spacing: 8
+            visible: storedOnKeycardList.visible
 
             StatusBaseText {
                 text: qsTr("Stored on keycard")
@@ -201,10 +187,10 @@ ColumnLayout {
         }
 
         StatusListView {
-            id: keycardKeypairs
+            id: storedOnKeycardList
             Layout.fillWidth: true
-            Layout.preferredHeight: keycardKeypairs.contentHeight
-            visible: keycardKeypairs.model.count > 0
+            Layout.preferredHeight: contentHeight
+            visible: count > 0
             spacing: Theme.padding
             model: SortFilterProxyModel {
                 sourceModel: root.keypairSigningModel
@@ -212,188 +198,7 @@ ColumnLayout {
                     expression: model.keyPair.migratedToColdWallet
                 }
             }
-            delegate: KeyPairItem {
-                id: kpOnKeycardDelegate
-                width: ListView.view.width
-                sensor.hoverEnabled: !model.keyPair.ownershipVerified
-                additionalInfoForProfileKeypair: ""
-
-                keyPairType: model.keyPair.pairType
-                keyPairKeyUid: model.keyPair.keyUid
-                keyPairName: model.keyPair.name
-                keyPairIcon: model.keyPair.icon
-                keyPairImage: model.keyPair.image
-                keyPairDerivedFrom: model.keyPair.derivedFrom
-                keyPairAccounts: model.keyPair.accounts
-
-                components: [
-                    StatusButton {
-                        text: qsTr("Authenticate")
-                        visible: !model.keyPair.ownershipVerified
-                        icon.name: "keycard"
-
-                        onClicked: {
-                            if (model.keyPair.keyUid === userProfile.keyUid) {
-                                root.signProfileKeypairAndAllNonKeycardKeypairs()
-                                return
-                            }
-                            root.signSharedAddressesForKeypair(model.keyPair.keyUid)
-                        }
-                    },
-                    StatusButton {
-                        text: qsTr("Authenticated")
-                        visible: model.keyPair.ownershipVerified
-                        enabled: false
-                        normalColor: "transparent"
-                        disabledColor: "transparent"
-                        disabledTextColor: Theme.palette.successColor1
-                        icon.name: "checkmark-circle"
-                    }
-                ]
-
-                SequentialAnimation {
-                    running: model.keyPair.ownershipVerified
-                    PropertyAnimation {
-                        target: kpOnKeycardDelegate
-                        property: "color"
-                        to: Theme.palette.successColor3
-                        duration: 500
-                    }
-                    PropertyAnimation {
-                        target: kpOnKeycardDelegate
-                        property: "color"
-                        to: Theme.palette.baseColor2
-                        duration: 1500
-                    }
-                }
-            }
-        }
-
-        Item {
-            visible: keycardKeypairs.visible
-            Layout.fillWidth: true
-            Layout.preferredHeight: Theme.xlPadding
-        }
-
-        RowLayout {
-            Layout.fillWidth: true
-            spacing: 8
-            visible: nonProfileRegularKeypairs.visible
-
-            StatusBaseText {
-                Layout.preferredWidth: !d.anyOfSelectedAddressesToRevealBelongToProfileKeypair &&
-                                       d.thereAreMoreThanOneNonProfileRegularKeypairs?
-                                           370
-                                         : -1
-                Layout.fillWidth: true
-                text: !d.anyOfSelectedAddressesToRevealBelongToProfileKeypair &&
-                      d.thereAreMoreThanOneNonProfileRegularKeypairs?
-                          qsTr("Authenticate via “%1” key pair").arg(userProfile.name)
-                        : qsTr("The following key pairs will be authenticated via “%1” key pair").arg(userProfile.name)
-                color: Theme.palette.baseColor1
-                wrapMode: Text.WrapAnywhere
-            }
-
-            StatusButton {
-                Layout.rightMargin: 16
-                text: qsTr("Authenticate")
-                visible: !d.anyOfSelectedAddressesToRevealBelongToProfileKeypair
-                         && d.thereAreMoreThanOneNonProfileRegularKeypairs
-                         && !d.allNonProfileRegularKeypairsSigned
-                icon.name: {
-                    if (userProfile.usingBiometricLogin) {
-                        return "touch-id"
-                    }
-
-                    if (userProfile.migratedToColdWallet) {
-                        return "keycard"
-                    }
-
-                    return "password"
-                }
-
-                onClicked: {
-                    root.signProfileKeypairAndAllNonKeycardKeypairs()
-                }
-            }
-        }
-
-        StatusListView {
-            id: nonProfileRegularKeypairs
-            Layout.fillWidth: true
-            Layout.preferredHeight: nonProfileRegularKeypairs.contentHeight
-            visible: nonProfileRegularKeypairs.model.count > 0
-            spacing: Theme.padding
-            model: SortFilterProxyModel {
-                sourceModel: root.keypairSigningModel
-                filters: ExpressionFilter {
-                    expression: !model.keyPair.migratedToColdWallet && model.keyPair.keyUid !== userProfile.keyUid
-                }
-            }
-            delegate: KeyPairItem {
-                id: dependantKpOnDeviceDelegate
-                width: ListView.view.width
-                sensor.hoverEnabled: false
-                additionalInfoForProfileKeypair: ""
-
-                keyPairType: model.keyPair.pairType
-                keyPairKeyUid: model.keyPair.keyUid
-                keyPairName: model.keyPair.name
-                keyPairIcon: model.keyPair.icon
-                keyPairImage: model.keyPair.image
-                keyPairDerivedFrom: model.keyPair.derivedFrom
-                keyPairAccounts: model.keyPair.accounts
-
-                components: [
-                    StatusButton {
-                        Layout.rightMargin: 16
-                        text: qsTr("Authenticate")
-                        visible: !d.anyOfSelectedAddressesToRevealBelongToProfileKeypair
-                                 && !d.thereAreMoreThanOneNonProfileRegularKeypairs
-                                 && !model.keyPair.ownershipVerified
-                        icon.name: {
-                            if (userProfile.usingBiometricLogin) {
-                                return "touch-id"
-                            }
-
-                            if (userProfile.migratedToColdWallet) {
-                                return "keycard"
-                            }
-
-                            return "password"
-                        }
-
-                        onClicked: {
-                            root.signProfileKeypairAndAllNonKeycardKeypairs()
-                        }
-                    },
-                    StatusButton {
-                        text: qsTr("Authenticated")
-                        visible: model.keyPair.ownershipVerified
-                        enabled: false
-                        normalColor: "transparent"
-                        disabledColor: "transparent"
-                        disabledTextColor: Theme.palette.successColor1
-                        icon.name: "checkmark-circle"
-                    }
-                ]
-
-                SequentialAnimation {
-                    running: model.keyPair.ownershipVerified
-                    PropertyAnimation {
-                        target: dependantKpOnDeviceDelegate
-                        property: "color"
-                        to: Theme.palette.successColor3
-                        duration: 500
-                    }
-                    PropertyAnimation {
-                        target: dependantKpOnDeviceDelegate
-                        property: "color"
-                        to: Theme.palette.baseColor2
-                        duration: 1500
-                    }
-                }
-            }
+            delegate: keypairDelegate
         }
     }
 }

--- a/ui/app/AppLayouts/stores/Messaging/Community/CommunityAccessStore.qml
+++ b/ui/app/AppLayouts/stores/Messaging/Community/CommunityAccessStore.qml
@@ -57,10 +57,6 @@ StatusQUtils.QObject {
         d.communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses))
     }
 
-    function signProfileKeypairAndAllNonKeycardKeypairs() {
-        d.communitiesModuleInst.signProfileKeypairAndAllNonKeycardKeypairs()
-    }
-
     function signSharedAddressesForKeypair(keyUid) {
         d.communitiesModuleInst.signSharedAddressesForKeypair(keyUid)
     }

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -1010,8 +1010,6 @@ QtObject {
                 walletAccountsModel: root.rootStore.walletAccountsModel
                 walletCollectiblesModel: WalletStores.RootStore.collectiblesStore.allCollectiblesModel
 
-                canProfileProveOwnershipOfProvidedAddressesFn: WalletStores.RootStore.canProfileProveOwnershipOfProvidedAddresses
-
                 walletAssetsModel: walletAssetsStore.groupedAccountAssetsModel
                 permissionsModel: {
                     if(communityAccessStore) {
@@ -1031,12 +1029,6 @@ QtObject {
                     if(communityAccessStore) {
                         communityAccessStore.prepareKeypairsForSigning(dialogRoot.communityId, dialogRoot.name, sharedAddresses, airdropAddress, false)
                         dialogRoot.keypairSigningModel = root.rootStore.communitiesModuleInst.keypairsSigningModel
-                    }
-                }
-
-                onSignProfileKeypairAndAllNonKeycardKeypairs: {
-                    if(communityAccessStore) {
-                        communityAccessStore.signProfileKeypairAndAllNonKeycardKeypairs()
                     }
                 }
 
@@ -1083,19 +1075,6 @@ QtObject {
                     }
 
                     function onAllSharedAddressesSigned() {
-
-                        if (dialogRoot.profileProvesOwnershipOfSelectedAddresses) {
-                            dialogRoot.joinCommunity()
-                            dialogRoot.close()
-                            return
-                        }
-
-                        if (dialogRoot.allAddressesToRevealBelongToSingleNonProfileKeypair) {
-                            dialogRoot.joinCommunity()
-                            dialogRoot.close()
-                            return
-                        }
-
                         if (!!dialogRoot.replaceItem) {
                             dialogRoot.replaceLoader.item.allSigned()
                         }
@@ -1272,8 +1251,6 @@ QtObject {
 
                 introMessage: chatStore.sectionDetails.introMessage
 
-                canProfileProveOwnershipOfProvidedAddressesFn: WalletStores.RootStore.canProfileProveOwnershipOfProvidedAddresses
-
                 walletAccountsModel: root.rootStore.walletAccountsModel
 
                 walletAssetsModel: walletAssetsStore.groupedAccountAssetsModel
@@ -1306,12 +1283,6 @@ QtObject {
                     }
                 }
 
-                onSignProfileKeypairAndAllNonKeycardKeypairs: {
-                    if(communityAccessStore) {
-                        communityAccessStore.signProfileKeypairAndAllNonKeycardKeypairs()
-                    }
-                }
-
                 onSignSharedAddressesForKeypair: {
                     if(communityAccessStore) {
                         communityAccessStore.signSharedAddressesForKeypair(keyUid)
@@ -1330,18 +1301,6 @@ QtObject {
                     target: editSharedAddressesPopup.communityAccessStore
 
                     function onAllSharedAddressesSigned() {
-                        if (editSharedAddressesPopup.profileProvesOwnershipOfSelectedAddresses) {
-                            editSharedAddressesPopup.editRevealedAddresses()
-                            editSharedAddressesPopup.close()
-                            return
-                        }
-
-                        if (editSharedAddressesPopup.allAddressesToRevealBelongToSingleNonProfileKeypair) {
-                            editSharedAddressesPopup.editRevealedAddresses()
-                            editSharedAddressesPopup.close()
-                            return
-                        }
-
                         if (!!editSharedAddressesPopup.replaceItem) {
                             editSharedAddressesPopup.replaceLoader.item.allSigned()
                         }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -3640,13 +3640,6 @@ file format</source>
         <source>Share all addresses to join</source>
         <translation type="unfinished"></translation>
     </message>
-    <message numerus="yes">
-        <source>Share %n address(s) to join</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
     <message>
         <source>Select addresses to share</source>
         <translation type="unfinished"></translation>
@@ -15096,8 +15089,16 @@ to load</source>
             <numerusform></numerusform>
         </translation>
     </message>
+    <message>
+        <source>Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Signed</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message numerus="yes">
-        <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, authenticate the associated key pairs...</source>
+        <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, sign with the associated key pairs...</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
@@ -15108,23 +15109,7 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Authenticate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Authenticated</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stored on keycard</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Authenticate via “%1” key pair</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The following key pairs will be authenticated via “%1” key pair</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -4448,14 +4448,6 @@
       <comment>CommunityMembershipSetupDialog</comment>
       <translation>Share all addresses to join</translation>
     </message>
-    <message numerus="yes">
-      <source>Share %n address(s) to join</source>
-      <comment>CommunityMembershipSetupDialog</comment>
-      <translation>
-        <numerusform>Share %n address to join</numerusform>
-        <numerusform>Share %n addresses to join</numerusform>
-      </translation>
-    </message>
     <message>
       <source>Select addresses to share</source>
       <comment>CommunityMembershipSetupDialog</comment>
@@ -18409,12 +18401,22 @@
         <numerusform>Share %n addresses to join</numerusform>
       </translation>
     </message>
+    <message>
+      <source>Sign</source>
+      <comment>SharedAddressesSigningPanel</comment>
+      <translation>Sign</translation>
+    </message>
+    <message>
+      <source>Signed</source>
+      <comment>SharedAddressesSigningPanel</comment>
+      <translation>Signed</translation>
+    </message>
     <message numerus="yes">
-      <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, authenticate the associated key pairs...</source>
+      <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, sign with the associated key pairs...</source>
       <comment>SharedAddressesSigningPanel</comment>
       <translation>
-        <numerusform>To share %n address with &lt;b&gt;%1&lt;/b&gt;, authenticate the associated key pairs...</numerusform>
-        <numerusform>To share %n addresses with &lt;b&gt;%1&lt;/b&gt;, authenticate the associated key pairs...</numerusform>
+        <numerusform></numerusform>
+        <numerusform></numerusform>
       </translation>
     </message>
     <message>
@@ -18423,29 +18425,9 @@
       <translation>Stored on device</translation>
     </message>
     <message>
-      <source>Authenticate</source>
-      <comment>SharedAddressesSigningPanel</comment>
-      <translation>Authenticate</translation>
-    </message>
-    <message>
-      <source>Authenticated</source>
-      <comment>SharedAddressesSigningPanel</comment>
-      <translation>Authenticated</translation>
-    </message>
-    <message>
       <source>Stored on keycard</source>
       <comment>SharedAddressesSigningPanel</comment>
       <translation>Stored on keycard</translation>
-    </message>
-    <message>
-      <source>Authenticate via “%1” key pair</source>
-      <comment>SharedAddressesSigningPanel</comment>
-      <translation>Authenticate via “%1” key pair</translation>
-    </message>
-    <message>
-      <source>The following key pairs will be authenticated via “%1” key pair</source>
-      <comment>SharedAddressesSigningPanel</comment>
-      <translation>The following key pairs will be authenticated via “%1” key pair</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -3655,14 +3655,6 @@ formát souboru</translation>
         <source>Share all addresses to join</source>
         <translation>Sdílet všechny adresy pro připojení</translation>
     </message>
-    <message numerus="yes">
-        <source>Share %n address(s) to join</source>
-        <translation>
-            <numerusform>Sdílet %n adresu pro připojení</numerusform>
-            <numerusform>Sdílet %n adresy pro připojení</numerusform>
-            <numerusform>Sdílet %n adres pro připojení</numerusform>
-        </translation>
-    </message>
     <message>
         <source>Select addresses to share</source>
         <translation>Vybrat adresy ke sdílení</translation>
@@ -15179,12 +15171,20 @@ selhalo</translation>
             <numerusform>Sdílet %n adres pro připojení</numerusform>
         </translation>
     </message>
+    <message>
+        <source>Sign</source>
+        <translation type="unfinished">Podepsat</translation>
+    </message>
+    <message>
+        <source>Signed</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message numerus="yes">
-        <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, authenticate the associated key pairs...</source>
-        <translation>
-            <numerusform>Pro sdílení %n adresy s &lt;b&gt;%1&lt;/b&gt; ověřte přidružené páry klíčů...</numerusform>
-            <numerusform>Pro sdílení %n adres s &lt;b&gt;%1&lt;/b&gt; ověřte přidružené páry klíčů...</numerusform>
-            <numerusform>Pro sdílení %n adres s &lt;b&gt;%1&lt;/b&gt; ověřte přidružené páry klíčů...</numerusform>
+        <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, sign with the associated key pairs...</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message>
@@ -15192,24 +15192,8 @@ selhalo</translation>
         <translation>Uloženo na zařízení</translation>
     </message>
     <message>
-        <source>Authenticate</source>
-        <translation>Ověřit</translation>
-    </message>
-    <message>
-        <source>Authenticated</source>
-        <translation>Ověřeno</translation>
-    </message>
-    <message>
         <source>Stored on keycard</source>
         <translation>Uloženo na keycard</translation>
-    </message>
-    <message>
-        <source>Authenticate via “%1” key pair</source>
-        <translation>Ověřit pomocí páru klíčů „%1“</translation>
-    </message>
-    <message>
-        <source>The following key pairs will be authenticated via “%1” key pair</source>
-        <translation>Následující páry klíčů budou ověřeny pomocí páru klíčů „%1“</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -114,16 +114,6 @@
     </message>
 </context>
 <context>
-    <name>CommunityMembershipSetupDialog</name>
-    <message numerus="yes">
-        <source>Share %n address(s) to join</source>
-        <translation>
-            <numerusform>Share %n address to join</numerusform>
-            <numerusform>Share %n addresses to join</numerusform>
-        </translation>
-    </message>
-</context>
-<context>
     <name>CommunitySettingsView</name>
     <message numerus="yes">
         <source>%n member(s)</source>
@@ -617,10 +607,10 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, authenticate the associated key pairs...</source>
-        <translation>
-            <numerusform>To share %n address with &lt;b&gt;%1&lt;/b&gt;, authenticate the associated key pairs...</numerusform>
-            <numerusform>To share %n addresses with &lt;b&gt;%1&lt;/b&gt;, authenticate the associated key pairs...</numerusform>
+        <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, sign with the associated key pairs...</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -3643,13 +3643,6 @@ no compatible</translation>
         <source>Share all addresses to join</source>
         <translation>Compartir todas las direcciones para unirse</translation>
     </message>
-    <message numerus="yes">
-        <source>Share %n address(s) to join</source>
-        <translation>
-            <numerusform>Compartir %n dirección para unirse</numerusform>
-            <numerusform>Compartir %n direcciones para unirse</numerusform>
-        </translation>
-    </message>
     <message>
         <source>Select addresses to share</source>
         <translation>Seleccionar direcciones para compartir</translation>
@@ -15111,11 +15104,19 @@ al cargar</translation>
             <numerusform>Compartir %n direcciones para unirse</numerusform>
         </translation>
     </message>
+    <message>
+        <source>Sign</source>
+        <translation type="unfinished">Firmar</translation>
+    </message>
+    <message>
+        <source>Signed</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message numerus="yes">
-        <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, authenticate the associated key pairs...</source>
-        <translation>
-            <numerusform>Para compartir %n dirección con &lt;b&gt;%1&lt;/b&gt;, autentica el par de claves asociado...</numerusform>
-            <numerusform>Para compartir %n direcciones con &lt;b&gt;%1&lt;/b&gt;, autentica los pares de claves asociados...</numerusform>
+        <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, sign with the associated key pairs...</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message>
@@ -15123,24 +15124,8 @@ al cargar</translation>
         <translation>Almacenado en el dispositivo</translation>
     </message>
     <message>
-        <source>Authenticate</source>
-        <translation>Autenticar</translation>
-    </message>
-    <message>
-        <source>Authenticated</source>
-        <translation>Autenticado</translation>
-    </message>
-    <message>
         <source>Stored on keycard</source>
         <translation>Almacenado en Keycard</translation>
-    </message>
-    <message>
-        <source>Authenticate via “%1” key pair</source>
-        <translation>Autenticar mediante el par de claves &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>The following key pairs will be authenticated via “%1” key pair</source>
-        <translation>Los siguientes pares de claves serán autenticados mediante el par de claves &quot;%1&quot;</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -3630,12 +3630,6 @@ file format</source>
         <source>Share all addresses to join</source>
         <translation>참여하려면 모든 주소를 공유하세요</translation>
     </message>
-    <message numerus="yes">
-        <source>Share %n address(s) to join</source>
-        <translation>
-            <numerusform>참여하려면 주소 %n개를 공유</numerusform>
-        </translation>
-    </message>
     <message>
         <source>Select addresses to share</source>
         <translation>공유할 주소 선택</translation>
@@ -15044,10 +15038,18 @@ to load</source>
             <numerusform>참여하려면 주소 %n개를 공유하세요</numerusform>
         </translation>
     </message>
+    <message>
+        <source>Sign</source>
+        <translation type="unfinished">서명</translation>
+    </message>
+    <message>
+        <source>Signed</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message numerus="yes">
-        <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, authenticate the associated key pairs...</source>
-        <translation>
-            <numerusform>&lt;b&gt;%1&lt;/b&gt;와(과) %n개의 주소를 공유하려면, 연결된 키 쌍을 인증하세요...</numerusform>
+        <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, sign with the associated key pairs...</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
         </translation>
     </message>
     <message>
@@ -15055,24 +15057,8 @@ to load</source>
         <translation>기기에 저장됨</translation>
     </message>
     <message>
-        <source>Authenticate</source>
-        <translation>인증</translation>
-    </message>
-    <message>
-        <source>Authenticated</source>
-        <translation>인증됨</translation>
-    </message>
-    <message>
         <source>Stored on keycard</source>
         <translation>Keycard에 저장됨</translation>
-    </message>
-    <message>
-        <source>Authenticate via “%1” key pair</source>
-        <translation>“%1” 키 쌍으로 인증</translation>
-    </message>
-    <message>
-        <source>The following key pairs will be authenticated via “%1” key pair</source>
-        <translation>다음 키 쌍은 “%1” 키 쌍을 통해 인증됩니다</translation>
     </message>
 </context>
 <context>

--- a/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
+++ b/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
@@ -54,27 +54,9 @@ StatusStackModal {
 
     property var getCurrencyAmount: function (balance, key){}
 
-    property var canProfileProveOwnershipOfProvidedAddressesFn: function(addresses) { return false }
-    readonly property bool hasUserProfile: typeof userProfile !== "undefined" && !!userProfile
-
-    readonly property bool profileProvesOwnershipOfSelectedAddresses: {
-        d.selectedSharedAddressesMap // needed for binding
-        const obj = d.getSelectedAddresses()
-        return root.canProfileProveOwnershipOfProvidedAddressesFn(obj.addresses)
-    }
-
-    readonly property bool allAddressesToRevealBelongToSingleNonProfileKeypair: {
-        const keyUids = new Set()
-        for (const [key, value] of d.selectedSharedAddressesMap) {
-            keyUids.add(value.keyUid)
-        }
-        return keyUids.size === 1 && (!root.hasUserProfile || !keyUids.has(userProfile.keyUid))
-    }
-
     signal prepareForSigning(string airdropAddress, var sharedAddresses)
     signal joinCommunity()
     signal editRevealedAddresses()
-    signal signProfileKeypairAndAllNonKeycardKeypairs()
     signal signSharedAddressesForKeypair(string keyUid)
     signal cancelMembershipRequest()
     signal sharedAddressesUpdated(var sharedAddresses)
@@ -88,6 +70,7 @@ StatusStackModal {
     rightButtons: [d.shareButton, finishButton]
 
     finishButton: StatusButton {
+        objectName: "membershipShareAllAddressesButton"
         interactive: {
             if (root.isInvitationPending || d.accessType !== Constants.communityChatOnRequestAccess)
                 return true
@@ -110,39 +93,10 @@ StatusStackModal {
 
             return ""
         }
-        text: {
-            if (root.isInvitationPending) {
-                return qsTr("Cancel Membership Request")
-            }
-            if (d.selectedSharedAddressesCount === d.totalNumOfAddressesForSharing) {
-                return qsTr("Share all addresses to join")
-            }
-            return qsTr("Share %n address(s) to join", "", d.selectedSharedAddressesCount)
-        }
+        text: root.isInvitationPending ? qsTr("Cancel Membership Request")
+                                       : qsTr("Share all addresses to join")
         type: root.isInvitationPending ? StatusBaseButton.Type.Danger
                                        : StatusBaseButton.Type.Normal
-
-        icon.name: {
-            if (root.isInvitationPending)
-                return ""
-
-            if (root.profileProvesOwnershipOfSelectedAddresses) {
-                if (root.hasUserProfile && userProfile.usingBiometricLogin) {
-                    return "touch-id"
-                }
-
-                if (root.hasUserProfile && userProfile.migratedToColdWallet) {
-                    return "keycard"
-                }
-
-                return "password"
-            }
-            if (root.allAddressesToRevealBelongToSingleNonProfileKeypair) {
-                return "keycard"
-            }
-
-            return ""
-        }
 
         onClicked: {
             if (root.isInvitationPending) {
@@ -151,6 +105,7 @@ StatusStackModal {
                 return
             }
 
+            d.reEvaluateModels()
             d.proceedToSigningOrSubmitRequest(d.communityIntroUid)
         }
     }
@@ -211,37 +166,25 @@ StatusStackModal {
         function proceedToSigningOrSubmitRequest(uidOfComponentThisFunctionIsCalledFrom) {
             const selected = d.getSelectedAddresses()
             root.prepareForSigning(selected.airdropAddress, selected.addresses)
-            if (root.profileProvesOwnershipOfSelectedAddresses) {
-                root.signProfileKeypairAndAllNonKeycardKeypairs()
-                return
-            }
-            if (root.allAddressesToRevealBelongToSingleNonProfileKeypair) {
-                if (d.selectedSharedAddressesMap.size === 0) {
-                    console.error("selected shared addresses must not be empty")
-                    return
-                }
-                const keyUid = d.selectedSharedAddressesMap.values().next().value.keyUid
-                root.signSharedAddressesForKeypair(keyUid)
-                return
-            }
 
             d.backActionGoesTo = uidOfComponentThisFunctionIsCalledFrom
             root.replace(sharedAddressesSigningPanelComponent)
         }
 
-        // This function deletes/adds it the address from/to the map.
+        // This function deletes/adds the address from/to the map.
         function toggleAddressSelection(keyUid, address) {
-            const tmpMap = d.selectedSharedAddressesMap
+            const tmpMap = new Map(d.selectedSharedAddressesMap)
 
             const lAddress = address.toLowerCase()
             const obj = tmpMap.get(lAddress)
             if (!!obj) {
                 if (tmpMap.size === 1) {
                     console.error("cannot remove the last selected address")
+                    return
                 }
                 tmpMap.delete(lAddress)
                 if (obj.isAirdrop) {
-                    d.selectAirdropAddressForTheFirstSelectedAddress()
+                    d.selectAirdropAddressForTheFirstSelectedAddress(tmpMap)
                 }
             } else {
                 tmpMap.set(lAddress, {keyUid: keyUid, selected: true, isAirdrop: false})
@@ -250,24 +193,19 @@ StatusStackModal {
             d.selectedSharedAddressesMap = tmpMap
         }
 
-        // This function selects new airdrop address, invalidating old airdrop address selection.
-        function selectAirdropAddressForTheFirstSelectedAddress() {
-            const tmpMap = d.selectedSharedAddressesMap
-
-            // clear previous airdrop address
+        // This function selects a new airdrop address, invalidating the old airdrop selection.
+        function selectAirdropAddressForTheFirstSelectedAddress(tmpMap) {
             for (const [key, value] of tmpMap) {
                 if (!value.isAirdrop) {
-                    d.selectedSharedAddressesMap.set(key, {keyUid: value.keyUid, selected: value.selected, isAirdrop: true})
+                    tmpMap.set(key, {keyUid: value.keyUid, selected: value.selected, isAirdrop: true})
                     break
                 }
             }
-
-            d.selectedSharedAddressesMap = tmpMap
         }
 
         // This function selects new airdrop address, invalidating old airdrop address selection.
         function selectAirdropAddress(address) {
-            const tmpMap = d.selectedSharedAddressesMap
+            const tmpMap = new Map(d.selectedSharedAddressesMap)
 
             // clear previous airdrop address
             for (const [key, value] of tmpMap) {
@@ -284,8 +222,7 @@ StatusStackModal {
                 console.error("cannot set airdrop address for unselected address")
                 return
             }
-            obj.isAirdrop = true
-            tmpMap.set(lAddress, obj)
+            tmpMap.set(lAddress, {keyUid: obj.keyUid, selected: obj.selected, isAirdrop: true})
 
             d.selectedSharedAddressesMap = tmpMap
         }
@@ -373,9 +310,6 @@ StatusStackModal {
             totalNumOfAddressesForSharing: d.totalNumOfAddressesForSharing
             eligibleToJoinAs: d.eligibleToJoinAs
 
-            profileProvesOwnershipOfSelectedAddresses: root.profileProvesOwnershipOfSelectedAddresses
-            allAddressesToRevealBelongToSingleNonProfileKeypair: root.allAddressesToRevealBelongToSingleNonProfileKeypair
-
             walletAssetsModel: root.walletAssetsModel
             walletCollectiblesModel: root.walletCollectiblesModel
 
@@ -418,10 +352,6 @@ StatusStackModal {
 
             communityName: root.communityName
             keypairSigningModel: root.keypairSigningModel
-
-            onSignProfileKeypairAndAllNonKeycardKeypairs: {
-                root.signProfileKeypairAndAllNonKeycardKeypairs()
-            }
 
             onSignSharedAddressesForKeypair: {
                 root.signSharedAddressesForKeypair(keyUid)

--- a/ui/imports/shared/popups/auth_sign_base/PopupBase.qml
+++ b/ui/imports/shared/popups/auth_sign_base/PopupBase.qml
@@ -31,8 +31,16 @@ StatusDialog {
     required property int remainingPinAttempts
     required property string userProfileKeyUid
     required property string userProfilePublicKey
+    required property bool userProfileMigratedToColdWallet
     required property bool isKeycardKeyPair
     property var keyPairForProcessing: null
+
+    // a logic about key pair being used for authentication/signing as well as the location of signing (keycard/keystore file) is determined by these readonly props here
+    readonly property bool useKeycard: root.isKeycardKeyPair
+                                       || root.userProfileMigratedToColdWallet
+    readonly property string useKeyUid: root.isKeycardKeyPair?
+                                            root.keyUid
+                                          : root.userProfileKeyUid
 
     // buttons
     required property string btnActionName
@@ -64,7 +72,7 @@ StatusDialog {
                     return biometricsComponent
                 }
 
-                if (!root.isKeycardKeyPair) {
+                if (!root.useKeycard) {
                     return enterPasswordComponent
                 }
 
@@ -119,8 +127,8 @@ StatusDialog {
                 text: d.credentialMismatchAfterBiometrics && d.usingBiometrics
                       ? root.btnPasswordActionAndUpdateName
                       : root.btnActionName
-                visible: !root.isKeycardKeyPair && !d.biometricsInProgress
-                enabled: !root.isKeycardKeyPair
+                visible: !root.useKeycard && !d.biometricsInProgress
+                enabled: !root.useKeycard
                          && !!contentLoader.item
                          && contentLoader.item.passwordValid
                          && !d.verifying
@@ -133,9 +141,9 @@ StatusDialog {
             StatusButton {
                 objectName: "keycardPopupBaseUpdatePinSubmitButton"
                 text: root.btnPinActionAndUpdateName
-                visible: root.isKeycardKeyPair && !d.biometricsInProgress && !d.verifying
+                visible: root.useKeycard && !d.biometricsInProgress && !d.verifying
                            && d.credentialMismatchAfterBiometrics && d.usingBiometrics
-                enabled: root.isKeycardKeyPair
+                enabled: root.useKeycard
                          && !!contentLoader.item
                          && contentLoader.item.pinValid
                          && !d.verifying
@@ -163,7 +171,7 @@ StatusDialog {
             d.showToast(status)
             d.credentialCameFromBiometrics = true
 
-            if (root.isKeycardKeyPair) {
+            if (root.useKeycard) {
                 d.biometricsInProgress = false
                 d.performKeycardActionInternal(secret)
                 return
@@ -180,8 +188,8 @@ StatusDialog {
         id: d
 
         readonly property bool usingBiometrics: root.keychain.available
-                                                && root.keyUid === root.userProfileKeyUid
-                                                && keychain.hasCredential(root.keyUid) === Keychain.StatusSuccess
+                                                && root.useKeyUid === root.userProfileKeyUid
+                                                && keychain.hasCredential(root.useKeyUid) === Keychain.StatusSuccess
 
         property bool biometricsInProgress: false
         property bool credentialMismatchAfterBiometrics: false
@@ -196,7 +204,7 @@ StatusDialog {
                 return
             }
 
-            const status = root.keychain.updateCredential(root.keyUid, credential)
+            const status = root.keychain.updateCredential(root.useKeyUid, credential)
             if (status !== Keychain.StatusSuccess) {
                 Global.displayToastMessage(qsTr("Failed to update stored credentials"), "", "warning", false, Constants.ephemeralNotificationType.danger, "")
             }
@@ -231,7 +239,7 @@ StatusDialog {
             d.error = ""
             d.credentialCameFromBiometrics = false
             d.credentialMismatchAfterBiometrics = false
-            root.keychain.requestGetCredential("authenticate", root.keyUid)
+            root.keychain.requestGetCredential("authenticate", root.useKeyUid)
         }
 
         function performPasswordActionInternal() {
@@ -266,7 +274,7 @@ StatusDialog {
             d.verifying = true
             d.error = ""
             d.lastPin = pin
-            root.performKeycardAction(root.keyUid, pin)
+            root.performKeycardAction(root.useKeyUid, pin)
         }
 
         // Called by the concrete popup when keycard action succeeds
@@ -364,7 +372,7 @@ StatusDialog {
     Component {
         id: biometricsComponent
         Biometrics {
-            isKeycardKeyPair: root.isKeycardKeyPair
+            isKeycardKeyPair: root.useKeycard
             signingPurpose: root.purpose === PopupBase.Purpose.Signing
         }
     }

--- a/ui/imports/shared/popups/authentication/AuthenticationPopup.qml
+++ b/ui/imports/shared/popups/authentication/AuthenticationPopup.qml
@@ -27,6 +27,7 @@ PopupBase {
     remainingPinAttempts: root.store.remainingPinAttempts
     userProfileKeyUid: root.store.userProfileKeyUid
     userProfilePublicKey: root.store.userProfilePubKey
+    userProfileMigratedToColdWallet: root.store.userProfileMigratedToColdWallet
     isKeycardKeyPair: root.store.ready && root.store.isKeypairMigratedToColdWallet(root.keyUid)
     keyPairForProcessing: root.store.keyPairForProcessing
 

--- a/ui/imports/shared/popups/authentication/stores/AuthenticationStore.qml
+++ b/ui/imports/shared/popups/authentication/stores/AuthenticationStore.qml
@@ -9,6 +9,7 @@ QtObject {
     readonly property bool ready: d.ready
     readonly property string userProfileKeyUid: userProfile.keyUid
     readonly property string userProfilePubKey: userProfile.pubKey
+    readonly property bool userProfileMigratedToColdWallet: userProfile.migratedToColdWallet
 
     readonly property QtObject d: QtObject {
         property bool ready: false

--- a/ui/imports/shared/popups/signing/SignPopup.qml
+++ b/ui/imports/shared/popups/signing/SignPopup.qml
@@ -38,6 +38,7 @@ PopupBase {
     remainingPinAttempts: root.store.remainingPinAttempts
     userProfileKeyUid: root.store.userProfileKeyUid
     userProfilePublicKey: root.store.userProfilePubKey
+    userProfileMigratedToColdWallet: root.store.userProfileMigratedToColdWallet
     isKeycardKeyPair: root.store.ready && root.store.isKeypairMigratedToColdWallet(root.keyUid)
     keyPairForProcessing: root.store.keyPairForProcessing
 

--- a/ui/imports/shared/popups/signing/stores/SigningStore.qml
+++ b/ui/imports/shared/popups/signing/stores/SigningStore.qml
@@ -9,6 +9,7 @@ QtObject {
     readonly property bool ready: d.ready
     readonly property string userProfileKeyUid: userProfile.keyUid
     readonly property string userProfilePubKey: userProfile.pubKey
+    readonly property bool userProfileMigratedToColdWallet: userProfile.migratedToColdWallet
 
     readonly property QtObject d: QtObject {
         property bool ready: false


### PR DESCRIPTION
The first commit is about improvements to resolving a key pair used in the signing/authentication flows.

The second commit actually changes how community join requests are signed and also simplifies the code.

In the previous implementation, there was a logic for signing each non-profile keycard migrated
key pair individually (cause each is using a different keycard) and when signing a profile key pair
to do a group joining community request signing for all other non-profile not keycard migrated
key pairs.

The old approach also used an "Authenticate" button for that action, which was not correct
since the joining community request had to be signed. That's also fixed in this commit.

With the new keycard rework, the app is explicit always, especially when it's a word about signing.
No background signing anymore, everything is transparent, which means that a single signing flow
is run for a single account. Once all accounts of all key pairs are signed the button to join gets
enabled, and the user is ready to send a request to join a community. That's implemented in this
commit.

Closes #21236

How it was:

<img width="2316" height="1962" alt="OldJoinCommRequest" src="https://github.com/user-attachments/assets/955ee83f-b80e-4bad-a4df-001ffae252c7" />



How it works now:


https://github.com/user-attachments/assets/9cabe459-3d9e-4a74-bf87-6f484c527a15


