### PR TITLE
fix(chat): update new message marker & badges, send button icon

### DIFF
--- a/storybook/pages/ChatAnchorButtonsPanelPage.qml
+++ b/storybook/pages/ChatAnchorButtonsPanelPage.qml
@@ -66,5 +66,5 @@ SplitView {
 }
 
 // category: Panels
-
+// status: good
 // https://www.figma.com/file/Mr3rqxxgKJ2zMQ06UAKiWL/%F0%9F%92%AC-Chat%E2%8E%9CDesktop?node-id=14632-460085&t=SGTU2JeRA8ifbv2E-0

--- a/ui/app/AppLayouts/Chat/panels/ChatAnchorButtonsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/ChatAnchorButtonsPanel.qml
@@ -34,7 +34,7 @@ Item {
 
     component AnchorButton: StatusButton {
         Layout.preferredHeight: 38
-        radius: 100
+        radius: height
         spacing: 2
 
         icon.width: Theme.primaryTextFontSize + 5

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -329,6 +329,7 @@ Item {
             // Don't show the mention anchor in 1-1 chats, because all messages count as mentions
             mentionsCount: d.chatDetails && d.chatDetails.type !== Constants.chatType.oneToOne ?
                         d.chatDetails.notificationCount : 0
+            recentMessagesCount: root.messageStore.newMessagesCount
             recentMessagesButtonVisible: {
                 chatLogView.contentY // trigger binding on contentY change
                 return chatLogView.contentHeight - (d.scrollY + chatLogView.height) > 400

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -8939,12 +8939,9 @@ Are you sure you want to do this?</source>
             <numerusform></numerusform>
         </translation>
     </message>
-    <message numerus="yes">
-        <source>Active Account(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+    <message>
+        <source>Active Accounts</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11612,17 +11609,17 @@ to load</source>
 </context>
 <context>
     <name>NewMessagesMarker</name>
+    <message>
+        <source>UNREAD</source>
+        <comment>unread message(s)</comment>
+        <translation type="unfinished"></translation>
+    </message>
     <message numerus="yes">
-        <source>%n missed message(s) since %1</source>
+        <source>%n unread message(s) since %1</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
-    </message>
-    <message>
-        <source>NEW</source>
-        <comment>new message(s)</comment>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -15558,12 +15555,9 @@ to load</source>
         <source>Please reduce the message length</source>
         <translation type="unfinished"></translation>
     </message>
-    <message numerus="yes">
-        <source>Maximum message character count is %n</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+    <message>
+        <source>Maximum message character count is %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Multiple payment requests</source>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -4966,8 +4966,8 @@
       <source>Key pair must be at least %n character(s)</source>
       <comment>Constants</comment>
       <translation>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
+        <numerusform>Key pair must be at least %n character</numerusform>
+        <numerusform>Key pair must be at least %n characters</numerusform>
       </translation>
     </message>
     <message>
@@ -10909,13 +10909,10 @@
         <numerusform>Contains %n accounts with Keycard incompatible derivation paths</numerusform>
       </translation>
     </message>
-    <message numerus="yes">
-      <source>Active Account(s)</source>
+    <message>
+      <source>Active Accounts</source>
       <comment>KeyPairItem</comment>
-      <translation>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
-      </translation>
+      <translation>Active Accounts</translation>
     </message>
   </context>
   <context>
@@ -12241,8 +12238,8 @@
       <source>PIN incorrect. %n attempt(s) remaining.</source>
       <comment>LoginKeycardBox</comment>
       <translation>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
+        <numerusform>PIN incorrect. %n attempt remaining.</numerusform>
+        <numerusform>PIN incorrect. %n attempts remaining.</numerusform>
       </translation>
     </message>
     <message>
@@ -14168,18 +14165,18 @@
   </context>
   <context>
     <name>NewMessagesMarker</name>
+    <message>
+      <source>UNREAD</source>
+      <comment>unread message(s)</comment>
+      <translation>UNREAD</translation>
+    </message>
     <message numerus="yes">
-      <source>%n missed message(s) since %1</source>
+      <source>%n unread message(s) since %1</source>
       <comment>NewMessagesMarker</comment>
       <translation>
-        <numerusform>%n missed message since %1</numerusform>
-        <numerusform>%n missed message since %1</numerusform>
+        <numerusform>%n unread message since %1</numerusform>
+        <numerusform>%n unread messages since %1</numerusform>
       </translation>
-    </message>
-    <message>
-      <source>NEW</source>
-      <comment>new message(s)</comment>
-      <translation>NEW</translation>
     </message>
   </context>
   <context>
@@ -18943,8 +18940,8 @@
       <source>%n Image(s)</source>
       <comment>StatusChatInputNew</comment>
       <translation>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
+        <numerusform>%n Image</numerusform>
+        <numerusform>%n Images</numerusform>
       </translation>
     </message>
     <message>
@@ -18962,13 +18959,10 @@
       <comment>StatusChatInputNew</comment>
       <translation>Please reduce the message length</translation>
     </message>
-    <message numerus="yes">
-      <source>Maximum message character count is %n</source>
+    <message>
+      <source>Maximum message character count is %1</source>
       <comment>StatusChatInputNew</comment>
-      <translation>
-        <numerusform>Maximum message character count is %n</numerusform>
-        <numerusform>Maximum message character count is %n</numerusform>
-      </translation>
+      <translation>Maximum message character count is %1</translation>
     </message>
     <message>
       <source>Multiple payment requests</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -8990,13 +8990,9 @@ Opravdu to chcete udělat?</translation>
             <numerusform>Obsahuje %n účtů s nekompatibilními odvozovacími cestami Keycard</numerusform>
         </translation>
     </message>
-    <message numerus="yes">
-        <source>Active Account(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+    <message>
+        <source>Active Accounts</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11681,18 +11677,18 @@ selhalo</translation>
 </context>
 <context>
     <name>NewMessagesMarker</name>
-    <message numerus="yes">
-        <source>%n missed message(s) since %1</source>
-        <translation>
-            <numerusform>%n zmeškaná zpráva od %1</numerusform>
-            <numerusform>%n zmeškané zprávy od %1</numerusform>
-            <numerusform>%n zmeškaných zpráv od %1</numerusform>
-        </translation>
-    </message>
     <message>
-        <source>NEW</source>
-        <comment>new message(s)</comment>
-        <translation>NOVÉ</translation>
+        <source>UNREAD</source>
+        <comment>unread message(s)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n unread message(s) since %1</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -15647,13 +15643,9 @@ selhalo</translation>
         <source>Please reduce the message length</source>
         <translation type="unfinished">Prosím zkraťte délku zprávy</translation>
     </message>
-    <message numerus="yes">
-        <source>Maximum message character count is %n</source>
-        <translation type="unfinished">
-            <numerusform>Maximální počet znaků je %n</numerusform>
-            <numerusform>Maximální počet znaků je %n</numerusform>
-            <numerusform>Maximální počet znaků je %n</numerusform>
-        </translation>
+    <message>
+        <source>Maximum message character count is %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Multiple payment requests</source>

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -137,9 +137,9 @@
     <name>Constants</name>
     <message numerus="yes">
         <source>Key pair must be at least %n character(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Key pair must be at least %n character</numerusform>
+            <numerusform>Key pair must be at least %n characters</numerusform>
         </translation>
     </message>
 </context>
@@ -235,7 +235,7 @@
     <name>EnterPin</name>
     <message numerus="yes">
         <source>%n attempt(s) remaining</source>
-        <translation type="unfinished">
+        <translation>
             <numerusform>%n attempt remaining</numerusform>
             <numerusform>%n attempts remaining</numerusform>
         </translation>
@@ -245,7 +245,7 @@
     <name>EnterPinState</name>
     <message numerus="yes">
         <source>%n attempt(s) remaining</source>
-        <translation type="unfinished">
+        <translation>
             <numerusform>%n attempt remaining</numerusform>
             <numerusform>%n attempts remaining</numerusform>
         </translation>
@@ -339,7 +339,7 @@
     <name>KeyPairCompactItem</name>
     <message numerus="yes">
         <source>Contains %n account(s) with Keycard incompatible derivation paths</source>
-        <translation type="unfinished">
+        <translation>
             <numerusform>Contains %n account with Keycard incompatible derivation paths</numerusform>
             <numerusform>Contains %n accounts with Keycard incompatible derivation paths</numerusform>
         </translation>
@@ -354,19 +354,12 @@
             <numerusform>Contains %n accounts with Keycard incompatible derivation paths</numerusform>
         </translation>
     </message>
-    <message numerus="yes">
-        <source>Active Account(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
 </context>
 <context>
     <name>KeycardProgressState</name>
     <message numerus="yes">
         <source>%n attempt(s) remaining</source>
-        <translation type="unfinished">
+        <translation>
             <numerusform>%n attempt remaining</numerusform>
             <numerusform>%n attempts remaining</numerusform>
         </translation>
@@ -430,9 +423,9 @@
     <name>LoginKeycardBox</name>
     <message numerus="yes">
         <source>PIN incorrect. %n attempt(s) remaining.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>PIN incorrect. %n attempt remaining.</numerusform>
+            <numerusform>PIN incorrect. %n attempts remaining.</numerusform>
         </translation>
     </message>
 </context>
@@ -506,10 +499,10 @@
 <context>
     <name>NewMessagesMarker</name>
     <message numerus="yes">
-        <source>%n missed message(s) since %1</source>
+        <source>%n unread message(s) since %1</source>
         <translation>
-            <numerusform>%n missed message since %1</numerusform>
-            <numerusform>%n missed message since %1</numerusform>
+            <numerusform>%n unread message since %1</numerusform>
+            <numerusform>%n unread messages since %1</numerusform>
         </translation>
     </message>
 </context>
@@ -665,16 +658,9 @@
     <name>StatusChatInputNew</name>
     <message numerus="yes">
         <source>%n Image(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>Maximum message character count is %n</source>
-        <translation type="unfinished">
-            <numerusform>Maximum message character count is %n</numerusform>
-            <numerusform>Maximum message character count is %n</numerusform>
+        <translation>
+            <numerusform>%n Image</numerusform>
+            <numerusform>%n Images</numerusform>
         </translation>
     </message>
 </context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -8951,12 +8951,9 @@ Are you sure you want to do this?</source>
             <numerusform>Contiene %n cuentas con rutas de derivación incompatibles con Keycard</numerusform>
         </translation>
     </message>
-    <message numerus="yes">
-        <source>Active Account(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+    <message>
+        <source>Active Accounts</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11626,15 +11623,15 @@ al cargar</translation>
 <context>
     <name>NewMessagesMarker</name>
     <message>
-        <source>NEW</source>
-        <comment>new message(s)</comment>
-        <translation>NUEVO</translation>
+        <source>UNREAD</source>
+        <comment>unread message(s)</comment>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%n missed message(s) since %1</source>
-        <translation>
-            <numerusform>%n mensaje sin leer desde %1</numerusform>
-            <numerusform>%n mensajes sin leer desde %1</numerusform>
+        <source>%n unread message(s) since %1</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -15573,12 +15570,9 @@ al cargar</translation>
         <source>Please reduce the message length</source>
         <translation type="unfinished">Por favor reduce la longitud del mensaje</translation>
     </message>
-    <message numerus="yes">
-        <source>Maximum message character count is %n</source>
-        <translation type="unfinished">
-            <numerusform>El conteo máximo de caracteres del mensaje es %n</numerusform>
-            <numerusform>El conteo máximo de caracteres del mensaje es %n</numerusform>
-        </translation>
+    <message>
+        <source>Maximum message character count is %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Multiple payment requests</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -8913,11 +8913,9 @@ Are you sure you want to do this?</source>
             <numerusform>Keycard와 호환되지 않는 파생 경로가 있는 계정 %n개 포함</numerusform>
         </translation>
     </message>
-    <message numerus="yes">
-        <source>Active Account(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
+    <message>
+        <source>Active Accounts</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11570,16 +11568,16 @@ to load</source>
 </context>
 <context>
     <name>NewMessagesMarker</name>
-    <message numerus="yes">
-        <source>%n missed message(s) since %1</source>
-        <translation>
-            <numerusform>%n개의 놓친 메시지, %1 이후</numerusform>
-        </translation>
-    </message>
     <message>
-        <source>NEW</source>
-        <comment>new message(s)</comment>
-        <translation>새로 만들기</translation>
+        <source>UNREAD</source>
+        <comment>unread message(s)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n unread message(s) since %1</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -15500,11 +15498,9 @@ to load</source>
         <source>Please reduce the message length</source>
         <translation type="unfinished">메시지 길이를 줄여 주세요</translation>
     </message>
-    <message numerus="yes">
-        <source>Maximum message character count is %n</source>
-        <translation type="unfinished">
-            <numerusform>최대 메시지 글자 수는 %n자입니다</numerusform>
-        </translation>
+    <message>
+        <source>Maximum message character count is %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Multiple payment requests</source>

--- a/ui/imports/shared/popups/keycard_new/helpers/KeyPairItem.qml
+++ b/ui/imports/shared/popups/keycard_new/helpers/KeyPairItem.qml
@@ -85,7 +85,7 @@ Rectangle {
             Layout.alignment: Qt.AlignLeft
             Layout.topMargin: !keypairInfo.visible? Theme.xlPadding : 0
             visible: !root.isKnownKeyPair
-            text: qsTr("Active Account(s)", "", Math.max(0, root.keyPairAccounts? root.keyPairAccounts.length : 0))
+            text: qsTr("Active Accounts")
             color: Theme.palette.baseColor1
             wrapMode: Text.WordWrap
         }

--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -624,7 +624,7 @@ Control {
             StatusQ.StatusToolTip {
                 id: lengthLimitTooltip
                 text: messageInputField.length >= root.messageLimitHard ? qsTr("Please reduce the message length")
-                      : qsTr("Maximum message character count is %n", "", root.messageLimit)
+                      : qsTr("Maximum message character count is %1").arg(root.messageLimit)
                 orientation: StatusQ.StatusToolTip.Orientation.Top
                 timeout: 3000 // show for 3 seconds
             }

--- a/ui/imports/shared/status/StatusChatInputSendButton.qml
+++ b/ui/imports/shared/status/StatusChatInputSendButton.qml
@@ -132,7 +132,7 @@ Control {
 
                 anchors.centerIn: parent
 
-                icon: "chat/up"
+                icon: "send"
                 color: Theme.palette.baseColor3
             }
 

--- a/ui/imports/shared/views/chat/NewMessagesMarker.qml
+++ b/ui/imports/shared/views/chat/NewMessagesMarker.qml
@@ -56,7 +56,7 @@ Item {
         StatusBaseText {
             id: newLabel
             anchors.centerIn: parent
-            text: qsTr("NEW", "new message(s)")
+            text: qsTr("UNREAD", "unread message(s)")
             color: Theme.palette.indirectColor1
             font.weight: Font.DemiBold
             font.pixelSize: Theme.fontSize(11)
@@ -73,8 +73,7 @@ Item {
         anchors.leftMargin: d.horizontalPadding + d.minimumLineWidth + d.internalPadding
         anchors.rightMargin: d.minimumLineWidth + d.internalPadding
 
-        text: qsTr("%n missed message(s) since %1", "", count).arg(
-                  LocaleUtils.formatDate(timestamp))
+        text: qsTr("%n unread message(s) since %1", "", root.count).arg(LocaleUtils.formatDate(root.timestamp))
         color: Theme.palette.primaryColor1
         font.weight: Font.Bold
         font.pixelSize: Theme.additionalTextSize


### PR DESCRIPTION
### What does the PR do

Separate commits to fix:
- StatusChatInputSendButton: use a dedicated "send" icon (Fixes https://github.com/status-im/status-app/issues/20821)
- ChatAnchorButtonsPanel: fix bg radius and display the unread count
- NewMessagesMarker: replace MISSED/NEW with UNREAD (Fixes https://github.com/status-im/status-app/issues/20846)
- TS files updates and fixes (mostly wrong/incorrect plurals)

### Affected areas

Chat

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

New messages marker:
<img width="3102" height="2062" alt="Snímek obrazovky z 2026-06-24 15-05-26" src="https://github.com/user-attachments/assets/3ba70195-f8c6-4645-920a-38c03faf1ae8" />

Chat anchor button with the actual new/unread message count number:
<img width="3102" height="2062" alt="Snímek obrazovky z 2026-06-24 15-07-29" src="https://github.com/user-attachments/assets/e3032b26-25c4-4171-b960-9c28e7335c97" />

### Impact on end user

Better Chat UI/UX

### How to test

- check new/unread/messages

### Risk 

low
