### PR TITLE
fix: align on icons being used for authentication/signing

### DIFF
--- a/storybook/pages/DAppSignRequestModalPage.qml
+++ b/storybook/pages/DAppSignRequestModalPage.qml
@@ -30,7 +30,8 @@ SplitView {
         DAppSignRequestModal {
             id: dappSignRequestModal
 
-            loginType: loginType.currentValue
+            keyUid: ""
+            migratedToColdWallet: loginTypeCombo.currentText === "Keycard"
             formatBigNumber: (number, symbol, noSymbolOption) => parseFloat(number).toLocaleString(Qt.locale(), 'f', 2)
                              + (noSymbolOption ? "" : " " + (symbol || Qt.locale().currencySymbol(Locale.CurrencyIsoCode)))
 
@@ -121,11 +122,17 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Fusce nibh. Etiam quis
             }
             ComboBox {
                 Layout.fillWidth: true
-                id: loginType
-                model: [{name: "Password", value: Constants.LoginType.Password}, {name: "Biometrics", value: Constants.LoginType.Biometrics}, {name: "Keycard", value: Constants.LoginType.Keycard}]
-                textRole: "name"
-                valueRole: "value"
+                id: loginTypeCombo
+                model: ["Password", "Biometrics", "Keycard"]
                 currentIndex: 0
+            }
+            // The auth/sign icon is resolved from userProfile via Utils.resolveAuthSignIcon,
+            // so drive the mock profile's biometric flag from the selector above.
+            Binding {
+                target: userProfile
+                property: "usingBiometricLogin"
+                value: loginTypeCombo.currentText === "Biometrics"
+                restoreMode: Binding.RestoreBindingOrValue
             }
             ComboBox {
                 Layout.fillWidth: true

--- a/storybook/pages/DAppsWorkflowPage.qml
+++ b/storybook/pages/DAppsWorkflowPage.qml
@@ -85,7 +85,6 @@ Item {
                     enabled: dappsService.isServiceOnline
 
                     readonly property var wcService: dappsService
-                    loginType: Constants.LoginType.Biometrics
                     selectedAccountAddress: ""
 
                     dAppsModel: wcService.dappsModel

--- a/storybook/pages/SendSignModalPage.qml
+++ b/storybook/pages/SendSignModalPage.qml
@@ -226,7 +226,8 @@ SplitView {
                     collectibleFallbackImageUrl:!!collectibleComboBox.currentCollectible ?
                                                     collectibleComboBox.currentCollectible.imageUrl : ""
 
-                    loginType: ctrlLoginType.currentIndex
+                    keyUid: ""
+                    migratedToColdWallet: ctrlLoginType.currentText === "Keycard"
 
                     feesLoading: ctrlLoading.checked
 
@@ -343,7 +344,15 @@ SplitView {
             ComboBox {
                 Layout.fillWidth: true
                 id: ctrlLoginType
-                model: Constants.authenticationIconByType
+                model: ["Password", "Biometrics", "Keycard"]
+            }
+            // The auth/sign icon is resolved from userProfile via Utils.resolveAuthSignIcon,
+            // so drive the mock profile's biometric flag from the selector above.
+            Binding {
+                target: userProfile
+                property: "usingBiometricLogin"
+                value: ctrlLoginType.currentText === "Biometrics"
+                restoreMode: Binding.RestoreBindingOrValue
             }
 
             TextField {

--- a/storybook/pages/SwapApproveCapModalPage.qml
+++ b/storybook/pages/SwapApproveCapModalPage.qml
@@ -100,7 +100,8 @@ SplitView {
                     cryptoFees: formatBigNumber("0.001", "ETH")
                     estimatedTime: ctrlEstimatedTime.currentValue
 
-                    loginType: ctrlLoginType.currentIndex
+                    keyUid: ""
+                    migratedToColdWallet: ctrlLoginType.currentText === "Keycard"
 
                     feesLoading: ctrlLoading.checked
 
@@ -165,7 +166,15 @@ SplitView {
             }
             ComboBox {
                 id: ctrlLoginType
-                model: Constants.authenticationIconByType
+                model: ["Password", "Biometrics", "Keycard"]
+            }
+            // The auth/sign icon is resolved from userProfile via Utils.resolveAuthSignIcon,
+            // so drive the mock profile's biometric flag from the selector above.
+            Binding {
+                target: userProfile
+                property: "usingBiometricLogin"
+                value: ctrlLoginType.currentText === "Biometrics"
+                restoreMode: Binding.RestoreBindingOrValue
             }
 
             Text {

--- a/storybook/pages/SwapModalPage.qml
+++ b/storybook/pages/SwapModalPage.qml
@@ -176,7 +176,6 @@ SplitView {
                 destroyOnClose: true
                 swapInputParamsForm: adaptor.swapFormData
                 swapAdaptor: adaptor
-                loginType: Constants.LoginType.Password
                 Binding {
                     target: swapInputParamsForm
                     property: "fromTokensKey"

--- a/storybook/pages/SwapSignModalPage.qml
+++ b/storybook/pages/SwapSignModalPage.qml
@@ -117,7 +117,8 @@ SplitView {
                     cryptoFees: formatBigNumber(0.06, "ETH")
                     slippage: 0.5
 
-                    loginType: ctrlLoginType.currentIndex
+                    keyUid: ""
+                    migratedToColdWallet: ctrlLoginType.currentText === "Keycard"
 
                     feesLoading: ctrlLoading.checked
 
@@ -208,7 +209,15 @@ SplitView {
             ComboBox {
                 Layout.fillWidth: true
                 id: ctrlLoginType
-                model: Constants.authenticationIconByType
+                model: ["Password", "Biometrics", "Keycard"]
+            }
+            // The auth/sign icon is resolved from userProfile via Utils.resolveAuthSignIcon,
+            // so drive the mock profile's biometric flag from the selector above.
+            Binding {
+                target: userProfile
+                property: "usingBiometricLogin"
+                value: ctrlLoginType.currentText === "Biometrics"
+                restoreMode: Binding.RestoreBindingOrValue
             }
 
             TextField {

--- a/storybook/qmlTests/main.cpp
+++ b/storybook/qmlTests/main.cpp
@@ -1,5 +1,12 @@
+#include <QDebug>
+#include <QDirIterator>
+#include <QQmlComponent>
+#include <QQmlContext>
 #include <QQmlEngine>
+#include <QUrl>
 #include <QtQuickTest>
+
+#include <memory>
 
 #include <StatusQ/typesregistration.h>
 
@@ -32,6 +39,30 @@ public slots:
             engine->addImportPath(path);
 
         registerStatusQTypes();
+
+        // Register the same context-property mocks the storybook app uses (e.g. userProfile),
+        // so components that read them (via Utils) behave the same under test.
+        QDirIterator mocksIt(QML_IMPORT_ROOT u"/stubs/nim/sectionmocks"_s, QDirIterator::Subdirectories);
+        while (mocksIt.hasNext()) {
+            mocksIt.next();
+            if (!mocksIt.fileInfo().isFile() || mocksIt.fileInfo().suffix() != u"qml"_s)
+                continue;
+
+            QQmlComponent component(engine, QUrl::fromLocalFile(mocksIt.filePath()));
+            if (component.status() != QQmlComponent::Ready) {
+                qWarning() << "Failed to load mock for" << mocksIt.filePath() << component.errorString();
+                continue;
+            }
+
+            auto objPtr = std::unique_ptr<QObject>(component.create());
+            if (!objPtr || !objPtr->property("contextPropertyName").isValid())
+                continue;
+
+            const auto contextPropertyName = objPtr->property("contextPropertyName").toString();
+            auto obj = objPtr.release();
+            obj->setParent(engine);
+            engine->rootContext()->setContextProperty(contextPropertyName, obj);
+        }
 
         QStandardPaths::setTestModeEnabled(true);
 

--- a/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
+++ b/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
@@ -887,7 +887,6 @@ Item {
     Component {
         id: componentUnderTest
         DAppsWorkflow {
-            loginType: Constants.LoginType.Password
             visualParent: root
             enabled: true
             dAppsModel: ListModel {}

--- a/storybook/qmlTests/tests/tst_SendSignModal.qml
+++ b/storybook/qmlTests/tests/tst_SendSignModal.qml
@@ -97,7 +97,8 @@ Item {
             cryptoFees: "0.001 ETH"
             estimatedTime: qsTr("> 5 minutes")
 
-            loginType: Constants.LoginType.Password
+            keyUid: ""
+            migratedToColdWallet: false
 
             isCollectible: false
             collectibleContractAddress: ""
@@ -143,6 +144,9 @@ Item {
             signalSpyAccepted.clear()
             signalSpyRejected.clear()
             signalSpyOpenLink.clear()
+
+            // Reset the shared userProfile mock so icon tests start from a known state
+            userProfile.usingBiometricLogin = false
         }
 
         function test_basicGeometry() {
@@ -563,23 +567,21 @@ Item {
 
         function test_loginType_data() {
             return [
-                        { tag: "password", loginType: Constants.LoginType.Password, iconName: "password" },
-                        { tag: "touchId", loginType: Constants.LoginType.Biometrics, iconName: "touch-id" },
-                        { tag: "keycard", loginType: Constants.LoginType.Keycard, iconName: "keycard" }
+                        { tag: "password", biometric: false, migrated: false, iconName: "password" },
+                        { tag: "touchId", biometric: true, migrated: false, iconName: "touch-id" },
+                        { tag: "keycard", biometric: false, migrated: true, iconName: "keycard" }
                     ]
         }
 
         function test_loginType(data) {
-            const loginType = data.loginType
-            const iconName = data.iconName
-
             verify(!!controlUnderTest)
 
-            controlUnderTest.loginType = loginType
+            userProfile.usingBiometricLogin = data.biometric
+            controlUnderTest.migratedToColdWallet = data.migrated
 
             const signButton = findChild(controlUnderTest.footer, "signButton")
             verify(!!signButton)
-            compare(signButton.icon.name, iconName)
+            compare(signButton.icon.name, data.iconName)
         }
 
         function test_loading() {

--- a/storybook/qmlTests/tests/tst_SwapApproveCapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapApproveCapModal.qml
@@ -44,7 +44,8 @@ Item {
             cryptoFees: "0.001 ETH"
             estimatedTime: Constants.TransactionEstimatedTime.Unknown
 
-            loginType: Constants.LoginType.Password
+            keyUid: ""
+            migratedToColdWallet: false
         }
     }
 
@@ -76,6 +77,9 @@ Item {
 
             signalSpyAccepted.clear()
             signalSpyRejected.clear()
+
+            // Reset the shared userProfile mock so icon tests start from a known state
+            userProfile.usingBiometricLogin = false
         }
 
         function test_basicGeometry() {
@@ -201,23 +205,21 @@ Item {
 
         function test_loginType_data() {
             return [
-                { tag: "password", loginType: Constants.LoginType.Password, iconName: "password" },
-                { tag: "touchId", loginType: Constants.LoginType.Biometrics, iconName: "touch-id" },
-                { tag: "keycard", loginType: Constants.LoginType.Keycard, iconName: "keycard" }
+                { tag: "password", biometric: false, migrated: false, iconName: "password" },
+                { tag: "touchId", biometric: true, migrated: false, iconName: "touch-id" },
+                { tag: "keycard", biometric: false, migrated: true, iconName: "keycard" }
             ]
         }
 
         function test_loginType(data) {
-            const loginType = data.loginType
-            const iconName = data.iconName
-
             verify(!!controlUnderTest)
 
-            controlUnderTest.loginType = loginType
+            userProfile.usingBiometricLogin = data.biometric
+            controlUnderTest.migratedToColdWallet = data.migrated
 
             const signButton = findChild(controlUnderTest.footer, "signButton")
             verify(!!signButton)
-            compare(signButton.icon.name, iconName)
+            compare(signButton.icon.name, data.iconName)
         }
 
         function test_loading() {

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -81,7 +81,6 @@ Item {
         SwapModal {
             swapInputParamsForm: root.swapFormData
             swapAdaptor: root.swapAdaptor
-            loginType: Constants.LoginType.Password
             buyEnabled: true
         }
     }

--- a/storybook/qmlTests/tests/tst_SwapSignModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapSignModal.qml
@@ -51,7 +51,8 @@ Item {
             cryptoFees: "0.001 ETH"
             slippage: 0.2
 
-            loginType: Constants.LoginType.Password
+            keyUid: ""
+            migratedToColdWallet: false
         }
     }
 
@@ -83,6 +84,9 @@ Item {
 
             signalSpyAccepted.clear()
             signalSpyRejected.clear()
+
+            // Reset the shared userProfile mock so icon tests start from a known state
+            userProfile.usingBiometricLogin = false
         }
 
         function test_basicGeometry() {
@@ -186,23 +190,21 @@ Item {
 
         function test_loginType_data() {
             return [
-                { tag: "password", loginType: Constants.LoginType.Password, iconName: "password" },
-                { tag: "touchId", loginType: Constants.LoginType.Biometrics, iconName: "touch-id" },
-                { tag: "keycard", loginType: Constants.LoginType.Keycard, iconName: "keycard" }
+                { tag: "password", biometric: false, migrated: false, iconName: "password" },
+                { tag: "touchId", biometric: true, migrated: false, iconName: "touch-id" },
+                { tag: "keycard", biometric: false, migrated: true, iconName: "keycard" }
             ]
         }
 
         function test_loginType(data) {
-            const loginType = data.loginType
-            const iconName = data.iconName
-
             verify(!!controlUnderTest)
 
-            controlUnderTest.loginType = loginType
+            userProfile.usingBiometricLogin = data.biometric
+            controlUnderTest.migratedToColdWallet = data.migrated
 
             const signButton = findChild(controlUnderTest.footer, "signButton")
             verify(!!signButton)
-            compare(signButton.icon.name, iconName)
+            compare(signButton.icon.name, data.iconName)
         }
 
         function test_loading() {

--- a/storybook/stubs/nim/sectionmocks/UserProfile.qml
+++ b/storybook/stubs/nim/sectionmocks/UserProfile.qml
@@ -5,4 +5,7 @@ QtObject {
     readonly property string contextPropertyName: "userProfile"
 
     property string pubKey: "0xdeadbeef"
+    property string keyUid: "0xprofilekeyuid"
+    property bool usingBiometricLogin: false
+    property bool migratedToColdWallet: false
 }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -344,7 +344,6 @@ QtObject {
 
     property bool isDebugEnabled: advancedModule ? advancedModule.isDebugEnabled : false
 
-    readonly property int loginType: getLoginType()
 
     property string name: d.userProfileInst.name
 
@@ -568,16 +567,6 @@ QtObject {
         return profileSectionModule.ensUsernamesModule.getEtherscanTxLink()
     }
 
-    function getLoginType() {
-        if(!d.userProfileInst)
-            return Constants.LoginType.Password
-
-        if(d.userProfileInst.usingBiometricLogin)
-            return Constants.LoginType.Biometrics
-        if(d.userProfileInst.migratedToColdWallet)
-            return Constants.LoginType.Keycard
-        return Constants.LoginType.Password
-    }
 
     readonly property Connections communitiesModuleConnections: Connections {
       target: communitiesModuleInst

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -74,7 +74,7 @@ StackView {
     // Models:
     property var tokensModel
     property var membersModel
-    property var accounts // Expected roles: address, name, color, emoji, walletType
+    property var accounts // Expected roles: address, name, color, emoji, walletType, keyUid, migratedToColdWallet
     required property var referenceTokenGroupsModel
 
     signal mintCollectible(var collectibleItem)
@@ -325,6 +325,10 @@ StackView {
                                                                         "address",
                                                                         editOwnerTokenView.ownerToken.accountAddress,
                                                                         "migratedToColdWallet")
+                    keyUid: SQUtils.ModelUtils.getByKey(root.accounts,
+                                                        "address",
+                                                        editOwnerTokenView.ownerToken.accountAddress,
+                                                        "keyUid") ?? ""
 
                     model: QtObject {
                         readonly property string title: editOwnerTokenView.feeLabel
@@ -551,6 +555,11 @@ StackView {
                                               "address",
                                               preview.token.accountAddress,
                                               "migratedToColdWallet")
+                    keyUid: SQUtils.ModelUtils.getByKey(
+                                root.accounts,
+                                "address",
+                                preview.token.accountAddress,
+                                "keyUid") ?? ""
 
                     model: QtObject {
                         readonly property string title: preview.feeLabel
@@ -761,6 +770,10 @@ StackView {
                                                                         "address",
                                                                         tokenMasterActionPopup.selectedAccount,
                                                                         "migratedToColdWallet")
+                    keyUid: SQUtils.ModelUtils.getByKey(root.accounts,
+                                                        "address",
+                                                        tokenMasterActionPopup.selectedAccount,
+                                                        "keyUid") ?? ""
 
                     model: QtObject {
                         readonly property string title: tokenMasterActionPopup.feeLabel
@@ -1017,6 +1030,10 @@ StackView {
                                                                     "address",
                                                                     footer.accountAddress,
                                                                     "migratedToColdWallet")
+                keyUid: SQUtils.ModelUtils.getByKey(root.accounts,
+                                                    "address",
+                                                    footer.accountAddress,
+                                                    "keyUid") ?? ""
 
                 totalFeeText: isRemotelyDestructTransaction
                               ? remotelyDestructPopup.feeText

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesSigningPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesSigningPanel.qml
@@ -79,15 +79,9 @@ ColumnLayout {
                     objectName: "signKeyPairButton"
                     text: qsTr("Sign")
                     visible: !model.keyPair.ownershipVerified
-                    icon.name: {
-                        if (userProfile.keyUid !== kpDelegate.keyPairKeyUid && kpDelegate.migratedToColdWallet)
-                            return "keycard"
-                        if (userProfile.usingBiometricLogin)
-                            return "touch-id"
-                        if (userProfile.migratedToColdWallet)
-                            return "keycard"
-                        return "password"
-                    }
+                    icon.name: Utils.resolveAuthSignIcon(kpDelegate.keyPairKeyUid,
+                                                         kpDelegate.migratedToColdWallet,
+                                                         Constants.AuthSignPurpose.General)
 
                     onClicked: {
                         root.signSharedAddressesForKeypair(model.keyPair.keyUid)

--- a/ui/app/AppLayouts/Communities/popups/SignTransactionsPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/SignTransactionsPopup.qml
@@ -24,6 +24,7 @@ StatusDialog {
     property alias totalFeeText: footer.totalFeeText
     property alias accountName: footer.accountName
 
+    property string keyUid: ""
     property bool migratedToColdWallet: false
 
     signal signTransactionClicked()
@@ -62,7 +63,7 @@ StatusDialog {
             StatusButton {
                 objectName: "signTransactionButton"
                 enabled: root.errorText === "" && !root.isFeeLoading
-                icon.name: root.migratedToColdWallet ? "keycard" : "password"
+                icon.name: Utils.resolveAuthSignIcon(root.keyUid, root.migratedToColdWallet, Constants.AuthSignPurpose.General)
                 text: qsTr("Sign transaction")
                 onClicked: {
                     root.signTransactionClicked()

--- a/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
@@ -649,6 +649,7 @@ StatusScrollView {
             onClicked: {
                 feesPopup.accountAddress = feesBox.accountsSelector.currentAccountAddress
                 feesPopup.accountName = feesBox.accountsSelector.currentAccount.name ?? ""
+                feesPopup.keyUid = feesBox.accountsSelector.currentAccount.keyUid ?? ""
                 feesPopup.migratedToColdWallet = feesBox.accountsSelector.currentAccount.migratedToColdWallet ?? false
                 feesPopup.open()
             }

--- a/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
+++ b/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
@@ -23,7 +23,8 @@ import utils
 StatusDialog {
     id: root
 
-    required property int loginType // RootStore.loginType -> Constants.LoginType enum
+    required property string keyUid
+    required property bool migratedToColdWallet
 
     /**
       Format a currency amount, represented as a float `number` as a string, e.g. "1.234",
@@ -69,7 +70,7 @@ StatusDialog {
                 id: signButton
                 interactive: !root.feesLoading && root.signButtonEnabled
                 visible: !root.hasExpiryDate || !countdownPill.isExpired
-                icon.name: Constants.authenticationIconByType[root.loginType]
+                icon.name: Utils.resolveAuthSignIcon(root.keyUid, root.migratedToColdWallet, Constants.AuthSignPurpose.General)
                 disabledColor: Theme.palette.directColor8
                 text: root.signButtonText
                 onClicked: root.accept() // close and emit accepted() signal

--- a/ui/app/AppLayouts/Wallet/popups/dapps/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/popups/dapps/DAppsWorkflow.qml
@@ -31,8 +31,6 @@ SQUtils.QObject {
     required property Item visualParent
     // Whether the dapps can interract with the wallet
     required property bool enabled
-    // Values mapped to Constants.LoginType
-    required property int loginType
     /*
         Accounts model
 
@@ -375,6 +373,7 @@ SQUtils.QObject {
                 address: "",
                 emoji: "",
                 colorId: 0,
+                keyUid: "",
                 migratedToColdWallet: false
             }
 
@@ -395,7 +394,8 @@ SQUtils.QObject {
 
             parent: root.visualParent
 
-            loginType: account.migratedToColdWallet ? Constants.LoginType.Keycard : root.loginType
+            keyUid: account.keyUid
+            migratedToColdWallet: account.migratedToColdWallet
             formatBigNumber: root.formatBigNumber
 
             visible: !!request.dappUrl

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -32,7 +32,6 @@ StatusDialog {
     parameters to the modal when being launched from elsewhere */
     required property SwapInputParamsForm swapInputParamsForm
     required property SwapModalAdaptor swapAdaptor
-    required property int loginType
 
     /** input property to indicate if buy action is enabled **/
     property bool buyEnabled
@@ -550,8 +549,9 @@ StatusDialog {
                     objectName: "signButton"
                     readonly property string fromTokenSymbol: !!root.swapAdaptor.fromToken ? root.swapAdaptor.fromToken.symbol ?? "" : ""
                     loadingWithText: root.swapAdaptor.approvalPending
-                    icon.name: !!d.selectedAccount && d.selectedAccount.migratedToColdWallet ? Constants.authenticationIconByType[Constants.LoginType.Keycard]
-                                                                                  : Constants.authenticationIconByType[root.loginType]
+                    icon.name: Utils.resolveAuthSignIcon(!!d.selectedAccount ? d.selectedAccount.keyUid : "",
+                                                         !!d.selectedAccount && d.selectedAccount.migratedToColdWallet,
+                                                         Constants.AuthSignPurpose.General)
                     text: {
                         if(root.swapAdaptor.validSwapProposalReceived) {
                             if(root.swapAdaptor.swapOutputData.approvalNeeded) {
@@ -601,7 +601,8 @@ StatusDialog {
 
             formatBigNumber: (number, symbol, noSymbolOption) => root.swapAdaptor.currencyStore.formatBigNumber(number, symbol, noSymbolOption)
 
-            loginType: !!d.selectedAccount && d.selectedAccount.migratedToColdWallet ? Constants.LoginType.Keycard : root.loginType
+            keyUid: !!d.selectedAccount ? d.selectedAccount.keyUid : ""
+            migratedToColdWallet: !!d.selectedAccount && d.selectedAccount.migratedToColdWallet
             feesLoading: root.swapAdaptor.swapProposalLoading
 
             fromTokenSymbol: root.swapAdaptor.fromToken.symbol
@@ -655,7 +656,8 @@ StatusDialog {
 
             formatBigNumber: (number, symbol, noSymbolOption) => root.swapAdaptor.currencyStore.formatBigNumber(number, symbol, noSymbolOption)
 
-            loginType: !!d.selectedAccount && d.selectedAccount.migratedToColdWallet ? Constants.LoginType.Keycard : root.loginType
+            keyUid: !!d.selectedAccount ? d.selectedAccount.keyUid : ""
+            migratedToColdWallet: !!d.selectedAccount && d.selectedAccount.migratedToColdWallet
             feesLoading: root.swapAdaptor.swapProposalLoading
 
             fromTokenSymbol: root.swapAdaptor.fromToken.symbol

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -258,18 +258,6 @@ QtObject {
     signal showToastPairingFallbackCompleted()
     // End of Settings related stuff
 
-    // Onboarding related properties and functions that shall be moved to `OnboardingRootStore`
-    readonly property int loginType: getLoginType()
-    function getLoginType() {
-        if(!d.userProfileInst)
-            return Constants.LoginType.Password
-
-        if(d.userProfileInst.usingBiometricLogin)
-            return Constants.LoginType.Biometrics
-        if(d.userProfileInst.migratedToColdWallet)
-            return Constants.LoginType.Keycard
-        return Constants.LoginType.Password
-    }
     // End of Onboarding related stuff
 
     // Chat related properties and functions that shall be moved to `ChatRootStore`

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2821,7 +2821,6 @@ Item {
 
                 enabled: dAppsService.isServiceOnline
                 visualParent: appMain
-                loginType: appMain.rootStore.getLoginType()
                 selectedAccountAddress: appMain.walletRootStore.selectedAddress
                 dAppsModel: dAppsService.dappsModel
                 accountsModel: appMain.walletRootStore.nonWatchAccounts

--- a/ui/app/mainui/Handlers/HandlersManager.qml
+++ b/ui/app/mainui/Handlers/HandlersManager.qml
@@ -95,7 +95,6 @@ QtObject {
 
         popupParent: root.popupParent
 
-        fnGetLoginType: root.rootStore.getLoginType
         transactionStore: root.transactionStore
         walletCollectiblesStore: root.walletCollectiblesStore
         transactionStoreNew: root.transactionStoreNew

--- a/ui/app/mainui/Handlers/SendModalHandler.qml
+++ b/ui/app/mainui/Handlers/SendModalHandler.qml
@@ -30,7 +30,6 @@ QtObject {
     required property WalletStores.TransactionStoreNew transactionStoreNew
     required property SharedStores.NetworksStore networksStore
     required property SharedStores.NetworkConnectionStore networkConnectionStore
-    property var fnGetLoginType: function() {}
 
     /** for ens flows **/
     required property string myPublicKey
@@ -998,7 +997,8 @@ QtObject {
                         return WalletUtils.formatEstimatedTime(0)
                     }
 
-                    loginType: root.fnGetLoginType()
+                    keyUid: signSendAdaptor.selectedAccount.keyUid
+                    migratedToColdWallet: signSendAdaptor.selectedAccount.migratedToColdWallet
 
                     isCollectible: simpleSendModal.sendType === Constants.SendType.ERC1155Transfer ||
                                    simpleSendModal.sendType === Constants.SendType.ERC721Transfer

--- a/ui/app/mainui/Handlers/SwapModalHandler.qml
+++ b/ui/app/mainui/Handlers/SwapModalHandler.qml
@@ -98,7 +98,6 @@ QtObject {
                 }
             }
             swapInputParamsForm: d.swapInputParams
-            loginType: root.rootStore.getLoginType()
             onClosed: {
                 destroy()
                 swapInputParamsForm.resetFormData()

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -1397,6 +1397,10 @@ QtObject {
                                                                         "address",
                                                                         finalisePopup.selectedAccountAddress,
                                                                         "migratedToColdWallet")
+                    keyUid: SQUtils.ModelUtils.getByKey(root.rootStore.walletAccountsModel,
+                                                        "address",
+                                                        finalisePopup.selectedAccountAddress,
+                                                        "keyUid") ?? ""
 
                     model: QtObject {
                         readonly property string title: finalisePopup.feeLabel

--- a/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
+++ b/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
@@ -302,17 +302,10 @@ StatusModal {
                     return ""
                 }
 
-                // Cold wallet keypairs derive from the stored xpub, so no authentication is required
-                if (root.store.selectedOrigin.migratedToColdWallet) {
-                    return ""
-                }
-
-                if (root.store.selectedOrigin.keyUid === root.store.userProfileKeyUid &&
-                        root.store.userProfileUsingBiometricLogin) {
-                    return "touch-id"
-                }
-
-                return "password"
+                return Utils.resolveAuthSignIcon(root.store.selectedOrigin.keyUid,
+                                                 root.store.selectedOrigin.migratedToColdWallet,
+                                                 Constants.AuthSignPurpose.AddAccount
+                                                 )
             }
 
             onClicked: {

--- a/ui/imports/shared/popups/addaccount/panels/DerivationPathSection.qml
+++ b/ui/imports/shared/popups/addaccount/panels/DerivationPathSection.qml
@@ -55,22 +55,10 @@ Column {
             visible: !root.store.addAccountModule.actionAuthenticated
             text: qsTr("Edit")
 
-            icon.name: {
-                // Cold wallet keypairs derive from the stored xpub, so no authentication is required
-                if (root.store.selectedOrigin.migratedToColdWallet) {
-                    return ""
-                }
-
-                if (root.store.userProfileUsingBiometricLogin) {
-                    return "touch-id"
-                }
-
-                if (root.store.userProfileMigratedToColdWallet) {
-                    return "keycard"
-                }
-
-                return "password"
-            }
+            icon.name: Utils.resolveAuthSignIcon(root.store.selectedOrigin.keyUid,
+                                                 root.store.selectedOrigin.migratedToColdWallet,
+                                                 Constants.AuthSignPurpose.AddAccountCustomPath
+                                                 )
 
             onClicked: {
                 root.store.authenticateForEditingDerivationPath()

--- a/ui/imports/shared/popups/addaccount/stores/AddAccountStore.qml
+++ b/ui/imports/shared/popups/addaccount/stores/AddAccountStore.qml
@@ -14,8 +14,6 @@ BasePopupStore {
 
     property string userProfilePublicKey: userProfile.pubKey
     property string userProfileKeyUid: userProfile.keyUid
-    property bool userProfileMigratedToColdWallet: userProfile.migratedToColdWallet
-    property bool userProfileUsingBiometricLogin: userProfile.usingBiometricLogin
 
     // Module Properties
     property var currentState: root.addAccountModule.currentState

--- a/ui/imports/shared/popups/keypairimport/KeypairImportPopup.qml
+++ b/ui/imports/shared/popups/keypairimport/KeypairImportPopup.qml
@@ -189,15 +189,7 @@ StatusModal {
                     return ""
                 }
 
-                if (root.store.userProfileUsingBiometricLogin) {
-                    return "touch-id"
-                }
-
-                if (root.store.userProfileMigratedToColdWallet) {
-                    return "keycard"
-                }
-
-                return "password"
+                return Utils.resolveAuthSignIcon("", false, Constants.AuthSignPurpose.General)
             }
 
             onClicked: {

--- a/ui/imports/shared/popups/keypairimport/stores/KeypairImportStore.qml
+++ b/ui/imports/shared/popups/keypairimport/stores/KeypairImportStore.qml
@@ -11,8 +11,6 @@ BasePopupStore {
     isAddAccountPopup: false
     required property var keypairImportModule
 
-    property bool userProfileMigratedToColdWallet: userProfile.migratedToColdWallet
-    property bool userProfileUsingBiometricLogin: userProfile.usingBiometricLogin
     property bool syncViaQr: true
 
     // Module Properties

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1140,17 +1140,11 @@ QtObject {
         readonly property string failed: "Failed"
     }
 
-    enum LoginType {
-        Password,
-        Biometrics,
-        Keycard
+    enum AuthSignPurpose {
+        General,
+        AddAccount,
+        AddAccountCustomPath
     }
-    // Needs to match the enum above
-    readonly property var authenticationIconByType: [
-        "password",
-        "touch-id",
-        "keycard",
-    ]
 
     enum ComputeFeeErrorCode {
         Success,

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -1148,6 +1148,41 @@ QtObject {
     property var sharedUrlsModuleInst: typeof  sharedUrlsModule !== "undefined" ? sharedUrlsModule : null
     property var globalUtilsInst: typeof globalUtils !== "undefined" ? globalUtils : null
     property var communitiesModuleInst: typeof communitiesModule !== "undefined" ? communitiesModule : null
+    property var userProfileInst: typeof userProfile !== "undefined" ? userProfile : null
+
+    // Returns icon for the passed keyUid and migratedToColdWallet params of the key pair being processed and authSignPurpose
+    function resolveAuthSignIcon(keyUid, migratedToColdWallet, authSignPurpose) {
+        const profile = userProfileInst
+
+        if (!profile) {
+            console.error("profile is not set yet")
+            return ""
+        }
+
+        // Cold wallet keypairs derive from the stored xpub, so no authentication is required
+        if (authSignPurpose === Constants.AuthSignPurpose.AddAccount ||
+                authSignPurpose === Constants.AuthSignPurpose.AddAccountCustomPath) {
+            if (migratedToColdWallet) {
+                return ""
+            }
+        }
+
+        let useKeyUid = keyUid?? profile.keyUid
+
+        if (useKeyUid !== profile.keyUid && migratedToColdWallet) {
+            return "keycard"
+        }
+
+        if (profile.usingBiometricLogin) {
+            return "touch-id"
+        }
+
+        if (profile.migratedToColdWallet) {
+            return "keycard"
+        }
+
+        return "password"
+    }
 
     function isChatKey(value) {
         return (startsWith0x(value) && isHex(value) && value.length === 132) || globalUtilsInst.isCompressedPubKey(value)


### PR DESCRIPTION
A new `Utils.resolveAuthSignIcon` function is introduced and integrated into the current code to resolve the icon that needs to be displayed for buttons that run the authentication/signing flow.

There is also `AuthSignPurpose` type in Constants.qml that can be extended if we need some special handling in the future. 

Fixes #21331