### PR TITLE
fix(browser): wire mobile webview storage profile and bump dependency

### DIFF
--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -302,7 +302,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG 2dbf28dd6655cf0e534ded440134982cd588658e
+      GIT_TAG b1917e84037ccae2acce76a5f4f60e989a8310f5
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)

--- a/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
@@ -37,7 +37,7 @@ AbstractWebView {
         webChannel: root.webChannel
 
         offTheRecord: root.profileParams.offTheRecord
-        storageName: "Profile_" + root.profileParams.userId
+        storageName: root.profileParams.storageName
         // TODO(mobile): profileParams.userAgent is not applied — no native backend API.
     }
 

--- a/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
@@ -5,8 +5,6 @@ import StatusQ.CustomWebView 1.0
 AbstractWebView {
     id: root
 
-    readonly property bool offTheRecord: false
-
     property alias url: backend.url
     readonly property alias loading: backend.loading
     readonly property alias title: backend.title
@@ -26,7 +24,7 @@ AbstractWebView {
     supportsZoom: true
     supportsDevTools: false
     supportsFindInPage: backend.findSupported
-    supportsIncognito: false
+    supportsIncognito: true
     supportsHistory: true
     hasNativeFindPanel: backend.hasNativeFindPanel
 
@@ -37,6 +35,10 @@ AbstractWebView {
         freeze: root.freeze
         userScripts: root.profileParams.scripts
         webChannel: root.webChannel
+
+        offTheRecord: root.profileParams.offTheRecord
+        storageName: "Profile_" + root.profileParams.userId
+        // TODO(mobile): profileParams.userAgent is not applied — no native backend API.
     }
 
     Connections {

--- a/ui/app/AppLayouts/Browser/adapters/ProfileManager.qml
+++ b/ui/app/AppLayouts/Browser/adapters/ProfileManager.qml
@@ -23,10 +23,10 @@ QtObject {
         }
     }
 
-    function _getProfilePrototype(storageName, offTheRecord) {
-        const storageNameProp = offTheRecord
-            ? ""
-            : `storageName: "${storageName.replace(/"/g, '\\"')}"`
+    function _getProfilePrototype(storageName, offTheRecord, key) {
+        const storageNameProp = storageName
+            ? `storageName: "${storageName.replace(/"/g, '\\"')}"`
+            : ""
         const persistentCookiesPolicy = offTheRecord
             ? "persistentCookiesPolicy: WebEngineProfile.NoPersistentCookies"
             : ""
@@ -37,19 +37,18 @@ QtObject {
                 ${storageNameProp}
                 ${persistentCookiesPolicy}
             }
-        `, root, "ProfilePrototype_" + storageName)
+        `, root, "ProfilePrototype_" + key)
     }
 
-    function getOrCreateStorageProfile(userId, offTheRecord) {
-        const key = root._key(userId, offTheRecord)
+    function getOrCreateStorageProfile(profileParams) {
+        const key = root._key(profileParams.userId, profileParams.offTheRecord)
         let p = root.profiles[key]
 
         if (!p) {
-            const storageName = offTheRecord
-                ? ("IncognitoProfile_" + userId)
-                : ("Profile_" + userId)
-
-            const prototype = root._getProfilePrototype(storageName, offTheRecord)
+            const prototype = root._getProfilePrototype(
+                profileParams.storageName,
+                profileParams.offTheRecord,
+                key)
             p = prototype.instance()
             root.profiles[key] = p
         }
@@ -58,7 +57,7 @@ QtObject {
     }
 
     function getProfile(profileParams) {
-        return getOrCreateStorageProfile(profileParams.userId, profileParams.offTheRecord)
+        return getOrCreateStorageProfile(profileParams)
     }
 
     function scriptListForParams(profileParams) {

--- a/ui/app/AppLayouts/Browser/adapters/ProfileParams.qml
+++ b/ui/app/AppLayouts/Browser/adapters/ProfileParams.qml
@@ -7,4 +7,6 @@ QtObject {
     required property string userAgent
     required property var scripts
     required property bool offTheRecord
+
+    readonly property string storageName: offTheRecord ? "" : "Profile_" + userId
 }

--- a/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
@@ -12,9 +12,7 @@ AbstractWebView {
     required property var profileManager
 
     property var profile: root.profileParams
-        ? root.profileManager.getOrCreateStorageProfile(
-              root.profileParams.userId,
-              root.profileParams.offTheRecord)
+        ? root.profileManager.getOrCreateStorageProfile(root.profileParams)
         : null
 
     // Expose internal WebEngineView properties


### PR DESCRIPTION
Connect offTheRecord and storageName from profileParams, enable incognito, and update mobilewebview to a build that supports profile-scoped storage.

mobilewebview PR: https://github.com/status-im/mobilewebview/pull/15 

fixes #21274 

<table>
  <tr>
    <th>Android</th>
    <th>iPhone</th>
  </tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/0053050d-f9e2-4545-b831-b6aded20b8b4" width="400" controls></video>
    </td>
    <td>       
<video src="https://github.com/user-attachments/assets/500b2210-b766-4be1-a2e5-8b7d59d2ad1a" width="400" controls></video>
    </td>
  </tr>
</table>




