### PR TITLE
fix(PinnedMessagesPopup): correct unpin button bg color

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -160,7 +160,7 @@ StatusDialog {
                                        case Qt.RightButton:
                                            Global.openMenu(pinnedPopupMessageContextMenuComponent, this, {
                                                                messageId: messageItem.messageId,
-                                                           })
+                                                           }, Qt.point(mouse.x, mouse.y))
                                            break
                                        case Qt.LeftButton:
                                            if (!!root.messageToPin) {
@@ -186,7 +186,7 @@ StatusDialog {
                     visible: root.isPinActionAvaliable && !root.messageToPin && (hovered || mouseArea.containsMouse)
                     icon.name: "unpin"
                     tooltip.text: qsTr("Unpin")
-                    color: hovered ? Theme.palette.primaryColor2 : Theme.palette.indirectColor1
+                    color: hovered ? Theme.palette.primaryColor2 : Theme.palette.indirectColor4
                     onClicked: {
                         root.messageStore.unpinMessage(model.id)
                     }


### PR DESCRIPTION
### What does the PR do

- also fix the context menu on mobile; needs an explicit position for touch

Fixes #20844

### Affected areas

PinnedMessagesPopup

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Hovered message:
<img width="3130" height="2080" alt="image" src="https://github.com/user-attachments/assets/0cf1711d-5159-4c46-bdb7-ff436b42e281" />

Hovered button:
<img width="3130" height="2080" alt="image" src="https://github.com/user-attachments/assets/1b69bb79-c7a3-47cd-ac97-2063f16f1a19" />

Hovered msg, light:
<img width="3130" height="2080" alt="image" src="https://github.com/user-attachments/assets/c80cd336-1d81-42dd-8b91-cdc86b79a866" />

Hovered btn, light:
<img width="3130" height="2080" alt="image" src="https://github.com/user-attachments/assets/b55a1721-84ab-4958-8141-4cf6b4e97081" />


### Impact on end user

Nicer UI in dark mode

### How to test

open the pinned msg popup

### Risk 

low
