### PR TITLE
fix: unify nim-sds path and clean shared artifacts on platform switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ vendor/.nimble
 *.AppImage
 tmp
 nimcache
+.platform-target
 .DS_Store
 nim-status-client*.tgz
 /package/

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ GIT_ROOT ?= $(shell git rev-parse --show-toplevel 2>/dev/null || echo .)
 	flatpak \
 	flatpak-install \
 	flatpak-run \
-	flatpak-clean
+	flatpak-clean \
+	platform-cleanup
 
 ifeq ($(NIM_PARAMS),)
 # "variables.mk" was not included, so we update the submodules.
@@ -278,12 +279,25 @@ ifeq ($(mkspecs),macx)
  endif
 endif
 
-NIM_SDS_SOURCE_DIR ?= $(GIT_ROOT)/../nim-sds
+NIM_SDS_SOURCE_DIR ?= $(GIT_ROOT)/vendor/nim-sds
 export NIM_SDS_SOURCE_DIR
 NIMSDS_LIBDIR := $(NIM_SDS_SOURCE_DIR)/build
 NIMSDS_LIBFILE := $(NIMSDS_LIBDIR)/libsds.$(LIB_EXT)
 NIM_EXTRA_PARAMS += --passL:"-L$(NIMSDS_LIBDIR)" --passL:"-lsds"
 STATUSGO_MAKE_PARAMS += NIM_SDS_SOURCE_DIR="$(NIM_SDS_SOURCE_DIR)"
+
+# desktop only; mobile cleanup lives in mobile/Makefile
+ifneq ($(filter $(mkspecs),macx linux),)
+PLATFORM_TARGET := $(host_os)-$(or $(QT_ARCH),$(shell uname -m))
+else ifeq ($(mkspecs),win32)
+PLATFORM_TARGET := windows-$(or $(QT_ARCH),$(shell uname -m))
+endif
+
+# Order-only prerequisite: delete shared vendor artifacts (qrcodegen, nim-sds, libstatus) when the build platform/arch changes.
+platform-cleanup:
+ifneq ($(PLATFORM_TARGET),)
+	scripts/platform_pre_build_cleanup.sh "$(PLATFORM_TARGET)"
+endif
 
 INCLUDE_DEBUG_SYMBOLS ?= false
 ifeq ($(INCLUDE_DEBUG_SYMBOLS),true)
@@ -533,7 +547,12 @@ STATUSGO := vendor/status-go/build/bin/libstatus.$(LIB_EXT)
 STATUSGO_LIBDIR := $(shell pwd)/$(shell dirname "$(STATUSGO)")
 export STATUSGO_LIBDIR
 
-$(STATUSGO): | deps status-go-deps
+# Rebuild libsds independently after platform switch cleanup deletes vendor/nim-sds/build.
+$(NIMSDS_LIBFILE): | platform-cleanup
+	echo -e $(BUILD_MSG) "nim-sds"
+	$(STATUSGO_MAKE_PARAMS) $(MAKE) -C vendor/status-go build-libsds SHELL=/bin/sh $(HANDLE_OUTPUT)
+
+$(STATUSGO): | deps status-go-deps $(NIMSDS_LIBFILE) platform-cleanup
 	echo -e $(BUILD_MSG) "status-go"
 	# FIXME: Nix shell usage breaks builds due to Glibc mismatch.
 	$(STATUSGO_MAKE_PARAMS) $(MAKE) -C vendor/status-go statusgo-shared-library SHELL=/bin/sh \
@@ -632,7 +651,7 @@ endif
 
 QRCODEGEN := vendor/QR-Code-generator/c/libqrcodegen.a
 
-$(QRCODEGEN): | deps
+$(QRCODEGEN): | deps platform-cleanup
 	echo -e $(BUILD_MSG) "QR-Code-generator"
 	+ cd vendor/QR-Code-generator/c && \
 	  $(MAKE) $(QRCODEGEN_MAKE_PARAMS) $(HANDLE_OUTPUT)
@@ -768,7 +787,11 @@ $(NIM_STATUS_CLIENT): NIM_PARAMS += $(RESOURCES_LAYOUT)
 ifneq ($(mkspecs),win32)
 $(NIM_STATUS_CLIENT): NIM_PARAMS += --passL:"$(QT_SEAQT_EXTRA_LIBS)"
 endif
-$(NIM_STATUS_CLIENT): $(NIM_SOURCES) | statusq dotherside check-qt-dir $(STATUSGO) $(STATUSKEYCARD_QT_LIB) $(QRCODEGEN) rcc deps
+# Problem: libstatus present + libsds deleted -> make never re-entered status-go,
+# so the client linked against a missing libsds and crashed in dyld at startup.
+# Solution: depend on libsds directly (order-only) so it is restored even when
+# libstatus is untouched.
+$(NIM_STATUS_CLIENT): $(NIM_SOURCES) | statusq dotherside check-qt-dir $(STATUSGO) $(NIMSDS_LIBFILE) $(STATUSKEYCARD_QT_LIB) $(QRCODEGEN) rcc deps
 	echo -e $(BUILD_MSG) "$@"
 	$(ENV_SCRIPT) nim c $(NIM_PARAMS) \
 		--mm:orc \

--- a/Makefile
+++ b/Makefile
@@ -787,10 +787,6 @@ $(NIM_STATUS_CLIENT): NIM_PARAMS += $(RESOURCES_LAYOUT)
 ifneq ($(mkspecs),win32)
 $(NIM_STATUS_CLIENT): NIM_PARAMS += --passL:"$(QT_SEAQT_EXTRA_LIBS)"
 endif
-# Problem: libstatus present + libsds deleted -> make never re-entered status-go,
-# so the client linked against a missing libsds and crashed in dyld at startup.
-# Solution: depend on libsds directly (order-only) so it is restored even when
-# libstatus is untouched.
 $(NIM_STATUS_CLIENT): $(NIM_SOURCES) | statusq dotherside check-qt-dir $(STATUSGO) $(NIMSDS_LIBFILE) $(STATUSKEYCARD_QT_LIB) $(QRCODEGEN) rcc deps
 	echo -e $(BUILD_MSG) "$@"
 	$(ENV_SCRIPT) nim c $(NIM_PARAMS) \

--- a/docs/adr/0003-platform-sentinel-ownership.md
+++ b/docs/adr/0003-platform-sentinel-ownership.md
@@ -4,128 +4,64 @@
 
 Accepted
 
-This ADR combines two platform-target-specific concerns that compose without overlap:
+Two platform-target-specific concerns that compose without overlap:
 
 - **Platform sentinel ownership** (desktop↔mobile artifact staleness) — Accepted.
-- **iOS libsds Nim-runtime symbol localization** (Nim-runtime symbol collision) — Superseded by an upstream fix in nim-sds `v0.2.5` (see [Part 2](#part-2-ios-libsds-nim-runtime-symbol-localization)).
+- **iOS libsds Nim-runtime symbol collision** — Superseded by an upstream fix in nim-sds `v0.2.5` (see [Part 2](#part-2-ios-libsds-nim-runtime-symbol-collision)).
 
 ## Part 1: Platform sentinel ownership
 
 ### Context
 
-Several third-party libraries built from `vendor/` write to **shared output paths** that are reused across desktop macOS, iOS, and Android builds in the same working tree:
+Some `vendor/` libraries write to **shared output paths** reused across desktop macOS, iOS, and Android builds in the same tree (`vendor/QR-Code-generator/c/`, `vendor/nim-sds/build/`, `vendor/status-go/build/`). Switching between `make run` (desktop) and `make mobile-run` (mobile) without cleaning them leaves stale platform-specific objects, so the link fails (`ld: building for 'iOS', but linking in object file … built for 'macOS'`) or the app crashes on mixed artifacts.
 
-- `vendor/QR-Code-generator/c/` (object files and `libqrcodegen.a` in the source tree; cleaned via `make clean`)
-- `vendor/nim-sds/build/` (whole directory: `libsds.*` plus nim-sds nimcache)
-- `vendor/status-go/build/` (whole directory: `libstatus.*`, generated bindings, etc.)
-- `nimcache/` (flat mobile nim cache at repo root plus desktop subdirs under `release/` / `debug/`)
-- `bin/libnim_status_client.*` (shared nim client static/shared library output)
-
-Switching between `make run` (desktop) and `make mobile-run` (iOS/Android) without cleaning these paths leaves stale platform-specific objects. The linker then fails (e.g. `ld: building for 'iOS', but linking in object file ... built for 'macOS'`) or the app crashes at runtime with mixed artifacts.
-
-An earlier fix added a per-artifact sentinel inside `vendor/status-go/Makefile` (`nim-sds-platform-check`, `.sds-build-id`) for libsds only. That did not cover qrcodegen or libstatus, and duplicated platform-key logic across submodules.
-
-#### Ownership of the status-go / nim-sds mobile build
-
-Issue [#18377](https://github.com/status-im/status-desktop/issues/18377) (commit `0b5f1106`) moved the status-go mobile build logic out of `mobile/scripts/buildStatusGo.sh` and into the **status-go repository**. The status-go `Makefile` now owns building both `libstatus` and `libsds` (it pins `NIM_SDS_VERSION`, clones, and builds nim-sds), exposed via the `.PHONY` targets `statusgo-ios-library` / `statusgo-android-library`.
-
-Consequently `$(STATUS_GO_LIB)` in `mobile/Makefile` must **not** re-introduce knowledge of status-go/nim-sds source files (e.g. `find`-based prerequisites): that would re-couple status-desktop to vendor internals and revert #18377. The freshness decision belongs to status-go's own (PHONY) build.
-
-The defect we hit: `$(STATUS_GO_LIB)` was a plain file target with **no prerequisites**, so once `mobile/lib/<variant>/libstatus.a` existed, Make never re-invoked the delegated sub-make. Stale copies then linked against a freshly rebuilt `libnim_status_client`, producing duplicate Nim runtime symbols and a runtime crash.
+Issue [#18377](https://github.com/status-im/status-desktop/issues/18377) moved the status-go/nim-sds mobile build into the **status-go repo** (`.PHONY` targets `statusgo-{ios,android}-library`, which own `NIM_SDS_VERSION` and the incremental-rebuild decision). status-desktop must therefore not re-introduce knowledge of status-go/nim-sds sources (e.g. `find`-based prerequisites), or it reverts #18377. But `$(STATUS_GO_LIB)` was a file target with **no prerequisites**: once it existed Make never re-ran the delegated sub-make, so stale copies linked against a fresh `libnim_status_client` and crashed.
 
 ### Decision
 
-Implement a **single umbrella platform sentinel in status-desktop**:
+A single umbrella platform sentinel in status-desktop:
 
-1. Caller Makefiles define a `.PHONY` target `platform-cleanup` that runs `scripts/platform_pre_build_cleanup.sh` with `PLATFORM_TARGET`:
-   - Root: `$(host_os)-$(QT_ARCH)` (e.g. `darwin-arm64`)
-   - Mobile: `$(OS)-$(ARCH)` (e.g. `ios-arm64`, `android-arm64`)
-2. Shared-artifact build targets (`$(NIMSDS_LIBFILE)`, `$(STATUSGO)`, `$(QRCODEGEN)` in root; `$(STATUS_GO_LIB)`, `$(QRCODEGEN_LIB)` in mobile) list `platform-cleanup` as an **order-only** prerequisite (`| platform-cleanup`), so cleanup runs before those targets are built without forcing them (or their dependents) to relink every time.
-3. The script compares the key to `.platform-target` at the repo root. On mismatch, **delete** shared artifacts (registry above) via coarse directory-level cleanup and write the new key.
-4. Remove the libsds-specific sentinel from `vendor/status-go/Makefile`. Keep the independent iOS C++ CGO fix (`CXX` / `CGO_CXXFLAGS` for libutp). The separate iOS duplicate-Nim-runtime collision is handled by [Part 2](#part-2-ios-libsds-nim-runtime-symbol-localization), not by this sentinel.
-5. Make `$(STATUS_GO_LIB)` in `mobile/Makefile` depend on a `FORCE` empty target so it **always** delegates to status-go's PHONY sub-make (which owns the incremental-rebuild decision per #18377). The recipe copies `libstatus`/`libsds` into `mobile/lib` with `cmp -s … || cp`, so dependents (`stub`, `service`, the app) only relink when the output actually changed. status-desktop therefore does not track status-go/nim-sds sources.
+1. Caller Makefiles define a `.PHONY` target `platform-cleanup` running `scripts/platform_pre_build_cleanup.sh` with `PLATFORM_TARGET` (root: `$(host_os)-$(QT_ARCH)`; mobile: `$(OS)-$(ARCH)`).
+2. Shared-artifact build targets list `platform-cleanup` as an **order-only** prerequisite (`| platform-cleanup`), so cleanup runs before them without forcing relinks.
+3. The script compares the key to `.platform-target`; on mismatch it deletes the shared paths in [Maintenance](#maintenance) (coarse, directory-level) and writes the new key.
+4. `$(STATUS_GO_LIB)` in `mobile/Makefile` depends on a `FORCE` target so it **always** delegates to status-go's sub-make, then copies into `mobile/lib` with `cmp -s … || cp` — dependents relink only when the library content actually changed.
 
-Because the copy is refreshed on every build via FORCE + `cmp||cp`, the sentinel does **not** clean `mobile/lib/<variant>/libstatus.*` / `libsds.*`; wiping the vendor `build/` dirs is sufficient to produce fresh per-platform copies.
-
-`clean_switch_os.sh` remains as a manual full reset for iOS↔Android; it is not replaced.
+The libsds-specific sentinel in `vendor/status-go/Makefile` is removed. `clean_switch_os.sh` remains as a manual full reset.
 
 ### Consequences
 
-#### Positive
+- The sentinel handles cross-platform contamination; `FORCE` + `cmp||cp` handles within-platform freshness with status-go owning the rebuild decision (honors #18377). No overlap; `mobile/lib` copies need no explicit cleanup.
+- Every mobile build invokes status-go's sub-make (a few seconds even when nothing changed), and each platform switch triggers a full rebuild of the deleted artifacts (~30–70s). Traded for correctness.
+- `scripts/platform_pre_build_cleanup.sh` is a manual registry of shared vendor paths (see [Maintenance](#maintenance)); accepted over per-artifact sentinels scattered across Makefiles.
 
-- One mechanism covers all shared vendor artifacts relevant to desktop↔mobile switching.
-- Coarse directory cleanup (`vendor/*/build`, `nimcache`, etc.) avoids maintaining a growing per-file registry.
-- `FORCE` delegation keeps status-desktop ignorant of status-go/nim-sds internals (honors #18377); the freshness decision stays in status-go's own build.
-- `cmp -s || cp` means dependents (`stub`/`service`/app) relink only when the library content changed, despite the recipe running every build.
-- The sentinel handles cross-platform contamination; FORCE handles within-platform freshness. No overlap, and `mobile/lib` copies need no explicit cleanup.
-- No symlink or per-platform directory layout changes in upstream vendors (nim-sds `sds.nims` still writes to `build/`).
+### Maintenance
 
-#### Negative
+`scripts/platform_pre_build_cleanup.sh` must stay aligned with vendor dependencies that write platform-specific artifacts into **shared paths** used by both desktop and mobile builds.
 
-- Every mobile build invokes status-go's sub-make (a go build-cache check plus a libsds check, typically a few seconds even when nothing changed). Accepted as the cost of #18377-style delegation.
-- Standalone builds of `vendor/status-go` outside status-desktop no longer auto-clean libsds on platform switch; developers must clean manually or use status-desktop's sentinel via the root/mobile Makefiles.
-- Each platform switch triggers full rebuild of deleted shared artifacts (~30–70s for nim-sds + status-go), traded for correctness over incremental speed.
+Currently cleaned on platform switch:
+
+| Path | Action |
+|------|--------|
+| `vendor/QR-Code-generator/c/` | `make clean` (artifacts in the source tree, not `build/`) |
+| `vendor/nim-sds/build/` | `rm -rf` |
+| `vendor/status-go/build/` | `rm -rf` (whole tree) |
+
+When adding a new shared-artifact vendor dependency: add `| platform-cleanup` on its build target, add a cleanup step to the script (prefer wiping a whole `build/` dir), and update the table above. Vendors with separate desktop/mobile output dirs (DOtherSide, status-keycard-qt) do not belong here.
 
 ### Alternatives considered
 
 | Alternative | Why rejected |
 |-------------|--------------|
 | Per-artifact sentinels in each Makefile | Duplicated logic; easy to miss a shared path |
-| C-pure platform-scoped output dirs | Upstream nim-sds/qrcodegen bake in `build/` paths; requires build-then-move and propagating keys to shell scripts |
-| C-symlink (per-platform dirs + symlink) | Same benefit as C-pure for speed, but extra failure modes (dangling symlinks, race with nim cache) for modest gain |
-| `find`-based source prerequisites on `$(STATUS_GO_LIB)` | Re-couples status-desktop to status-go/nim-sds sources; reverts #18377 (the build was deliberately delegated to status-go) |
-| Sentinel only (no FORCE) | Leaves the no-prerequisites file target; stale `mobile/lib` copies still block the delegated sub-make within a platform |
-| Parse-time `$(shell …)` hook | Runs on every Make invocation (including `help`, `clean`, dry-run); side effects during variable assignment are not idiomatic Make |
-| **Accepted: order-only `platform-cleanup` + FORCE delegation + coarse clean-on-switch** | Cleanup is a proper target in the dependency graph; sentinel for cross-platform contamination; FORCE + `cmp||cp` for within-platform freshness, with status-go owning the rebuild decision |
+| Platform-scoped output dirs (build-then-move or symlink) | Upstream vendors bake in `build/` paths; needs key propagation into shell scripts, extra failure modes |
+| `find`-based source prerequisites on `$(STATUS_GO_LIB)` | Re-couples to status-go/nim-sds sources; reverts #18377 |
+| Sentinel only (no FORCE) | Stale `mobile/lib` copies still block the delegated sub-make within a platform |
+| Parse-time `$(shell …)` hook | Runs on every Make invocation; side effects during variable assignment are not idiomatic |
 
-## Part 2: iOS libsds Nim-runtime symbol localization
+## Part 2: iOS libsds Nim-runtime symbol collision
 
-> Superseded — fix landed upstream in nim-sds `v0.2.5` (see [Decision history](#decision-history)).
+> Superseded — fixed upstream in nim-sds `v0.2.5`.
 
-### Context
+On iOS the app statically linked both `libsds.a` and `libnim_status_client.a`, each shipping a full copy of the Nim runtime as **global** symbols. The linker collapsed the duplicates onto `libnim_status_client`'s copy (a different Nim version), so libsds ran against a runtime it wasn't compiled for and crashed with SIGSEGV after login (first SDS call). `-load_hidden` didn't help (changes visibility, not the duplicate symbols); dropping `-lsds` broke undefined refs from libstatus.
 
-On iOS the final app binary statically links both:
-
-- `libsds.a` — the nim-sds reliability layer (built by status-go's `statusgo-ios-library` → `build-libsds-ios`, see Part 1).
-- `libnim_status_client.a` — the status-desktop Nim client.
-
-Both are compiled from Nim and therefore each ship a **full copy of the Nim runtime** (`_allocSharedImpl`, `_newSeqPayload`, `_rawNewString`, `_nimAsgnStrV2`, …) exported as **global** (`T`) symbols. Diagnostics on the failing build showed `libsds.a` exporting ~20 global Nim-stdlib symbols and `libnim_status_client.a` ~21, with a large overlap; `libstatus.a`, `libMobileWebView.a`, `libStatusQ.a` export **zero** (they are not Nim or already localized).
-
-When the linker sees the duplicate definitions it collapses them into a single copy. The surviving copy comes from `libnim_status_client` (built with a different Nim version than nim-sds), so `libsds`'s code runs against a runtime it was not compiled for. The app then crashes with **SIGSEGV at runtime** — specifically after login, when the messenger first calls into SDS (`UnwrapReceivedMessage`).
-
-This is *not* the platform-switch / stale-artifact problem solved in Part 1 (that was a freshness bug; this is a symbol-collision bug present even on a clean build).
-
-#### Alternatives tried and rejected
-
-| Alternative | Why rejected |
-|-------------|--------------|
-| `-Wl,-load_hidden,libsds.a` in `vendor/status-go/Makefile` (CGO_LDFLAGS) and/or `mobile/wrapperApp/Status.pro` | `-load_hidden` changes symbol **visibility** but does not **remove** the global symbols from `libsds.a`. The duplicate-symbol collision happens before visibility is applied, so the wrong runtime is still picked. Verified not to fix the crash; reverted. |
-| Drop `-lsds` from `Status.pro` | `libstatus.a` keeps undefined references into SDS (`U _SdsNewReliabilityManager`); `libsds.a` is genuinely required as a separate input. |
-
-### Decision history
-
-#### 1. Post-build localization in status-desktop (interim)
-
-Localize `libsds.a` as a **post-build step in status-desktop**, after status-go produces it and before it is copied into `mobile/lib`. This kept the fix in our repo instead of patching upstream nim-sds or status-go while we waited for an upstream release.
-
-`mobile/Makefile` (iOS only) ran `mobile/scripts/localize_libsds_ios.sh` on `$(NIM_SDS_SOURCE_DIR)/build/libsds.a` right after the `statusgo-ios-library` sub-make and before the `cmp -s … || cp` into `$(LIB_PATH)`.
-
-The script exploded the archive (`ar x`), merged all objects into one relocatable object exporting **only** the public API via `xcrun ld -r -arch <arch> -exported_symbol '_Sds*'`, and repacked with `ar rcs`.
-
-#### 2. Upstream fix in nim-sds `v0.2.5` (current)
-
-nim-sds `v0.2.5` localizes symbols during the iOS build in `sds.nimble` (`libsdsIOS` task). status-go pins `NIM_SDS_VERSION=v0.2.5`; status-desktop no longer runs a post-build localization step.
-
-The result is unchanged: `libsds.a` exposes only `_Sds*`; its Nim runtime is internalized, so there is exactly one global Nim runtime (from `libnim_status_client`) at final link.
-
-### Consequences
-
-#### Positive
-
-- Fix lives in nim-sds where the iOS build is defined; status-desktop mobile Makefile stays a thin delegate + copy layer (honors #18377).
-- Orthogonal to Part 1: the sentinel handles platform-switch staleness; symbol localization handles the Nim-runtime collision. They compose without overlap.
-
-#### Negative
-
-- iOS-only and macOS-toolchain-specific (`xcrun ld -r`, `-exported_symbol`) inside nim-sds. Android/desktop are unaffected.
-- Couples the fix to the exact public-symbol prefix (`_Sds*`). If nim-sds renames its exported API, the exported-symbol pattern must be updated or the link will drop needed symbols.
+Interim fix was a post-build localization step in status-desktop (`ar x` → merge into one object exporting only `_Sds*` via `xcrun ld -r -exported_symbol` → `ar rcs`). nim-sds `v0.2.5` now does this in `sds.nimble` (`libsdsIOS`), so status-desktop carries no localization code. Orthogonal to Part 1 (freshness vs symbol collision). Caveat: the fix is coupled to the `_Sds*` public-symbol prefix — renaming the exported API requires updating the pattern.

--- a/docs/adr/0003-platform-sentinel-ownership.md
+++ b/docs/adr/0003-platform-sentinel-ownership.md
@@ -1,0 +1,131 @@
+# ADR 0003: Platform-target-specific build artifacts in status-desktop
+
+## Status
+
+Accepted
+
+This ADR combines two platform-target-specific concerns that compose without overlap:
+
+- **Platform sentinel ownership** (desktop↔mobile artifact staleness) — Accepted.
+- **iOS libsds Nim-runtime symbol localization** (Nim-runtime symbol collision) — Superseded by an upstream fix in nim-sds `v0.2.5` (see [Part 2](#part-2-ios-libsds-nim-runtime-symbol-localization)).
+
+## Part 1: Platform sentinel ownership
+
+### Context
+
+Several third-party libraries built from `vendor/` write to **shared output paths** that are reused across desktop macOS, iOS, and Android builds in the same working tree:
+
+- `vendor/QR-Code-generator/c/` (object files and `libqrcodegen.a` in the source tree; cleaned via `make clean`)
+- `vendor/nim-sds/build/` (whole directory: `libsds.*` plus nim-sds nimcache)
+- `vendor/status-go/build/` (whole directory: `libstatus.*`, generated bindings, etc.)
+- `nimcache/` (flat mobile nim cache at repo root plus desktop subdirs under `release/` / `debug/`)
+- `bin/libnim_status_client.*` (shared nim client static/shared library output)
+
+Switching between `make run` (desktop) and `make mobile-run` (iOS/Android) without cleaning these paths leaves stale platform-specific objects. The linker then fails (e.g. `ld: building for 'iOS', but linking in object file ... built for 'macOS'`) or the app crashes at runtime with mixed artifacts.
+
+An earlier fix added a per-artifact sentinel inside `vendor/status-go/Makefile` (`nim-sds-platform-check`, `.sds-build-id`) for libsds only. That did not cover qrcodegen or libstatus, and duplicated platform-key logic across submodules.
+
+#### Ownership of the status-go / nim-sds mobile build
+
+Issue [#18377](https://github.com/status-im/status-desktop/issues/18377) (commit `0b5f1106`) moved the status-go mobile build logic out of `mobile/scripts/buildStatusGo.sh` and into the **status-go repository**. The status-go `Makefile` now owns building both `libstatus` and `libsds` (it pins `NIM_SDS_VERSION`, clones, and builds nim-sds), exposed via the `.PHONY` targets `statusgo-ios-library` / `statusgo-android-library`.
+
+Consequently `$(STATUS_GO_LIB)` in `mobile/Makefile` must **not** re-introduce knowledge of status-go/nim-sds source files (e.g. `find`-based prerequisites): that would re-couple status-desktop to vendor internals and revert #18377. The freshness decision belongs to status-go's own (PHONY) build.
+
+The defect we hit: `$(STATUS_GO_LIB)` was a plain file target with **no prerequisites**, so once `mobile/lib/<variant>/libstatus.a` existed, Make never re-invoked the delegated sub-make. Stale copies then linked against a freshly rebuilt `libnim_status_client`, producing duplicate Nim runtime symbols and a runtime crash.
+
+### Decision
+
+Implement a **single umbrella platform sentinel in status-desktop**:
+
+1. Caller Makefiles define a `.PHONY` target `platform-cleanup` that runs `scripts/platform_pre_build_cleanup.sh` with `PLATFORM_TARGET`:
+   - Root: `$(host_os)-$(QT_ARCH)` (e.g. `darwin-arm64`)
+   - Mobile: `$(OS)-$(ARCH)` (e.g. `ios-arm64`, `android-arm64`)
+2. Shared-artifact build targets (`$(NIMSDS_LIBFILE)`, `$(STATUSGO)`, `$(QRCODEGEN)` in root; `$(STATUS_GO_LIB)`, `$(QRCODEGEN_LIB)` in mobile) list `platform-cleanup` as an **order-only** prerequisite (`| platform-cleanup`), so cleanup runs before those targets are built without forcing them (or their dependents) to relink every time.
+3. The script compares the key to `.platform-target` at the repo root. On mismatch, **delete** shared artifacts (registry above) via coarse directory-level cleanup and write the new key.
+4. Remove the libsds-specific sentinel from `vendor/status-go/Makefile`. Keep the independent iOS C++ CGO fix (`CXX` / `CGO_CXXFLAGS` for libutp). The separate iOS duplicate-Nim-runtime collision is handled by [Part 2](#part-2-ios-libsds-nim-runtime-symbol-localization), not by this sentinel.
+5. Make `$(STATUS_GO_LIB)` in `mobile/Makefile` depend on a `FORCE` empty target so it **always** delegates to status-go's PHONY sub-make (which owns the incremental-rebuild decision per #18377). The recipe copies `libstatus`/`libsds` into `mobile/lib` with `cmp -s … || cp`, so dependents (`stub`, `service`, the app) only relink when the output actually changed. status-desktop therefore does not track status-go/nim-sds sources.
+
+Because the copy is refreshed on every build via FORCE + `cmp||cp`, the sentinel does **not** clean `mobile/lib/<variant>/libstatus.*` / `libsds.*`; wiping the vendor `build/` dirs is sufficient to produce fresh per-platform copies.
+
+`clean_switch_os.sh` remains as a manual full reset for iOS↔Android; it is not replaced.
+
+### Consequences
+
+#### Positive
+
+- One mechanism covers all shared vendor artifacts relevant to desktop↔mobile switching.
+- Coarse directory cleanup (`vendor/*/build`, `nimcache`, etc.) avoids maintaining a growing per-file registry.
+- `FORCE` delegation keeps status-desktop ignorant of status-go/nim-sds internals (honors #18377); the freshness decision stays in status-go's own build.
+- `cmp -s || cp` means dependents (`stub`/`service`/app) relink only when the library content changed, despite the recipe running every build.
+- The sentinel handles cross-platform contamination; FORCE handles within-platform freshness. No overlap, and `mobile/lib` copies need no explicit cleanup.
+- No symlink or per-platform directory layout changes in upstream vendors (nim-sds `sds.nims` still writes to `build/`).
+
+#### Negative
+
+- Every mobile build invokes status-go's sub-make (a go build-cache check plus a libsds check, typically a few seconds even when nothing changed). Accepted as the cost of #18377-style delegation.
+- Standalone builds of `vendor/status-go` outside status-desktop no longer auto-clean libsds on platform switch; developers must clean manually or use status-desktop's sentinel via the root/mobile Makefiles.
+- Each platform switch triggers full rebuild of deleted shared artifacts (~30–70s for nim-sds + status-go), traded for correctness over incremental speed.
+
+### Alternatives considered
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| Per-artifact sentinels in each Makefile | Duplicated logic; easy to miss a shared path |
+| C-pure platform-scoped output dirs | Upstream nim-sds/qrcodegen bake in `build/` paths; requires build-then-move and propagating keys to shell scripts |
+| C-symlink (per-platform dirs + symlink) | Same benefit as C-pure for speed, but extra failure modes (dangling symlinks, race with nim cache) for modest gain |
+| `find`-based source prerequisites on `$(STATUS_GO_LIB)` | Re-couples status-desktop to status-go/nim-sds sources; reverts #18377 (the build was deliberately delegated to status-go) |
+| Sentinel only (no FORCE) | Leaves the no-prerequisites file target; stale `mobile/lib` copies still block the delegated sub-make within a platform |
+| Parse-time `$(shell …)` hook | Runs on every Make invocation (including `help`, `clean`, dry-run); side effects during variable assignment are not idiomatic Make |
+| **Accepted: order-only `platform-cleanup` + FORCE delegation + coarse clean-on-switch** | Cleanup is a proper target in the dependency graph; sentinel for cross-platform contamination; FORCE + `cmp||cp` for within-platform freshness, with status-go owning the rebuild decision |
+
+## Part 2: iOS libsds Nim-runtime symbol localization
+
+> Superseded — fix landed upstream in nim-sds `v0.2.5` (see [Decision history](#decision-history)).
+
+### Context
+
+On iOS the final app binary statically links both:
+
+- `libsds.a` — the nim-sds reliability layer (built by status-go's `statusgo-ios-library` → `build-libsds-ios`, see Part 1).
+- `libnim_status_client.a` — the status-desktop Nim client.
+
+Both are compiled from Nim and therefore each ship a **full copy of the Nim runtime** (`_allocSharedImpl`, `_newSeqPayload`, `_rawNewString`, `_nimAsgnStrV2`, …) exported as **global** (`T`) symbols. Diagnostics on the failing build showed `libsds.a` exporting ~20 global Nim-stdlib symbols and `libnim_status_client.a` ~21, with a large overlap; `libstatus.a`, `libMobileWebView.a`, `libStatusQ.a` export **zero** (they are not Nim or already localized).
+
+When the linker sees the duplicate definitions it collapses them into a single copy. The surviving copy comes from `libnim_status_client` (built with a different Nim version than nim-sds), so `libsds`'s code runs against a runtime it was not compiled for. The app then crashes with **SIGSEGV at runtime** — specifically after login, when the messenger first calls into SDS (`UnwrapReceivedMessage`).
+
+This is *not* the platform-switch / stale-artifact problem solved in Part 1 (that was a freshness bug; this is a symbol-collision bug present even on a clean build).
+
+#### Alternatives tried and rejected
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| `-Wl,-load_hidden,libsds.a` in `vendor/status-go/Makefile` (CGO_LDFLAGS) and/or `mobile/wrapperApp/Status.pro` | `-load_hidden` changes symbol **visibility** but does not **remove** the global symbols from `libsds.a`. The duplicate-symbol collision happens before visibility is applied, so the wrong runtime is still picked. Verified not to fix the crash; reverted. |
+| Drop `-lsds` from `Status.pro` | `libstatus.a` keeps undefined references into SDS (`U _SdsNewReliabilityManager`); `libsds.a` is genuinely required as a separate input. |
+
+### Decision history
+
+#### 1. Post-build localization in status-desktop (interim)
+
+Localize `libsds.a` as a **post-build step in status-desktop**, after status-go produces it and before it is copied into `mobile/lib`. This kept the fix in our repo instead of patching upstream nim-sds or status-go while we waited for an upstream release.
+
+`mobile/Makefile` (iOS only) ran `mobile/scripts/localize_libsds_ios.sh` on `$(NIM_SDS_SOURCE_DIR)/build/libsds.a` right after the `statusgo-ios-library` sub-make and before the `cmp -s … || cp` into `$(LIB_PATH)`.
+
+The script exploded the archive (`ar x`), merged all objects into one relocatable object exporting **only** the public API via `xcrun ld -r -arch <arch> -exported_symbol '_Sds*'`, and repacked with `ar rcs`.
+
+#### 2. Upstream fix in nim-sds `v0.2.5` (current)
+
+nim-sds `v0.2.5` localizes symbols during the iOS build in `sds.nimble` (`libsdsIOS` task). status-go pins `NIM_SDS_VERSION=v0.2.5`; status-desktop no longer runs a post-build localization step.
+
+The result is unchanged: `libsds.a` exposes only `_Sds*`; its Nim runtime is internalized, so there is exactly one global Nim runtime (from `libnim_status_client`) at final link.
+
+### Consequences
+
+#### Positive
+
+- Fix lives in nim-sds where the iOS build is defined; status-desktop mobile Makefile stays a thin delegate + copy layer (honors #18377).
+- Orthogonal to Part 1: the sentinel handles platform-switch staleness; symbol localization handles the Nim-runtime collision. They compose without overlap.
+
+#### Negative
+
+- iOS-only and macOS-toolchain-specific (`xcrun ld -r`, `-exported_symbol`) inside nim-sds. Android/desktop are unaffected.
+- Couples the fix to the exact public-symbol prefix (`_Sds*`). If nim-sds renames its exported API, the exported-symbol pattern must be updated or the link will drop needed symbols.

--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -1,6 +1,8 @@
 -include ./scripts/EnvVariables.mk
 -include ./scripts/Common.mk
 
+PLATFORM_TARGET := $(OS)-$(ARCH)
+
 # FLAG_KEYCARD_ENABLED: Controls NFC/Keycard support
 # - iOS: Default 1 (enabled) - Build with NFC support, works with free Apple Developer account
 # - Android: Default 1 (enabled) - NFC support doesn't require paid account on Android
@@ -29,7 +31,8 @@ status-keycard-qt: clean-status-keycard-qt $(STATUS_KEYCARD_QT_LIB)
 nim-status-client: clean-nim-status-client $(NIM_STATUS_CLIENT_LIB)
 status-desktop-rcc: clean-status-desktop-rcc $(STATUS_DESKTOP_RCC)
 
-$(STATUS_GO_LIB):
+# Always delegate to status-go's PHONY sub-make (it owns incremental rebuild, see issue #18377), then copy only on change.
+$(STATUS_GO_LIB): FORCE | platform-cleanup
 	@echo "Building status-go mobile library"
 	@mkdir -p $(LIB_PATH)
 ifeq ($(OS),android)
@@ -47,12 +50,13 @@ else ifeq ($(OS),ios)
 		ARCH=$(ARCH) \
 		IPHONE_SDK="$(IPHONE_SDK)" \
 		IOS_TARGET="$(IOS_TARGET)" \
+		NIM_SDS_SOURCE_DIR="$(NIM_SDS_SOURCE_DIR)" \
 		USE_SYSTEM_NIM=$(USE_SYSTEM_NIM) \
 		SHELL=/bin/sh
 endif
 	@echo "Copying library to mobile lib directory"
-	@cp $(NIM_SDS_SOURCE_DIR)/build/libsds$(LIB_EXT) $(LIB_PATH)/libsds$(LIB_EXT)
-	@cp ../vendor/status-go/build/bin/libstatus$(LIB_EXT) $(LIB_PATH)/libstatus$(LIB_EXT)
+	@cmp -s $(NIM_SDS_SOURCE_DIR)/build/libsds$(LIB_EXT) $(LIB_PATH)/libsds$(LIB_EXT) || cp $(NIM_SDS_SOURCE_DIR)/build/libsds$(LIB_EXT) $(LIB_PATH)/libsds$(LIB_EXT)
+	@cmp -s ../vendor/status-go/build/bin/libstatus$(LIB_EXT) $(LIB_PATH)/libstatus$(LIB_EXT) || cp ../vendor/status-go/build/bin/libstatus$(LIB_EXT) $(LIB_PATH)/libstatus$(LIB_EXT)
 
 $(STATUS_GO_STUB_LIB): $(STATUS_GO_LIB)
 	@echo "Building status-go stub library (UI process)"
@@ -91,7 +95,7 @@ $(OPENSSL_LIB): $(OPENSSL_FILES)
 	@echo "Building OpenSSL"
 	@LIB_PATH=$(LIB_PATH) LIB_EXT=$(LIB_EXT) OPENSSL=$(OPENSSL) BUILD_DIR=$(BUILD_PATH) $(OPENSSL_SCRIPT) $(HANDLE_OUTPUT)
 
-$(QRCODEGEN_LIB): $(QRCODEGEN_FILES)
+$(QRCODEGEN_LIB): $(QRCODEGEN_FILES) | platform-cleanup
 	@echo "Building QRCodeGen"
 	@QRCODEGEN=$(QRCODEGEN) $(QRCODEGEN_SCRIPT) $(HANDLE_OUTPUT)
 	@echo "QRCodeGen built $(QRCODEGEN_LIB)"
@@ -151,6 +155,15 @@ endif
 	@echo "Built $(TARGET)"
 
 # phony rules
+
+# Order-only prerequisite: delete shared vendor artifacts (qrcodegen, nim-sds, libstatus) when the build platform/arch changes.
+.PHONY: platform-cleanup FORCE
+platform-cleanup:
+	@../scripts/platform_pre_build_cleanup.sh "$(PLATFORM_TARGET)"
+
+# Empty target: anything depending on FORCE is always rebuilt.
+FORCE:
+
 .PHONY: makedir
 makedir:
 	@mkdir -p $(BIN_PATH) $(LIB_PATH) $(BUILD_PATH)

--- a/mobile/scripts/buildNimStatusClient.sh
+++ b/mobile/scripts/buildNimStatusClient.sh
@@ -71,6 +71,7 @@ APP_CONFIG_DEFINES=(
 NIM_FLAGS=(
     --mm:orc
     -d:useMalloc
+    -d:lto
     --opt:size
     --cc:clang
     --cpu:"$CARCH"

--- a/scripts/platform_pre_build_cleanup.sh
+++ b/scripts/platform_pre_build_cleanup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Platform-switch cleanup for shared vendor artifacts. See docs/adr/0003-platform-sentinel-ownership.md.
 set -euo pipefail
 
 # $1 = platform target: darwin-arm64 / ios-arm64 / android-arm64
@@ -18,7 +19,7 @@ make -C "$GIT_ROOT/vendor/QR-Code-generator/c" clean 2>/dev/null || true
 # 2) nim-sds (shared libsds.* + nimcache)
 rm -rf "$GIT_ROOT/vendor/nim-sds/build" 2>/dev/null || true
 [ -n "${HOME:-}" ] && rm -rf "$HOME"/.cache/nim/libsds_* 2>/dev/null || true
-# 3) libstatus.* (shared bin between make run and mobile-run)
-rm -f "$GIT_ROOT"/vendor/status-go/build/bin/libstatus.* 2>/dev/null || true
+# 3) status-go (shared build/ between make run and mobile-run)
+rm -rf "$GIT_ROOT/vendor/status-go/build" 2>/dev/null || true
 
 echo "$KEY" > "$STATE"

--- a/scripts/platform_pre_build_cleanup.sh
+++ b/scripts/platform_pre_build_cleanup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# $1 = platform target: darwin-arm64 / ios-arm64 / android-arm64
+KEY="${1:-}"
+GIT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STATE="$GIT_ROOT/.platform-target"
+
+[ -n "$KEY" ] || { echo "platform_pre_build_cleanup: empty PLATFORM_TARGET" >&2; exit 1; }
+
+PREV="$(cat "$STATE" 2>/dev/null || echo none)"
+[ "$PREV" = "$KEY" ] && exit 0
+
+echo "platform changed ($PREV -> $KEY); cleaning shared artifacts" >&2
+
+# 1) qrcodegen (desktop links directly, mobile builds into the same tree)
+make -C "$GIT_ROOT/vendor/QR-Code-generator/c" clean 2>/dev/null || true
+# 2) nim-sds (shared libsds.* + nimcache)
+rm -rf "$GIT_ROOT/vendor/nim-sds/build" 2>/dev/null || true
+[ -n "${HOME:-}" ] && rm -rf "$HOME"/.cache/nim/libsds_* 2>/dev/null || true
+# 3) libstatus.* (shared bin between make run and mobile-run)
+rm -f "$GIT_ROOT"/vendor/status-go/build/bin/libstatus.* 2>/dev/null || true
+
+echo "$KEY" > "$STATE"


### PR DESCRIPTION
upd:

localize libsds after build to prevent Nim runtime SIGSEGV:
Duplicate Nim runtime symbols exported from libsds.a collide with libnim_status_client on iOS. 

* fix: https://github.com/logos-messaging/nim-sds/pull/84
* status-go PR: https://github.com/status-im/status-go/pull/7583

## Problem

When the same source tree is used to build for multiple platforms/arches (e.g. `make run` after `mobile-run`, or switching desktop arm64 ↔ x86_64), shared build artifacts are reused across incompatible targets:

1. **qrcodegen** — `libqrcodegen.a` has the same name on every platform, so a stale-arch copy gets linked.
2. **nim-sds / libstatus** — `libsds.*` and `libstatus.*` collide by name (e.g. linux/android both `*.so`) and the stale-arch binary is reused.
3. **libsds not regenerated on desktop** — `libsds` was only ever built as a side effect of `libstatus`, which is an order-only prereq. When `libstatus` was already present, a missing/stale `libsds` was never rebuilt, so `nim_status_client` crashed at startup: `dyld: Library not loaded: .../libsds.dylib`.

## Solution

- Default `NIM_SDS_SOURCE_DIR` to `vendor/nim-sds` so desktop and mobile use one path. (instead of `../nimsds`)
- Add a **platform sentinel** (`scripts/platform_build_check.sh`, included via `scripts/platform-build.mk`): on a platform/arch change it clears the shared `qrcodegen`, `nim-sds/build`, and `libstatus.*` so the next build regenerates them.
- Make **libsds a first-class make target** (`$(NIMSDS_LIBFILE)`) and depend on it (order-only) from both `$(STATUSGO)` and `$(NIM_STATUS_CLIENT)`, so a deleted libsds is restored even when libstatus is untouched.


##Demo:

1. run_macos.sh
```
export QTDIR="$HOME/Qt/6.11.0/macos"
export PATH="$QTDIR/bin:${PATH}"
export QMAKE="$QTDIR/bin/qmake"

make -j16 run
```
2. run_ios.sh

```
export QTDIR="$HOME/Qt/6.11.0/ios"
export PATH="$QTDIR/bin:$HOME/Qt/6.11.0/macos/libexec:$HOME/Qt/6.11.0/macos/bin:${PATH}"
export QTTARGET=ios
export QT_HOST_PATH="$HOME/Qt/6.11.0/macos"
export QMAKE_DEVELOPMENT_TEAM=8B5X2M6H2Y
export QMAKE="$QTDIR/bin/qmake"
export IPHONE_SDK=iphoneos
export ARCH="${ARCH:-arm64}"

make -j16 mobile-run V=1
```
3. run_android.sh
```
export ANDROID_SDK_ROOT="$HOME/Library/Android/sdk"
export ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk/27.2.12479018"
export ARCH="${ARCH:-arm64}"
export OS=android
export QTDIR="$HOME/Qt/6.11.0/android_arm64_v8a"
export QT_HOST_PATH="$HOME/Qt/6.11.0/macos"
export PATH="$QTDIR/bin:$QT_HOST_PATH/bin:$QT_HOST_PATH/libexec:${PATH}"
export QMAKE="$QTDIR/bin/qmake"
export QT_ANDROID_DIR="${QTDIR}/src/android/java"

export CGO_LDFLAGS_ALLOW='.*'
make -j16 mobile-run V=1 \
	CGO_LDFLAGS="-Wl,-z,max-page-size=16384 -lc++_shared -L${REPO_ROOT}/vendor/nim-sds/build -lsds"
```

run_macos->run_ios->run_android->run_macos:

https://github.com/user-attachments/assets/d0277de0-229f-472e-bc40-3898cc8613e5

