### PR TITLE
fix(ProfileShowcase): close Profile dialog when opening a link

### DIFF
--- a/ui/imports/shared/views/profile/ProfileShowcaseSocialLinksView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseSocialLinksView.qml
@@ -21,6 +21,7 @@ Item {
     property alias cellHeight: webView.cellHeight
 
     signal copyToClipboard(string text)
+    signal closeRequested()
 
 
     StatusBaseText {
@@ -77,6 +78,7 @@ Item {
 
                     onClicked: {
                         Global.requestOpenLink(model.url)
+                        root.closeRequested()
                     }
                 }
             }

--- a/ui/imports/shared/views/profile/ProfileShowcaseView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseView.qml
@@ -190,6 +190,7 @@ Control {
             socialLinksModel: socialLinksProxyModel
 
             onCopyToClipboard: text => root.copyToClipboard(text)
+            onCloseRequested: root.closeRequested()
         }
     }
 


### PR DESCRIPTION
### What does the PR do

Fixes #21112

### Affected areas

Profile/Showcase

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality


https://github.com/user-attachments/assets/1fb3a63e-1c1f-465a-886c-5101c379d80a



### Impact on end user

UI/UX improvement

### How to test

- Open Profile dialog
- Open Showcase/Links
- Click on a link
- The Profile dialog should close upon activating the link

### Risk 

low
