### PR TITLE
New Model helper functions

### DIFF
--- a/src/app/modules/main/app_search/models/chat_search_model.nim
+++ b/src/app/modules/main/app_search/models/chat_search_model.nim
@@ -1,7 +1,6 @@
 import app/modules/shared_models/model_utils
 import nimqml, tables
 import chat_search_item
-import ../../../shared_models/model_utils
 import ../io_interface
 
 type
@@ -122,10 +121,10 @@ QtObject:
 
     var roles: seq[int] = @[]
 
-    updateRole(name, Name)
-    updateRole(color, Color)
-    updateRole(icon, Icon)
-    updateRole(emoji, Emoji)
+    updateRole(name)
+    updateRole(color)
+    updateRole(icon)
+    updateRole(emoji)
 
     if roles.len == 0:
       return
@@ -141,7 +140,7 @@ QtObject:
 
     var roles: seq[int] = @[]
 
-    updateRole(sectionName, SectionName)
+    updateRole(sectionName)
 
     if roles.len == 0:
       return
@@ -157,7 +156,7 @@ QtObject:
 
     var roles: seq[int] = @[]
 
-    updateRole(lastMessageText, LastMessageText)
+    updateRole(lastMessageText)
 
     if roles.len == 0:
       return

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -410,10 +410,10 @@ QtObject:
 
     var roles: seq[int] = @[]
 
-    updateRole(canView, CanView)
-    updateRole(canPost, CanPost)
-    updateRole(canPostReactions, CanPostReactions)
-    updateRole(viewersCanPostReactions, ViewersCanPostReactions)
+    updateRole(canView)
+    updateRole(canPost)
+    updateRole(canPostReactions)
+    updateRole(viewersCanPostReactions)
 
     if roles.len == 0:
       return
@@ -457,10 +457,10 @@ QtObject:
 
     var roles: seq[int] = @[]
 
-    updateRole(name, Name)
-    updateRole(icon, Icon)
-    updateRole(trustStatus, TrustStatus)
-    updateRole(usesDefaultName, UsesDefaultName)
+    updateRole(name)
+    updateRole(icon)
+    updateRole(trustStatus)
+    updateRole(usesDefaultName)
 
     if roles.len == 0:
       return
@@ -476,13 +476,13 @@ QtObject:
 
     var roles: seq[int] = @[]
 
-    updateRole(name, Name)
-    updateRole(description, Description)
-    updateRole(emoji, Emoji)
-    updateRole(color, Color)
+    updateRole(name)
+    updateRole(description)
+    updateRole(emoji)
+    updateRole(color)
     if self.items[ind].hideIfPermissionsNotMet != hideIfPermissionsNotMet:
       roles.add(ModelRole.ShouldBeHiddenBecausePermissionsAreNotMet.int)
-    updateRole(hideIfPermissionsNotMet, HideIfPermissionsNotMet)
+    updateRole(hideIfPermissionsNotMet)
 
     if roles.len == 0:
       return
@@ -500,9 +500,9 @@ QtObject:
 
     var roles: seq[int] = @[]
 
-    updateRole(name, Name)
-    updateRole(color, Color)
-    updateRole(icon, Icon)
+    updateRole(name)
+    updateRole(color)
+    updateRole(icon)
 
     if roles.len == 0:
       return
@@ -523,8 +523,8 @@ QtObject:
 
     var roles: seq[int] = @[]
 
-    updateRole(name, Name)
-    updateRole(categoryPosition, CategoryPosition)
+    updateRole(name)
+    updateRole(categoryPosition)
 
     if roles.len == 0:
       return
@@ -603,7 +603,7 @@ QtObject:
     
     var roles: seq[int] = @[]
 
-    updateRole(name, Name)
+    updateRole(name)
 
     if roles.len == 0:
       return
@@ -629,7 +629,7 @@ QtObject:
       return
 
     var roles: seq[int] = @[]
-    updateRole(onlineStatus, OnlineStatus)
+    updateRole(onlineStatus)
     if roles.len == 0:
       return
 
@@ -645,8 +645,8 @@ QtObject:
 
     var roles: seq[int] = @[]
 
-    updateRole(hasUnreadMessages, HasUnreadMessages)
-    updateRole(notificationsCount, NotificationsCount)
+    updateRole(hasUnreadMessages)
+    updateRole(notificationsCount)
 
     if roles.len == 0:
       return
@@ -662,8 +662,8 @@ QtObject:
 
     var roles: seq[int] = @[]
 
-    updateRole(lastMessageText, LastMessageText)
-    updateRole(lastMessageTimestamp, LastMessageTimestamp)
+    updateRole(lastMessageText)
+    updateRole(lastMessageTimestamp)
 
     if roles.len == 0:
       return

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -1,4 +1,4 @@
-import chronicles, stint, strutils
+import chronicles, stint
 import app/global/global_singleton
 import app/global/app_signals
 import app/core/signals/types as signal_types

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -3,7 +3,7 @@ import std/[strformat, strutils, tables, json, sequtils, marshal, times], chroni
 
 import io_interface, view, controller
 import ephemeral_notification_item, ephemeral_notification_model
-import app/modules/shared_models/[user_item, member_item, member_model, section_item, section_model, section_details, contacts_utils]
+import app/modules/shared_models/[user_item, member_item, member_model, section_item, section_model, section_details]
 import app/modules/shared_modules/authentication/module as authentication_module
 import app/modules/shared_modules/signing/module as signing_module
 import app/modules/shared_modules/keycard_management/module as keycard_management_module

--- a/src/app/modules/main/profile_section/devices/io_interface.nim
+++ b/src/app/modules/main/profile_section/devices/io_interface.nim
@@ -1,4 +1,4 @@
-import nimqml, tables
+import nimqml
 import app_service/service/devices/service
 
 type

--- a/src/app/modules/main/profile_section/devices/module.nim
+++ b/src/app/modules/main/profile_section/devices/module.nim
@@ -1,4 +1,4 @@
-import nimqml, tables, strutils, chronicles
+import nimqml, chronicles
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller, model, item

--- a/src/app/modules/main/profile_section/notifications/model.nim
+++ b/src/app/modules/main/profile_section/notifications/model.nim
@@ -125,10 +125,10 @@ QtObject:
     
     var roles: seq[int] = @[]
 
-    updateRole(muteAllMessages, MuteAllMessages)
-    updateRole(personalMentions, PersonalMentions)
-    updateRole(globalMentions, GlobalMentions)
-    updateRole(otherMessages, OtherMessages)
+    updateRole(muteAllMessages)
+    updateRole(personalMentions)
+    updateRole(globalMentions)
+    updateRole(otherMessages)
 
     if roles.len == 0:
       return
@@ -157,9 +157,9 @@ QtObject:
 
     var roles: seq[int] = @[]
 
-    updateRole(name, Name)
-    updateRole(image, Image)
-    updateRole(color, Color)
+    updateRole(name)
+    updateRole(image)
+    updateRole(color)
 
     if roles.len == 0:
       return

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -273,17 +273,17 @@ QtObject:
 
       let usesDefaultName = resolveUsesDefaultName(localNickname, ensName, displayName)
 
-      updateRole(displayName, DisplayName)
-      updateRole(ensName, EnsName)
-      updateRole(localNickname, LocalNickname)
-      updateRole(usesDefaultName, UsesDefaultName)
+      updateRole(displayName)
+      updateRole(ensName)
+      updateRole(localNickname)
+      updateRole(usesDefaultName)
 
       if preferredDisplayNameChanged:
         roles.add(ModelRole.PreferredDisplayName.int)
 
   proc setIcon*(self: Model, pubKey: string, icon: string) =
     updateItemRolesAndNotify self.findIndexForMember(pubKey):
-      updateRole(icon, Icon)
+      updateRole(icon)
 
   proc updateItem*(
       self: Model,
@@ -316,28 +316,28 @@ QtObject:
     let trustStatusChanged = trustStatus != self.items[ind].trustStatus
     let usesDefaultName = resolveUsesDefaultName(localNickname, ensName, displayName)
 
-    updateRole(displayName, DisplayName)
-    updateRole(usesDefaultName, UsesDefaultName)
-    updateRole(ensName, EnsName)
-    updateRole(localNickname, LocalNickname)
-    updateRole(isEnsVerified, IsEnsVerified)
+    updateRole(displayName)
+    updateRole(usesDefaultName)
+    updateRole(ensName)
+    updateRole(localNickname)
+    updateRole(isEnsVerified)
     # `alias` is deterministic from the pubkey — preserve any previously
     # resolved value when the incoming alias is empty (typical for
     # `getContactDetails` placeholders that haven't been enriched yet).
     updateRolePreserveOnEmpty(alias, Alias)
-    updateRole(icon, Icon)
-    updateRole(isContact, IsContact)
-    updateRole(memberRole, MemberRole)
-    updateRole(joined, Joined)
-    updateRole(trustStatus, TrustStatus)
-    updateRole(isBlocked, IsBlocked)
-    updateRole(contactRequest, ContactRequest)
+    updateRole(icon)
+    updateRole(isContact)
+    updateRole(memberRole)
+    updateRole(joined)
+    updateRole(trustStatus)
+    updateRole(isBlocked)
+    updateRole(contactRequest)
 
     var updatedMembershipRequestState = membershipRequestState
     if updatedMembershipRequestState == MembershipRequestState.None:
       updatedMembershipRequestState = self.items[ind].membershipRequestState
 
-    updateRoleWithValue(membershipRequestState, MembershipRequestState, updatedMembershipRequestState)
+    updateRoleWithValue(membershipRequestState, updatedMembershipRequestState)
 
     if preferredDisplayNameChanged:
       roles.add(ModelRole.PreferredDisplayName.int)

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -1,4 +1,3 @@
-import app/modules/shared_models/model_utils
 import nimqml, tables, std/strformat, sequtils, sugar
 # TODO: use generics to remove duplication between user_model and member_model
 
@@ -267,46 +266,24 @@ QtObject:
     return self.findIndexForMember(id) != -1
 
   proc setName*(self: Model, pubKey: string, displayName: string, ensName: string, localNickname: string) =
-    let ind = self.findIndexForMember(pubKey)
-    if ind == -1:
-      return
+    updateItemRolesAndNotify self.findIndexForMember(pubKey):
+      let preferredDisplayNameChanged =
+        resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias) !=
+        resolvePreferredDisplayName(localNickname, ensName, displayName, self.items[ind].alias)
 
-    var roles: seq[int] = @[]
+      let usesDefaultName = resolveUsesDefaultName(localNickname, ensName, displayName)
 
-    let preferredDisplayNameChanged =
-      resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias) !=
-      resolvePreferredDisplayName(localNickname, ensName, displayName, self.items[ind].alias)
+      updateRole(displayName, DisplayName)
+      updateRole(ensName, EnsName)
+      updateRole(localNickname, LocalNickname)
+      updateRole(usesDefaultName, UsesDefaultName)
 
-    let usesDefaultName = resolveUsesDefaultName(localNickname, ensName, displayName)
-
-    updateRole(displayName, DisplayName)
-    updateRole(ensName, EnsName)
-    updateRole(localNickname, LocalNickname)
-    updateRole(usesDefaultName, UsesDefaultName)
-
-    if roles.len == 0:
-      return
-
-    if preferredDisplayNameChanged:
-      roles.add(ModelRole.PreferredDisplayName.int)
-
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, roles)
+      if preferredDisplayNameChanged:
+        roles.add(ModelRole.PreferredDisplayName.int)
 
   proc setIcon*(self: Model, pubKey: string, icon: string) =
-    let ind = self.findIndexForMember(pubKey)
-    if ind == -1:
-      return
-
-    if self.items[ind].icon == icon:
-      return
-
-    self.items[ind].icon = icon
-
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.Icon.int])
+    updateItemRolesAndNotify self.findIndexForMember(pubKey):
+      updateRole(icon, Icon)
 
   proc updateItem*(
       self: Model,

--- a/src/app/modules/shared_models/model_utils.nim
+++ b/src/app/modules/shared_models/model_utils.nim
@@ -24,34 +24,38 @@ template guardModelSetDataRole*[T](role: int, _: typedesc[T]) =
   if role < ord(low(T)) or role > ord(high(T)):
     return false
 
+proc roleNameFromProperty(propertyName: NimNode): NimNode =
+  let propertyNameStr = $propertyName
+  ident(propertyNameStr[0].toUpperAscii() & propertyNameStr[1 .. ^1])
+
 # Macro that simplifies checking and updating values in a model
 # IMPORTANT:
   # The model's items need to be in a `seq` called `items`
   # A `seq[int]` named `roles` needs to exist
   # The index of the item being checked must be named `ind`
-macro updateRole*(propertyName: untyped, roleName: untyped): untyped =
+macro updateRole*(propertyName: untyped): untyped =
+  let roleName = roleNameFromProperty(propertyName)
   quote do:
     if self.items[ind].`propertyName` != `propertyName`:
       self.items[ind].`propertyName` = `propertyName`
       roles.add(ModelRole.`roleName`.int)
 
 # Same thing as updateRole where you have a value to set that is not the same **exact** name as the propertyName
-# Eg: updateRoleWithValue(name, Name, item.name)
-macro updateRoleWithValue*(propertyName: untyped, roleName: untyped, value: untyped): untyped =
+# Eg: updateRoleWithValue(name, item.name)
+macro updateRoleWithValue*(propertyName: untyped, value: untyped): untyped =
+  let roleName = roleNameFromProperty(propertyName)
   quote do:
     if self.items[ind].`propertyName` != `value`:
       self.items[ind].`propertyName` = `value`
       roles.add(ModelRole.`roleName`.int)
 
-# Expands a list of item fields into updateRoleWithValue(field, FieldRole, item.field).
+# Expands a list of item fields into updateRoleWithValue(field, item.field).
 # Example usage: updateRolesFromItem(item, name, memberRole, icon)
 macro updateRolesFromItem*(item: untyped, propertyNames: varargs[untyped]): untyped =
   result = newStmtList()
   for propertyName in propertyNames:
-    let propertyNameStr = $propertyName
-    let roleName = ident(propertyNameStr[0].toUpperAscii() & propertyNameStr[1 .. ^1])
     result.add quote do:
-      updateRoleWithValue(`propertyName`, `roleName`, `item`.`propertyName`)
+      updateRoleWithValue(`propertyName`, `item`.`propertyName`)
 
 # Like updateRole but skip the assignment when the incoming string value is
 # empty AND the existing value is non-empty. Use for fields that are
@@ -65,8 +69,8 @@ macro updateRolePreserveOnEmpty*(propertyName: untyped, roleName: untyped): unty
 # Wrap one or more updateRole calls and notify the row at `ind` if any roles changed.
 # Example usage:
 #   updateRolesAndNotify:
-#     updateRole(name, Name)
-#     updateRole(icon, Icon)
+#     updateRole(name)
+#     updateRole(icon)
 template updateRolesAndNotify*(body: untyped) {.dirty.} =
   var roles: seq[int] = @[]
 
@@ -82,7 +86,7 @@ template updateRolesAndNotify*(body: untyped) {.dirty.} =
 # Like updateRolesAndNotify, but first resolves `ind` from a model-specific lookup expression.
 # Example usage:
 #   updateItemRolesAndNotify self.findIndexById(id):
-#     updateRole(name, Name)
+#     updateRole(name)
 template updateItemRolesAndNotify*(findIndex: untyped, body: untyped) {.dirty.} =
   let ind = findIndex
   if ind == -1:

--- a/src/app/modules/shared_models/model_utils.nim
+++ b/src/app/modules/shared_models/model_utils.nim
@@ -51,3 +51,32 @@ macro updateRolePreserveOnEmpty*(propertyName: untyped, roleName: untyped): unty
     if `propertyName`.len > 0 and self.items[ind].`propertyName` != `propertyName`:
       self.items[ind].`propertyName` = `propertyName`
       roles.add(ModelRole.`roleName`.int)
+
+# Wrap one or more updateRole calls and notify the row at `ind` if any roles changed.
+# Example usage:
+#   updateRolesAndNotify:
+#     updateRole(name, Name)
+#     updateRole(icon, Icon)
+template updateRolesAndNotify*(body: untyped) {.dirty.} =
+  var roles: seq[int] = @[]
+
+  body
+
+  if roles.len == 0:
+    return
+
+  let modelIndex = self.createIndex(ind, 0, nil)
+  defer: modelIndex.delete
+  self.dataChanged(modelIndex, modelIndex, roles)
+
+# Like updateRolesAndNotify, but first resolves `ind` from a model-specific lookup expression.
+# Example usage:
+#   updateItemRolesAndNotify self.findIndexById(id):
+#     updateRole(name, Name)
+template updateItemRolesAndNotify*(findIndex: untyped, body: untyped) {.dirty.} =
+  let ind = findIndex
+  if ind == -1:
+    return
+
+  updateRolesAndNotify:
+    body

--- a/src/app/modules/shared_models/model_utils.nim
+++ b/src/app/modules/shared_models/model_utils.nim
@@ -1,4 +1,4 @@
-import std/macros
+import std/[macros, strutils]
 
 template guardModelDataIndex*(index: untyped, count: int) =
   if not index.isValid:
@@ -42,6 +42,16 @@ macro updateRoleWithValue*(propertyName: untyped, roleName: untyped, value: unty
     if self.items[ind].`propertyName` != `value`:
       self.items[ind].`propertyName` = `value`
       roles.add(ModelRole.`roleName`.int)
+
+# Expands a list of item fields into updateRoleWithValue(field, FieldRole, item.field).
+# Example usage: updateRolesFromItem(item, name, memberRole, icon)
+macro updateRolesFromItem*(item: untyped, propertyNames: varargs[untyped]): untyped =
+  result = newStmtList()
+  for propertyName in propertyNames:
+    let propertyNameStr = $propertyName
+    let roleName = ident(propertyNameStr[0].toUpperAscii() & propertyNameStr[1 .. ^1])
+    result.add quote do:
+      updateRoleWithValue(`propertyName`, `roleName`, `item`.`propertyName`)
 
 # Like updateRole but skip the assignment when the incoming string value is
 # empty AND the existing value is non-empty. Use for fields that are

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -1,4 +1,3 @@
-import app/modules/shared_models/model_utils
 import nimqml, tables, strutils, std/strformat
 
 import json
@@ -287,51 +286,41 @@ QtObject:
     self.dataChanged(dataIndex, dataIndex, @[ModelRole.Muted.int])
 
   proc editItem*(self: SectionModel, item: SectionItem) =
-    let ind = self.getItemIndex(item.id)
-    if ind == -1:
-      return
-    
-    var roles: seq[int] = @[]
+    updateItemRolesAndNotify self.getItemIndex(item.id):
+      updateRolesFromItem(item,
+        name,
+        memberRole,
+        isControlNode,
+        description,
+        introMessage,
+        outroMessage,
+        image,
+        bannerImageData,
+        icon,
+        color,
+        tags,
+        hasNotification,
+        notificationsCount,
+        active,
+        enabled,
+        joined,
+        spectated,
+        isMember,
+        canJoin,
+        canManageUsers,
+        canRequestAccess,
+        access,
+        ensOnly,
+        muted,
+        historyArchiveSupportEnabled,
+        pinMessageAllMembersEnabled,
+        encrypted,
+        isPendingOwnershipRequest,
+        activeMembersCount,
+        joinedMembersCount,
+      )
 
-    updateRoleWithValue(name, Name, item.name)
-    updateRoleWithValue(memberRole, MemberRole, item.memberRole)
-    updateRoleWithValue(isControlNode, IsControlNode, item.isControlNode)
-    updateRoleWithValue(description, Description, item.description)
-    updateRoleWithValue(introMessage, IntroMessage, item.introMessage)
-    updateRoleWithValue(outroMessage, OutroMessage, item.outroMessage)
-    updateRoleWithValue(image, Image, item.image)
-    updateRoleWithValue(bannerImageData, BannerImageData, item.bannerImageData)
-    updateRoleWithValue(icon, Icon, item.icon)
-    updateRoleWithValue(color, Color, item.color)
-    updateRoleWithValue(tags, Tags, item.tags)
-    updateRoleWithValue(hasNotification, HasNotification, item.hasNotification)
-    updateRoleWithValue(notificationsCount, NotificationsCount, item.notificationsCount)
-    updateRoleWithValue(active, Active, item.active)
-    updateRoleWithValue(enabled, Enabled, item.enabled)
-    updateRoleWithValue(joined, Joined, item.joined)
-    updateRoleWithValue(spectated, Spectated, item.spectated)
-    updateRoleWithValue(isMember, IsMember, item.isMember)
-    updateRoleWithValue(canJoin, CanJoin, item.canJoin)
-    updateRoleWithValue(canManageUsers, CanManageUsers, item.canManageUsers)
-    updateRoleWithValue(canRequestAccess, CanRequestAccess, item.canRequestAccess)
-    updateRoleWithValue(access, Access, item.access)
-    updateRoleWithValue(ensOnly, EnsOnly, item.ensOnly)
-    updateRoleWithValue(muted, Muted, item.muted)
-    updateRoleWithValue(historyArchiveSupportEnabled, HistoryArchiveSupportEnabled, item.historyArchiveSupportEnabled)
-    updateRoleWithValue(pinMessageAllMembersEnabled, PinMessageAllMembersEnabled, item.pinMessageAllMembersEnabled)
-    updateRoleWithValue(encrypted, Encrypted, item.encrypted)
-    updateRoleWithValue(isPendingOwnershipRequest, IsPendingOwnershipRequest, item.isPendingOwnershipRequest)
-    updateRoleWithValue(activeMembersCount, ActiveMembersCount, item.activeMembersCount)
-    updateRoleWithValue(joinedMembersCount, JoinedMembersCount, item.joinedMembersCount)
-
-    self.items[ind].members.updateToTheseItems(item.members.getItems())
-
-    if roles.len == 0:
-      return
-
-    let dataIndex = self.createIndex(ind, 0, nil)
-    defer: dataIndex.delete
-    self.dataChanged(dataIndex, dataIndex, roles)
+      self.items[ind].members.updateToTheseItems(item.members.getItems())
 
   proc updateMemberItemInSections*(
       self: SectionModel,

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -41,7 +41,7 @@ type
     PinMessageAllMembersEnabled
     Encrypted
     CommunityTokensModel
-    AmIBanned
+    IsBanned
     IsPendingOwnershipRequest
     ActiveMembersCount
     MembersLoaded
@@ -119,7 +119,7 @@ QtObject:
       ModelRole.PinMessageAllMembersEnabled.int:"pinMessageAllMembersEnabled",
       ModelRole.Encrypted.int:"encrypted",
       ModelRole.CommunityTokensModel.int:"communityTokens",
-      ModelRole.AmIBanned.int:"amIBanned",
+      ModelRole.IsBanned.int:"amIBanned",
       ModelRole.IsPendingOwnershipRequest.int:"isPendingOwnershipRequest",
       ModelRole.ActiveMembersCount.int:"activeMembersCount",
       ModelRole.MembersLoaded.int:"membersLoaded",
@@ -197,7 +197,7 @@ QtObject:
       result = newQVariant(item.encrypted)
     of ModelRole.CommunityTokensModel:
       result = newQVariant(item.communityTokens)
-    of ModelRole.AmIBanned:
+    of ModelRole.IsBanned:
       result = newQVariant(item.isBanned)
     of ModelRole.IsPendingOwnershipRequest:
       result = newQVariant(item.isPendingOwnershipRequest)
@@ -459,8 +459,8 @@ QtObject:
       if self.items[ind].id == id:
         var roles: seq[int] = @[]
 
-        updateRole(hasNotification, HasNotification)
-        updateRole(notificationsCount, NotificationsCount)
+        updateRole(hasNotification)
+        updateRole(notificationsCount)
 
         if roles.len == 0:
           return
@@ -583,7 +583,7 @@ QtObject:
 
     var roles: seq[int] = @[]
 
-    updateRole(isBanned, AmIBanned)
+    updateRole(isBanned)
 
     if roles.len == 0:
       return

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -276,9 +276,9 @@ QtObject:
       resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias) !=
       resolvePreferredDisplayName(localNickname, ensName, displayName, self.items[ind].alias)
 
-    updateRole(displayName, DisplayName)
-    updateRole(ensName, EnsName)
-    updateRole(localNickname, LocalNickname)
+    updateRole(displayName)
+    updateRole(ensName)
+    updateRole(localNickname)
 
     if preferredDisplayNameChanged:
       roles.add(ModelRole.PreferredDisplayName.int)
@@ -337,25 +337,25 @@ QtObject:
 
     let trustStatusChanged = trustStatus != self.items[ind].trustStatus
 
-    updateRole(displayName, DisplayName)
-    updateRole(ensName, EnsName)
-    updateRole(localNickname, LocalNickname)
+    updateRole(displayName)
+    updateRole(ensName)
+    updateRole(localNickname)
     # `alias` is deterministic from the pubkey — preserve if set
     updateRolePreserveOnEmpty(alias, Alias)
-    updateRole(icon, Icon)
-    updateRole(trustStatus, TrustStatus)
-    updateRole(onlineStatus, OnlineStatus)
-    updateRole(isContact, IsContact)
-    updateRole(isBlocked, IsBlocked)
-    updateRole(contactRequest, ContactRequest)
-    updateRole(lastUpdated, LastUpdated)
-    updateRole(lastUpdatedLocally, LastUpdatedLocally)
-    updateRole(bio, Bio)
-    updateRole(thumbnailImage, ThumbnailImage)
-    updateRole(largeImage, LargeImage)
-    updateRole(isContactRequestReceived, IsContactRequestReceived)
-    updateRole(isContactRequestSent, IsContactRequestSent)
-    updateRole(isRemoved, IsRemoved)
+    updateRole(icon)
+    updateRole(trustStatus)
+    updateRole(onlineStatus)
+    updateRole(isContact)
+    updateRole(isBlocked)
+    updateRole(contactRequest)
+    updateRole(lastUpdated)
+    updateRole(lastUpdatedLocally)
+    updateRole(bio)
+    updateRole(thumbnailImage)
+    updateRole(largeImage)
+    updateRole(isContactRequestReceived)
+    updateRole(isContactRequestSent)
+    updateRole(isRemoved)
 
     if preferredDisplayNameChanged:
       roles.add(ModelRole.PreferredDisplayName.int)

--- a/src/app/modules/shared_modules/authentication/module.nim
+++ b/src/app/modules/shared_modules/authentication/module.nim
@@ -6,7 +6,7 @@ import app/core/eventemitter
 import app/modules/shared_models/keypair_item
 
 import app/global/global_singleton
-from app_service/common/account_constants import PATH_ENCRYPTION
+from app_service/common/account_constants import PATH_ENCRYPTION, PATH_WHISPER
 import app_service/service/accounts/service as accounts_service
 import app_service/service/wallet_account/service as wallet_account_service
 import app_service/service/keycardV2/service as keycard_serviceV2
@@ -64,9 +64,9 @@ method startKeycardAuthentication*[T](self: Module[T], keyUid: string, pin: stri
                    else: singletonInstance.userProfile.getKeyUid()
     exportPrivate = true
     exportMasterAddr = false
-  var paths = @[account_constants.PATH_ENCRYPTION]
+  var paths = @[PATH_ENCRYPTION]
   if exportChatKey:
-    paths.add(account_constants.PATH_WHISPER)
+    paths.add(PATH_WHISPER)
   self.controller.startKeycardAuthentication(targetKeyUid, paths, exportPrivate, exportMasterAddr, pin)
 
 method stopKeycardAuthentication*[T](self: Module[T]) =

--- a/src/app/modules/shared_modules/keycard_management/module.nim
+++ b/src/app/modules/shared_modules/keycard_management/module.nim
@@ -6,8 +6,6 @@ import app/global/global_singleton
 import app/core/eventemitter
 import app/modules/shared/keypairs
 
-import app_service/common/account_constants
-import app_service/common/utils
 import app_service/service/keycardV2/service as keycard_serviceV2
 import app_service/service/accounts/service as accounts_service
 import app_service/service/wallet_account/service as wallet_account_service
@@ -18,6 +16,7 @@ export io_interface
 logScope:
   topics = "keycard-management-module"
 
+import app_service/common/account_constants
 type AccountData = object
   name: string
   colorId: string

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -1,4 +1,4 @@
-import nimqml, tables, os, json, std/strformat, sequtils, strutils, times, std/options
+import nimqml, tables, os, json, std/strformat, sequtils, strutils, std/options
 import json_serialization, chronicles
 
 import app/global/global_singleton


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-app/issues/20168

Added shared model helpers in model_utils.nim to remove the repeated “find row, update roles, emit `dataChanged`” boilerplate. `updateRolesAndNotify` now wraps role collection and notification, while `updateItemRolesAndNotify` also handles resolving `ind` from a model-specific lookup expression and returning when the item is missing.

Simplified role-update macros so role names are inferred from property names. `updateRole(displayName)` now maps to `ModelRole.DisplayName`, and `updateRoleWithValue(membershipRequestState, updatedMembershipRequestState)` maps to `ModelRole.MembershipRequestState`. `updateRolesFromItem(item, ...)` was added to generate repeated `updateRoleWithValue(field, item.field)` calls from a listed set of fields.

Applied the new helpers across the model code. `member_model`, `section_model`, `user_model`, `chat_search_model`, `chat_section/model`, and `profile_section/notifications/model` now use the shorter inferred-role calls where applicable. `section_model.editItem` was reduced to an `updateRolesFromItem` field list, and the `AmIBanned` role was renamed to `IsBanned` so it follows the inference convention. Validation with focused `nim check` commands passed, with only existing QtObject/NimQML deprecation warnings.

I recommend reviewing per commit to understand the scope of each of the changes. The last commit is purely a refactor/small change, because I learned that we can "generate" the role name from the propertyName.

If you guys like the new helpers, I can work to apply them to all the places in the app where we use `updateRole`. Then we can work to even fix previous model changes that don't even use `updateRole` to increase performance.

### Affected areas

Models

### Impact on end user

None. Only Nim-side code cleanliness

### How to test

Use the app and it should work as before

### Risk 

Low
