### PR TITLE
fix: expose the edited-message indicator to accessibility

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -98,8 +98,12 @@ Item {
         // (HTML), which Qt's Android a11y backend does not surface, so the body
         // is otherwise invisible to screen readers and e2e. Expose the unstyled
         // text via Accessible.name on the text element instead.
-        readonly property string plainText:
-            Utils.stripHtmlTags(root.messageDetails.messageText)
+        readonly property string plainText: {
+            const base = Utils.stripHtmlTags(root.messageDetails.messageText)
+            // The "(edited)" indicator is only a visual HTML span in the rendered
+            // text; append it here so it reaches Accessible.name too.
+            return root.isEdited ? base + " " + qsTr("(edited)") : base
+        }
 
         function showDisabledTooltipForAddressEnsName(link) {
             return link.startsWith('//send-via-personal-chat//') && !!root.disabledTooltipText


### PR DESCRIPTION
### What does the PR do
Exposes the "(edited)" message indicator to accessibility. It is currently
rendered only as a visual HTML span in the message text, while the text
element's `Accessible.name` is built from the raw (unformatted) message text —
so screen readers and e2e cannot tell an edited message from an unedited one.
This appends the indicator to the accessible name when a message is edited.

### Affected areas
StatusQ — message rendering (`StatusTextMessage`), accessibility only. No visual change.

### Impact on end user
Screen-reader users can now perceive that a message was edited. No change for sighted users.

### How to test
- A11y tree: an edited message's `content-desc` now ends with "(edited)".
- e2e: removing the xfail on `test_edit_message_and_verify_on_both_devices`
  (added in #21367) and running the Android gate should then pass.

### Risk
Low — additive accessibility string; only changes `Accessible.name` when `isEdited`.
No effect on the rendered/visual text.
