### PR TITLE
feat(keycard): runs the app against simulated keycard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ nim_status_client.log
 .flatpak-builder
 /ui/StatusQ/sandbox/android/.gradle/
 .qmake_previous
+# Used to track the simulated keycard mode changes via the USE_SIMULATED_KEYCARD build flag
+.use_simulated_keycard_previous
 *.qm
 
 # Squish test ================================================================

--- a/Makefile
+++ b/Makefile
@@ -571,13 +571,19 @@ else
 STATUS_KEYCARD_QT_BUILD_DIR := $(STATUS_KEYCARD_QT_SOURCE_DIR)/build/linux
 endif
 
+ifeq ($(USE_SIMULATED_KEYCARD),true)
+STATUS_KEYCARD_QT_BUILD_DIR := $(STATUS_KEYCARD_QT_BUILD_DIR)-simulated-keycard
+STATUS_KEYCARD_QT_CMAKE_PARAMS += -DUSE_SIMULATED_KEYCARD=ON
+NIM_PARAMS += -d:useSimulatedKeycard
+endif
+
 STATUSKEYCARD_QT_LIB_PREFIX := lib
 STATUSKEYCARD_QT_LIB_SUBDIR :=
 ifeq ($(mkspecs),win32)
 STATUSKEYCARD_QT_LIB_PREFIX :=
 STATUSKEYCARD_QT_LIB_SUBDIR := /$(COMMON_CMAKE_BUILD_TYPE)
 endif
-export STATUSKEYCARD_QT_LIBDIR := $(STATUS_KEYCARD_QT_BUILD_DIR)$(STATUSKEYCARD_QT_LIB_SUBDIR)
+export STATUSKEYCARD_QT_LIBDIR := $(abspath $(STATUS_KEYCARD_QT_BUILD_DIR)$(STATUSKEYCARD_QT_LIB_SUBDIR))
 export STATUSKEYCARD_QT_LIB := $(STATUSKEYCARD_QT_LIBDIR)/$(STATUSKEYCARD_QT_LIB_PREFIX)status-keycard-qt.$(LIB_EXT)
 STATUSKEYCARD_QT_DYLIB_NAME := $(notdir $(STATUSKEYCARD_QT_LIB))
 STATUSKEYCARD_QT_LINKNAME := $(patsubst lib%,%,$(basename $(STATUSKEYCARD_QT_DYLIB_NAME)))
@@ -739,6 +745,16 @@ update-qmake-previous:
 # Add a dependency on update-qmake-previous if QMAKE has changed
 ifeq ($(QMAKE_CHANGED),yes)
 $(NIM_STATUS_CLIENT): update-qmake-previous
+endif
+
+# Force a rebuild of nim_status_client when USE_SIMULATED_KEYCARD is toggled.
+SIMKC_MODE := $(if $(filter true,$(USE_SIMULATED_KEYCARD)),on,off)
+SIMKC_PREVIOUS := .use_simulated_keycard_previous
+SIMKC_CHANGED := $(shell [ -f $(SIMKC_PREVIOUS) ] && [ "$$(cat $(SIMKC_PREVIOUS))" = "$(SIMKC_MODE)" ] && echo "no" || echo "yes")
+update-use-simulated-keycard-previous:
+	@echo $(SIMKC_MODE) > $(SIMKC_PREVIOUS)
+ifeq ($(SIMKC_CHANGED),yes)
+$(NIM_STATUS_CLIENT): update-use-simulated-keycard-previous
 endif
 
 STATUSQ_LIB_PATH := $(STATUSQ_INSTALL_PATH)/StatusQ

--- a/app.status.desktop.yml
+++ b/app.status.desktop.yml
@@ -157,7 +157,10 @@ modules:
         path: vendor/status-go/build/bin/libstatus.so.0
         dest: native-libs
       - type: file
-        path: vendor/status-keycard-go/build/libkeycard/libkeycard.so
+        path: vendor/status-keycard-qt/build/linux/libstatus-keycard-qt.so.1
+        dest: native-libs
+      - type: file
+        path: vendor/status-keycard-qt/build/linux/libstatus-keycard-qt.so.1.0.0
         dest: native-libs
       # libsds.so is staged into tmp/linux/flatpak/in by bundle-flatpak.sh
       # because it's built outside the workspace tree.

--- a/ci/Jenkinsfile.flatpak
+++ b/ci/Jenkinsfile.flatpak
@@ -45,8 +45,8 @@ pipeline {
       defaultValue: ''
     )
     booleanParam(
-      name: 'USE_MOCKED_KEYCARD_LIB',
-      description: 'Decides whether the mocked status-keycard-go library is built.',
+      name: 'USE_SIMULATED_KEYCARD',
+      description: 'Build with the simulated (jcardsim) keycard backend (used by keycard e2e tests).',
       defaultValue: false
     )
   }
@@ -95,7 +95,7 @@ pipeline {
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
     VERBOSE =                "${params.VERBOSE}"
-    USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
+    USE_SIMULATED_KEYCARD = "${params.USE_SIMULATED_KEYCARD}"
     /* FIXME: figure out why NIMFLAGS are not respected */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}"
     /* Ensure nimcache is not shared between builds. */

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -45,8 +45,8 @@ pipeline {
       defaultValue: ''
     )
     booleanParam(
-      name: 'USE_MOCKED_KEYCARD_LIB',
-      description: 'Decides whether the mocked status-keycard-go library is built.',
+      name: 'USE_SIMULATED_KEYCARD',
+      description: 'Build with the simulated (jcardsim) keycard backend (used by keycard e2e tests).',
       defaultValue: false
     )
   }
@@ -93,7 +93,7 @@ pipeline {
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
     VERBOSE =                "${params.VERBOSE}"
-    USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
+    USE_SIMULATED_KEYCARD = "${params.USE_SIMULATED_KEYCARD}"
     /* FIXME: figure out why NIMFLAGS are not respected */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}"
     /* Ensure nimcache is not shared between builds. */

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -31,8 +31,8 @@ pipeline {
       defaultValue: ''
     )
     booleanParam(
-      name: 'USE_MOCKED_KEYCARD_LIB',
-      description: 'Decides whether the mocked status-keycard-go library is built.',
+      name: 'USE_SIMULATED_KEYCARD',
+      description: 'Build with the simulated (jcardsim) keycard backend (used by keycard e2e tests).',
       defaultValue: false
     )
   }
@@ -74,7 +74,7 @@ pipeline {
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
     VERBOSE =                "${params.VERBOSE}"
-    USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
+    USE_SIMULATED_KEYCARD = "${params.USE_SIMULATED_KEYCARD}"
     /* FIXME: figure out why NIMFLAGS are not respected */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
     /* Ensure nimcache is not shared between builds. */

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -29,8 +29,8 @@ pipeline {
       choices: ['0', '1', '2']
     )
     booleanParam(
-      name: 'USE_MOCKED_KEYCARD_LIB',
-      description: 'Decides whether the mocked status-keycard-go library is built.',
+      name: 'USE_SIMULATED_KEYCARD',
+      description: 'Build with the simulated (jcardsim) keycard backend (used by keycard e2e tests).',
       defaultValue: false
     )
     choice(
@@ -94,7 +94,7 @@ pipeline {
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
     VERBOSE =                "${params.VERBOSE}"
-    USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
+    USE_SIMULATED_KEYCARD = "${params.USE_SIMULATED_KEYCARD}"
     /* FIXME: figure out why NIMFLAGS are not respected */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
     /* Ensure nimcache is not shared between builds. */

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -31,8 +31,8 @@ pipeline {
       defaultValue: ''
     )
     booleanParam(
-      name: 'USE_MOCKED_KEYCARD_LIB',
-      description: 'Decides whether the mocked status-keycard-go library is built.',
+      name: 'USE_SIMULATED_KEYCARD',
+      description: 'Build with the simulated (jcardsim) keycard backend (used by keycard e2e tests).',
       defaultValue: false
     )
     choice(
@@ -96,7 +96,7 @@ pipeline {
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
     VERBOSE =                "${params.VERBOSE}"
-    USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
+    USE_SIMULATED_KEYCARD = "${params.USE_SIMULATED_KEYCARD}"
     /* FIXME: figure out why NIMFLAGS are not respected */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
     /* Nim build on Windows puts nimcache in user HOME. */

--- a/config.nims
+++ b/config.nims
@@ -1,7 +1,11 @@
+# Keep a separate nimcache per USE_SIMULATED_KEYCARD mode. That flag toggles -d:useSimulatedKeycard,
+# which adds/removes the KeycardTest* imports from libstatus-keycard-qt; sharing one cache let stale
+# (simulated) codegen leak into a non-simulated build -> dyld "Symbol not found: _KeycardTestCreateCard".
+let kcSuffix = when defined(useSimulatedKeycard): "-simkeycard" else: ""
 if defined(release):
-  switch("nimcache", "nimcache/release/$projectName")
+  switch("nimcache", "nimcache/release" & kcSuffix & "/$projectName")
 else:
-  switch("nimcache", "nimcache/debug/$projectName")
+  switch("nimcache", "nimcache/debug" & kcSuffix & "/$projectName")
 
 --threads:on
 --opt:speed # -O3

--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -124,6 +124,12 @@ QtObject:
   QtProperty[bool] testEnvironment:
     read = getTestEnvironment
 
+  proc getUseSimulatedKeycard*(self: LocalAppSettings): bool {.slot.} =
+    return defined(useSimulatedKeycard)
+
+  QtProperty[bool] useSimulatedKeycard:
+    read = getUseSimulatedKeycard
+
   proc refreshTokenEnabledChanged*(self: LocalAppSettings) {.signal.}
   proc getRefreshTokenEnabled*(self: LocalAppSettings): bool {.slot.} =
     self.settings.value(LAS_KEY_REFRESH_TOKEN_ENABLED, newQVariant(false)).boolVal

--- a/src/app_service/service/keycardV2/test_controller.nim
+++ b/src/app_service/service/keycardV2/test_controller.nim
@@ -1,0 +1,149 @@
+import nimqml
+
+when defined(useSimulatedKeycard):
+  import std/[os, osproc, strutils, json]
+  import chronicles
+  import keycard_go
+  import constants as status_const
+  import rpc
+  import app/core/tasks/[qt, threadpool]
+
+  logScope:
+    topics = "keycard-simulator-controller"
+
+  const
+    KEYCARD_SIMULATOR_DEFAULT_VERSION = "3.2"
+    KEYCARD_SIMULATOR_DEFAULT_SIMULATOR_ADDRESS = "127.0.0.1:9025"
+    KEYCARD_SIMULATOR_DEFAULT_SIMULATOR_DIR = "vendor/status-keycard-qt/test/keycard-simulator"
+
+  var ignoreKeycardLibSignals = false # used to avoid triggering of any keycard actions while setting up the test keycard
+
+  proc shouldIgnoreKeycardLibSignals*(): bool =
+    return ignoreKeycardLibSignals
+
+  type
+    LoadCardArg = ref object of QObjectTaskArg
+      params: JsonNode
+
+  proc loadCardTask(argEncoded: string) {.gcsafe, nimcall.} =
+    let arg = decode[LoadCardArg](argEncoded)
+    var output = %*{"response": "", "error": ""}
+    try:
+      output["response"] = %* callRPC("Load", arg.params)
+    except Exception as e:
+      output["error"] = %* e.msg
+    arg.finish(output)
+
+  QtObject:
+    type KeycardTestController* = ref object of QObject
+      simProcess: Process  # the spawned jcardsim simulator server (if started from the app)
+      threadpool: ThreadPool
+
+    ## Forward declaration
+    proc delete*(self: KeycardTestController)
+
+    proc newKeycardTestController*(): KeycardTestController =
+      new(result, delete)
+      result.QObject.setup
+      result.threadpool = newThreadPool()
+
+    proc delete*(self: KeycardTestController) =
+      if not self.simProcess.isNil and self.simProcess.running:
+        self.simProcess.terminate()
+        self.simProcess.close()
+      if not self.threadpool.isNil:
+        self.threadpool.teardown()
+      self.QObject.delete
+
+    proc startSimulator*(self: KeycardTestController, version: string) {.slot.} =
+      if not self.simProcess.isNil and self.simProcess.running:
+        info "keycard simulator already running"
+        return
+      var safeVersion = ""
+      for c in version:
+        if c in {'0'..'9', '.'}: safeVersion.add(c)
+      if safeVersion.len == 0:
+        safeVersion = KEYCARD_SIMULATOR_DEFAULT_VERSION
+      let simDir = getEnv("STATUS_KEYCARD_SIM_DIR", KEYCARD_SIMULATOR_DEFAULT_SIMULATOR_DIR)
+      let port = getEnv("STATUS_KEYCARD_SIM_ENDPOINT", KEYCARD_SIMULATOR_DEFAULT_SIMULATOR_ADDRESS).rsplit(":", 1)[^1]
+      try:
+        self.simProcess = startProcess("/bin/bash",
+          args = @["-c", "cd '" & simDir & "' && ./build.sh && exec ./run.sh " & port & " " & safeVersion],
+          options = {poParentStreams})
+        info "starting keycard simulator", dir = simDir, port = port, version = safeVersion
+      except CatchableError as e:
+        error "failed to start keycard simulator", err = e.msg
+
+    proc createCard*(self: KeycardTestController, cardId: string) {.slot.} =
+      info "creating a new keycard with id: ", cardId
+      discard keycard_go.keycardTestCreateCard(cardId)
+
+    proc onLoadCardDone(self: KeycardTestController, response: string) {.slot.} =
+      info "load card task done with response: ", response
+      defer:
+        ignoreKeycardLibSignals = false
+      discard callRPC("Stop") # fully resets the SessionManager, returning the lib to its pre-call idle state
+      discard keycard_go.keycardTestRemoveCard()
+      discard keycard_go.keycardTestUnplugReader()
+      try:
+        let obj = response.parseJson
+        let err = obj{"error"}.getStr
+        if err.len > 0:
+          error "createKeycardWithSeed: task error", err = err
+          return
+        let rpcObj = obj{"response"}.getStr.parseJson
+        if rpcObj.hasKey("error") and rpcObj["error"].kind != JNull:
+          error "createKeycardWithSeed: Load error", err = $rpcObj["error"]
+        else:
+          info "createKeycardWithSeed: card provisioned"
+      except CatchableError as e:
+        warn "createKeycardWithSeed: bad Load response", err = e.msg
+
+    proc createKeycardWithSeed*(self: KeycardTestController, cardId: string, mnemonic: string, pin: string, puk: string,
+      metadataName: string, metadataPaths: string) {.slot.} =
+      ignoreKeycardLibSignals = true
+
+      var paths: seq[string]
+      for p in metadataPaths.split({',', ' ', '\n', '\t'}):
+        let t = p.strip()
+        if t.len > 0:
+          paths.add(t)
+
+      discard keycard_go.keycardTestCreateCard(cardId)
+      discard keycard_go.keycardTestPlugReader()
+      discard keycard_go.keycardTestInsertCard(cardId)
+
+      let params = %*{
+        "pin": pin,
+        "puk": puk,
+        "pairingPassword": "",
+        "mnemonic": mnemonic,
+        "metadataName": metadataName,
+        "metadataPaths": paths,
+        "storageFilePath": status_const.KEYCARDPAIRINGDATAFILE,
+        "logEnabled": status_const.KEYCARD_LOGS_ENABLED,
+        "logFilePath": status_const.KEYCARD_LOG_FILE_PATH,
+      }
+      info "starting load card task", params=params.pretty()
+      self.threadpool.start(LoadCardArg(
+        tptr: loadCardTask,
+        vptr: cast[uint](self.vptr),
+        slot: "onLoadCardDone",
+        params: params,
+      ))
+
+    proc insertCard*(self: KeycardTestController, cardId: string) {.slot.} =
+      info "inserting card with id: ", cardId
+      discard keycard_go.keycardTestInsertCard(cardId)
+
+    proc removeCard*(self: KeycardTestController) {.slot.} =
+      info "removing card"
+      discard keycard_go.keycardTestRemoveCard()
+
+    proc plugReader*(self: KeycardTestController) {.slot.} =
+      info "plugging reader"
+      discard keycard_go.keycardTestPlugReader()
+
+    proc unplugReader*(self: KeycardTestController) {.slot.} =
+      info "unplugging reader"
+      discard keycard_go.keycardTestUnplugReader()

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -52,8 +52,6 @@ let
 
   # runtime variables
   TEST_MODE_ENABLED* = desktopConfig.testMode
-  # TODO: revisit/implement when preparing keycard lib for testing
-  # DISPLAY_MOCKED_KEYCARD_WINDOW* = desktopConfig.displayMockedKeycardWindow
   WALLET_ENABLED* = desktopConfig.enableWallet
   TORRENT_CONFIG_PORT* = desktopConfig.defaultTorentConfigPort
   LOG_LEVEL* = desktopConfig.logLevel

--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -294,12 +294,6 @@ type StatusDesktopConfig = object
     desc: "Sets Waku fleets config file path"
     name: "WAKU_FLEETS_CONFIG"
     abbr: "waku-fleets-config" .}: string
-  # TODO: revisit/implement when preparing keycard lib for testing
-  # displayMockedKeycardWindow* {.
-  #   defaultValue: false
-  #   desc: "Determines if the app should use mocked keycard"
-  #   name: "USE_MOCKED_KEYCARD"
-  #   abbr: "use-mocked-keycard" .}: bool
   httpApiEnabled* {.
     defaultValue: CONNECTOR_ENABLED
     desc: "Enable HTTP RPC API"

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -24,6 +24,10 @@ featureGuard KEYCARD_ENABLED:
 when defined(macosx) and defined(arm64):
   import posix
 
+when defined(useSimulatedKeycard):
+  import app_service/service/keycardV2/test_controller
+  var keycardTestControllerInstance: KeycardTestController
+
 when defined(windows):
     {.link: "../status.o".}
 
@@ -109,7 +113,12 @@ proc setupRemoteSignalsHandling() =
 
   featureGuard KEYCARD_ENABLED:
     var callbackKeycardGo: keycard_go.KeycardSignalCallback = proc(p0: cstring) {.cdecl.} =
-      if isShuttingDown(): return
+      if isShuttingDown():
+        return
+      when defined(useSimulatedKeycard):
+        if test_controller.shouldIgnoreKeycardLibSignals():
+          return
+
       if keycardServiceV2QObjPointer != nil:
         signal_handler(keycardServiceV2QObjPointer, p0, "receiveKeycardSignalV2")
 
@@ -243,6 +252,10 @@ proc mainProc() =
 
   # Ensure we have the featureFlags instance available from the start
   singletonInstance.engine.setRootContextProperty("featureFlagsRootContextProperty", newQVariant(singletonInstance.featureFlags()))
+
+  when defined(useSimulatedKeycard):
+    keycardTestControllerInstance = newKeycardTestController()
+    singletonInstance.engine.setRootContextProperty("keycardTestController", newQVariant(keycardTestControllerInstance))
 
   statusq_registerQmlTypes()
 

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -9596,6 +9596,117 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
 </context>
 <context>
+    <name>KeycardSimulatorController</name>
+    <message>
+        <source>Keycard Simulator Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Applet version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use applet tag 4.0 (SecureChannel V2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tag 4.0 needs keycard-qt SecureChannel V2 support — not driveable by the app yet and refers to status-keycard after #72e9574 commit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default: tag 3.2 (classic password pairing), matches the current keycard-qt and refers to status-keycard #72e9574 commit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1. Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart Keycard Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Keycard Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>2. Create keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Card id:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Empty Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>— or create one with a seed —</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seed phrase (mandatory)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PIN:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PUK:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keycard name (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paths, comma-separated (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>3. Select keycard (does not insert it)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;no keycard selected&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>4. Reader &amp; card</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inserts the selected keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removes the selected keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plug reader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unplug reader</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>KeycardViewNew</name>
     <message>
         <source>Read Keycard</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -9647,6 +9647,117 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
 </context>
 <context>
+    <name>KeycardSimulatorController</name>
+    <message>
+        <source>Keycard Simulator Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Applet version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use applet tag 4.0 (SecureChannel V2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tag 4.0 needs keycard-qt SecureChannel V2 support — not driveable by the app yet and refers to status-keycard after #72e9574 commit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default: tag 3.2 (classic password pairing), matches the current keycard-qt and refers to status-keycard #72e9574 commit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1. Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart Keycard Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Keycard Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>2. Create keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Card id:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Empty Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>— or create one with a seed —</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seed phrase (mandatory)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PIN:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PUK:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keycard name (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paths, comma-separated (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>3. Select keycard (does not insert it)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;no keycard selected&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>4. Reader &amp; card</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inserts the selected keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removes the selected keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plug reader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unplug reader</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>KeycardViewNew</name>
     <message>
         <source>Read Keycard</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -9608,6 +9608,117 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
 </context>
 <context>
+    <name>KeycardSimulatorController</name>
+    <message>
+        <source>Keycard Simulator Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Applet version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use applet tag 4.0 (SecureChannel V2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tag 4.0 needs keycard-qt SecureChannel V2 support — not driveable by the app yet and refers to status-keycard after #72e9574 commit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default: tag 3.2 (classic password pairing), matches the current keycard-qt and refers to status-keycard #72e9574 commit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1. Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart Keycard Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Keycard Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>2. Create keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Card id:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Empty Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>— or create one with a seed —</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seed phrase (mandatory)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PIN:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PUK:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keycard name (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paths, comma-separated (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>3. Select keycard (does not insert it)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;no keycard selected&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>4. Reader &amp; card</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inserts the selected keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removes the selected keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plug reader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unplug reader</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>KeycardViewNew</name>
     <message>
         <source>Read Keycard</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -9570,6 +9570,117 @@ corruption, loss of your Status profile and the inability to restart Status.</so
     </message>
 </context>
 <context>
+    <name>KeycardSimulatorController</name>
+    <message>
+        <source>Keycard Simulator Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Applet version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use applet tag 4.0 (SecureChannel V2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tag 4.0 needs keycard-qt SecureChannel V2 support — not driveable by the app yet and refers to status-keycard after #72e9574 commit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default: tag 3.2 (classic password pairing), matches the current keycard-qt and refers to status-keycard #72e9574 commit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1. Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restart Keycard Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start Keycard Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>2. Create keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Card id:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Empty Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>— or create one with a seed —</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seed phrase (mandatory)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PIN:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PUK:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keycard name (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paths, comma-separated (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create Keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>3. Select keycard (does not insert it)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;no keycard selected&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>4. Reader &amp; card</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inserts the selected keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removes the selected keycard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plug reader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unplug reader</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>KeycardViewNew</name>
     <message>
         <source>Read Keycard</source>

--- a/ui/imports/shared/panels/KeycardSimulatorController.qml
+++ b/ui/imports/shared/panels/KeycardSimulatorController.qml
@@ -1,0 +1,291 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Controls
+
+ApplicationWindow {
+    id: root
+
+    required property var controller
+
+    property var mainWindow: null
+
+    readonly property bool loggedIn: !!(mainWindow && mainWindow.userLoggedIn)
+
+    title: qsTr("Keycard Simulator Controller")
+    width: 380
+    minimumWidth: 380
+    height: 800
+    minimumHeight: 800
+
+    x: mainWindow ? Math.max(0, mainWindow.x + mainWindow.width + 4) : 100
+    y: mainWindow ? mainWindow.y + 32 : 100
+
+    QtObject {
+        id: d
+
+        property bool simulatorStarted: false
+        property var cardIds: []
+        property bool readerPlugged: false
+        property bool cardInserted: false
+
+
+        readonly property string keycardVersion32: "3.2"
+        readonly property string keycardVersion40: "4.0"
+        readonly property string selectedVersion: useTag40Check.checked?
+                                                      d.keycardVersion40
+                                                    : d.keycardVersion32
+
+        readonly property string selectedCardId: cardSelector.currentIndex >= 0
+                                                 && cardSelector.currentIndex < d.cardIds.length?
+                                                     d.cardIds[cardSelector.currentIndex]
+                                                   : ""
+
+        function resetState() {
+            d.cardIds = []
+            d.readerPlugged = false
+            d.cardInserted = false
+            cardSelector.currentIndex = -1
+        }
+    }
+
+    component SectionHeader: StatusBaseText {
+        font.bold: true
+        Layout.topMargin: 4
+    }
+    component Separator: Rectangle {
+        Layout.fillWidth: true
+        Layout.preferredHeight: 1
+        color: Theme.palette.directColor2
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 8
+
+        // ---- Section 0. Applet version ----
+        SectionHeader { text: qsTr("Applet version") }
+        CheckBox {
+            id: useTag40Check
+            objectName: "keycardSimUseTag40"
+            text: qsTr("Use applet tag 4.0 (SecureChannel V2)")
+            checked: false
+            enabled: !d.simulatorStarted
+        }
+        StatusBaseText {
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+            font.pixelSize: 12
+            color: Theme.palette.baseColor1
+            text: useTag40Check.checked
+                  ? qsTr("Tag 4.0 needs keycard-qt SecureChannel V2 support — not driveable by the app yet and refers to status-keycard after #72e9574 commit.")
+                  : qsTr("Default: tag 3.2 (classic password pairing), matches the current keycard-qt and refers to status-keycard #72e9574 commit.")
+        }
+
+        Separator {}
+
+        // ---- Section 1. Simulator ----
+        SectionHeader { text: qsTr("1. Simulator") }
+        StatusButton {
+            objectName: "keycardSimStartButton"
+            Layout.fillWidth: true
+            text: d.simulatorStarted ? qsTr("Restart Keycard Simulator")
+                                     : qsTr("Start Keycard Simulator")
+            onClicked: {
+                root.controller.startSimulator(d.selectedVersion)
+                d.simulatorStarted = true
+                d.resetState()
+            }
+        }
+
+        Separator {}
+
+        // ---- Section 2. Create keycard ----
+        SectionHeader { text: qsTr("2. Create keycard") }
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 8
+            StatusBaseText { text: qsTr("Card id:") }
+            TextField {
+                id: cardIdField
+                objectName: "keycardSimCardId"
+                enabled: d.simulatorStarted
+                selectByMouse: true
+                Layout.fillWidth: true
+            }
+        }
+
+        StatusButton {
+            objectName: "keycardSimCreateEmptyButton"
+            Layout.fillWidth: true
+            text: qsTr("Create Empty Keycard")
+            enabled: d.simulatorStarted
+                     && cardIdField.text.trim() !== ""
+                     && d.cardIds.indexOf(cardIdField.text.trim()) === -1
+            onClicked: {
+                const id = cardIdField.text.trim()
+                root.controller.createCard(id)
+                d.cardIds = d.cardIds.concat([id])
+                cardIdField.clear()
+            }
+        }
+
+        StatusBaseText {
+            Layout.topMargin: 4
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+            font.pixelSize: 12
+            color: Theme.palette.baseColor1
+            text: qsTr("— or create one with a seed —")
+        }
+        TextField {
+            id: seedField
+            objectName: "keycardSimSeed"
+            enabled: d.simulatorStarted
+            selectByMouse: true
+            Layout.fillWidth: true
+            placeholderText: qsTr("Seed phrase (mandatory)")
+        }
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 8
+            StatusBaseText { text: qsTr("PIN:") }
+            TextField {
+                id: pinField
+                objectName: "keycardSimPin"
+                enabled: d.simulatorStarted
+                Layout.preferredWidth: 90
+                text: "111111"
+                maximumLength: 6
+                inputMethodHints: Qt.ImhDigitsOnly
+                validator: RegularExpressionValidator { regularExpression: /[0-9]{0,6}/ }
+            }
+            StatusBaseText { text: qsTr("PUK:") }
+            TextField {
+                id: pukField
+                objectName: "keycardSimPuk"
+                enabled: d.simulatorStarted
+                Layout.fillWidth: true
+                text: "000000000000"
+                maximumLength: 12
+                inputMethodHints: Qt.ImhDigitsOnly
+                validator: RegularExpressionValidator { regularExpression: /[0-9]{0,12}/ }
+            }
+        }
+        TextField {
+            id: nameField
+            objectName: "keycardSimName"
+            enabled: d.simulatorStarted
+            selectByMouse: true
+            Layout.fillWidth: true
+            text: "StatusKeycard"
+            placeholderText: qsTr("Keycard name (optional)")
+        }
+        TextField {
+            id: pathsField
+            objectName: "keycardSimPaths"
+            enabled: d.simulatorStarted
+            selectByMouse: true
+            Layout.fillWidth: true
+            text: "m/44'/60'/0'/0/0"
+            placeholderText: qsTr("Paths, comma-separated (optional)")
+        }
+        StatusButton {
+            objectName: "keycardSimCreateWithSeedButton"
+            Layout.fillWidth: true
+            text: qsTr("Create Keycard")
+            enabled: d.simulatorStarted
+                     && cardIdField.text.trim() !== ""
+                     && d.cardIds.indexOf(cardIdField.text.trim()) === -1
+                     && seedField.text.trim() !== ""
+                     && pinField.text.length === 6
+                     && pukField.text.length === 12
+            onClicked: {
+                const id = cardIdField.text.trim()
+                root.controller.createKeycardWithSeed(id, seedField.text.trim(),
+                                                      pinField.text, pukField.text, nameField.text.trim(), pathsField.text.trim())
+                d.cardIds = d.cardIds.concat([id])
+                cardIdField.clear()
+                seedField.clear()
+            }
+        }
+
+        Separator {}
+
+        // ---- Section 3. Select keycard ----
+        SectionHeader { text: qsTr("3. Select keycard (does not insert it)") }
+        ComboBox {
+            id: cardSelector
+            objectName: "keycardSimCardSelector"
+            Layout.fillWidth: true
+            enabled: d.simulatorStarted && !d.cardInserted && d.cardIds.length > 0
+            model: d.cardIds
+            displayText: d.selectedCardId === "" ? qsTr("<no keycard selected>")
+                                                 : d.selectedCardId
+            Component.onCompleted: currentIndex = -1
+            onCountChanged: currentIndex = -1
+        }
+
+        Separator {}
+
+        // ---- Section 4. Reader & card (one reader, one card at a time) ----
+        SectionHeader { text: qsTr("4. Reader & card") }
+        Flow {
+            Layout.fillWidth: true
+            spacing: 8
+
+            StatusButton {
+                objectName: "keycardSimInsertButton"
+                text: qsTr("Insert keycard")
+                ToolTip.text: qsTr("Inserts the selected keycard")
+                ToolTip.visible: hovered
+                enabled: d.simulatorStarted && d.readerPlugged
+                         && d.selectedCardId !== "" && !d.cardInserted
+                onClicked: {
+                    root.controller.insertCard(d.selectedCardId)
+                    d.cardInserted = true
+                }
+            }
+            StatusButton {
+                objectName: "keycardSimRemoveButton"
+                text: qsTr("Remove keycard")
+                ToolTip.text: qsTr("Removes the selected keycard")
+                ToolTip.visible: hovered
+                enabled: d.cardInserted
+                onClicked: {
+                    root.controller.removeCard()
+                    d.cardInserted = false
+                    cardSelector.currentIndex = -1   // no selection once removed
+                }
+            }
+            StatusButton {
+                objectName: "keycardSimPlugReaderButton"
+                text: qsTr("Plug reader")
+                enabled: d.simulatorStarted && !d.readerPlugged
+                onClicked: {
+                    root.controller.plugReader()
+                    d.readerPlugged = true
+                }
+            }
+            StatusButton {
+                objectName: "keycardSimUnplugReaderButton"
+                text: qsTr("Unplug reader")
+                enabled: d.readerPlugged
+                onClicked: {
+                    root.controller.unplugReader()
+                    d.readerPlugged = false
+                    if (d.cardInserted) {
+                        d.cardInserted = false
+                        cardSelector.currentIndex = -1
+                    }
+                }
+            }
+        }
+
+        Item { Layout.fillHeight: true }
+    }
+}

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -58,6 +58,7 @@ Window {
     readonly property bool appThemeDark: Theme.style === Theme.Style.Dark
     readonly property KeycardStateStore keycardStateStore: KeycardStateStore {}
     readonly property bool portraitLayout: height > width
+    readonly property bool userLoggedIn: loader.item !== null
     property bool biometricFlowPending: false
 
     // Use native Android keyboard tracking via WindowInsets API
@@ -210,6 +211,24 @@ Window {
         property int lastNonMinVisibility
 
         property bool showSkippedBiometricFlow: false
+
+        property var keycardSimulatorWindow
+        function createKeycardSimulatorController() {
+            if (d.keycardSimulatorWindow)
+                return
+            if (!localAppSettings || !localAppSettings.useSimulatedKeycard)
+                return
+            if (typeof keycardTestController === "undefined" || !keycardTestController)
+                return
+            const c = Qt.createComponent("qrc:/imports/shared/panels/KeycardSimulatorController.qml")
+            if (c.status === Component.Ready) {
+                d.keycardSimulatorWindow = c.createObject(applicationWindow, { "controller": keycardTestController, "mainWindow": applicationWindow })
+                if (d.keycardSimulatorWindow)
+                    d.keycardSimulatorWindow.show()
+            } else {
+                console.warn("KeycardSimulatorController failed to load:", c.errorString())
+            }
+        }
     }
 
     Binding {
@@ -414,6 +433,8 @@ Window {
         }
 
         restoreAppState()
+
+        d.createKeycardSimulatorController()
 
         Global.openShakeToSharePopupRequested.connect(openShakeToSharePopup)
 


### PR DESCRIPTION
Corresponding `status-keycard-qt` PR:
- https://github.com/status-im/status-keycard-qt/pull/30

Corresponding `nim-keycard-go` PR:
- https://github.com/keycard-tech/nim-keycard-go/pull/8


Behind the compile-time USE_SIMULATED_KEYCARD flag (off by default, so production is unaffected), the app drives a real Status Keycard applet running in jcardsim instead of a physical reader — enabling keycard e2e and manual testing without hardware.

- Bump status-keycard-qt (SimulatedChannelBackend + test-only KeycardTest* C API) and nim-keycard-go (matching bindings), both gated by the flag.
- Add KeycardTestController (Nim) and the KeycardSimulatorController window to start the simulator and create/insert/remove empty or seed-loaded cards.
- Wire USE_SIMULATED_KEYCARD through Makefile and CI, with a per-mode nimcache so toggling the flag rebuilds cleanly.

Closes #20305

----

In the video below the changes can be seen in action:


https://github.com/user-attachments/assets/6d37e18d-1db9-4ea4-ad7d-588f85fca680


https://github.com/user-attachments/assets/e56652c4-0b24-4703-932d-5ca4e0892100

