### PR TITLE
fix: Avoid showing unnecessary IOS paste permissions

### DIFF
--- a/ui/StatusQ/include/StatusQ/clipboardutils.h
+++ b/ui/StatusQ/include/StatusQ/clipboardutils.h
@@ -46,6 +46,11 @@ public:
 
     Q_INVOKABLE void clear();
 
+    // iOS workaround: stop Qt's text controls from reactively re-reading the
+    // clipboard on every change (which triggers the system "paste from..." prompt
+    // on app foreground). Call once at startup on iOS. See the .cpp for details.
+    Q_INVOKABLE void suppressChangeNotifications();
+
     static QObject* qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine);
 
 signals:

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -83,7 +83,12 @@ TextField {
         }
         StatusAction {
             text: qsTr("Paste")
-            enabled: root.canPaste
+            // On iOS, never read the clipboard for UI enablement: reading
+            // canPaste touches UIPasteboard and triggers the system
+            // "paste from..." prompt. Keep Paste always enabled there and let
+            // the actual paste() be the only (user-initiated) clipboard read.
+            // On desktop, reading canPaste is free and keeps the disabled state.
+            enabled: Utils.isIOS || root.canPaste
             onTriggered: root.paste()
         }
         StatusMenuSeparator {}

--- a/ui/StatusQ/src/clipboardutils.cpp
+++ b/ui/StatusQ/src/clipboardutils.cpp
@@ -123,6 +123,19 @@ void ClipboardUtils::clear()
     QGuiApplication::clipboard()->clear();
 }
 
+void ClipboardUtils::suppressChangeNotifications()
+{
+    // iOS only. Qt's QQuickTextInput/QQuickTextEdit connect to the clipboard's
+    // change signal and, in the slot, read the clipboard to recompute canPaste.
+    // That read triggers the iOS "paste from..." system prompt on every clipboard
+    // change - e.g. when the app returns to the foreground after the clipboard was
+    // changed in another app - even with no user paste. Blocking the clipboard's
+    // signals stops those reactive reads. Explicit copy()/paste() still work: they
+    // read/write the clipboard directly rather than via the change signal.
+    if (auto* clipboard = QGuiApplication::clipboard())
+        clipboard->blockSignals(true);
+}
+
 QObject* ClipboardUtils::qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine)
 {
     Q_UNUSED(engine);

--- a/ui/StatusQ/src/clipboardutils.cpp
+++ b/ui/StatusQ/src/clipboardutils.cpp
@@ -125,6 +125,7 @@ void ClipboardUtils::clear()
 
 void ClipboardUtils::suppressChangeNotifications()
 {
+#if defined(Q_OS_IOS)
     // iOS only. Qt's QQuickTextInput/QQuickTextEdit connect to the clipboard's
     // change signal and, in the slot, read the clipboard to recompute canPaste.
     // That read triggers the iOS "paste from..." system prompt on every clipboard
@@ -134,6 +135,7 @@ void ClipboardUtils::suppressChangeNotifications()
     // read/write the clipboard directly rather than via the change signal.
     if (auto* clipboard = QGuiApplication::clipboard())
         clipboard->blockSignals(true);
+#endif
 }
 
 QObject* ClipboardUtils::qmlInstance(QQmlEngine* engine, QJSEngine* scriptEngine)

--- a/ui/app/AppLayouts/Wallet/controls/SendRecipientInput.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SendRecipientInput.qml
@@ -7,6 +7,7 @@ import StatusQ.Components
 import StatusQ.Controls
 import StatusQ.Core
 import StatusQ.Core.Theme
+import StatusQ.Core.Utils
 
 StatusInput {
     id: root
@@ -41,7 +42,9 @@ StatusInput {
             font.weight: Font.Normal
             size: StatusBaseButton.Size.Small
             text: qsTr("Paste")
-            visible: root.input.edit.length === 0 && root.input.edit.canPaste
+            // On iOS, reading canPaste triggers the system "paste from..." prompt.
+            // Show the paste button whenever the field is empty; the tap reads.
+            visible: root.input.edit.length === 0 && (Utils.isIOS || root.input.edit.canPaste)
             focusPolicy: Qt.NoFocus
             onClicked: {
                 root.input.edit.forceActiveFocus()

--- a/ui/imports/shared/controls/StatusSyncCodeInput.qml
+++ b/ui/imports/shared/controls/StatusSyncCodeInput.qml
@@ -3,6 +3,7 @@ import QtQuick
 import StatusQ
 import StatusQ.Core
 import StatusQ.Core.Theme
+import StatusQ.Core.Utils
 import StatusQ.Controls
 
 StatusInput {
@@ -25,8 +26,10 @@ StatusInput {
     input.rightComponent: {
         switch (root.mode) {
         case StatusSyncCodeInput.Mode.WriteMode:
+            // On iOS, don't read ClipboardUtils.hasText to decide the paste button:
+            // it triggers the system "paste from..." prompt. Always offer paste there.
             return root.valid ? validCodeIconComponent
-                              : ClipboardUtils.hasText ? pasteButtonComponent : null
+                              : (Utils.isIOS || ClipboardUtils.hasText) ? pasteButtonComponent : null
         case StatusSyncCodeInput.Mode.ReadMode:
             return copyButtonComponent
         }
@@ -50,7 +53,7 @@ StatusInput {
         StatusButton {
             objectName: "syncCodePasteButton"
             size: StatusBaseButton.Size.Tiny
-            enabled: !root.readOnly && ClipboardUtils.hasText
+            enabled: !root.readOnly && (Utils.isIOS || ClipboardUtils.hasText)
             text: qsTr("Paste")
             onClicked: root.input.text = ClipboardUtils.text
         }

--- a/ui/imports/shared/controls/StatusSyncCodeInput.qml
+++ b/ui/imports/shared/controls/StatusSyncCodeInput.qml
@@ -55,7 +55,11 @@ StatusInput {
             size: StatusBaseButton.Size.Tiny
             enabled: !root.readOnly && (Utils.isIOS || ClipboardUtils.hasText)
             text: qsTr("Paste")
-            onClicked: root.input.text = ClipboardUtils.text
+            onClicked: {
+                const pasted = ClipboardUtils.text
+                if (pasted.length > 0)
+                    root.input.text = pasted
+            }
         }
     }
 

--- a/ui/imports/shared/popups/send/controls/SendRecipientInput.qml
+++ b/ui/imports/shared/popups/send/controls/SendRecipientInput.qml
@@ -7,6 +7,7 @@ import StatusQ.Controls
 import StatusQ.Components
 import StatusQ.Core
 import StatusQ.Core.Theme
+import StatusQ.Core.Utils
 
 StatusInput {
     id: root
@@ -42,7 +43,9 @@ StatusInput {
             borderWidth: 1
             size: StatusBaseButton.Size.Tiny
             text: qsTr("Paste")
-            visible: root.input.edit.length === 0 && root.input.edit.canPaste
+            // On iOS, reading canPaste triggers the system "paste from..." prompt.
+            // Show the paste button whenever the field is empty; the tap reads.
+            visible: root.input.edit.length === 0 && (Utils.isIOS || root.input.edit.canPaste)
             focusPolicy: Qt.NoFocus
             onClicked: {
                 root.input.edit.forceActiveFocus()

--- a/ui/imports/shared/popups/walletconnect/PairWCModal/WCUriInput.qml
+++ b/ui/imports/shared/popups/walletconnect/PairWCModal/WCUriInput.qml
@@ -81,7 +81,9 @@ ColumnLayout {
                 borderWidth: enabled ? 1 : 0
                 borderColor: textColor
 
-                enabled: input.edit.canPaste
+                // On iOS, reading canPaste touches UIPasteboard and triggers the
+                // system "paste from..." prompt. Keep enabled; the actual paste reads.
+                enabled: SQUtils.Utils.isIOS || input.edit.canPaste
 
                 onClicked: {
                     input.edit.paste()

--- a/ui/imports/shared/status/StatusChatInputTextArea.qml
+++ b/ui/imports/shared/status/StatusChatInputTextArea.qml
@@ -707,7 +707,11 @@ StatusQ.StatusTextArea {
             if (!ClipboardUtils.hasText)
                 return false
 
-            const clipboardText = StatusQUtils.StringUtils.plainText(ClipboardUtils.text)
+            const rawClipboardText = ClipboardUtils.text
+            const clipboardHtml = ClipboardUtils.html
+            const nbEmojis = StatusQUtils.Emoji.nbEmojis(clipboardHtml)
+
+            const clipboardText = StatusQUtils.StringUtils.plainText(rawClipboardText)
             // prevent repetitive & huge clipboard paste, where huge is total char count > than messageLimitHard
             const selectionLength = root.selectionEnd - root.selectionStart
             if ((length + clipboardText.length - selectionLength) > root.messageLimitHard)
@@ -757,9 +761,9 @@ StatusQ.StatusTextArea {
                 d.copiedTextPlain = ""
                 d.copiedTextFormatted = ""
                 d.copiedMentionsPos = []
-                root.insert(d.copyTextStart, ((d.nbEmojisInClipboard() === 0) ?
-                ("<div style='white-space: pre-wrap'>" + StatusQUtils.StringUtils.escapeHtml(ClipboardUtils.text) + "</div>")
-                : StatusQUtils.Emoji.deparse(ClipboardUtils.html)))
+                root.insert(d.copyTextStart, ((nbEmojis === 0) ?
+                ("<div style='white-space: pre-wrap'>" + StatusQUtils.StringUtils.escapeHtml(rawClipboardText) + "</div>")
+                : StatusQUtils.Emoji.deparse(clipboardHtml)))
             }
 
             // Reset readOnly immediately after paste completes
@@ -767,7 +771,7 @@ StatusQ.StatusTextArea {
             if (StatusQUtils.Utils.isMobile || immediateCleanup) {
                 if (toggleReadOnly)
                     root.readOnly = false
-                root.cursorPosition = (d.copyTextStart + ClipboardUtils.text.length + d.nbEmojisInClipboard())
+                root.cursorPosition = (d.copyTextStart + rawClipboardText.length + nbEmojis)
             }
 
             return true

--- a/ui/imports/shared/status/StatusChatInputTextArea.qml
+++ b/ui/imports/shared/status/StatusChatInputTextArea.qml
@@ -185,7 +185,7 @@ StatusQ.StatusTextArea {
 
         if (root.readOnly) {
             root.readOnly = false
-            root.cursorPosition = d.copyTextStart + ClipboardUtils.text.length + d.nbEmojisInClipboard
+            root.cursorPosition = d.copyTextStart + ClipboardUtils.text.length + d.nbEmojisInClipboard()
         }
 
         if (suggestedMentionPubKey) {
@@ -398,8 +398,13 @@ StatusQ.StatusTextArea {
         property int copyTextStart: 0
 
         // Emojis
-        readonly property int nbEmojisInClipboard:
-            StatusQUtils.Emoji.nbEmojis(ClipboardUtils.html)
+        // NOTE: must be a function, not a property binding. An eager binding here
+        // reads ClipboardUtils.html when the chat input is created (on chat open),
+        // which touches UIPasteboard and triggers the iOS "paste from..." prompt.
+        // As a function it only reads the clipboard during an actual paste.
+        function nbEmojisInClipboard() {
+            return StatusQUtils.Emoji.nbEmojis(ClipboardUtils.html)
+        }
 
         property string emojiFilter: ""
 
@@ -752,7 +757,7 @@ StatusQ.StatusTextArea {
                 d.copiedTextPlain = ""
                 d.copiedTextFormatted = ""
                 d.copiedMentionsPos = []
-                root.insert(d.copyTextStart, ((d.nbEmojisInClipboard === 0) ?
+                root.insert(d.copyTextStart, ((d.nbEmojisInClipboard() === 0) ?
                 ("<div style='white-space: pre-wrap'>" + StatusQUtils.StringUtils.escapeHtml(ClipboardUtils.text) + "</div>")
                 : StatusQUtils.Emoji.deparse(ClipboardUtils.html)))
             }
@@ -762,7 +767,7 @@ StatusQ.StatusTextArea {
             if (StatusQUtils.Utils.isMobile || immediateCleanup) {
                 if (toggleReadOnly)
                     root.readOnly = false
-                root.cursorPosition = (d.copyTextStart + ClipboardUtils.text.length + d.nbEmojisInClipboard)
+                root.cursorPosition = (d.copyTextStart + ClipboardUtils.text.length + d.nbEmojisInClipboard())
             }
 
             return true
@@ -842,7 +847,11 @@ StatusQ.StatusTextArea {
         }
         StatusAction {
             text: qsTr("Paste")
-            enabled: ClipboardUtils.hasText || ClipboardUtils.hasImage
+            // On iOS, never read the clipboard for UI enablement: hasText/hasImage
+            // touch UIPasteboard and trigger the system "paste from..." prompt when
+            // the menu is instantiated. Keep Paste enabled and let the user-initiated
+            // d.paste() be the only clipboard read.
+            enabled: StatusQUtils.Utils.isIOS || ClipboardUtils.hasText || ClipboardUtils.hasImage
             onTriggered: d.paste(true)
         }
         StatusMenuSeparator{}

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -434,6 +434,13 @@ Window {
             SystemUtils.setAndroidStatusBarIconColor(applicationWindow.appThemeDark)
         }
 
+        // iOS: stop Qt text controls from reactively re-reading the clipboard on
+        // every change, which triggers the system "paste from..." prompt when the
+        // app returns to the foreground. See ClipboardUtils::suppressChangeNotifications().
+        if (SQUtils.Utils.isIOS) {
+            ClipboardUtils.suppressChangeNotifications()
+        }
+
         restoreAppState()
 
         Global.openShakeToSharePopupRequested.connect(openShakeToSharePopup)


### PR DESCRIPTION
### What does the PR do

Closes: #21365
- Don't bind to `canPaste`. Reading a canPaste will trigger the IOS paste permissions
- Block QClipboard signals. When the app is activated, QClipboard will trigger a clipboard read and implicitly a IOS paste permission popup


Changes:
1. All paste buttons are now active by default on IOS. Previously we've had `Paste` actions available only when the clipboard has some text suitable to be applied

2. QClipboard signals are blocked and TextInput.canPaste will not fire when the app gets back to foreground on IOS. Programatic reads will still work, but we need to be careful with these reads, to be triggered only by a user Paste intention.


### Affected areas

All the text input fields
All custom `Paste` actions

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

The user will not see the paste permissions popup for unsolicited paste-related actions,


### How to test
1. Startup (no prompt on launch)

  1. Copy some text so the clipboard is non-empty.
  2. Fully close Status, then launch it.
  3. Expected: no prompt on the login screen and no prompt/banner on the loading screen after login.

2. Foreground / resume (the main regression this PR targets)

  - Recipe: open Status → background it → copy something new in another app → return to Status. Run it in each state below — none should show a
  prompt/banner on return:
  - [ ] While in Messages / a chat (input focused, keyboard up)
  - [ ] While in Messages with the keyboard dismissed
  - [ ] While on a non-text screen (Wallet home / Settings)
  - [ ] Repeat once more (change the clipboard again and foreground again)

3. Per-surface navigation (no prompt when the screen opens)

  With a non-empty clipboard, open each surface and confirm no prompt appears on opening:
  - [ ] Open a chat (message input)
  - [ ] Wallet → Send (recipient field)
  - [ ] Sync-code entry (onboarding and Settings → Sync new device)
  - [ ] WalletConnect "connect via URI/pairing" modal
  - [ ] Other text inputs: ENS name, contact chat key, seed phrase, private key, PIN

4. Paste still works (user-initiated)

  - [ ] In a chat input, tap Paste (menu or the paste button) → text pastes. A one-time iOS prompt here is acceptable.
  - [ ] Paste text containing emoji → content and cursor position are correct.
  - [ ] The paste button on Send-recipient / Sync-code / WalletConnect pastes correctly.

5. Copy still works (important — the fix blocks clipboard change signals on iOS)

  - [ ] Tap a Copy button in Status (chat key, wallet address, a message) → open Notes and paste → the copied text arrives.
  - [ ] Copy from one field in Status and paste into another → works.

6. Settings variants (iOS)

  Repeat checks 1–2 with Settings → Status → Paste from other apps set to Ask, then to Allow. Neither state should produce a prompt or the "pasted from
  …" banner on navigation/foreground.

7. No regression on desktop / Android

  - [ ] Desktop: Paste menu items still grey-out when the clipboard is empty; copy/paste work as before.
  - [ ] Android: paste affordances and copy/paste behave as before (Android is unaffected by this fix).


### Risk 

medium
