### PR TITLE
fix: expose send-confirm values to accessibility

### DIFF
--- a/ui/app/AppLayouts/Wallet/panels/SignAccountInfoBox.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SignAccountInfoBox.qml
@@ -31,6 +31,9 @@ ColumnLayout {
     RecipientViewDelegate {
         id: delegate
         objectName: "recipientDelegate"
+        // StatusListItem sets Accessible.name but no role; roleless items are
+        // dropped from the Android accessibility tree, hiding the account/address.
+        Accessible.role: Accessible.StaticText
 
         Layout.fillWidth: true
         Layout.preferredHeight: root.listItemHeight

--- a/ui/app/AppLayouts/Wallet/panels/SignInfoBox.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SignInfoBox.qml
@@ -28,6 +28,10 @@ ColumnLayout {
     }
     StatusListItem {
         id: listItem
+        objectName: root.objectName ? root.objectName + "Value" : ""
+        // StatusListItem sets Accessible.name but no role; roleless items are
+        // dropped from the Android accessibility tree, hiding the value text.
+        Accessible.role: Accessible.StaticText
         Layout.fillWidth: true
         Layout.preferredHeight: root.listItemHeight
         title: root.primaryText


### PR DESCRIPTION
The send/sign confirmation screen shows the amount, recipient and network, but none of these values reach the Android accessibility tree. StatusListItem sets Accessible.name from its title but no Accessible.role, and Qt's Android accessibility backend drops items that have no role — so screen readers and UI automation cannot read the values a user is asked to confirm.

Set Accessible.StaticText on the value items in SignInfoBox and SignAccountInfoBox, and give SignInfoBox's value item a derived objectName (sendAssetBoxValue, networkBoxValue) so tests can target it.

Needed by #21383 (wallet-send e2e smoke), which must check that the confirmed amount, recipient and chain match what was entered. Same fix shape as #21368 (edited-message indicator).
