### PR TITLE
refactor(models): stop calling dataChanged inneficiently in models

### DIFF
--- a/src/app/modules/main/activity_center/item.nim
+++ b/src/app/modules/main/activity_center/item.nim
@@ -109,41 +109,80 @@ proc `$`*(self: Item): string =
 proc id*(self: Item): string =
   return self.id
 
+proc `id=`*(self: Item, value: string) =
+  self.id = value
+
 proc name*(self: Item): string =
   return self.name
+
+proc `name=`*(self: Item, value: string) =
+  self.name = value
 
 proc newsTitle*(self: Item): string =
   return self.newsTitle
 
+proc `newsTitle=`*(self: Item, value: string) =
+  self.newsTitle = value
+
 proc newsDescription*(self: Item): string =
   return self.newsDescription
+
+proc `newsDescription=`*(self: Item, value: string) =
+  self.newsDescription = value
 
 proc newsContent*(self: Item): string =
   return self.newsContent
 
+proc `newsContent=`*(self: Item, value: string) =
+  self.newsContent = value
+
 proc newsImageUrl*(self: Item): string =
   return self.newsImageUrl
+
+proc `newsImageUrl=`*(self: Item, value: string) =
+  self.newsImageUrl = value
 
 proc newsLink*(self: Item): string =
   return self.newsLink
 
+proc `newsLink=`*(self: Item, value: string) =
+  self.newsLink = value
+
 proc newsLinkLabel*(self: Item): string =
   return self.newsLinkLabel
+
+proc `newsLinkLabel=`*(self: Item, value: string) =
+  self.newsLinkLabel = value
 
 proc author*(self: Item): string =
   return self.author
 
+proc `author=`*(self: Item, value: string) =
+  self.author = value
+
 proc installationId*(self: Item): string =
   return self.installationId
+
+proc `installationId=`*(self: Item, value: string) =
+  self.installationId = value
 
 proc chatId*(self: Item): string =
   return self.chatId
 
+proc `chatId=`*(self: Item, value: string) =
+  self.chatId = value
+
 proc chatType*(self: Item): ChatType =
   return self.chatType
 
+proc `chatType=`*(self: Item, value: ChatType) =
+  self.chatType = value
+
 proc communityId*(self: Item): string =
   return self.communityId
+
+proc `communityId=`*(self: Item, value: string) =
+  self.communityId = value
 
 proc membershipStatus*(self: Item): ActivityCenterMembershipStatus =
   return self.membershipStatus
@@ -154,11 +193,20 @@ proc `membershipStatus=`*(self: Item, value: ActivityCenterMembershipStatus) =
 proc sectionId*(self: Item): string =
   return self.sectionId
 
+proc `sectionId=`*(self: Item, value: string) =
+  self.sectionId = value
+
 proc notificationType*(self: Item): ActivityCenterNotificationType =
   return self.notificationType
 
+proc `notificationType=`*(self: Item, value: ActivityCenterNotificationType) =
+  self.notificationType = value
+
 proc timestamp*(self: Item): int64 =
   return self.timestamp
+
+proc `timestamp=`*(self: Item, value: int64) =
+  self.timestamp = value
 
 proc read*(self: Item): bool =
   return self.read
@@ -181,8 +229,17 @@ proc `accepted=`*(self: Item, value: bool) =
 proc messageItem*(self: Item): MessageItem =
   return self.messageItem
 
+proc `messageItem=`*(self: Item, value: MessageItem) =
+  self.messageItem = value
+
 proc repliedMessageItem*(self: Item): MessageItem =
   return self.repliedMessageItem
 
+proc `repliedMessageItem=`*(self: Item, value: MessageItem) =
+  self.repliedMessageItem = value
+
 proc tokenDataItem*(self: Item): TokenDataItem =
   return self.tokenDataItem
+
+proc `tokenDataItem=`*(self: Item, value: TokenDataItem) =
+  self.tokenDataItem = value

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -4,7 +4,7 @@ import ./item
 import ../../../../app_service/service/activity_center/dto/notification
 
 type
-  NotifRoles {.pure.} = enum
+  ModelRole {.pure.} = enum
     Id = UserRole + 1
     ChatId
     CommunityId
@@ -33,165 +33,136 @@ type
 QtObject:
   type
     Model* = ref object of QAbstractListModel
-      activityCenterNotifications*: seq[Item]
+      items*: seq[Item]
 
   proc setup(self: Model)
   proc delete(self: Model)
   proc newModel*(): Model =
     new(result, delete)
-    result.activityCenterNotifications = @[]
+    result.items = @[]
     result.setup()
 
   proc getUnreadNotificationsForChat*(self: Model, chatId: string): seq[string] =
     result =  @[]
-    for notification in self.activityCenterNotifications:
+    for notification in self.items:
       if (notification.chatId == chatId and not notification.read):
         result.add(notification.id)
 
   proc markAllAsRead*(self: Model) =
-    for activityCenterNotification in self.activityCenterNotifications:
+    for activityCenterNotification in self.items:
       activityCenterNotification.read = true
 
-    let topLeft = self.createIndex(0, 0, nil)
-    let bottomRight = self.createIndex(self.activityCenterNotifications.len - 1, 0, nil)
-    defer: topLeft.delete
-    defer: bottomRight.delete
-    self.dataChanged(topLeft, bottomRight, @[NotifRoles.Read.int])
+    if self.items.len > 0:
+      notifyRangeRolesChanged(0, self.items.len - 1, @[ModelRole.Read.int])
 
-  method rowCount*(self: Model, index: QModelIndex = nil): int = self.activityCenterNotifications.len
+  method rowCount*(self: Model, index: QModelIndex = nil): int = self.items.len
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
-    guardModelData(index, self.activityCenterNotifications.len, role, NotifRoles)
+    guardModelData(index, self.items.len, role, ModelRole)
 
-    let activityNotificationItem = self.activityCenterNotifications[index.row]
-    let notificationItemRole = role.NotifRoles
+    let activityNotificationItem = self.items[index.row]
+    let notificationItemRole = role.ModelRole
     case notificationItemRole:
-      of NotifRoles.Id: result = newQVariant(activityNotificationItem.id)
-      of NotifRoles.ChatId: result = newQVariant(activityNotificationItem.chatId)
-      of NotifRoles.CommunityId: result = newQVariant(activityNotificationItem.communityId)
-      of NotifRoles.MembershipStatus: result = newQVariant(activityNotificationItem.membershipStatus.int)
-      of NotifRoles.SectionId: result = newQVariant(activityNotificationItem.sectionId)
-      of NotifRoles.Name: result = newQVariant(activityNotificationItem.name)
-      of NotifRoles.NewsTitle: result = newQVariant(activityNotificationItem.newsTitle)
-      of NotifRoles.NewsDescription: result = newQVariant(activityNotificationItem.newsDescription)
-      of NotifRoles.NewsContent: result = newQVariant(activityNotificationItem.newsContent)
-      of NotifRoles.NewsImageUrl: result = newQVariant(activityNotificationItem.newsImageUrl)
-      of NotifRoles.NewsLink: result = newQVariant(activityNotificationItem.newsLink)
-      of NotifRoles.NewsLinkLabel: result = newQVariant(activityNotificationItem.newsLinkLabel)
-      of NotifRoles.Author: result = newQVariant(activityNotificationItem.author)
-      of NotifRoles.NotificationType: result = newQVariant(activityNotificationItem.notificationType.int)
-      of NotifRoles.Message: result = if not activityNotificationItem.messageItem.isNil:
+      of ModelRole.Id: result = newQVariant(activityNotificationItem.id)
+      of ModelRole.ChatId: result = newQVariant(activityNotificationItem.chatId)
+      of ModelRole.CommunityId: result = newQVariant(activityNotificationItem.communityId)
+      of ModelRole.MembershipStatus: result = newQVariant(activityNotificationItem.membershipStatus.int)
+      of ModelRole.SectionId: result = newQVariant(activityNotificationItem.sectionId)
+      of ModelRole.Name: result = newQVariant(activityNotificationItem.name)
+      of ModelRole.NewsTitle: result = newQVariant(activityNotificationItem.newsTitle)
+      of ModelRole.NewsDescription: result = newQVariant(activityNotificationItem.newsDescription)
+      of ModelRole.NewsContent: result = newQVariant(activityNotificationItem.newsContent)
+      of ModelRole.NewsImageUrl: result = newQVariant(activityNotificationItem.newsImageUrl)
+      of ModelRole.NewsLink: result = newQVariant(activityNotificationItem.newsLink)
+      of ModelRole.NewsLinkLabel: result = newQVariant(activityNotificationItem.newsLinkLabel)
+      of ModelRole.Author: result = newQVariant(activityNotificationItem.author)
+      of ModelRole.NotificationType: result = newQVariant(activityNotificationItem.notificationType.int)
+      of ModelRole.Message: result = if not activityNotificationItem.messageItem.isNil:
                                         newQVariant(activityNotificationItem.messageItem)
                                       else:
                                         newQVariant()
-      of NotifRoles.Timestamp: result = newQVariant(activityNotificationItem.timestamp)
-      of NotifRoles.PreviousTimestamp: result = newQVariant(if index.row > 0:
-                                                              self.activityCenterNotifications[index.row - 1].timestamp
+      of ModelRole.Timestamp: result = newQVariant(activityNotificationItem.timestamp)
+      of ModelRole.PreviousTimestamp: result = newQVariant(if index.row > 0:
+                                                              self.items[index.row - 1].timestamp
                                                             else:
                                                               0)
-      of NotifRoles.Read: result = newQVariant(activityNotificationItem.read.bool)
-      of NotifRoles.Dismissed: result = newQVariant(activityNotificationItem.dismissed.bool)
-      of NotifRoles.Accepted: result = newQVariant(activityNotificationItem.accepted.bool)
-      of NotifRoles.RepliedMessage: result = if not activityNotificationItem.repliedMessageItem.isNil:
+      of ModelRole.Read: result = newQVariant(activityNotificationItem.read.bool)
+      of ModelRole.Dismissed: result = newQVariant(activityNotificationItem.dismissed.bool)
+      of ModelRole.Accepted: result = newQVariant(activityNotificationItem.accepted.bool)
+      of ModelRole.RepliedMessage: result = if not activityNotificationItem.repliedMessageItem.isNil:
                                         newQVariant(activityNotificationItem.repliedMessageItem)
                                       else:
                                         newQVariant()
-      of NotifRoles.ChatType: result = newQVariant(activityNotificationItem.chatType.int)
-      of NotifRoles.TokenData: result = newQVariant(activityNotificationItem.tokenDataItem)
-      of NotifRoles.InstallationId: result = newQVariant(activityNotificationItem.installationId)
+      of ModelRole.ChatType: result = newQVariant(activityNotificationItem.chatType.int)
+      of ModelRole.TokenData: result = newQVariant(activityNotificationItem.tokenDataItem)
+      of ModelRole.InstallationId: result = newQVariant(activityNotificationItem.installationId)
 
   method roleNames(self: Model): Table[int, string] =
     {
-      NotifRoles.Id.int:"id",
-      NotifRoles.ChatId.int:"chatId",
-      NotifRoles.CommunityId.int:"communityId",
-      NotifRoles.MembershipStatus.int: "membershipStatus",
-      NotifRoles.SectionId.int: "sectionId",
-      NotifRoles.Name.int: "name",
-      NotifRoles.NewsTitle.int: "newsTitle",
-      NotifRoles.NewsDescription.int: "newsDescription",
-      NotifRoles.NewsContent.int: "newsContent",
-      NotifRoles.NewsImageUrl.int: "newsImageUrl",
-      NotifRoles.NewsLink.int: "newsLink",
-      NotifRoles.NewsLinkLabel.int: "newsLinkLabel",
-      NotifRoles.Author.int: "author",
-      NotifRoles.NotificationType.int: "notificationType",
-      NotifRoles.Message.int: "message",
-      NotifRoles.Timestamp.int: "timestamp",
-      NotifRoles.PreviousTimestamp.int: "previousTimestamp",
-      NotifRoles.Read.int: "read",
-      NotifRoles.Dismissed.int: "dismissed",
-      NotifRoles.Accepted.int: "accepted",
-      NotifRoles.RepliedMessage.int: "repliedMessage",
-      NotifRoles.ChatType.int: "chatType",
-      NotifRoles.TokenData.int: "tokenData",
-      NotifRoles.InstallationId.int: "installationId",
+      ModelRole.Id.int:"id",
+      ModelRole.ChatId.int:"chatId",
+      ModelRole.CommunityId.int:"communityId",
+      ModelRole.MembershipStatus.int: "membershipStatus",
+      ModelRole.SectionId.int: "sectionId",
+      ModelRole.Name.int: "name",
+      ModelRole.NewsTitle.int: "newsTitle",
+      ModelRole.NewsDescription.int: "newsDescription",
+      ModelRole.NewsContent.int: "newsContent",
+      ModelRole.NewsImageUrl.int: "newsImageUrl",
+      ModelRole.NewsLink.int: "newsLink",
+      ModelRole.NewsLinkLabel.int: "newsLinkLabel",
+      ModelRole.Author.int: "author",
+      ModelRole.NotificationType.int: "notificationType",
+      ModelRole.Message.int: "message",
+      ModelRole.Timestamp.int: "timestamp",
+      ModelRole.PreviousTimestamp.int: "previousTimestamp",
+      ModelRole.Read.int: "read",
+      ModelRole.Dismissed.int: "dismissed",
+      ModelRole.Accepted.int: "accepted",
+      ModelRole.RepliedMessage.int: "repliedMessage",
+      ModelRole.ChatType.int: "chatType",
+      ModelRole.TokenData.int: "tokenData",
+      ModelRole.InstallationId.int: "installationId",
     }.toTable
 
   proc findNotificationIndex(self: Model, notificationId: string): int {.slot.} =
     if notificationId.len == 0:
       return -1
-    for i in 0 ..< self.activityCenterNotifications.len:
-      if self.activityCenterNotifications[i].id == notificationId:
+    for i in 0 ..< self.items.len:
+      if self.items[i].id == notificationId:
         return i
     return -1
 
   proc markActivityCenterNotificationUnread*(self: Model, notificationId: string) =
-    let i = self.findNotificationIndex(notificationId)
-    if i == -1:
-      return
-
-    self.activityCenterNotifications[i].read = false
-    let index = self.createIndex(i, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[NotifRoles.Read.int])
+    updateItemRolesAndNotify self.findNotificationIndex(notificationId):
+      updateRoleWithValue(read, false)
 
   proc markActivityCenterNotificationRead*(self: Model, notificationId: string) =
-    let i = self.findNotificationIndex(notificationId)
-    if i == -1:
-      return
-
-    self.activityCenterNotifications[i].read = true
-    let index = self.createIndex(i, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[NotifRoles.Read.int])
+    updateItemRolesAndNotify self.findNotificationIndex(notificationId):
+      updateRoleWithValue(read, true)
 
   proc activityCenterNotificationAccepted*(self: Model, notificationId: string) =
-    let i = self.findNotificationIndex(notificationId)
-    if i == -1:
-      return
-
-    self.activityCenterNotifications[i].read = true
-    self.activityCenterNotifications[i].accepted = true
-    let index = self.createIndex(i, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[NotifRoles.Accepted.int, NotifRoles.Read.int])
+    updateItemRolesAndNotify self.findNotificationIndex(notificationId):
+      updateRoleWithValue(accepted, true)
+      updateRoleWithValue(read, true)
 
   proc activityCenterNotificationDismissed*(self: Model, notificationId: string) =
-    let i = self.findNotificationIndex(notificationId)
-    if i == -1:
-      return
-
-    self.activityCenterNotifications[i].read = true
-    self.activityCenterNotifications[i].dismissed = true
-    let index = self.createIndex(i, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[NotifRoles.Dismissed.int, NotifRoles.Read.int])
+    updateItemRolesAndNotify self.findNotificationIndex(notificationId):
+      updateRoleWithValue(dismissed, true)
+      updateRoleWithValue(read, true)
 
   proc updateCommunityMembershipStatus*(self: Model, communityId: string, memberPubkey: string, status: ActivityCenterMembershipStatus) =
-    for i, notification in self.activityCenterNotifications:
+    for ind, notification in self.items:
       if notification.notificationType == ActivityCenterNotificationType.CommunityMembershipRequest and
           notification.communityId == communityId and
           (notification.author == memberPubkey or notification.chatId == memberPubkey):
-        notification.membershipStatus = status
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index, @[NotifRoles.MembershipStatus.int])
+        updateRolesAndNotify:
+          updateRoleWithValue(membershipStatus, status)
 
   proc removeNotifications*(self: Model, ids: seq[string]) =
     var i = 0
     var indexesToDelete: seq[int] = @[]
-    for activityCenterNotification in self.activityCenterNotifications:
+    for activityCenterNotification in self.items:
       for id in ids:
         if (activityCenterNotification.id == id):
           indexesToDelete.add(i)
@@ -204,18 +175,18 @@ QtObject:
       let modelIndex = newQModelIndex()
       defer: modelIndex.delete
       self.beginRemoveRows(modelIndex, indexUpdated, indexUpdated)
-      self.activityCenterNotifications.delete(indexUpdated)
+      self.items.delete(indexUpdated)
       self.endRemoveRows()
       i = i + 1
 
   proc setNewData*(self: Model, activityCenterNotifications: seq[Item]) =
     self.beginResetModel()
-    self.activityCenterNotifications = activityCenterNotifications
+    self.items = activityCenterNotifications
     self.endResetModel()
 
   proc updateActivityCenterNotification*(self: Model, ind: int, newNotification: Item) =
-    if self.activityCenterNotifications[ind].notificationType == ActivityCenterNotificationType.CommunityMembershipRequest and
-        self.activityCenterNotifications[ind].membershipStatus in [
+    if self.items[ind].notificationType == ActivityCenterNotificationType.CommunityMembershipRequest and
+        self.items[ind].membershipStatus in [
           ActivityCenterMembershipStatus.Accepted,
           ActivityCenterMembershipStatus.Declined,
         ] and
@@ -223,15 +194,20 @@ QtObject:
           ActivityCenterMembershipStatus.Accepted,
           ActivityCenterMembershipStatus.Declined,
         ]:
-      newNotification.membershipStatus = self.activityCenterNotifications[ind].membershipStatus
+      newNotification.membershipStatus = self.items[ind].membershipStatus
 
-    self.activityCenterNotifications[ind] = newNotification
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index)
+    updateRolesAndNotify:
+      updateRolesFromItem(newNotification,
+        id, chatId, communityId, membershipStatus, sectionId, name, newsTitle,
+        newsDescription, newsContent, newsImageUrl, newsLink, newsLinkLabel,
+        author, notificationType, timestamp, read, dismissed, accepted, chatType,
+        installationId)
+      updateRoleWithValue(messageItem, newNotification.messageItem, Message)
+      updateRoleWithValue(repliedMessageItem, newNotification.repliedMessageItem, RepliedMessage)
+      updateRoleWithValue(tokenDataItem, newNotification.tokenDataItem, TokenData)
 
   proc upsertActivityCenterNotification*(self: Model, newNotification: Item) =
-    for i, notification in self.activityCenterNotifications:
+    for i, notification in self.items:
       if newNotification.id == notification.id:
         self.updateActivityCenterNotification(i, newNotification)
         return
@@ -239,24 +215,22 @@ QtObject:
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
 
-    var indexToInsert = self.activityCenterNotifications.len
-    for i, notification in self.activityCenterNotifications:
+    var indexToInsert = self.items.len
+    for i, notification in self.items:
       if newNotification.timestamp > notification.timestamp:
         indexToInsert = i
         break
 
     self.beginInsertRows(parentModelIndex, indexToInsert, indexToInsert)
-    self.activityCenterNotifications.insert(newNotification, indexToInsert)
+    self.items.insert(newNotification, indexToInsert)
     self.endInsertRows()
 
     let indexToUpdate = indexToInsert - 2
-    if indexToUpdate >= 0 and indexToUpdate < self.activityCenterNotifications.len:
-      let index = self.createIndex(indexToUpdate, 0, nil)
-      defer: index.delete
-      self.dataChanged(index, index, @[NotifRoles.PreviousTimestamp.int])
+    if indexToUpdate >= 0 and indexToUpdate < self.items.len:
+      notifyRangeRolesChanged(indexToUpdate, indexToUpdate, @[ModelRole.PreviousTimestamp.int])
 
   proc upsertActivityCenterNotifications*(self: Model, activityCenterNotifications: seq[Item]) =
-    if self.activityCenterNotifications.len == 0:
+    if self.items.len == 0:
       self.setNewData(activityCenterNotifications)
     else:
       for activityCenterNotification in activityCenterNotifications:

--- a/src/app/modules/main/browser_section/bookmark/item.nim
+++ b/src/app/modules/main/browser_section/bookmark/item.nim
@@ -18,11 +18,20 @@ proc `$`*(self: Item): string =
     imageUrl: {self.imageUrl}
     ]"""
 
-proc getName*(self: Item): string =
+proc name*(self: Item): string =
   return self.name
 
-proc getUrl*(self: Item): string =
+proc `name=`*(self: var Item, value: string) =
+  self.name = value
+
+proc url*(self: Item): string =
   return self.url
 
-proc getImageUrl*(self: Item): string =
+proc `url=`*(self: var Item, value: string) =
+  self.url = value
+
+proc imageUrl*(self: Item): string =
   return self.imageUrl
+
+proc `imageUrl=`*(self: var Item, value: string) =
+  self.imageUrl = value

--- a/src/app/modules/main/browser_section/bookmark/model.nim
+++ b/src/app/modules/main/browser_section/bookmark/model.nim
@@ -26,15 +26,6 @@ QtObject:
       [{i}]:({$self.items[i]})
       """
 
-  proc modelChanged(self: Model) {.signal.}
-
-  proc getCount(self: Model): int {.slot.} =
-    self.items.len
-
-  QtProperty[int] count:
-    read = getCount
-    notify = countChanged
-
   method rowCount(self: Model, index: QModelIndex = nil): int =
     return self.items.len
 
@@ -54,31 +45,30 @@ QtObject:
 
     case enumRole:
     of ModelRole.Name:
-      result = newQVariant(item.getName())
+      result = newQVariant(item.name)
     of ModelRole.Url:
-      result = newQVariant(item.getUrl())
+      result = newQVariant(item.url)
     of ModelRole.ImageUrl:
-      result = newQVariant(item.getImageUrl())
+      result = newQVariant(item.imageUrl)
 
   proc addItem*(self: Model, item: Item) =
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
 
     for i in self.items:
-      if i.getUrl() == item.getUrl():
+      if i.url == item.url:
         return
 
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()
-    self.modelChanged()
 
   proc getBookmarkIndexByUrl*(self: Model, url: string): int {.slot.} =
     var index = -1
     var i = -1
     for item in self.items:
       i += 1
-      if item.getUrl() == url:
+      if item.url == url:
         index = i
         break
     return index
@@ -93,22 +83,13 @@ QtObject:
     self.beginRemoveRows(parentModelIndex, index, index)
     self.items.delete(index)
     self.endRemoveRows()
-    self.modelChanged()
 
 
   proc updateItemByUrl*(self: Model, oldUrl: string, item: Item) =
-    var index = self.getBookmarkIndexByUrl(oldUrl)
-    if index == -1:
-      return
-
-    let topLeft = self.createIndex(index, index, nil)
-    let bottomRight = self.createIndex(index, index, nil)
-    defer: topLeft.delete
-    defer: bottomRight.delete
-
-    self.items[index] = item
-    self.dataChanged(topLeft, bottomRight)
-    self.modelChanged()
+    updateItemRolesAndNotify self.getBookmarkIndexByUrl(oldUrl):
+      updateRoleWithValue(name, item.name)
+      updateRoleWithValue(url, item.url)
+      updateRoleWithValue(imageUrl, item.imageUrl)
 
   proc delete(self: Model) =
     self.items = @[]

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -428,6 +428,10 @@ method getNumberOfPinnedMessages*(self: Module): int =
 
 method updateContactDetails*(self: Module, contactId: string) =
   let updatedContact = self.controller.getContactDetails(contactId)
+  let chatDto = self.controller.getChatDetails()
+
+  if chatDto.chatType == ChatType.OneToOne and chatDto.id == contactId:
+    self.updateChatIdentifier()
 
   for item in self.view.model().modelContactUpdateIterator(contactId):
     if item.senderId == contactId:
@@ -508,10 +512,9 @@ method onHistoryCleared*(self: Module) =
 method updateChatIdentifier*(self: Module) =
   let chatDto = self.controller.getChatDetails()
   self.setChatDetails(chatDto)
-  # Delete the old ChatIdentifier message first
-  self.view.model().removeItem(CHAT_IDENTIFIER_MESSAGE_ID)
-  # Add new loaded messages
-  self.view.model().insertItemBasedOnClock(self.createChatIdentifierItem())
+  let item = self.createChatIdentifierItem()
+  if not self.view.model().updateChatIdentifier(item):
+    self.view.model().insertItemBasedOnClock(item)
 
 method updateChatFetchMoreMessages*(self: Module) =
   self.view.model().removeItem(FETCH_MORE_MESSAGES_MESSAGE_ID)
@@ -569,7 +572,7 @@ method onChatMemberUpdated*(self: Module, publicKey: string, memberRole: MemberR
   if(publicKey != myPublicKey):
     return
 
-  self.view.model().refreshItemWithId(CHAT_IDENTIFIER_MESSAGE_ID)
+  self.updateChatIdentifier()
 
 method onMailserverSynced*(self: Module, syncedFrom: int64) =
   let chatDto = self.controller.getChatDetails()

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -1,9 +1,8 @@
-import app/modules/shared_models/model_utils
 import nimqml, tables, std/strformat, json, sequtils, system
 import ../../../../app_service/common/types
 import ../../../../app_service/service/chat/dto/chat
 import item
-import ../../shared_models/model_utils
+import app/modules/shared_models/model_utils
 
 type
   ModelRole {.pure.} = enum
@@ -271,14 +270,10 @@ QtObject:
     self.countChanged()
 
   proc changeCategoryOpened*(self: Model, categoryId: string, opened: bool) {.slot.} =
-    for i in 0 ..< self.items.len:
-      if self.items[i].categoryId == categoryId:
-        if self.items[i].categoryOpened == opened:
-          return
-        self.items[i].categoryOpened = opened
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index, @[ModelRole.CategoryOpened.int])
+    for ind in 0 ..< self.items.len:
+      if self.items[ind].categoryId == categoryId:
+        updateRolesAndNotify:
+          updateRoleWithValue(categoryOpened, opened)
 
   # This function only refreshes ShouldBeHiddenBecausePermissionsAreNotMet.
   # Then itemShouldBeHiddenBecauseNotPermitted() is used in data() to determined whether category is hidden or not.
@@ -290,9 +285,7 @@ QtObject:
       return
     if not self.items[index].isCategory:
       return
-    let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
-    self.dataChanged(modelIndex, modelIndex, @[ModelRole.ShouldBeHiddenBecausePermissionsAreNotMet.int])
+    notifyRangeRolesChanged(index, index, @[ModelRole.ShouldBeHiddenBecausePermissionsAreNotMet.int])
 
   proc removeItemByIndex(self: Model, idx: int) =
     if idx == -1:
@@ -330,29 +323,17 @@ QtObject:
         return it
 
   proc setCategoryHasUnreadMessages*(self: Model, categoryId: string, unread: bool) =
-    let index = self.getItemIdxById(categoryId)
-    if index == -1:
-      return
-    if self.items[index].hasUnreadMessages == unread:
-      return
-    self.items[index].hasUnreadMessages = unread
-    let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
-    self.dataChanged(modelIndex, modelIndex, @[ModelRole.HasUnreadMessages.int])
+    updateItemRolesAndNotify self.getItemIdxById(categoryId):
+      updateRoleWithValue(hasUnreadMessages, unread)
 
   proc setActiveItem*(self: Model, id: string) =
-    for i in 0 ..< self.items.len:
-      let isChannelToSetActive = (self.items[i].id == id)
-      if self.items[i].active != isChannelToSetActive:
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        # Set active channel to true and others to false
-        self.items[i].active = isChannelToSetActive
-        if (isChannelToSetActive):
-          self.items[i].loaderActive = true
-          self.dataChanged(index, index, @[ModelRole.Active.int, ModelRole.LoaderActive.int])
-        else:
-          self.dataChanged(index, index, @[ModelRole.Active.int])
+    for ind in 0 ..< self.items.len:
+      let isChannelToSetActive = (self.items[ind].id == id)
+      if self.items[ind].active != isChannelToSetActive:
+        updateRolesAndNotify:
+          updateRoleWithValue(active, isChannelToSetActive)
+          if isChannelToSetActive:
+            updateRoleWithValue(loaderActive, true)
 
   proc activeItem*(self: Model): ChatItem =
     for i in 0 ..< self.items.len:
@@ -360,30 +341,12 @@ QtObject:
         return self.items[i]
 
   proc setItemLocked*(self: Model, id: string, locked: bool) =
-    let index = self.getItemIdxById(id)
-    if index == -1:
-      return
-
-    if (self.items[index].locked == locked):
-      return
-
-    self.items[index].locked = locked
-    let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
-    self.dataChanged(modelIndex, modelIndex, @[ModelRole.Locked.int])
+    updateItemRolesAndNotify self.getItemIdxById(id):
+      updateRole(locked)
 
   proc setItemPermissionsRequired*(self: Model, id: string, value: bool) =
-    let index = self.getItemIdxById(id)
-    if index == -1:
-      return
-
-    if (self.items[index].requiresPermissions == value):
-      return
-
-    self.items[index].requiresPermissions = value
-    let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
-    self.dataChanged(modelIndex, modelIndex, @[ModelRole.RequiresPermissions.int])
+    updateItemRolesAndNotify self.getItemIdxById(id):
+      updateRoleWithValue(requiresPermissions, value)
 
   proc getItemPermissionsRequired*(self: Model, id: string): bool =
     let index = self.getItemIdxById(id)
@@ -393,15 +356,8 @@ QtObject:
     return self.items[index].requiresPermissions
 
   proc changeMutedOnItemById*(self: Model, id: string, muted: bool) =
-    let index = self.getItemIdxById(id)
-    if index == -1:
-      return
-    if(self.items[index].muted == muted):
-      return
-    self.items[index].muted = muted
-    let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
-    self.dataChanged(modelIndex, modelIndex, @[ModelRole.Muted.int])
+    updateItemRolesAndNotify self.getItemIdxById(id):
+      updateRole(muted)
 
   proc changeCanPostValues*(self: Model, id: string, canPost, canView, canPostReactions, viewersCanPostReactions: bool): seq[int] =
     updateItemRolesAndNotify self.getItemIdxById(id):
@@ -415,12 +371,10 @@ QtObject:
         result = roles # return roles so that we can use it in tests
 
   proc changeMutedOnItemByCategoryId*(self: Model, categoryId: string, muted: bool) =
-    for i in 0 ..< self.items.len:
-      if self.items[i].categoryId == categoryId and self.items[i].muted != muted:
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.items[i].muted = muted
-        self.dataChanged(index, index, @[ModelRole.Muted.int])
+    for ind in 0 ..< self.items.len:
+      if self.items[ind].categoryId == categoryId and self.items[ind].muted != muted:
+        updateRolesAndNotify:
+          updateRole(muted)
 
   proc allChannelsAreHiddenBecauseNotPermitted*(self: Model): bool =
     for i in 0 ..< self.items.len:
@@ -429,15 +383,8 @@ QtObject:
     return true
 
   proc changeBlockedOnItemById*(self: Model, id: string, blocked: bool) =
-    let index = self.getItemIdxById(id)
-    if index == -1:
-      return
-    if(self.items[index].blocked == blocked):
-      return
-    self.items[index].blocked = blocked
-    let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
-    self.dataChanged(modelIndex, modelIndex, @[ModelRole.Blocked.int])
+    updateItemRolesAndNotify self.getItemIdxById(id):
+      updateRole(blocked)
 
   proc updateUserItemDetailsById*(self: Model, id, name: string, usesDefaultName: bool, icon: string, trustStatus: TrustStatus) =
     updateItemRolesAndNotify self.getItemIdxById(id):
@@ -451,7 +398,8 @@ QtObject:
     if ind == -1:
       return
 
-    updateRolesAndNotify:
+    var rolesChanged = false
+    updateRolesAndNotify rolesChanged:
       updateRole(name)
       updateRole(description)
       updateRole(emoji)
@@ -462,7 +410,8 @@ QtObject:
       if roles.len > 0:
         result = roles # return roles so that we can use it in tests
 
-    self.updateHiddenFlagForCategory(self.items[ind].categoryId)
+    if rolesChanged:
+      self.updateHiddenFlagForCategory(self.items[ind].categoryId)
 
   proc updateNameColorIconOnGroupItemById*(self: Model, id, name, color, icon: string) =
     updateItemRolesAndNotify self.getItemIdxById(id):
@@ -474,11 +423,11 @@ QtObject:
       self: Model,
       categoryId,
       name: string,
-      categoryPosition: int,
+      newCategoryPosition: int,
     ) =
     updateItemRolesAndNotify self.getItemIdxById(categoryId):
       updateRole(name)
-      updateRole(categoryPosition)
+      updateRoleWithValue(categoryPosition, newCategoryPosition)
 
   proc updateItemsWithCategoryDetailsById*(
       self: Model,
@@ -486,8 +435,8 @@ QtObject:
       categoryId: string,
       newCategoryPosition: int,
     ) =
-    for i in 0 ..< self.items.len:
-      var item = self.items[i]
+    for ind in 0 ..< self.items.len:
+      let item = self.items[ind]
       if item.`type` == CATEGORY_TYPE:
         continue
       var nowHasCategory = false
@@ -497,20 +446,16 @@ QtObject:
           continue
         found = true
         nowHasCategory = chat.categoryId == categoryId
-        item.position = chat.position
-        item.categoryId = chat.categoryId
-        item.categoryPosition = if nowHasCategory: newCategoryPosition else: -1
-        let modelIndex = self.createIndex(i, 0, nil)
-        defer: modelIndex.delete
-        var roleChanges = @[
-          ModelRole.Position.int,
-          ModelRole.CategoryId.int,
-          ModelRole.CategoryPosition.int,
-        ]
-        if not nowHasCategory:
-          item.categoryOpened = true
-          roleChanges.add(ModelRole.CategoryOpened.int)
-        self.dataChanged(modelIndex, modelIndex, roleChanges)
+        let targetPosition = chat.position
+        let targetCategoryId = chat.categoryId
+        let targetCategoryPosition = if nowHasCategory: newCategoryPosition else: -1
+        let targetCategoryOpened = not nowHasCategory
+        updateRolesAndNotify:
+          updateRoleWithValue(position, targetPosition)
+          updateRoleWithValue(categoryId, targetCategoryId)
+          updateRoleWithValue(categoryPosition, targetCategoryPosition)
+          if targetCategoryOpened:
+            updateRoleWithValue(categoryOpened, true)
         break
 
   proc removeCategory*(
@@ -520,8 +465,8 @@ QtObject:
     ) =
     self.removeItemById(categoryId)
 
-    for i in 0 ..< self.items.len:
-      var item = self.items[i]
+    for ind in 0 ..< self.items.len:
+      let item = self.items[ind]
       if item.categoryId != categoryId:
         continue
 
@@ -529,18 +474,12 @@ QtObject:
         if chat.id != item.id:
           continue
 
-        item.position = chat.position
-        item.categoryId = ""
-        item.categoryPosition = -1
-        item.categoryOpened = true
-        let modelIndex = self.createIndex(i, 0, nil)
-        defer: modelIndex.delete
-        self.dataChanged(modelIndex, modelIndex, @[
-          ModelRole.Position.int,
-          ModelRole.CategoryId.int,
-          ModelRole.CategoryPosition.int,
-          ModelRole.CategoryOpened.int,
-        ])
+        let targetPosition = chat.position
+        updateRolesAndNotify:
+          updateRoleWithValue(position, targetPosition)
+          updateRoleWithValue(categoryId, "")
+          updateRoleWithValue(categoryPosition, -1)
+          updateRoleWithValue(categoryOpened, true)
         break
 
   proc renameCategory*(self: Model, categoryId, name: string) =
@@ -548,15 +487,10 @@ QtObject:
       updateRole(name)
 
   proc renameItemById*(self: Model, id, name: string) =
-    let index = self.getItemIdxById(id)
-    if index == -1:
-      return
-    if(self.items[index].name == name):
-      return
-    self.items[index].name = name
-    let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
-    self.dataChanged(modelIndex, modelIndex, @[ModelRole.Name.int, ModelRole.UsesDefaultName.int])
+    updateItemRolesAndNotify self.getItemIdxById(id):
+      updateRole(name)
+      if roles.len > 0:
+        roles.add(ModelRole.UsesDefaultName.int)
 
   proc updateItemOnlineStatusById*(self: Model, id: string, onlineStatus: OnlineStatus) =
     updateItemRolesAndNotify self.getItemIdxById(id):
@@ -578,47 +512,40 @@ QtObject:
       updatedChats: seq[ChatDto],
     ) =
     for updatedChat in updatedChats:
-      let index = self.getItemIdxById(updatedChat.id)
-      if index == -1:
+      let ind = self.getItemIdxById(updatedChat.id)
+      if ind == -1:
         continue
 
-      var roles = @[ModelRole.Position.int]
-      if(self.items[index].categoryId != updatedChat.categoryId):
+      let categoryChanged = self.items[ind].categoryId != updatedChat.categoryId
+      var targetCategoryPosition = self.items[ind].categoryPosition
+      if categoryChanged:
         if updatedChat.categoryId == "":
-          # Moved out of a category
-          self.items[index].categoryId = updatedChat.categoryId
-          self.items[index].categoryPosition = -1
+          targetCategoryPosition = -1
         else:
           let category = self.getItemById(updatedChat.categoryId)
           if category.id == "":
             continue
-          self.items[index].categoryId = category.id
-          self.items[index].categoryPosition = category.categoryPosition
-        roles = roles.concat(@[
-          ModelRole.CategoryId.int,
-          ModelRole.CategoryPosition.int,
-        ])
+          targetCategoryPosition = category.categoryPosition
 
-      self.items[index].position = updatedChat.position
-      let modelIndex = self.createIndex(index, 0, nil)
-      defer: modelIndex.delete
-      self.dataChanged(modelIndex, modelIndex, roles)
+      let targetPosition = updatedChat.position
+      let targetCategoryId = updatedChat.categoryId
+      updateRolesAndNotify:
+        updateRoleWithValue(position, targetPosition)
+        if categoryChanged:
+          updateRoleWithValue(categoryId, targetCategoryId)
+          updateRoleWithValue(categoryPosition, targetCategoryPosition)
 
   proc reorderCategoryById*(
       self: Model,
       categoryId: string,
       position: int,
     ) =
-    for i in 0 ..< self.items.len:
-      var item = self.items[i]
+    for ind in 0 ..< self.items.len:
+      let item = self.items[ind]
       if item.categoryId != categoryId:
         continue
-      if item.categoryPosition == position:
-        continue
-      item.categoryPosition = position
-      let modelIndex = self.createIndex(i, 0, nil)
-      defer: modelIndex.delete
-      self.dataChanged(modelIndex, modelIndex, @[ModelRole.CategoryPosition.int])
+      updateRolesAndNotify:
+        updateRoleWithValue(categoryPosition, position)
 
   proc clearItems*(self: Model) =
     self.beginResetModel()
@@ -633,37 +560,17 @@ QtObject:
     return self.items[index].toJsonNode()
 
   proc disableChatLoader*(self: Model, chatId: string) =
-    let index = self.getItemIdxById(chatId)
-    if index == -1:
-      return
-
-    self.items[index].loaderActive = false
-    self.items[index].active = false
-    let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
-    self.dataChanged(modelIndex, modelIndex, @[ModelRole.Active.int, ModelRole.LoaderActive.int])
+    updateItemRolesAndNotify self.getItemIdxById(chatId):
+      updateRoleWithValue(loaderActive, false)
+      updateRoleWithValue(active, false)
 
   proc updateMissingEncryptionKey*(self: Model, id: string, missingEncryptionKey: bool) =
-    let index = self.getItemIdxById(id)
-    if index == -1:
-      return
-
-    if self.items[index].missingEncryptionKey != missingEncryptionKey:
-      self.items[index].missingEncryptionKey = missingEncryptionKey
-      let modelIndex = self.createIndex(index, 0, nil)
-      defer: modelIndex.delete
-      self.dataChanged(modelIndex, modelIndex, @[ModelRole.MissingEncryptionKey.int])
+    updateItemRolesAndNotify self.getItemIdxById(id):
+      updateRole(missingEncryptionKey)
 
   proc updatePermissionsCheckOngoing*(self: Model, id: string, permissionsCheckOngoing: bool) =
-    let index = self.getItemIdxById(id)
-    if index == -1:
-      return
-
-    if self.items[index].permissionsCheckOngoing != permissionsCheckOngoing:
-      self.items[index].permissionsCheckOngoing = permissionsCheckOngoing
-      let modelIndex = self.createIndex(index, 0, nil)
-      defer: modelIndex.delete
-      self.dataChanged(modelIndex, modelIndex, @[ModelRole.PermissionsCheckOngoing.int])
+    updateItemRolesAndNotify self.getItemIdxById(id):
+      updateRole(permissionsCheckOngoing)
 
   proc delete*(self: Model) =
     self.QAbstractListModel.delete

--- a/src/app/modules/main/communities/models/curated_community_item.nim
+++ b/src/app/modules/main/communities/models/curated_community_item.nim
@@ -73,38 +73,110 @@ proc `$`*(self: CuratedCommunityItem): string =
 proc getId*(self: CuratedCommunityItem): string =
   return self.id
 
+proc id*(self: CuratedCommunityItem): string =
+  return self.id
+
+proc `id=`*(self: var CuratedCommunityItem, value: string) =
+  self.id = value
+
 proc getName*(self: CuratedCommunityItem): string =
   return self.name
+
+proc name*(self: CuratedCommunityItem): string =
+  return self.name
+
+proc `name=`*(self: var CuratedCommunityItem, value: string) =
+  self.name = value
 
 proc getDescription*(self: CuratedCommunityItem): string =
   return self.description
 
+proc description*(self: CuratedCommunityItem): string =
+  return self.description
+
+proc `description=`*(self: var CuratedCommunityItem, value: string) =
+  self.description = value
+
 proc isAvailable*(self: CuratedCommunityItem): bool =
   return self.available
+
+proc available*(self: CuratedCommunityItem): bool =
+  return self.available
+
+proc `available=`*(self: var CuratedCommunityItem, value: bool) =
+  self.available = value
 
 proc getIcon*(self: CuratedCommunityItem): string =
   return self.icon
 
+proc icon*(self: CuratedCommunityItem): string =
+  return self.icon
+
+proc `icon=`*(self: var CuratedCommunityItem, value: string) =
+  self.icon = value
+
 proc getBanner*(self: CuratedCommunityItem): string =
   return self.banner
+
+proc banner*(self: CuratedCommunityItem): string =
+  return self.banner
+
+proc `banner=`*(self: var CuratedCommunityItem, value: string) =
+  self.banner = value
 
 proc getMembers*(self: CuratedCommunityItem): int =
   return self.members
 
+proc members*(self: CuratedCommunityItem): int =
+  return self.members
+
+proc `members=`*(self: var CuratedCommunityItem, value: int) =
+  self.members = value
+
 proc getActiveMembers*(self: CuratedCommunityItem): int =
   return self.activeMembers
+
+proc activeMembers*(self: CuratedCommunityItem): int =
+  return self.activeMembers
+
+proc `activeMembers=`*(self: var CuratedCommunityItem, value: int) =
+  self.activeMembers = value
 
 proc getColor*(self: CuratedCommunityItem): string =
   return self.color
 
+proc color*(self: CuratedCommunityItem): string =
+  return self.color
+
+proc `color=`*(self: var CuratedCommunityItem, value: string) =
+  self.color = value
+
 proc getTags*(self: CuratedCommunityItem): string =
   return self.tags
+
+proc tags*(self: CuratedCommunityItem): string =
+  return self.tags
+
+proc `tags=`*(self: var CuratedCommunityItem, value: string) =
+  self.tags = value
 
 proc getFeatured*(self: CuratedCommunityItem): bool =
   return self.featured
 
+proc featured*(self: CuratedCommunityItem): bool =
+  return self.featured
+
+proc `featured=`*(self: var CuratedCommunityItem, value: bool) =
+  self.featured = value
+
 proc getPermissionsModel*(self: CuratedCommunityItem): TokenPermissionsModel =
   return self.permissionModel
+
+proc permissionModel*(self: CuratedCommunityItem): TokenPermissionsModel =
+  return self.permissionModel
+
+proc `permissionModel=`*(self: var CuratedCommunityItem, value: TokenPermissionsModel) =
+  self.permissionModel = value
 
 proc setPermissionModelItems*(self: CuratedCommunityItem, items: seq[TokenPermissionItem]) =
   self.permissionModel.setItems(items)
@@ -112,8 +184,26 @@ proc setPermissionModelItems*(self: CuratedCommunityItem, items: seq[TokenPermis
 proc getAmIBanned*(self: CuratedCommunityItem): bool =
   return self.amIBanned
 
+proc amIBanned*(self: CuratedCommunityItem): bool =
+  return self.amIBanned
+
+proc `amIBanned=`*(self: var CuratedCommunityItem, value: bool) =
+  self.amIBanned = value
+
 proc getJoined*(self: CuratedCommunityItem): bool =
   return self.joined
 
+proc joined*(self: CuratedCommunityItem): bool =
+  return self.joined
+
+proc `joined=`*(self: var CuratedCommunityItem, value: bool) =
+  self.joined = value
+
 proc getEncrypted*(self: CuratedCommunityItem): bool =
   return self.encrypted
+
+proc encrypted*(self: CuratedCommunityItem): bool =
+  return self.encrypted
+
+proc `encrypted=`*(self: var CuratedCommunityItem, value: bool) =
+  self.encrypted = value

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -46,7 +46,7 @@ QtObject:
     read = getCount
     notify = countChanged
 
-  method rowCount(self: CuratedCommunityModel, index: QModelIndex = nil): int =
+  method rowCount*(self: CuratedCommunityModel, index: QModelIndex = nil): int =
     return self.items.len
 
   method roleNames(self: CuratedCommunityModel): Table[int, string] =

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -140,19 +140,19 @@ QtObject:
     self.countChanged()
 
   proc addItem*(self: CuratedCommunityModel, item: CuratedCommunityItem) =
-    let idx = self.findIndexById(item.getId())
-    if idx > -1:
-      let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
-      self.items[idx] = item
-      self.dataChanged(index, index)
-    else:
-      let parentModelIndex = newQModelIndex()
-      defer: parentModelIndex.delete
-      self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
-      self.items.add(item)
-      self.endInsertRows()
-      self.countChanged()
+    let ind = self.findIndexById(item.getId())
+    if ind != -1:
+      updateRolesAndNotify:
+        updateRolesFromItem(item, id, available, name, description, icon, banner, featured, members, activeMembers, color, tags, amIBanned, joined, encrypted)
+        updateRoleWithValue(permissionModel, item.permissionModel, Permissions)
+      return
+
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+    self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
+    self.items.add(item)
+    self.endInsertRows()
+    self.countChanged()
 
   proc setPermissionItems*(self: CuratedCommunityModel, itemId: string, items: seq[TokenPermissionItem]) =
     let idx = self.findIndexById(itemId)

--- a/src/app/modules/main/communities/models/discord_categories_model.nim
+++ b/src/app/modules/main/communities/models/discord_categories_model.nim
@@ -90,27 +90,17 @@ QtObject:
     self.countChanged()
 
   proc unselectItem*(self: DiscordCategoriesModel, id: string) =
-    let idx = self.findIndexById(id)
-    if idx > -1:
-      let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
-      self.items[idx].selected = false
-      self.dataChanged(index, index, @[ModelRole.Selected.int])
+    updateItemRolesAndNotify self.findIndexById(id):
+      updateRoleWithValue(selected, false)
 
   proc selectItem*(self: DiscordCategoriesModel, id: string) =
-    let idx = self.findIndexById(id)
-    if idx > -1:
-      let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
-      self.items[idx].selected = true
-      self.dataChanged(index, index, @[ModelRole.Selected.int])
+    updateItemRolesAndNotify self.findIndexById(id):
+      updateRoleWithValue(selected, true)
 
   proc selectOneItem*(self: DiscordCategoriesModel, id: string) =
-    for i in 0 ..< self.items.len:
-      let index = self.createIndex(i, 0, nil)
-      defer: index.delete
-      self.items[i].selected = self.items[i].getId() == id
-      self.dataChanged(index, index, @[ModelRole.Selected.int])
+    for ind in 0 ..< self.items.len:
+      updateRolesAndNotify:
+        updateRoleWithValue(selected, self.items[ind].getId() == id)
 
   proc setup(self: DiscordCategoriesModel) =
     self.QAbstractListModel.setup

--- a/src/app/modules/main/communities/models/discord_channel_item.nim
+++ b/src/app/modules/main/communities/models/discord_channel_item.nim
@@ -37,18 +37,54 @@ proc `$`*(self: DiscordChannelItem): string =
 proc getId*(self: DiscordChannelItem): string =
   return self.id
 
+proc id*(self: DiscordChannelItem): string =
+  return self.id
+
+proc `id=`*(self: var DiscordChannelItem, value: string) =
+  self.id = value
+
 proc getCategoryId*(self: DiscordChannelItem): string =
   return self.categoryId
+
+proc categoryId*(self: DiscordChannelItem): string =
+  return self.categoryId
+
+proc `categoryId=`*(self: var DiscordChannelItem, value: string) =
+  self.categoryId = value
 
 proc getName*(self: DiscordChannelItem): string =
   return self.name
 
+proc name*(self: DiscordChannelItem): string =
+  return self.name
+
+proc `name=`*(self: var DiscordChannelItem, value: string) =
+  self.name = value
+
 proc getDescription*(self: DiscordChannelItem): string =
   return self.description
+
+proc description*(self: DiscordChannelItem): string =
+  return self.description
+
+proc `description=`*(self: var DiscordChannelItem, value: string) =
+  self.description = value
 
 proc getFilePath*(self: DiscordChannelItem): string =
   return self.filePath
 
+proc filePath*(self: DiscordChannelItem): string =
+  return self.filePath
+
+proc `filePath=`*(self: var DiscordChannelItem, value: string) =
+  self.filePath = value
+
 proc getSelected*(self: DiscordChannelItem): bool =
   return self.selected
+
+proc selected*(self: DiscordChannelItem): bool =
+  return self.selected
+
+proc `selected=`*(self: var DiscordChannelItem, value: bool) =
+  self.selected = value
 

--- a/src/app/modules/main/communities/models/discord_channels_model.nim
+++ b/src/app/modules/main/communities/models/discord_channels_model.nim
@@ -65,80 +65,79 @@ QtObject:
     let enumRole = role.ModelRole
     case enumRole:
       of ModelRole.Id:
-        result = newQVariant(item.getId())
+        result = newQVariant(item.id)
       of ModelRole.CategoryId:
-        result = newQVariant(item.getCategoryId())
+        result = newQVariant(item.categoryId)
       of ModelRole.Name:
-        result = newQVariant(item.getName())
+        result = newQVariant(item.name)
       of ModelRole.Description:
-        result = newQVariant(item.getDescription())
+        result = newQVariant(item.description)
       of ModelRole.FilePath:
-        result = newQVariant(item.getFilePath())
+        result = newQVariant(item.filePath)
       of ModelRole.Selected:
-        result = newQVariant(item.getSelected())
+        result = newQVariant(item.selected)
 
   method setData(self: DiscordChannelsModel, index: QModelIndex, value: QVariant, role: int): bool =
     let row = index.row
     guardModelSetDataIndex(index, row, self.items.len)
     guardModelSetDataRole(role, ModelRole)
 
-    case role.ModelRole:
-      of ModelRole.Id:
-        self.items[row].id = value.stringVal()
-        self.dataChanged(index, index, @[ModelRole.Id.int])
-      of ModelRole.CategoryId:
-        self.items[row].categoryId = value.stringVal()
-        self.dataChanged(index, index, @[ModelRole.CategoryId.int])
-      of ModelRole.Name:
-        self.items[row].name = value.stringVal()
-        self.dataChanged(index, index, @[ModelRole.Name.int])
-      of ModelRole.Description:
-        self.items[row].description = value.stringVal()
-        self.dataChanged(index, index, @[ModelRole.Description.int])
-      of ModelRole.FilePath:
-        self.items[row].filePath = value.stringVal()
-        self.dataChanged(index, index, @[ModelRole.FilePath.int])
-      of ModelRole.Selected:
-        self.items[row].selected = value.boolVal()
-        self.dataChanged(index, index, @[ModelRole.Selected.int])
-        self.hasSelectedItemsChanged()
+    let notifyHasSelectedItems = role.ModelRole == ModelRole.Selected and self.items[row].selected != value.boolVal()
+
+    let ind = row
+    updateRolesAndNotify:
+      case role.ModelRole:
+        of ModelRole.Id:
+          updateRoleWithValue(id, value.stringVal())
+        of ModelRole.CategoryId:
+          updateRoleWithValue(categoryId, value.stringVal())
+        of ModelRole.Name:
+          updateRoleWithValue(name, value.stringVal())
+        of ModelRole.Description:
+          updateRoleWithValue(description, value.stringVal())
+        of ModelRole.FilePath:
+          updateRoleWithValue(filePath, value.stringVal())
+        of ModelRole.Selected:
+          updateRoleWithValue(selected, value.boolVal())
+    if notifyHasSelectedItems:
+      self.hasSelectedItemsChanged()
     return true
 
   proc findIndexById(self: DiscordChannelsModel, id: string): int =
     for i in 0 ..< self.items.len:
-      if(self.items[i].getId() == id):
+      if(self.items[i].id == id):
         return i
     return -1
 
   proc findIndicesByFilePath(self: DiscordChannelsModel, filePath: string): seq[int] =
     var indices: seq[int] = @[]
     for i in 0 ..< self.items.len:
-      if(self.items[i].getFilePath() == filePath):
+      if(self.items[i].filePath == filePath):
         indices.add(i)
     return indices
 
   proc getItem*(self: DiscordChannelsModel, id: string): DiscordChannelItem =
     for i in 0 ..< self.items.len:
-      if(self.items[i].getId() == id):
+      if(self.items[i].id == id):
         return self.items[i]
 
   proc allChannelsByCategoryUnselected*(self: DiscordChannelsModel, id: string): bool =
     var allUnselected = true
     for i in 0 ..< self.items.len:
-      if self.items[i].getCategoryId() == id and self.items[i].getSelected():
+      if self.items[i].categoryId == id and self.items[i].selected:
         allUnselected = false
         break
     return allUnselected
 
   proc hasItemsWithCategoryId*(self: DiscordChannelsModel, categoryId: string): bool =
     for i in 0 ..< self.items.len:
-      if(self.items[i].getCategoryId() == categoryId):
+      if(self.items[i].categoryId == categoryId):
         return true
     return false
 
   proc getHasSelectedItems*(self: DiscordChannelsModel): bool {.slot.} =
     for i in 0 ..< self.items.len:
-      if self.items[i].getSelected():
+      if self.items[i].selected:
         return true
     return false
 
@@ -167,22 +166,28 @@ QtObject:
     self.countChanged()
 
   proc unselectItemsByCategoryId*(self: DiscordChannelsModel, id: string) =
-    for i in 0 ..< self.items.len:
-      if(self.items[i].getCategoryId() == id):
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.items[i].selected = false
-        self.dataChanged(index, index, @[ModelRole.Selected.int])
-    self.hasSelectedItemsChanged()
+    var hasChanged = false
+
+    for ind in 0 ..< self.items.len:
+      if(self.items[ind].getCategoryId() == id):
+        updateRolesAndNotify:
+          updateRoleWithValue(selected, false)
+          if roles.len > 0:
+            hasChanged = true
+    if hasChanged:
+      self.hasSelectedItemsChanged()
 
   proc selectItemsByCategoryId*(self: DiscordChannelsModel, id: string) =
-    for i in 0 ..< self.items.len:
-      if(self.items[i].getCategoryId() == id):
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.items[i].selected = true
-        self.dataChanged(index, index, @[ModelRole.Selected.int])
-    self.hasSelectedItemsChanged()
+    var hasChanged = false
+
+    for ind in 0 ..< self.items.len:
+      if(self.items[ind].getCategoryId() == id):
+        updateRolesAndNotify:
+          updateRoleWithValue(selected, true)
+          if roles.len > 0:
+            hasChanged = true
+    if hasChanged:
+      self.hasSelectedItemsChanged()
 
   proc getChannelCategoryIdByFilePath*(self: DiscordChannelsModel, filePath: string): string =
     for i in 0 ..< self.items.len:
@@ -196,30 +201,35 @@ QtObject:
         result.add(self.items[i])
 
   proc unselectItem*(self: DiscordChannelsModel, id: string) =
-    let idx = self.findIndexById(id)
-    if idx > -1:
-      let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
-      self.items[idx].selected = false
-      self.dataChanged(index, index, @[ModelRole.Selected.int])
+    var hasChanged = false
+
+    updateItemRolesAndNotify self.findIndexById(id):
+      updateRoleWithValue(selected, false)
+      if roles.len > 0:
+        hasChanged = true
+    if hasChanged:
       self.hasSelectedItemsChanged()
 
   proc selectItem*(self: DiscordChannelsModel, id: string) =
-    let idx = self.findIndexById(id)
-    if idx > -1:
-      let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
-      self.items[idx].selected = true
-      self.dataChanged(index, index, @[ModelRole.Selected.int])
+    var hasChanged = false
+
+    updateItemRolesAndNotify self.findIndexById(id):
+      updateRoleWithValue(selected, true)
+      if roles.len > 0:
+        hasChanged = true
+    if hasChanged:
       self.hasSelectedItemsChanged()
 
   proc selectOneItem*(self: DiscordChannelsModel, id: string) =
-    for i in 0 ..< self.items.len:
-      let index = self.createIndex(i, 0, nil)
-      defer: index.delete
-      self.items[i].selected = self.items[i].getId() == id
-      self.dataChanged(index, index, @[ModelRole.Selected.int])
-    self.hasSelectedItemsChanged()
+    var hasChanged = false
+
+    for ind in 0 ..< self.items.len:
+      updateRolesAndNotify:
+        updateRoleWithValue(selected, self.items[ind].getId() == id)
+        if roles.len > 0:
+          hasChanged = true
+    if hasChanged:
+      self.hasSelectedItemsChanged()
 
   proc setup(self: DiscordChannelsModel) =
     self.QAbstractListModel.setup

--- a/src/app/modules/main/communities/models/discord_file_item.nim
+++ b/src/app/modules/main/communities/models/discord_file_item.nim
@@ -32,14 +32,44 @@ proc `$`*(self: DiscordFileItem): string =
 proc getFilePath*(self: DiscordFileItem): string =
   return self.filePath
 
+proc filePath*(self: DiscordFileItem): string =
+  return self.filePath
+
+proc `filePath=`*(self: var DiscordFileItem, value: string) =
+  self.filePath = value
+
 proc getErrorMessage*(self: DiscordFileItem): string =
   return self.errorMessage
+
+proc errorMessage*(self: DiscordFileItem): string =
+  return self.errorMessage
+
+proc `errorMessage=`*(self: var DiscordFileItem, value: string) =
+  self.errorMessage = value
 
 proc getErrorCode*(self: DiscordFileItem): int =
   return self.errorCode
 
+proc errorCode*(self: DiscordFileItem): int =
+  return self.errorCode
+
+proc `errorCode=`*(self: var DiscordFileItem, value: int) =
+  self.errorCode = value
+
 proc getSelected*(self: DiscordFileItem): bool =
   return self.selected
 
+proc selected*(self: DiscordFileItem): bool =
+  return self.selected
+
+proc `selected=`*(self: var DiscordFileItem, value: bool) =
+  self.selected = value
+
 proc getValidated*(self: DiscordFileItem): bool =
   return self.validated
+
+proc validated*(self: DiscordFileItem): bool =
+  return self.validated
+
+proc `validated=`*(self: var DiscordFileItem, value: bool) =
+  self.validated = value

--- a/src/app/modules/main/communities/models/discord_file_list_model.nim
+++ b/src/app/modules/main/communities/models/discord_file_list_model.nim
@@ -24,7 +24,7 @@ QtObject:
 
   proc getSelectedFilesValid*(self: DiscordFileListModel): bool {.slot.} =
     for i in 0 ..< self.items.len:
-      if self.items[i].getSelected() and not self.items[i].getValidated():
+      if self.items[i].selected and not self.items[i].validated:
         return false
     return true
 
@@ -35,7 +35,7 @@ QtObject:
   proc getSelectedFilePaths*(self: DiscordFileListModel): seq[string] =
     var filePaths: seq[string] = @[]
     for i in 0 ..< self.items.len:
-      filePaths.add(self.items[i].getFilePath())
+      filePaths.add(self.items[i].filePath)
     return filePaths
 
   proc countChanged(self: DiscordFileListModel) {.signal.}
@@ -50,7 +50,7 @@ QtObject:
   proc selectedCountChanged(self: DiscordFileListModel) {.signal.}
   proc getSelectedCount(self: DiscordFileListModel): int {.slot.} =
     for i in 0 ..< self.items.len:
-      if self.items[i].getSelected():
+      if self.items[i].selected:
         result = result + 1
 
   QtProperty[int] selectedCount:
@@ -82,24 +82,26 @@ QtObject:
     guardModelSetDataIndex(index, row, self.items.len)
     guardModelSetDataRole(role, ModelRole)
 
-    case role.ModelRole:
-      of ModelRole.FilePath:
-        self.items[index.row].filePath = value.stringVal()
-        self.dataChanged(index, index, @[ModelRole.FilePath.int])
-      of ModelRole.ErrorMessage:
-        self.items[index.row].errorMessage = value.stringVal()
-        self.dataChanged(index, index, @[ModelRole.ErrorMessage.int])
-      of ModelRole.ErrorCode:
-        self.items[index.row].errorCode = value.intVal()
-        self.dataChanged(index, index, @[ModelRole.ErrorCode.int])
-      of ModelRole.Selected:
-        self.items[index.row].selected = value.boolVal()
-        self.dataChanged(index, index, @[ModelRole.Selected.int])
-        self.selectedCountChanged()
-      of ModelRole.Validated:
-        self.items[index.row].validated = value.boolVal()
-        self.dataChanged(index, index, @[ModelRole.Validated.int])
-        self.selectedFilesValidChanged()
+    let notifySelectedCount = role.ModelRole == ModelRole.Selected and self.items[row].selected != value.boolVal()
+    let notifySelectedFilesValid = role.ModelRole == ModelRole.Validated and self.items[row].validated != value.boolVal()
+
+    let ind = row
+    updateRolesAndNotify:
+      case role.ModelRole:
+        of ModelRole.FilePath:
+          updateRoleWithValue(filePath, value.stringVal())
+        of ModelRole.ErrorMessage:
+          updateRoleWithValue(errorMessage, value.stringVal())
+        of ModelRole.ErrorCode:
+          updateRoleWithValue(errorCode, value.intVal())
+        of ModelRole.Selected:
+          updateRoleWithValue(selected, value.boolVal())
+        of ModelRole.Validated:
+          updateRoleWithValue(validated, value.boolVal())
+    if notifySelectedCount:
+      self.selectedCountChanged()
+    if notifySelectedFilesValid:
+      self.selectedFilesValidChanged()
     return true
 
   method data(self: DiscordFileListModel, index: QModelIndex, role: int): QVariant =
@@ -110,19 +112,19 @@ QtObject:
     let enumRole = role.ModelRole
     case enumRole:
       of ModelRole.FilePath:
-        result = newQVariant(item.getFilePath())
+        result = newQVariant(item.filePath)
       of ModelRole.ErrorMessage:
-        result = newQVariant(item.getErrorMessage())
+        result = newQVariant(item.errorMessage)
       of ModelRole.ErrorCode:
-        result = newQVariant(item.getErrorCode())
+        result = newQVariant(item.errorCode)
       of ModelRole.Selected:
-        result = newQVariant(item.getSelected())
+        result = newQVariant(item.selected)
       of ModelRole.Validated:
-        result = newQVariant(item.getValidated())
+        result = newQVariant(item.validated)
 
   proc findIndexByFilePath(self: DiscordFileListModel, filePath: string): int =
     for i in 0 ..< self.items.len:
-      if(self.items[i].getFilePath() == filePath):
+      if(self.items[i].filePath == filePath):
         return i
     return -1
 
@@ -148,29 +150,19 @@ QtObject:
       self.countChanged()
 
   proc setAllValidated*(self: DiscordFileListModel) =
-    for i in 0 ..< self.items.len:
-      let index = self.createIndex(i, 0, nil)
-      defer: index.delete
-      self.items[i].validated = true
-      self.dataChanged(index, index, @[ModelRole.Validated.int])
+    for ind in 0 ..< self.items.len:
+      updateRolesAndNotify:
+        updateRoleWithValue(validated, true)
     self.selectedFilesValidChanged()
 
   proc updateErrorState*(self: DiscordFileListModel, filePath: string, errorMessage: string, errorCode: int) =
-    let idx = self.findIndexByFilePath(filePath)
-    if idx > -1:
-      let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
-      self.items[idx].errorMessage = errorMessage
-      self.items[idx].errorCode = errorCode
-      self.items[idx].selected = false
-      self.items[idx].validated = true
-      self.dataChanged(index, index, @[
-        ModelRole.ErrorMessage.int,
-        ModelRole.ErrorCode.int,
-        ModelRole.Selected.int,
-        ModelRole.Validated.int
-      ])
-      self.selectedCountChanged()
+    updateItemRolesAndNotify self.findIndexByFilePath(filePath):
+      updateRole(errorMessage)
+      updateRole(errorCode)
+      updateRoleWithValue(selected, false)
+      updateRoleWithValue(validated, true)
+      if ModelRole.Selected.int in roles:
+        self.selectedCountChanged()
 
   proc clearItems*(self: DiscordFileListModel) =
     self.beginResetModel()

--- a/src/app/modules/main/communities/models/discord_import_task_item.nim
+++ b/src/app/modules/main/communities/models/discord_import_task_item.nim
@@ -47,22 +47,64 @@ proc initDiscordImportTaskItem*(
       result.errors.addItem(initDiscordImportErrorItem(`type`, error.code, error.message))
 
 proc getType*(self: DiscordImportTaskItem): string =
-  return self.type
+  return self.`type`
+
+proc `type`*(self: DiscordImportTaskItem): string =
+  return self.`type`
+
+proc `type=`*(self: var DiscordImportTaskItem, value: string) =
+  self.`type` = value
 
 proc getProgress*(self: DiscordImportTaskItem): float =
   return self.progress
 
+proc progress*(self: DiscordImportTaskItem): float =
+  return self.progress
+
+proc `progress=`*(self: var DiscordImportTaskItem, value: float) =
+  self.progress = value
+
 proc getState*(self: DiscordImportTaskItem): string =
   return self.state
+
+proc state*(self: DiscordImportTaskItem): string =
+  return self.state
+
+proc `state=`*(self: var DiscordImportTaskItem, value: string) =
+  self.state = value
 
 proc getErrors*(self: DiscordImportTaskItem): DiscordImportErrorsModel =
   return self.errors
 
+proc errors*(self: DiscordImportTaskItem): DiscordImportErrorsModel =
+  return self.errors
+
+proc `errors=`*(self: var DiscordImportTaskItem, value: DiscordImportErrorsModel) =
+  self.errors = value
+
 proc getStopped*(self: DiscordImportTaskItem): bool =
   return self.stopped
+
+proc stopped*(self: DiscordImportTaskItem): bool =
+  return self.stopped
+
+proc `stopped=`*(self: var DiscordImportTaskItem, value: bool) =
+  self.stopped = value
 
 proc getErrorsCount*(self: DiscordImportTaskItem): int =
   return self.errorsCount
 
+proc errorsCount*(self: DiscordImportTaskItem): int =
+  return self.errorsCount
+
+proc `errorsCount=`*(self: var DiscordImportTaskItem, value: int) =
+  self.errorsCount = value
+
 proc getWarningsCount*(self: DiscordImportTaskItem): int =
   return self.warningsCount
+
+proc warningsCount*(self: DiscordImportTaskItem): int =
+  return self.warningsCount
+
+proc `warningsCount=`*(self: var DiscordImportTaskItem, value: int) =
+  self.warningsCount = value

--- a/src/app/modules/main/communities/models/discord_import_tasks_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_tasks_model.nim
@@ -43,19 +43,19 @@ QtObject:
     let enumRole = role.ModelRole
     case enumRole:
       of ModelRole.Type:
-        result = newQVariant(item.getType())
+        result = newQVariant(item.`type`)
       of ModelRole.Progress:
-        result = newQVariant(item.getProgress())
+        result = newQVariant(item.progress)
       of ModelRole.State:
-        result = newQVariant(item.getState())
+        result = newQVariant(item.state)
       of ModelRole.Errors:
-        result = newQVariant(item.getErrors())
+        result = newQVariant(item.errors)
       of ModelRole.Stopped:
-        result = newQVariant(item.getStopped())
+        result = newQVariant(item.stopped)
       of ModelRole.ErrorsCount:
-        result = newQVariant(item.getErrorsCount())
+        result = newQVariant(item.errorsCount)
       of ModelRole.WarningsCount:
-        result = newQVariant(item.getWarningsCount())
+        result = newQVariant(item.warningsCount)
 
   method rowCount(self: DiscordImportTasksModel, index: QModelIndex = nil): int =
     return self.items.len
@@ -85,34 +85,25 @@ QtObject:
     return -1
 
   proc updateItem*(self: DiscordImportTasksModel, item: DiscordImportTaskProgress) =
-    let idx = self.findIndexByType(item.`type`)
-    if idx > -1:
-      let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
-      let errorsAndWarningsCount = self.items[idx].warningsCount + self.items[idx].errorsCount
-      self.items[idx].progress = item.progress
-      self.items[idx].state = item.state
-      self.items[idx].stopped = item.stopped
-      self.items[idx].errorsCount = item.errorsCount
-      self.items[idx].warningsCount = item.warningsCount
+    updateItemRolesAndNotify self.findIndexByType(item.`type`):
+      updateRoleWithValue(progress, item.progress)
+      updateRoleWithValue(state, item.state)
+      updateRoleWithValue(stopped, item.stopped)
+      updateRoleWithValue(errorsCount, item.errorsCount)
+      updateRoleWithValue(warningsCount, item.warningsCount)
 
-      let errorItemsCount = self.items[idx].errors.items.len
+      let errorItemsCount = self.items[ind].errors.items.len
+      var errorsChanged = false
 
       # We only show the first 3 warnings + any error per task,
       # then we add another "#n more issues" item in the UI
       for i, error in item.errors:
         if (errorItemsCount + i < taskItem.MAX_VISIBLE_ERROR_ITEMS) or error.code > ord(DiscordImportErrorCode.Warning):
           let errorItem = initDiscordImportErrorItem(item.`type`, error.code, error.message)
-          self.items[idx].errors.addItem(errorItem)
+          self.items[ind].errors.addItem(errorItem)
+          errorsChanged = true
 
-      self.dataChanged(index, index, @[
-        ModelRole.Progress.int,
-        ModelRole.State.int,
-        ModelRole.Errors.int,
-        ModelRole.Stopped.int,
-        ModelRole.ErrorsCount.int,
-        ModelRole.WarningsCount.int
-      ])
+      addChangedRole(roles, false, errorsChanged, ModelRole.Errors.int): discard
 
 
   proc clearItems*(self: DiscordImportTasksModel) =

--- a/src/app/modules/main/communities/tokens/models/token_item.nim
+++ b/src/app/modules/main/communities/tokens/models/token_item.nim
@@ -61,3 +61,15 @@ proc `$`*(self: TokenItem): string =
     remoteDestructedAddresses: {self.remoteDestructedAddresses}
     ]"""
 
+proc tokenAddress*(self: TokenItem): string =
+  self.tokenDto.address
+
+proc `tokenAddress=`*(self: var TokenItem, value: string) =
+  self.tokenDto.address = value
+
+proc deployState*(self: TokenItem): DeployState =
+  self.tokenDto.deployState
+
+proc `deployState=`*(self: var TokenItem, value: DeployState) =
+  self.tokenDto.deployState = value
+

--- a/src/app/modules/main/communities/tokens/models/token_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_model.nim
@@ -55,68 +55,35 @@ QtObject:
     return -1
 
   proc updateDeployState*(self: TokenModel, chainId: int, contractAddress: string, deployState: DeployState) =
-    let itemIdx = self.getItemIndex(chainId, contractAddress)
-    if itemIdx == -1 or self.items[itemIdx].tokenDto.deployState == deployState:
-      return
-
-    self.items[itemIdx].tokenDto.deployState = deployState
-    let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.DeployState.int])
+    updateItemRolesAndNotify self.getItemIndex(chainId, contractAddress):
+      updateRole(deployState)
 
   proc updateAddress*(self: TokenModel, chainId: int, oldContractAddress: string, newContractAddress: string) =
-    let itemIdx = self.getItemIndex(chainId, oldContractAddress)
-    if itemIdx == -1 or self.items[itemIdx].tokenDto.address == newContractAddress:
-      return
-
-    self.items[itemIdx].tokenDto.address = newContractAddress
-    let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.TokenAddress.int])
+    updateItemRolesAndNotify self.getItemIndex(chainId, oldContractAddress):
+      updateRoleWithValue(tokenAddress, newContractAddress)
 
   proc updateBurnState*(self: TokenModel, chainId: int, contractAddress: string, burnState: ContractTransactionStatus) =
-    let itemIdx = self.getItemIndex(chainId, contractAddress)
-    if itemIdx == -1 or self.items[itemIdx].burnState == burnState:
-      return
-  
-    self.items[itemIdx].burnState = burnState
-    let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.BurnState.int])
+    updateItemRolesAndNotify self.getItemIndex(chainId, contractAddress):
+      updateRole(burnState)
 
   proc updateRemoteDestructedAddresses*(self: TokenModel, chainId: int, contractAddress: string, remoteDestructedAddresses: seq[string]) =
-    let itemIdx = self.getItemIndex(chainId, contractAddress)
-    if itemIdx == -1 or self.items[itemIdx].remoteDestructedAddresses == remoteDestructedAddresses:
-      return
-
-    self.items[itemIdx].remoteDestructedAddresses = remoteDestructedAddresses
-    let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.RemotelyDestructState.int])
-    self.items[itemIdx].tokenOwnersModel.updateRemoteDestructState(remoteDestructedAddresses)
-    self.dataChanged(index, index, @[ModelRole.TokenOwnersModel.int])
+    updateItemRolesAndNotify self.getItemIndex(chainId, contractAddress):
+      addChangedRole(roles, self.items[ind].remoteDestructedAddresses, remoteDestructedAddresses, ModelRole.RemotelyDestructState.int):
+        self.items[ind].remoteDestructedAddresses = remoteDestructedAddresses
+        self.items[ind].tokenOwnersModel.updateRemoteDestructState(remoteDestructedAddresses)
+        roles.add(ModelRole.TokenOwnersModel.int)
 
   proc updateSupply*(self: TokenModel, chainId: int, contractAddress: string, supply: Uint256, destructedAmount: Uint256) =
-    let itemIdx = self.getItemIndex(chainId, contractAddress)
-    if itemIdx == -1:
-      return
-
-    if self.items[itemIdx].tokenDto.supply != supply or self.items[itemIdx].destructedAmount != destructedAmount:
-      self.items[itemIdx].tokenDto.supply = supply
-      self.items[itemIdx].destructedAmount = destructedAmount
-      let index = self.createIndex(itemIdx, 0, nil)
-      defer: index.delete
-      self.dataChanged(index, index, @[ModelRole.Supply.int])
+    updateItemRolesAndNotify self.getItemIndex(chainId, contractAddress):
+      let previousSupply = self.items[ind].tokenDto.supply - self.items[ind].destructedAmount
+      let currentSupply = supply - destructedAmount
+      self.items[ind].tokenDto.supply = supply
+      self.items[ind].destructedAmount = destructedAmount
+      addChangedRole(roles, previousSupply, currentSupply, ModelRole.Supply.int): discard
 
   proc updateRemainingSupply*(self: TokenModel, chainId: int, contractAddress: string, remainingSupply: Uint256) =
-    let itemIdx = self.getItemIndex(chainId, contractAddress)
-    if itemIdx == -1 or self.items[itemIdx].remainingSupply == remainingSupply:
-      return
-
-    self.items[itemIdx].remainingSupply = remainingSupply
-    let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.RemainingSupply.int])
+    updateItemRolesAndNotify self.getItemIndex(chainId, contractAddress):
+      updateRole(remainingSupply)
 
   proc hasTokenHolders*(self: TokenModel, chainId: int, contractAddress: string): bool =
     let itemIdx = self.getItemIndex(chainId, contractAddress)
@@ -125,36 +92,26 @@ QtObject:
     return self.items[itemIdx].tokenOwnersModel.count > 0
 
   proc setCommunityTokenOwners*(self: TokenModel, chainId: int, contractAddress: string, owners: seq[CommunityCollectibleOwner], isOwner: bool) =
-    let itemIdx = self.getItemIndex(chainId, contractAddress)
-    if itemIdx == -1:
-      return
-
-    self.items[itemIdx].tokenHoldersLoading = false
-    let isMyOwnerToken = isOwner and self.items[itemIdx].tokenDto.privilegesLevel == PrivilegesLevel.Owner
-    self.items[itemIdx].tokenOwnersModel.setItems(owners.map(proc(owner: CommunityCollectibleOwner): TokenOwnersItem =
-      var contactId = owner.contactId
-      var name = owner.name
-      if isMyOwnerToken:
-        # This is the Owner token and we are the Owner. We can hardcode the pubkey
-        # The DB doesn't store our own address in the RevealedAddresses list so we patch it here
-        contactId = singletonInstance.userProfile.getPubKey()
-        name = singletonInstance.userProfile.getName()
-      # TODO: provide number of messages here
-      result = initTokenOwnersItem(contactId, name, owner.imageSource, 0, owner.collectibleOwner, self.items[itemIdx].remoteDestructedAddresses)
-    ))
-    let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.TokenOwnersModel.int, ModelRole.TokenHoldersLoading.int])
+    updateItemRolesAndNotify self.getItemIndex(chainId, contractAddress):
+      let isMyOwnerToken = isOwner and self.items[ind].tokenDto.privilegesLevel == PrivilegesLevel.Owner
+      let tokenOwners = owners.map(proc(owner: CommunityCollectibleOwner): TokenOwnersItem =
+        var contactId = owner.contactId
+        var name = owner.name
+        if isMyOwnerToken:
+          # This is the Owner token and we are the Owner. We can hardcode the pubkey
+          # The DB doesn't store our own address in the RevealedAddresses list so we patch it here
+          contactId = singletonInstance.userProfile.getPubKey()
+          name = singletonInstance.userProfile.getName()
+        # TODO: provide number of messages here
+        result = initTokenOwnersItem(contactId, name, owner.imageSource, 0, owner.collectibleOwner, self.items[ind].remoteDestructedAddresses)
+      )
+      self.items[ind].tokenOwnersModel.setItems(tokenOwners)
+      roles.add(ModelRole.TokenOwnersModel.int)
+      updateRoleWithValue(tokenHoldersLoading, false)
 
   proc setCommunityTokenHoldersLoading*(self: TokenModel, chainId: int, contractAddress: string, value: bool) =
-    let itemIdx = self.getItemIndex(chainId, contractAddress)
-    if itemIdx == -1 or self.items[itemIdx].tokenHoldersLoading == value:
-      return
-
-    self.items[itemIdx].tokenHoldersLoading = value
-    let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.TokenHoldersLoading.int])
+    updateItemRolesAndNotify self.getItemIndex(chainId, contractAddress):
+      updateRoleWithValue(tokenHoldersLoading, value)
 
   proc countChanged(self: TokenModel) {.signal.}
 

--- a/src/app/modules/main/communities/tokens/models/token_owners_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_owners_model.nim
@@ -52,13 +52,9 @@ QtObject:
     }.toTable
 
   proc updateRemoteDestructState*(self: TokenOwnersModel, remoteDestructedAddresses: seq[string]) =
-    let indexBegin = self.createIndex(0, 0, nil)
-    let indexEnd = self.createIndex(self.items.len - 1, 0, nil)
-    defer: indexBegin.delete
-    defer: indexEnd.delete
-    for i in 0 ..< self.items.len:
-      self.items[0].remotelyDestructState = remoteDestructTransactionStatus(remoteDestructedAddresses, self.items[0].ownerDetails.address)
-    self.dataChanged(indexBegin, indexEnd, @[ModelRole.RemotelyDestructState.int])
+    for ind in 0 ..< self.items.len:
+      updateRolesAndNotify:
+        updateRoleWithValue(remotelyDestructState, remoteDestructTransactionStatus(remoteDestructedAddresses, self.items[ind].ownerDetails.address))
 
   method data(self: TokenOwnersModel, index: QModelIndex, role: int): QVariant =
     guardModelData(index, self.items.len, role, ModelRole)

--- a/src/app/modules/main/market_section/market_leaderboard_model.nim
+++ b/src/app/modules/main/market_section/market_leaderboard_model.nim
@@ -82,8 +82,6 @@ QtObject:
 
   proc pageUpdated*(self: MarketLeaderboardModel, updates: seq[LeaderboardTokenUpdated]) =
     for update in updates:
-      let modelIndex = self.createIndex(update.index, 0, nil)
-      defer: modelIndex.delete
       var changedRoles: seq[int] = @[]
       for field in update.changedFields:
         let roleOpt = self.getRoleFromName(field)
@@ -91,7 +89,7 @@ QtObject:
           changedRoles.add(roleOpt.get())
 
       if changedRoles.len > 0:
-        self.dataChanged(modelIndex, modelIndex, changedRoles)
+        notifyRangeRolesChanged(update.index, update.index, changedRoles)
 
   proc setup(self: MarketLeaderboardModel) =
     self.QAbstractListModel.setup

--- a/src/app/modules/main/profile_section/devices/item.nim
+++ b/src/app/modules/main/profile_section/devices/item.nim
@@ -17,6 +17,18 @@ proc installation*(self: Item): InstallationDto =
 proc `installation=`*(self: Item, installation: InstallationDto) =
   self.installation = installation
 
+proc identity*(self: Item): string =
+  self.installation.identity
+
+proc `identity=`*(self: Item, value: string) =
+  self.installation.identity = value
+
+proc version*(self: Item): int =
+  self.installation.version
+
+proc `version=`*(self: Item, value: int) =
+  self.installation.version = value
+
 proc name*(self: Item): string =
   self.installation.metadata.name
 
@@ -28,6 +40,24 @@ proc enabled*(self: Item): bool =
 
 proc `enabled=`*(self: Item, value: bool) =
   self.installation.enabled = value
+
+proc timestamp*(self: Item): int64 =
+  self.installation.timestamp
+
+proc `timestamp=`*(self: Item, value: int64) =
+  self.installation.timestamp = value
+
+proc deviceType*(self: Item): string =
+  self.installation.metadata.deviceType
+
+proc `deviceType=`*(self: Item, value: string) =
+  self.installation.metadata.deviceType = value
+
+proc fcmToken*(self: Item): string =
+  self.installation.metadata.fcmToken
+
+proc `fcmToken=`*(self: Item, value: string) =
+  self.installation.metadata.fcmToken = value
 
 proc isCurrentDevice*(self: Item): bool =
   self.isCurrentDevice

--- a/src/app/modules/main/profile_section/devices/model.nim
+++ b/src/app/modules/main/profile_section/devices/model.nim
@@ -116,48 +116,24 @@ QtObject:
     return self.findIndexByInstallationId(installationId) != -1
 
   proc updateItem*(self: Model, installation: InstallationDto) =
-    var i = self.findIndexByInstallationId(installation.id)
-    if(i == -1):
-      return
+    updateItemRolesAndNotify self.findIndexByInstallationId(installation.id):
+      updateRoleWithValue(identity, installation.identity)
+      updateRoleWithValue(version, installation.version)
+      updateRoleWithValue(enabled, installation.enabled)
+      updateRoleWithValue(timestamp, installation.timestamp)
+      updateRoleWithValue(name, installation.metadata.name)
+      updateRoleWithValue(deviceType, installation.metadata.deviceType)
+      updateRoleWithValue(fcmToken, installation.metadata.fcmToken)
 
-    let index = self.createIndex(i, 0, nil)
-    defer: index.delete
-
-    self.items[i].installation = installation
-    self.dataChanged(index, index, @[
-      ModelRole.Identity.int,
-      ModelRole.Version.int,
-      ModelRole.Enabled.int,
-      ModelRole.Timestamp.int,
-      ModelRole.Name.int,
-      ModelRole.DeviceType.int,
-      ModelRole.FcmToken.int,
-    ])
     self.updatePairedCount()
 
   proc updateItemName*(self: Model, installationId: string, name: string) =
-    var i = self.findIndexByInstallationId(installationId)
-    if i == -1 or self.items[i].installation.metadata.name == name:
-      return
-
-    self.items[i].installation.metadata.name = name
-
-    let index = self.createIndex(i, 0, nil)
-    defer: index.delete
-
-    self.dataChanged(index, index, @[ModelRole.Name.int])
+    updateItemRolesAndNotify self.findIndexByInstallationId(installationId):
+      updateRoleWithValue(name, name)
 
   proc updateItemEnabled*(self: Model, installationId: string, enabled: bool) =
-    var i = self.findIndexByInstallationId(installationId)
-    if i == -1 or self.items[i].installation.enabled == enabled:
-      return
-
-    self.items[i].installation.enabled = enabled
-
-    let index = self.createIndex(i, 0, nil)
-    defer: index.delete
-
-    self.dataChanged(index, index, @[ModelRole.Enabled.int])
+    updateItemRolesAndNotify self.findIndexByInstallationId(installationId):
+      updateRoleWithValue(enabled, enabled)
 
   proc getIsDeviceSetup*(self: Model, installationId: string): bool =
     return anyIt(self.items, it.installation.id == installationId and it.name != "")

--- a/src/app/modules/main/profile_section/ens_usernames/model.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/model.nim
@@ -92,15 +92,8 @@ QtObject:
     self.countChanged()
 
   proc updatePendingStatus*(self: Model, chainId: int, ensUsername: string, pendingStatus: bool) =
-    let ind = self.findIndex(chainId, ensUsername)
-    if(ind == -1):
-      return
-
-    self.items[ind].isPending = pendingStatus
-
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.IsPending.int])
+    updateItemRolesAndNotify self.findIndex(chainId, ensUsername):
+      updateRoleWithValue(isPending, pendingStatus)
 
   proc delete(self: Model) =
     self.QAbstractListModel.delete

--- a/src/app/modules/main/profile_section/notifications/controller.nim
+++ b/src/app/modules/main/profile_section/notifications/controller.nim
@@ -90,6 +90,14 @@ proc init*(self: Controller) =
     var args = ChatRenameArgs(e)
     self.delegate.setName(args.id, args.newName)
 
+  self.events.on(SIGNAL_GROUP_CHAT_DETAILS_UPDATED) do(e: Args):
+    var args = ChatUpdateDetailsArgs(e)
+    self.delegate.editChat(args.id)
+
+  self.events.on(SIGNAL_CONTACT_UPDATED) do(e: Args):
+    let args = ContactArgs(e)
+    self.delegate.editChat(args.contactId)
+
   self.events.on(SIGNAL_CHAT_SWITCH_TO_OR_CREATE_1_1_CHAT) do(e:Args):
     let args = ChatExtArgs(e)
     self.delegate.addChat(args.chatId)

--- a/src/app/modules/main/profile_section/notifications/io_interface.nim
+++ b/src/app/modules/main/profile_section/notifications/io_interface.nim
@@ -45,5 +45,8 @@ method addChat*(self: AccessInterface, chatDto: ChatDto) {.base.} =
 method addChat*(self: AccessInterface, itemId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method editChat*(self: AccessInterface, itemId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method setName*(self: AccessInterface, itemId: string, name: string) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/notifications/model.nim
+++ b/src/app/modules/main/profile_section/notifications/model.nim
@@ -21,7 +21,7 @@ type
 QtObject:
   type
     Model* = ref object of QAbstractListModel
-      items: seq[Item]
+      items*: seq[Item]
 
   proc delete*(self: Model)
   proc setup(self: Model)
@@ -29,7 +29,7 @@ QtObject:
     new(result, delete)
     result.setup
 
-  method rowCount(self: Model, index: QModelIndex = nil): int =
+  method rowCount*(self: Model, index: QModelIndex = nil): int =
     return self.items.len
 
   method roleNames(self: Model): Table[int, string] =

--- a/src/app/modules/main/profile_section/notifications/model.nim
+++ b/src/app/modules/main/profile_section/notifications/model.nim
@@ -1,9 +1,8 @@
-import app/modules/shared_models/model_utils
 import nimqml, tables
 import item
+import app/modules/shared_models/model_utils
 
-import ../../../../../app_service/service/settings/dto/settings
-import ../../../shared_models/model_utils
+import app_service/service/settings/dto/settings
 
 type
   ModelRole {.pure.} = enum
@@ -120,23 +119,16 @@ QtObject:
   proc updateExemptions*(self: Model, id: string, muteAllMessages = false, personalMentions = VALUE_NOTIF_SEND_ALERTS, 
     globalMentions = VALUE_NOTIF_SEND_ALERTS, otherMessages = VALUE_NOTIF_TURN_OFF) =
     updateItemRolesAndNotify self.findIndexForItemId(id):
+      let previousCustomized = self.items[ind].customized
       updateRole(muteAllMessages)
       updateRole(personalMentions)
       updateRole(globalMentions)
       updateRole(otherMessages)
-      if roles.len > 0:
-        roles.add(ModelRole.Customized.int)
+      addChangedRole(roles, previousCustomized, self.items[ind].customized, ModelRole.Customized.int): discard
 
   proc updateName*(self: Model, id: string, name: string) =
-    let ind = self.findIndexForItemId(id)
-    if ind == -1 or self.items[ind].name == name:
-      return
-
-    self.items[ind].name = name
-
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.Name.int])
+    updateItemRolesAndNotify self.findIndexForItemId(id):
+      updateRole(name)
 
   proc updateItem*(self: Model, id, name, image, color: string) =
     updateItemRolesAndNotify self.findIndexForItemId(id):

--- a/src/app/modules/main/profile_section/notifications/module.nim
+++ b/src/app/modules/main/profile_section/notifications/module.nim
@@ -150,5 +150,27 @@ method addChat*(self: Module, itemId: string) =
     return
   self.addChat(chatDto)
 
+method editChat*(self: Module, itemId: string) =
+  let chatDto = self.controller.getChatDetails(itemId)
+  if chatDto.chatType == ChatType.OneToOne:
+    let contactDetails = self.controller.getContactDetails(itemId)
+    self.view.exemptionsModel().updateItem(
+      itemId,
+      contactDetails.dto.displayName,
+      contactDetails.icon,
+      chatDto.color,
+    )
+    return
+
+  if chatDto.chatType != ChatType.PrivateGroupChat:
+    return
+
+  self.view.exemptionsModel().updateItem(
+    itemId,
+    chatDto.name,
+    chatDto.icon,
+    chatDto.color,
+  )
+
 method setName*(self: Module, itemId: string, name: string) =
   self.view.exemptionsModel().updateName(itemId, name)

--- a/src/app/modules/main/profile_section/wallet/accounts/model.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/model.nim
@@ -63,17 +63,13 @@ QtObject:
     self.countChanged()
 
   proc onUpdatedAccount*(self: Model, account: WalletAccountItem) =
-    var i = 0
-    for item in self.items.mitems:
-      if account.address == item.address:
-        item.name = account.name
-        item.colorId = account.colorId
-        item.emoji = account.emoji
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index, @[ModelRole.Name.int, ModelRole.ColorId.int, ModelRole.Emoji.int])
+    for ind in 0 ..< self.items.len:
+      if account.address == self.items[ind].address:
+        updateRolesAndNotify:
+          updateRoleWithValue(name, account.name)
+          updateRoleWithValue(colorId, account.colorId)
+          updateRoleWithValue(emoji, account.emoji)
         break
-      i.inc
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
     guardModelData(index, self.items.len, role, ModelRole)

--- a/src/app/modules/main/stickers/models/sticker_pack_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_pack_list.nim
@@ -111,19 +111,22 @@ QtObject:
     self.endRemoveRows()
 
   proc updateStickerPackInList*(self: StickerPackList, packId: string, installed: bool, pending: bool) =
-    let idx = self.findIndexById(packId)
-    if idx == -1:
+    let ind = self.findIndexById(packId)
+    if ind == -1:
       return
-    let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
-    self.packs.apply(proc(it: var StickerPackView) =
-      if it.pack.id == packId:
-        it.installed = installed
-        if installed:
-          it.bought = true
-        it.pending = pending)
-    self.dataChanged(index, index, @[StickerPackRoles.Installed.int, StickerPackRoles.Bought.int,
-      StickerPackRoles.Pending.int])
+
+    updateRolesAndNotify:
+      if self.packs[ind].installed != installed:
+        self.packs[ind].installed = installed
+        roles.add(StickerPackRoles.Installed.int)
+
+      if installed and not self.packs[ind].bought:
+        self.packs[ind].bought = true
+        roles.add(StickerPackRoles.Bought.int)
+
+      if self.packs[ind].pending != pending:
+        self.packs[ind].pending = pending
+        roles.add(StickerPackRoles.Pending.int)
 
   # We cannot return QVariant from the proc which has arguments.
   # First findStickersById has to be called, then getFoundStickers

--- a/src/app/modules/main/wallet_section/accounts/item.nim
+++ b/src/app/modules/main/wallet_section/accounts/item.nim
@@ -77,18 +77,6 @@ QtObject:
     result = result & "\canSend: " & $self.canSend
     result = result & ")"
 
-  proc currencyBalance*(self: Item): CurrencyAmount =
-    return self.currencyBalance
-
-  proc assetsLoading*(self: Item): bool =
-    return self.assetsLoading
-
-  proc createdAt*(self: Item): int =
-    return self.createdAt
-
-  proc isWallet*(self: Item): bool =
-    return self.isWallet
-
   proc currencyBalanceChanged*(self: Item) {.signal.}
   proc getCurrencyBalanceAsQVariant*(self: Item): QVariant {.slot.} =
     return newQVariant(self.currencyBalance)
@@ -96,8 +84,36 @@ QtObject:
     read = getCurrencyBalanceAsQVariant
     notify = currencyBalanceChanged
 
+  proc currencyBalance*(self: Item): CurrencyAmount =
+    return self.currencyBalance
+
+  proc `currencyBalance=`*(self: Item, value: CurrencyAmount) =
+    self.currencyBalance = value
+    self.currencyBalanceChanged()
+
+  proc assetsLoading*(self: Item): bool =
+    return self.assetsLoading
+
+  proc `assetsLoading=`*(self: Item, value: bool) =
+    self.assetsLoading = value
+
+  proc createdAt*(self: Item): int =
+    return self.createdAt
+
+  proc `createdAt=`*(self: Item, value: int) =
+    self.createdAt = value
+
+  proc isWallet*(self: Item): bool =
+    return self.isWallet
+
+  proc `isWallet=`*(self: Item, value: bool) =
+    self.isWallet = value
+
   proc canSend*(self: Item): bool =
     return self.canSend
+
+  proc `canSend=`*(self: Item, value: bool) =
+    self.canSend = value
 
   proc setAssetsLoading*(self: Item, value: bool) =
     self.assetsLoading = value

--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -1,5 +1,5 @@
 import app/modules/shared_models/model_utils
-import nimqml, tables, strutils, std/strformat, std/sequtils, chronicles
+import nimqml, tables, strutils, std/strformat, std/sequtils
 
 import ./item
 import ../../../shared_models/currency_amount
@@ -99,6 +99,32 @@ QtObject:
     return self.findAccountIndex(account.address())
 
   proc setItems*(self: Model, items: seq[Item]) =
+    proc updateExistingItem(account: Item): bool =
+      var itemFound = false
+
+      proc updateRoles() =
+        updateItemRolesAndNotify self.findAccountIndex(account):
+          itemFound = true
+          updateRoleWithValue(name, account.name())
+          updateRoleWithValue(address, account.address())
+          updateRoleWithValue(mixedcaseAddress, account.mixedcaseAddress())
+          updateRoleWithValue(path, account.path())
+          updateRoleWithValue(colorId, account.colorId())
+          updateRoleWithValue(walletType, account.walletType())
+          updateRoleWithValue(currencyBalance, account.currencyBalance())
+          updateRoleWithValue(emoji, account.emoji())
+          updateRoleWithValue(keyUid, account.keyUid())
+          updateRoleWithValue(createdAt, account.createdAt())
+          updateRoleWithValue(position, account.position())
+          updateRoleWithValue(migratedToColdWallet, account.migratedToColdWallet())
+          updateRoleWithValue(assetsLoading, account.assetsLoading())
+          updateRoleWithValue(isWallet, account.isWallet())
+          updateRoleWithValue(hideFromTotalBalance, account.hideFromTotalBalance())
+          updateRoleWithValue(canSend, account.canSend())
+
+      updateRoles()
+      return itemFound
+
     var indexesToRemove: seq[int]
 
     #remove
@@ -112,14 +138,8 @@ QtObject:
 
     # Update or insert
     for i in 0 ..< items.len:
-      var account = items[i]
-      let index = self.findAccountIndex(account)
-      if index >= 0:
-        let qIndex = self.createIndex(i, 0, nil)
-        defer: qIndex.delete
-
-        self.items[index] = account
-        self.dataChanged(qIndex, qIndex)
+      let account = items[i]
+      if updateExistingItem(account):
         continue
       self.insertItem(account, i)
       
@@ -129,14 +149,34 @@ QtObject:
       self.itemChanged(item.address())
 
   proc updateItems*(self: Model, items: seq[Item]) =
+    proc updateExistingItem(account: Item): bool =
+      var itemUpdated = false
+
+      proc updateRoles() =
+        updateItemRolesAndNotify self.findAccountIndex(account):
+          itemUpdated = true
+          updateRoleWithValue(name, account.name())
+          updateRoleWithValue(address, account.address())
+          updateRoleWithValue(mixedcaseAddress, account.mixedcaseAddress())
+          updateRoleWithValue(path, account.path())
+          updateRoleWithValue(colorId, account.colorId())
+          updateRoleWithValue(walletType, account.walletType())
+          updateRoleWithValue(currencyBalance, account.currencyBalance())
+          updateRoleWithValue(emoji, account.emoji())
+          updateRoleWithValue(keyUid, account.keyUid())
+          updateRoleWithValue(createdAt, account.createdAt())
+          updateRoleWithValue(position, account.position())
+          updateRoleWithValue(migratedToColdWallet, account.migratedToColdWallet())
+          updateRoleWithValue(assetsLoading, account.assetsLoading())
+          updateRoleWithValue(isWallet, account.isWallet())
+          updateRoleWithValue(hideFromTotalBalance, account.hideFromTotalBalance())
+          updateRoleWithValue(canSend, account.canSend())
+
+      updateRoles()
+      return itemUpdated
+
     for account in items:
-      let i = self.findAccountIndex(account)
-      if i >= 0:
-        self.items[i] = account
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index)
-      else:
+      if not updateExistingItem(account):
         self.insertItem(account, self.getCount())
         self.countChanged()
 
@@ -185,37 +225,18 @@ QtObject:
       result = newQVariant(item.canSend())
 
   proc updateBalance*(self: Model, address: string, balance: CurrencyAmount, assetsLoading: bool) =
-    let i = self.findAccountIndex(address)
-    if i < 0:
-      error "Trying to update invalid account"
-      return
-    self.items[i].setBalance(balance)
-    self.items[i].setAssetsLoading(assetsLoading)
-    let index = self.createIndex(i, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.CurrencyBalance.int, ModelRole.AssetsLoading.int])
+    updateItemRolesAndNotify self.findAccountIndex(address):
+      updateRoleWithValue(currencyBalance, balance)
+      updateRoleWithValue(assetsLoading, assetsLoading)
 
   proc updateAccountHiddenFromTotalBalance*(self: Model, address: string, hideFromTotalBalance: bool) =
-    let i = self.findAccountIndex(address)
-    if i < 0:
-      return
-    self.items[i].setHideFromTotalBalance(hideFromTotalBalance)
-    let index = self.createIndex(i, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.HideFromTotalBalance.int])
+    updateItemRolesAndNotify self.findAccountIndex(address):
+      updateRole(hideFromTotalBalance)
 
   proc updateAccountsPositions*(self: Model, values: Table[string, int]) =
     for address, position in values:
-      let i = self.findAccountIndex(address)
-      if i < 0:
-        continue
-      self.items[i].setPosition(position)
-    let firstIndex = self.createIndex(0, 0, nil)
-    let lastIndex = self.createIndex(self.rowCount() - 1, 0, nil)
-    defer: 
-      firstIndex.delete
-      lastIndex.delete
-    self.dataChanged(firstIndex, lastIndex, @[ModelRole.Position.int])
+      updateItemRolesAndNotify self.findAccountIndex(address):
+        updateRole(position)
 
   proc deleteAccount*(self: Model, address: string) =
     let i = self.findAccountIndex(address)

--- a/src/app/modules/main/wallet_section/activity/model.nim
+++ b/src/app/modules/main/wallet_section/activity/model.nim
@@ -127,12 +127,10 @@ QtObject:
     notify = hasMoreChanged
     
   proc refreshItemsContainingAddress*(self: Model, address: string) =
-    for i in 0..self.entries.high:
-      if cmpIgnoreCase(self.entries[i].getSender(), address) == 0 or
-        cmpIgnoreCase(self.entries[i].getRecipient(), address) == 0:
-          let index = self.createIndex(i, 0, nil)
-          defer: index.delete
-          self.dataChanged(index, index, @[ModelRole.ActivityEntryRole.int])
+    for ind in 0..self.entries.high:
+      if cmpIgnoreCase(self.entries[ind].getSender(), address) == 0 or
+        cmpIgnoreCase(self.entries[ind].getRecipient(), address) == 0:
+          notifyRangeRolesChanged(ind, ind, @[ModelRole.ActivityEntryRole.int])
 
   proc refreshAmountCurrency*(self: Model, currencyService: Service) =
     for i in 0..self.entries.high:

--- a/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
@@ -430,20 +430,12 @@ QtObject:
   proc tokensMarketValuesAboutToUpdate*(self: TokenGroupsModel) =
     let tokenGroupsListLength = self.rowCount()
     if tokenGroupsListLength > 0:
-      let index = self.createIndex(0, 0, nil)
-      let lastindex = self.createIndex(tokenGroupsListLength-1, 0, nil)
-      defer: index.delete
-      defer: lastindex.delete
-      self.dataChanged(index, lastindex, @[ModelRole.MarketDetailsLoading.int])
+      notifyRangeRolesChanged(0, tokenGroupsListLength - 1, @[ModelRole.MarketDetailsLoading.int])
 
   proc tokensDetailsUpdated*(self: TokenGroupsModel) =
     let tokenGroupsListLength = self.rowCount()
     if tokenGroupsListLength > 0:
-      let index = self.createIndex(0, 0, nil)
-      let lastindex = self.createIndex(tokenGroupsListLength-1, 0, nil)
-      defer: index.delete
-      defer: lastindex.delete
-      self.dataChanged(index, lastindex, @[ModelRole.Description.int, ModelRole.WebsiteUrl.int, ModelRole.DetailsLoading.int])
+      notifyRangeRolesChanged(0, tokenGroupsListLength - 1, @[ModelRole.Description.int, ModelRole.WebsiteUrl.int, ModelRole.DetailsLoading.int])
 
   proc currencyFormatsUpdated*(self: TokenGroupsModel) =
     if ModelMode.NoMarketDetails in self.modelModes:
@@ -455,11 +447,7 @@ QtObject:
   proc tokenPreferencesUpdated*(self: TokenGroupsModel) =
     let tokenGroupsListLength = self.rowCount()
     if tokenGroupsListLength > 0:
-      let index = self.createIndex(0, 0, nil)
-      let lastindex = self.createIndex(tokenGroupsListLength-1, 0, nil)
-      defer: index.delete
-      defer: lastindex.delete
-      self.dataChanged(index, lastindex, @[ModelRole.Visible.int, ModelRole.Position.int])
+      notifyRangeRolesChanged(0, tokenGroupsListLength - 1, @[ModelRole.Visible.int, ModelRole.Position.int])
 
   proc marketDetailsItemForKey*(self: TokenGroupsModel, groupKey: string): MarketDetailsItem =
     ## Test/inspection accessor: the MarketDetailsItem instance held for a group

--- a/src/app/modules/main/wallet_section/send/network_route_item.nim
+++ b/src/app/modules/main/wallet_section/send/network_route_item.nim
@@ -55,40 +55,48 @@ proc getChainId*(self: NetworkRouteItem): int =
 proc getLayer*(self: NetworkRouteItem): int =
   return self.layer
 
-proc getIsRouteEnabled*(self: NetworkRouteItem): bool =
+proc isRouteEnabled*(self: NetworkRouteItem): bool =
   return self.isRouteEnabled
 proc `isRouteEnabled=`*(self: NetworkRouteItem, value: bool) {.inline.} =
   self.isRouteEnabled = value
 
-proc getIsRoutePreferred*(self: NetworkRouteItem): bool =
+proc isRoutePreferred*(self: NetworkRouteItem): bool =
   return self.isRoutePreferred
 proc `isRoutePreferred=`*(self: NetworkRouteItem, value: bool) {.inline.} =
   self.isRoutePreferred = value
 
-proc getHasGas*(self: NetworkRouteItem): bool =
+proc hasGas*(self: NetworkRouteItem): bool =
   return self.hasGas
 proc `hasGas=`*(self: NetworkRouteItem, value: bool) {.inline.} =
   self.hasGas = value
 
 proc getTokenBalance*(self: NetworkRouteItem): CurrencyAmount =
   return self.tokenBalance
+proc tokenBalance*(self: NetworkRouteItem): CurrencyAmount =
+  return self.tokenBalance
 proc `tokenBalance=`*(self: NetworkRouteItem, value: CurrencyAmount) {.inline.} =
   self.tokenBalance = value
 
-proc getAmountIn*(self: NetworkRouteItem): string =
+proc amountIn*(self: NetworkRouteItem): string =
   return self.amountIn
 proc `amountIn=`*(self: NetworkRouteItem, value: string) {.inline.} =
   self.amountIn = value
 
-proc getAmountOut*(self: NetworkRouteItem): string =
+proc amountOut*(self: NetworkRouteItem): string =
   return self.amountOut
 proc `amountOut=`*(self: NetworkRouteItem, value: string) {.inline.} =
   self.amountOut = value
 
-proc getToNetworks*(self: NetworkRouteItem): string =
+proc toNetworks*(self: NetworkRouteItem): string =
   return self.toNetworks.join(":")
 proc `toNetworks=`*(self: NetworkRouteItem, value: int) {.inline.} =
   self.toNetworks.add(value)
+proc `toNetworks=`*(self: NetworkRouteItem, value: string) {.inline.} =
+  self.toNetworks = @[]
+  if value.len == 0:
+    return
+  for chainId in value.split(':'):
+    self.toNetworks.add(parseInt(chainId))
 proc resetToNetworks*(self: NetworkRouteItem) =
    self.toNetworks = @[]
 

--- a/src/app/modules/main/wallet_section/send/network_route_model.nim
+++ b/src/app/modules/main/wallet_section/send/network_route_model.nim
@@ -65,19 +65,19 @@ QtObject:
     of ModelRole.ChainId:
       result = newQVariant(item.getChainId())
     of ModelRole.IsRouteEnabled:
-      result = newQVariant(item.getIsRouteEnabled())
+      result = newQVariant(item.isRouteEnabled())
     of ModelRole.IsRoutePreferred:
-      result = newQVariant(item.getIsRoutePreferred())
+      result = newQVariant(item.isRoutePreferred())
     of ModelRole.HasGas:
-      result = newQVariant(item.getHasGas())
+      result = newQVariant(item.hasGas())
     of ModelRole.TokenBalance:
       result = newQVariant(item.getTokenBalance())
     of ModelRole.AmountIn:
-      result = newQVariant(item.getAmountIn())
+      result = newQVariant(item.amountIn())
     of ModelRole.AmountOut:
-      result = newQVariant(item.getAmountOut())
+      result = newQVariant(item.amountOut())
     of ModelRole.ToNetworks:
-      result = newQVariant(item.getToNetworks())
+      result = newQVariant(item.toNetworks())
 
   proc setItems*(self: NetworkRouteModel, items: seq[NetworkRouteItem]) =
     self.beginResetModel()
@@ -88,108 +88,109 @@ QtObject:
   proc getAllNetworksChainIds*(self: NetworkRouteModel): seq[int] =
     return self.items.map(x => x.getChainId())
 
-  proc reset*(self: NetworkRouteModel) =
+  proc findIndexByChainId(self: NetworkRouteModel, chainId: int): int =
     for i in 0 ..< self.items.len:
-      let index = self.createIndex(i, 0, nil)
-      defer: index.delete
-      self.items[i].amountIn = ""
-      self.items[i].amountOut = ""
-      self.items[i].resetToNetworks()
-      self.items[i].hasGas = true
-      self.items[i].isRouteEnabled = true
-      self.items[i].isRoutePreferred = true
-      self.dataChanged(index, index, @[ModelRole.AmountIn.int, ModelRole.ToNetworks.int, ModelRole.HasGas.int,
-        ModelRole.AmountOut.int, ModelRole.IsRouteEnabled.int, ModelRole.IsRoutePreferred.int])
+      if self.items[i].getChainId() == chainId:
+        return i
+    return -1
+
+  proc reset*(self: NetworkRouteModel) =
+    for ind in 0 ..< self.items.len:
+      let amountIn = ""
+      let amountOut = ""
+      let toNetworks = ""
+      let hasGas = true
+      let isRouteEnabled = true
+      let isRoutePreferred = true
+      updateRolesAndNotify:
+        updateRole(amountIn)
+        updateRole(amountOut)
+        updateRole(toNetworks)
+        updateRole(hasGas)
+        updateRole(isRouteEnabled)
+        updateRole(isRoutePreferred)
 
   proc updateTokenBalanceForSymbol*(self: NetworkRouteModel, chainId: int, tokenBalance: CurrencyAmount) =
-    for i in 0 ..< self.items.len:
-      if(self.items[i].getChainId() == chainId):
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.items[i].tokenBalance = tokenBalance
-        self.dataChanged(index, index, @[ModelRole.TokenBalance.int])
+    updateItemRolesAndNotify self.findIndexByChainId(chainId):
+      updateRole(tokenBalance)
 
   proc updateFromNetworks*(self: NetworkRouteModel, path: SuggestedRouteItem, hasGas: bool) =
-    for i in 0 ..< self.items.len:
-      if path.getfromNetwork() == self.items[i].getChainId():
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.items[i].amountIn = path.getAmountIn()
-        self.items[i].toNetworks = path.getToNetwork()
-        self.items[i].hasGas = hasGas
-        self.dataChanged(index, index, @[ModelRole.AmountIn.int, ModelRole.ToNetworks.int, ModelRole.HasGas.int])
+    for ind in 0 ..< self.items.len:
+      if path.getfromNetwork() == self.items[ind].getChainId():
+        let amountIn = path.getAmountIn()
+        let toNetworks = if self.items[ind].toNetworks().len == 0:
+          $path.getToNetwork()
+        else:
+          self.items[ind].toNetworks() & ":" & $path.getToNetwork()
+        updateRolesAndNotify:
+          updateRole(amountIn)
+          updateRole(toNetworks)
+          updateRole(hasGas)
 
   proc updateToNetworks*(self: NetworkRouteModel, path: SuggestedRouteItem) =
-    for i in 0 ..< self.items.len:
-      if path.getToNetwork() == self.items[i].getChainId():
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        if self.items[i].getAmountOut().len != 0:
-          self.items[i].amountOut = $(stint.u256(self.items[i].getAmountOut()) + stint.u256(path.getAmountOut()))
+    for ind in 0 ..< self.items.len:
+      if path.getToNetwork() == self.items[ind].getChainId():
+        let targetAmountOut = if self.items[ind].amountOut().len != 0:
+          $(stint.u256(self.items[ind].amountOut()) + stint.u256(path.getAmountOut()))
         else:
-          self.items[i].amountOut = path.getAmountOut()
-        self.dataChanged(index, index, @[ModelRole.AmountOut.int])
+          path.getAmountOut()
+        updateRolesAndNotify:
+          updateRoleWithValue(amountOut, targetAmountOut)
 
   proc resetPathData*(self: NetworkRouteModel) =
-    for i in 0 ..< self.items.len:
-      let index = self.createIndex(i, 0, nil)
-      defer: index.delete
-      self.items[i].amountIn = ""
-      self.items[i].resetToNetworks()
-      self.items[i].hasGas = true
-      self.items[i].amountOut = ""
-      self.dataChanged(index, index, @[ModelRole.AmountIn.int, ModelRole.ToNetworks.int, ModelRole.HasGas.int, ModelRole.AmountOut.int])
+    for ind in 0 ..< self.items.len:
+      let amountIn = ""
+      let amountOut = ""
+      let toNetworks = ""
+      let hasGas = true
+      updateRolesAndNotify:
+        updateRole(amountIn)
+        updateRole(amountOut)
+        updateRole(toNetworks)
+        updateRole(hasGas)
 
   proc getSelectedChain*(self: NetworkRouteModel): int =
     for item in self.items:
-      if item.getIsRouteEnabled():
+      if item.isRouteEnabled():
         return item.getChainId()
     return 0
 
   proc updateRoutePreferredChains*(self: NetworkRouteModel, chainIds: string) =
     try:
-      for i in 0 ..< self.items.len:
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.items[i].isRoutePreferred = false
-        self.items[i].isRouteEnabled = false
+      for ind in 0 ..< self.items.len:
+        var isRoutePreferred = false
         if chainIds.len == 0:
-          if self.items[i].getLayer() == NETWORK_LAYER_1:
-            self.items[i].isRoutePreferred = true
-            self.items[i].isRouteEnabled = true
+          isRoutePreferred = self.items[ind].getLayer() == NETWORK_LAYER_1
         else:
           for chainID in chainIds.split(':'):
-            if $self.items[i].getChainId() == chainID:
-              self.items[i].isRoutePreferred = true
-              self.items[i].isRouteEnabled = true
-        self.dataChanged(index, index, @[ModelRole.IsRoutePreferred.int, ModelRole.IsRouteEnabled.int])
+            if $self.items[ind].getChainId() == chainID:
+              isRoutePreferred = true
+
+        let isRouteEnabled = isRoutePreferred
+        updateRolesAndNotify:
+          updateRole(isRoutePreferred)
+          updateRole(isRouteEnabled)
     except:
       discard
 
   proc disableRouteUnpreferredChains*(self: NetworkRouteModel) =
-    for i in 0 ..< self.items.len:
-      if not self.items[i].getIsRoutePreferred():
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.items[i].isRouteEnabled = false
-        self.dataChanged(index, index, @[ModelRole.IsRouteEnabled.int])
+    for ind in 0 ..< self.items.len:
+      if not self.items[ind].isRoutePreferred():
+        updateRolesAndNotify:
+          updateRoleWithValue(isRouteEnabled, false)
 
   proc enableRouteUnpreferredChains*(self: NetworkRouteModel) =
-    for i in 0 ..< self.items.len:
-      if not self.items[i].getIsRoutePreferred():
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.items[i].isRouteEnabled = true
-        self.dataChanged(index, index, @[ModelRole.IsRouteEnabled.int])
+    for ind in 0 ..< self.items.len:
+      if not self.items[ind].isRoutePreferred():
+        updateRolesAndNotify:
+          updateRoleWithValue(isRouteEnabled, true)
 
 
   proc setRouteEnabledChain*(self: NetworkRouteModel, chainId: int) {.slot.} =
-    for i in 0 ..< self.items.len:
-      let index = self.createIndex(i, 0, nil)
-      self.items[i].isRouteEnabled = false
-      if(self.items[i].getChainId() == chainId):
-        self.items[i].isRouteEnabled = true
-      self.dataChanged(index, index, @[ModelRole.IsRouteEnabled.int])
+    for ind in 0 ..< self.items.len:
+      let isRouteEnabled = self.items[ind].getChainId() == chainId
+      updateRolesAndNotify:
+        updateRole(isRouteEnabled)
 
   proc delete(self: NetworkRouteModel) =
     self.QAbstractListModel.delete

--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -1,3 +1,4 @@
+import app/modules/shared_models/model_utils
 import nimqml, json, std/strformat, sequtils, strutils, stint, strutils
 import options
 
@@ -233,6 +234,12 @@ QtObject:
     read = getCollectionImageURL
     notify = collectionImageURLChanged
 
+  proc getTraitsKey(self: CollectiblesEntry): string =
+    if not self.hasCollectibleData() or isNone(self.getCollectibleData().traits):
+      return ""
+    for trait in self.getCollectibleData().traits.get():
+      result &= $trait
+
   proc traitsChanged*(self: CollectiblesEntry) {.signal.}
   proc getTraits*(self: CollectiblesEntry): QVariant {.slot.} =
     return newQVariant(self.traits)
@@ -372,26 +379,64 @@ QtObject:
   proc updateDataIfSameID*(self: CollectiblesEntry, update: backend.Collectible): bool =
     if self.id != update.id:
       return false
-    
-    self.setData(update)
 
-    # Notify changes for all properties
-    self.nameChanged()
-    self.imageUrlChanged()
-    self.mediaUrlChanged()
-    self.mediaTypeChanged()
-    self.backgroundColorChanged()
-    self.descriptionChanged()
-    self.collectionSlugChanged()
-    self.collectionNameChanged()
-    self.collectionImageUrlChanged()
-    self.traitsChanged()
-    # Ownership doesn't change with updated data
-    self.communityIdChanged()
-    self.communityNameChanged()
-    self.communityColorChanged()
-    self.communityPrivilegesLevelChanged()
-    self.communityImageChanged()
+    let name = self.getName()
+    let imageUrl = self.getImageURL()
+    let mediaUrl = self.getMediaURL()
+    let mediaType = self.getMediaType()
+    let backgroundColor = self.getBackgroundColor()
+    let description = self.getDescription()
+    let collectionSlug = self.getCollectionSlug()
+    let collectionName = self.getCollectionName()
+    let collectionImageUrl = self.getCollectionImageURL()
+    let traits = self.getTraitsKey()
+    let communityId = self.getCommunityId()
+    let communityName = self.getCommunityName()
+    let communityColor = self.getCommunityColor()
+    let communityPrivilegesLevel = self.getCommunityPrivilegesLevel()
+    let communityImage = self.getCommunityImage()
+    let tokenType = self.getTokenType()
+    let soulbound = self.getSoulbound()
+
+    self.setData(update)
+    self.tokenType = contractTypeToTokenType(update.contractType.get(ContractType.ContractTypeUnknown))
+
+    var changedProperties: seq[string] = @[]
+    addChangedRole(changedProperties, name, self.getName(), "name"):
+      self.nameChanged()
+    addChangedRole(changedProperties, imageUrl, self.getImageURL(), "imageUrl"):
+      self.imageUrlChanged()
+    addChangedRole(changedProperties, mediaUrl, self.getMediaURL(), "mediaUrl"):
+      self.mediaUrlChanged()
+    addChangedRole(changedProperties, mediaType, self.getMediaType(), "mediaType"):
+      self.mediaTypeChanged()
+    addChangedRole(changedProperties, backgroundColor, self.getBackgroundColor(), "backgroundColor"):
+      self.backgroundColorChanged()
+    addChangedRole(changedProperties, description, self.getDescription(), "description"):
+      self.descriptionChanged()
+    addChangedRole(changedProperties, collectionSlug, self.getCollectionSlug(), "collectionSlug"):
+      self.collectionSlugChanged()
+    addChangedRole(changedProperties, collectionName, self.getCollectionName(), "collectionName"):
+      self.collectionNameChanged()
+    addChangedRole(changedProperties, collectionImageUrl, self.getCollectionImageURL(), "collectionImageUrl"):
+      self.collectionImageUrlChanged()
+    addChangedRole(changedProperties, traits, self.getTraitsKey(), "traits"):
+      self.traitsChanged()
+    addChangedRole(changedProperties, communityId, self.getCommunityId(), "communityId"):
+      self.communityIdChanged()
+    addChangedRole(changedProperties, communityName, self.getCommunityName(), "communityName"):
+      self.communityNameChanged()
+    addChangedRole(changedProperties, communityColor, self.getCommunityColor(), "communityColor"):
+      self.communityColorChanged()
+    addChangedRole(changedProperties, communityPrivilegesLevel, self.getCommunityPrivilegesLevel(), "communityPrivilegesLevel"):
+      self.communityPrivilegesLevelChanged()
+    addChangedRole(changedProperties, communityImage, self.getCommunityImage(), "communityImage"):
+      self.communityImageChanged()
+    addChangedRole(changedProperties, tokenType, self.getTokenType(), "tokenType"):
+      self.tokenTypeChanged()
+    addChangedRole(changedProperties, soulbound, self.getSoulbound(), "soulbound"):
+      self.soulboundChanged()
+
     return true
 
   proc contractTypeToTokenType(contractType : ContractType): TokenType =
@@ -430,12 +475,17 @@ QtObject:
     if not self.hasCollectionData():
       return
 
+    let website = self.getWebsite()
+    let twitterHandle = self.getTwitterHandle()
+
     self.getCollectionData().socials.website = update.socials.website
     self.getCollectionData().socials.twitterHandle = update.socials.twitterHandle
 
-    # Notify changes for all properties
-    self.twitterHandleChanged()
-    self.websiteChanged()
+    var changedRoles: seq[string] = @[]
+    addChangedRole(changedRoles, twitterHandle, self.getTwitterHandle(), "twitterHandle"):
+      self.twitterHandleChanged()
+    addChangedRole(changedRoles, website, self.getWebsite(), "website"):
+      self.websiteChanged()
 
   proc setup(self: CollectiblesEntry) =
     self.QObject.setup

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -301,15 +301,50 @@ QtObject:
   proc itemsDataUpdated*(self: Model) {.signal.}
   proc updateItemsData*(self: Model, updates: seq[backend_collectibles.Collectible]) =
     var anyUpdated = false
+
+    proc updateEntry(ind: int, update: backend_collectibles.Collectible): bool =
+      let entry = self.items[ind]
+      let name = entry.getName()
+      let imageUrl = entry.getImageURL()
+      let mediaUrl = entry.getMediaURL()
+      let mediaType = entry.getMediaType()
+      let backgroundColor = entry.getBackgroundColor()
+      let collectionName = entry.getCollectionName()
+      let collectionSlug = entry.getCollectionSlug()
+      let collectionImageUrl = entry.getCollectionImageURL()
+      let communityId = entry.getCommunityId()
+      let communityPrivilegesLevel = entry.getCommunityPrivilegesLevel()
+      let tokenType = entry.getTokenType()
+      let soulbound = entry.getSoulbound()
+
+      if not entry.updateDataIfSameID(update):
+        return false
+
+      var changedRoles: seq[int] = @[]
+      addChangedRole(changedRoles, name, entry.getName(), CollectibleRole.Name.int): discard
+      addChangedRole(changedRoles, imageUrl, entry.getImageURL(), CollectibleRole.ImageUrl.int): discard
+      addChangedRole(changedRoles, mediaUrl, entry.getMediaURL(), CollectibleRole.MediaUrl.int): discard
+      addChangedRole(changedRoles, mediaType, entry.getMediaType(), CollectibleRole.MediaType.int): discard
+      addChangedRole(changedRoles, backgroundColor, entry.getBackgroundColor(), CollectibleRole.BackgroundColor.int): discard
+      addChangedRole(changedRoles, collectionName, entry.getCollectionName(), CollectibleRole.CollectionName.int): discard
+      addChangedRole(changedRoles, collectionSlug, entry.getCollectionSlug(), CollectibleRole.CollectionSlug.int): discard
+      addChangedRole(changedRoles, collectionImageUrl, entry.getCollectionImageURL(), CollectibleRole.CollectionImageUrl.int): discard
+      addChangedRole(changedRoles, communityId, entry.getCommunityId(), CollectibleRole.CommunityId.int): discard
+      addChangedRole(changedRoles, communityPrivilegesLevel, entry.getCommunityPrivilegesLevel(), CollectibleRole.CommunityPrivilegesLevel.int): discard
+      addChangedRole(changedRoles, tokenType, entry.getTokenType(), CollectibleRole.TokenType.int): discard
+      addChangedRole(changedRoles, soulbound, entry.getSoulbound(), CollectibleRole.Soulbound.int): discard
+
+      if changedRoles.len > 0:
+        notifyRangeRolesChanged(ind, ind, changedRoles)
+        return true
+      return false
+
     for i in countdown(self.items.high, 0):
-      let entry = self.items[i]
       for j in countdown(updates.high, 0):
         let update = updates[j]
-        if entry.updateDataIfSameID(update):
-          let index = self.createIndex(i, 0, nil)
-          defer: index.delete
-          self.dataChanged(index, index)
-          anyUpdated = true
+        if self.items[i].getID() == update.id:
+          if updateEntry(i, update):
+            anyUpdated = true
           break
     if anyUpdated:
       self.itemsDataUpdated()

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -182,6 +182,30 @@ QtObject:
         return i
     return -1
 
+  proc previewDataRoles(self: Model): seq[int] =
+    return @[
+      ModelRole.Unfurled.int,
+      ModelRole.Empty.int,
+      ModelRole.PreviewType.int,
+      ModelRole.StandardPreview.int,
+      ModelRole.StandardPreviewThumbnail.int,
+      ModelRole.StatusContactPreview.int,
+      ModelRole.StatusContactPreviewThumbnail.int,
+      ModelRole.StatusCommunityPreview.int,
+      ModelRole.StatusCommunityPreviewIcon.int,
+      ModelRole.StatusCommunityPreviewBanner.int,
+      ModelRole.StatusCommunityChannelPreview.int,
+      ModelRole.StatusCommunityChannelCommunityPreview.int,
+      ModelRole.StatusCommunityChannelCommunityPreviewIcon.int,
+      ModelRole.StatusCommunityChannelCommunityPreviewBanner.int,
+    ]
+
+  proc immutablePreviewDataRoles(self: Model): seq[int] =
+    return @[
+      ModelRole.Unfurled.int,
+      ModelRole.Immutable.int,
+    ]
+
   proc moveRow(self: Model, fromRow: int, to: int) =
     if fromRow == to:
       return
@@ -207,9 +231,7 @@ QtObject:
         continue
       item.unfurled = true
       item.linkPreview = linkPreviews[item.linkPreview.url]
-      let modelIndex = self.createIndex(row, 0, nil)
-      defer: modelIndex.delete
-      self.dataChanged(modelIndex, modelIndex)
+      notifyRangeRolesChanged(row, row, self.previewDataRoles())
 
   proc setUrls*(self: Model, urls: seq[string]) =
     var itemsToInsert: seq[Item]
@@ -259,20 +281,14 @@ QtObject:
       return
 
     self.items[index].markAsImmutable()
-
-    let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
-    self.dataChanged(modelIndex, modelIndex)
+    notifyRangeRolesChanged(index, index, self.immutablePreviewDataRoles())
 
   proc removeAllPreviewData*(self: Model) {.slot.} =
     for i in 0 ..< self.items.len:
       self.items[i].markAsImmutable()
-  
-    let indexStart = self.createIndex(0, 0, nil)
-    let indexEnd = self.createIndex(self.items.len, 0, nil)
-    defer: indexStart.delete
-    defer: indexEnd.delete
-    self.dataChanged(indexStart, indexEnd)
+
+    if self.items.len > 0:
+      notifyRangeRolesChanged(0, self.items.len - 1, self.immutablePreviewDataRoles())
       
   proc getLinkPreviewType*(self: Model, url: string): int {.slot.} =
     let index = self.findUrlIndex(url)
@@ -305,25 +321,18 @@ QtObject:
       if communityId != "":
         result[communityId] = item.linkPreview.url
 
-  proc setItemLoadingLocalData(self: Model, row: int, item: Item, value: bool) = 
-    if item.loadingLocalData == value:
-      return
-    item.loadingLocalData = value
-    let modelIndex = self.createIndex(row, 0, nil)
-    defer: modelIndex.delete
-    self.dataChanged(modelIndex, modelIndex, @[ModelRole.LoadingLocalData.int])
+  proc setItemLoadingLocalData(self: Model, row: int, value: bool) =
+    let ind = row
+    updateRolesAndNotify:
+      updateRoleWithValue(loadingLocalData, value)
 
-  proc setItemIsLocalData(self: Model, row: int, item: Item) = 
+  proc setItemIsLocalData(self: Model, row: int, item: Item) =
     if item.isLocalData:
       return
-    var roles = @[ModelRole.IsLocalData.int]
-    item.isLocalData = true
-    if item.loadingLocalData:
-      item.loadingLocalData = false
-      roles.add(ModelRole.LoadingLocalData.int)
-    let modelIndex = self.createIndex(row, 0, nil)
-    defer: modelIndex.delete
-    self.dataChanged(modelIndex, modelIndex, roles)
+    let ind = row
+    updateRolesAndNotify:
+      updateRoleWithValue(isLocalData, true)
+      updateRoleWithValue(loadingLocalData, false)
 
   proc setContactInfo*(self: Model, contactDetails: ContactDetails) =
     for row, item in self.items:
@@ -338,12 +347,12 @@ QtObject:
   proc onContactDataRequested*(self: Model, contactId: string) =
     for row, item in self.items:
       if item.linkPreview.getContactId() == contactId:
-        self.setItemLoadingLocalData(row, item, true)
+        self.setItemLoadingLocalData(row, true)
 
   proc onCommunityInfoRequested*(self: Model, communityId: string) =
     for row, item in self.items:
       if item.linkPreview.getCommunityId() == communityId:
-        self.setItemLoadingLocalData(row, item, true)
+        self.setItemLoadingLocalData(row, true)
 
   proc delete*(self: Model) = 
     self.QAbstractListModel.delete

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -267,10 +267,8 @@ QtObject:
 
   proc setName*(self: Model, pubKey: string, displayName: string, ensName: string, localNickname: string) =
     updateItemRolesAndNotify self.findIndexForMember(pubKey):
-      let preferredDisplayNameChanged =
-        resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias) !=
-        resolvePreferredDisplayName(localNickname, ensName, displayName, self.items[ind].alias)
-
+      let previousPreferredDisplayName = resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias)
+      let currentPreferredDisplayName = resolvePreferredDisplayName(localNickname, ensName, displayName, self.items[ind].alias)
       let usesDefaultName = resolveUsesDefaultName(localNickname, ensName, displayName)
 
       updateRole(displayName)
@@ -278,8 +276,7 @@ QtObject:
       updateRole(localNickname)
       updateRole(usesDefaultName)
 
-      if preferredDisplayNameChanged:
-        roles.add(ModelRole.PreferredDisplayName.int)
+      addChangedRole(roles, previousPreferredDisplayName, currentPreferredDisplayName, ModelRole.PreferredDisplayName.int): discard
 
   proc setIcon*(self: Model, pubKey: string, icon: string) =
     updateItemRolesAndNotify self.findIndexForMember(pubKey):
@@ -304,11 +301,9 @@ QtObject:
       callDataChanged: bool = true,
     ): seq[int] =
     updateItemRolesAndNotify self.findIndexForMember(pubKey):
-      let preferredDisplayNameChanged =
-        resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias) !=
-        resolvePreferredDisplayName(localNickname, ensName, displayName, self.items[ind].alias)
-
-      let trustStatusChanged = trustStatus != self.items[ind].trustStatus
+      let previousPreferredDisplayName = resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias)
+      let currentPreferredDisplayName = resolvePreferredDisplayName(localNickname, ensName, displayName, self.items[ind].alias)
+      let previousTrustStatus = self.items[ind].trustStatus
       let usesDefaultName = resolveUsesDefaultName(localNickname, ensName, displayName)
 
       updateRole(displayName)
@@ -334,12 +329,9 @@ QtObject:
 
       updateRoleWithValue(membershipRequestState, updatedMembershipRequestState)
 
-      if preferredDisplayNameChanged:
-        roles.add(ModelRole.PreferredDisplayName.int)
-
-      if trustStatusChanged:
-        roles.add(ModelRole.IsUntrustworthy.int)
-        roles.add(ModelRole.IsVerified.int)
+      addChangedRole(roles, previousPreferredDisplayName, currentPreferredDisplayName, ModelRole.PreferredDisplayName.int): discard
+      addChangedRole(roles, previousTrustStatus, trustStatus, ModelRole.IsUntrustworthy.int): discard
+      addChangedRole(roles, previousTrustStatus, trustStatus, ModelRole.IsVerified.int): discard
 
       if roles.len > 0:
         if callDataChanged:
@@ -382,11 +374,7 @@ QtObject:
     if allRoles.len == 0:
       return
 
-    let startModelIndex = self.createIndex(startIndex, 0, nil)
-    let endModelIndex = self.createIndex(endIndex, 0, nil)
-    defer: startModelIndex.delete
-    defer: endModelIndex.delete
-    self.dataChanged(startModelIndex, endModelIndex, allRoles)
+    notifyRangeRolesChanged(startIndex, endIndex, allRoles)
 
 
   proc updateToTheseItems*(self: Model, items: seq[MemberItem]) =
@@ -462,34 +450,12 @@ QtObject:
     )
 
   proc setOnlineStatus*(self: Model, pubKey: string, onlineStatus: OnlineStatus) =
-    let idx = self.findIndexForMember(pubKey)
-    if idx == -1:
-      return
-
-    if self.items[idx].onlineStatus == onlineStatus:
-      return
-
-    self.items[idx].onlineStatus = onlineStatus
-    let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[
-      ModelRole.OnlineStatus.int
-    ])
+    updateItemRolesAndNotify self.findIndexForMember(pubKey):
+      updateRole(onlineStatus)
 
   proc setAirdropAddress*(self: Model, pubKey: string, airdropAddress: string) =
-    let idx = self.findIndexForMember(pubKey)
-    if idx == -1:
-      return
-
-    if self.items[idx].airdropAddress == airdropAddress:
-      return
-
-    self.items[idx].airdropAddress = airdropAddress
-    let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[
-      ModelRole.AirdropAddress.int
-    ])
+    updateItemRolesAndNotify self.findIndexForMember(pubKey):
+      updateRole(airdropAddress)
 
   proc getAirdropAddressForMember*(self: Model, pubKey: string): string =
     let idx = self.findIndexForMember(pubKey)
@@ -503,49 +469,16 @@ QtObject:
     return self.items.map(i => i.pubKey)
 
   proc updateLoadingState*(self: Model, memberKey: string, requestToJoinLoading: bool) =
-    let idx = self.findIndexForMember(memberKey)
-    if idx == -1:
-      return
-
-    if self.items[idx].requestToJoinLoading == requestToJoinLoading:
-      return
-
-    self.items[idx].requestToJoinLoading = requestToJoinLoading
-    let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[
-      ModelRole.RequestToJoinLoading.int
-    ])
+    updateItemRolesAndNotify self.findIndexForMember(memberKey):
+      updateRole(requestToJoinLoading)
 
   proc updateDeclineLoadingState*(self: Model, memberKey: string, declineRequestToJoinLoading: bool) =
-    let idx = self.findIndexForMember(memberKey)
-    if idx == -1:
-      return
-
-    if self.items[idx].declineRequestToJoinLoading == declineRequestToJoinLoading:
-      return
-
-    self.items[idx].declineRequestToJoinLoading = declineRequestToJoinLoading
-    let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[
-      ModelRole.DeclineRequestToJoinLoading.int
-    ])
+    updateItemRolesAndNotify self.findIndexForMember(memberKey):
+      updateRole(declineRequestToJoinLoading)
 
   proc updateMembershipStatus*(self: Model, memberKey: string, membershipRequestState: MembershipRequestState) {.inline.} =
-    let idx = self.findIndexForMember(memberKey)
-    if idx == -1:
-      return
-
-    if self.items[idx].membershipRequestState == membershipRequestState:
-      return
-
-    self.items[idx].membershipRequestState = membershipRequestState
-    let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[
-      ModelRole.MembershipRequestState.int
-    ])
+    updateItemRolesAndNotify self.findIndexForMember(memberKey):
+      updateRole(membershipRequestState)
 
   proc getNewMembers*(self: Model, pubkeys: seq[string]): seq[string] =
     for pubkey in pubkeys:

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -355,10 +355,19 @@ QtObject:
     of ModelRole.CompressedKey:
       result = newQVariant(item.compressedKey)
 
-  proc updateItemAtIndex(self: Model, index: int) =
-    let ind = self.createIndex(index, 0, nil)
-    defer: ind.delete
-    self.dataChanged(ind, ind)
+  proc updateAdjacentMessageRolesAtIndex(self: Model, row: int) =
+    if row < 0 or row >= self.items.len:
+      return
+
+    notifyRangeRolesChanged(row, row, @[
+      ModelRole.PrevMsgTimestamp.int,
+      ModelRole.PrevMsgIndex.int,
+      ModelRole.PrevMsgSenderId.int,
+      ModelRole.PrevMsgContentType.int,
+      ModelRole.PrevMsgDeleted.int,
+      ModelRole.NextMsgIndex.int,
+      ModelRole.NextMsgTimestamp.int,
+    ])
 
   proc findIndexForMessageId*(self: Model, messageId: string): int =
     result = -1
@@ -389,6 +398,17 @@ QtObject:
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
 
+    proc updateQuotedItem(ind: int, targetQuotedMessageFrom, targetQuotedMessageAuthorDisplayName,
+        targetQuotedMessageAuthorAvatar, targetQuotedMessageParsedText, targetQuotedMessageText: string,
+        targetQuotedMessageContentType: ContentType) =
+      updateRolesAndNotify:
+        updateRoleWithValue(quotedMessageFrom, targetQuotedMessageFrom)
+        updateRoleWithValue(quotedMessageAuthorDisplayName, targetQuotedMessageAuthorDisplayName)
+        updateRoleWithValue(quotedMessageAuthorAvatar, targetQuotedMessageAuthorAvatar, QuotedMessageAuthorThumbnailImage)
+        updateRoleWithValue(quotedMessageParsedText, targetQuotedMessageParsedText)
+        updateRoleWithValue(quotedMessageText, targetQuotedMessageText)
+        updateRoleWithValue(quotedMessageContentType, targetQuotedMessageContentType)
+
     # Update replied to messages if there are
     # We update replies before adding, since we do not need to update the new items, they should already be up to date
     for i in 0 ..< self.items.len:
@@ -397,32 +417,16 @@ QtObject:
         continue
       for newItem in items:
         if oldItem.responseToMessageWithId == newItem.id:
-          oldItem.quotedMessageFrom = newItem.senderId
-          oldItem.quotedMessageAuthorDisplayName = newItem.senderDisplayName
-          oldItem.quotedMessageAuthorAvatar = newItem.senderIcon
-          oldItem.quotedMessageParsedText = newItem.messageText
-          oldItem.quotedMessageText = newItem.unparsedText
-          oldItem.quotedMessageContentType = newItem.contentType
-          let index = self.createIndex(i, 0, nil)
-          defer: index.delete
-          self.dataChanged(index, index, @[
-            ModelRole.QuotedMessageFrom.int,
-            ModelRole.QuotedMessageAuthorDisplayName.int,
-            ModelRole.QuotedMessageAuthorThumbnailImage.int,
-            ModelRole.QuotedMessageText.int,
-            ModelRole.QuotedMessageParsedText.int,
-            ModelRole.QuotedMessageContentType.int,
-          ])
+          updateQuotedItem(i, newItem.senderId, newItem.senderDisplayName, newItem.senderIcon,
+            newItem.messageText, newItem.unparsedText, newItem.contentType)
 
 
     self.beginInsertRows(parentModelIndex, position, position + items.len - 1)
     self.items.insert(items, position)
     self.endInsertRows()
 
-    if position > 0:
-      self.updateItemAtIndex(position - 1)
-    if position + items.len - 1 < self.items.len:
-      self.updateItemAtIndex(position + items.len)
+    self.updateAdjacentMessageRolesAtIndex(position - 1)
+    self.updateAdjacentMessageRolesAtIndex(position + items.len)
     self.countChanged()
 
   proc filterExistingItems(self: Model, items: seq[Item]): seq[Item] =
@@ -462,19 +466,12 @@ QtObject:
 
   # Replied message was deleted
   proc updateMessagesWhenQuotedMessageDeleted(self: Model, messageId: string) =
-    for i in 0 ..< self.items.len:
-      if(self.items[i].responseToMessageWithId == messageId):
-        let ind = self.createIndex(i, 0, nil)
-        defer: ind.delete
-        var item = self.items[i]
-        item.quotedMessageText = ""
-        item.quotedMessageParsedText = ""
-        item.quotedMessageDeleted = true
-        self.dataChanged(ind, ind, @[
-          ModelRole.QuotedMessageText.int,
-          ModelRole.QuotedMessageParsedText.int,
-          ModelRole.QuotedMessageDeleted.int,
-        ])
+    for ind in 0 ..< self.items.len:
+      if(self.items[ind].responseToMessageWithId == messageId):
+        updateRolesAndNotify:
+          updateRoleWithValue(quotedMessageText, "")
+          updateRoleWithValue(quotedMessageParsedText, "")
+          updateRoleWithValue(quotedMessageDeleted, true)
 
   proc removeItem*(self: Model, messageId: string) =
     let ind = self.findIndexForMessageId(messageId)
@@ -490,36 +487,28 @@ QtObject:
 
     self.resetNewMessagesMarker()
 
-    if ind > 0 and ind < self.items.len:
-      self.updateItemAtIndex(ind - 1)
-    if ind + 1 < self.items.len:
-      self.updateItemAtIndex(ind + 1)
+    self.updateAdjacentMessageRolesAtIndex(ind - 1)
+    self.updateAdjacentMessageRolesAtIndex(ind + 1)
 
     self.countChanged()
     self.updateMessagesWhenQuotedMessageDeleted(messageId)
 
   proc messageRemoved*(self: Model, messageId: string, deletedBy: string, deletedByContactDetails: ContactDetails) =
-    let i = self.findIndexForMessageId(messageId)
-    if(i == -1):
+    let ind = self.findIndexForMessageId(messageId)
+    if(ind == -1):
       return
 
-    let ind = self.createIndex(i, 0, nil)
-    defer: ind.delete
-
-    var item = self.items[i]
-    item.messageText = ""
-    item.unparsedText = ""
-    item.deleted = true
-    item.deletedBy = deletedBy
-    item.deletedByContactDetails = deletedByContactDetails
-    self.dataChanged(ind, ind, @[
-      ModelRole.MessageText.int,
-      ModelRole.UnparsedText.int,
-      ModelRole.Deleted.int,
-      ModelRole.DeletedBy.int,
-      ModelRole.DeletedByContactDisplayName.int,
-      ModelRole.DeletedByContactIcon.int,
-    ])
+    let targetDeletedBy = deletedBy
+    let targetDeletedByContactDetails = deletedByContactDetails
+    updateRolesAndNotify:
+      updateRoleWithValue(messageText, "")
+      updateRoleWithValue(unparsedText, "")
+      updateRoleWithValue(deleted, true)
+      updateRoleWithValue(deletedBy, targetDeletedBy)
+      if self.items[ind].deletedByContactDetails != targetDeletedByContactDetails:
+        self.items[ind].deletedByContactDetails = targetDeletedByContactDetails
+        roles.add(ModelRole.DeletedByContactDisplayName.int)
+        roles.add(ModelRole.DeletedByContactIcon.int)
 
     self.updateMessagesWhenQuotedMessageDeleted(messageId)
 
@@ -538,15 +527,10 @@ QtObject:
     return self.items[ind]
 
   proc setOutgoingStatus(self: Model, messageId: string, status: string) =
-    let ind = self.findIndexForMessageId(messageId)
-    if(ind == -1):
-      return
-    if self.items[ind].outgoingStatus == PARSED_TEXT_OUTGOING_STATUS_DELIVERED:
-      return
-    self.items[ind].outgoingStatus = status
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.OutgoingStatus.int])
+    updateItemRolesAndNotify self.findIndexForMessageId(messageId):
+      if self.items[ind].outgoingStatus == PARSED_TEXT_OUTGOING_STATUS_DELIVERED:
+        return
+      updateRoleWithValue(outgoingStatus, status)
 
   proc itemSending*(self: Model, messageId: string) =
     self.setOutgoingStatus(messageId, PARSED_TEXT_OUTGOING_STATUS_SENDING)
@@ -561,13 +545,22 @@ QtObject:
     self.setOutgoingStatus(messageId, PARSED_TEXT_OUTGOING_STATUS_EXPIRED)
 
   proc itemFailedResending*(self: Model, messageId: string, error: string) =
-    let ind = self.findIndexForMessageId(messageId)
-    if(ind == -1):
-      return
-    self.items[ind].resendError = error
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.ResendError.int])
+    updateItemRolesAndNotify self.findIndexForMessageId(messageId):
+      updateRoleWithValue(resendError, error)
+
+  proc updateChatIdentifier*(self: Model, item: Item): bool =
+    var itemFound = false
+
+    proc updateExistingItem() =
+      updateItemRolesAndNotify self.findIndexForMessageId(item.id):
+        itemFound = true
+        updateRoleWithValue(senderDisplayName, item.senderDisplayName)
+        updateRoleWithValue(senderIcon, item.senderIcon)
+        updateRoleWithValue(senderIsAdded, item.senderIsAdded)
+        updateRoleWithValue(senderUsesDefaultName, item.senderUsesDefaultName, UsesDefaultName)
+
+    updateExistingItem()
+    return itemFound
 
   proc addReaction*(self: Model, messageId: string, emoji: string, didIReactWithThisEmoji: bool,
     userPublicKey: string, userDisplayName: string, reactionId: string) =
@@ -591,24 +584,13 @@ QtObject:
 
     self.items[ind].removeReaction(emoji, reactionId, didIRemoveThisReaction)
 
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.Reactions.int])
-
   proc pinUnpinMessage*(self: Model, messageId: string, pinned: bool, pinnedBy: string) =
-    let ind = self.findIndexForMessageId(messageId)
-    if ind == -1:
-      return
-
-    if self.items[ind].pinned == pinned:
-      return
-
-    self.items[ind].pinned = pinned
-    self.items[ind].pinnedBy = pinnedBy
-
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.Pinned.int, ModelRole.PinnedBy.int])
+    let targetPinnedBy = pinnedBy
+    updateItemRolesAndNotify self.findIndexForMessageId(messageId):
+      if self.items[ind].pinned == pinned:
+        return
+      updateRole(pinned)
+      updateRoleWithValue(pinnedBy, targetPinnedBy)
 
   proc getMessageByIdAsJson*(self: Model, messageId: string): JsonNode =
     for it in self.items:
@@ -626,55 +608,68 @@ QtObject:
 
   iterator modelContactUpdateIterator*(self: Model, contactId: string): Item =
     for i in 0 ..< self.items.len:
+      let senderMatches = self.items[i].senderId == contactId
+      let oldSenderDisplayName = self.items[i].senderDisplayName
+      let oldSenderOptionalName = self.items[i].senderOptionalName
+      let oldSenderUsesDefaultName = self.items[i].senderUsesDefaultName
+      let oldSenderIcon = self.items[i].senderIcon
+      let oldSenderIsAdded = self.items[i].senderIsAdded
+      let oldSenderTrustStatus = self.items[i].senderTrustStatus
+      let oldSenderEnsVerified = self.items[i].senderEnsVerified
+
+      let pinnedByMatches = self.items[i].pinnedBy == contactId
+      let oldPinnedBy = self.items[i].pinnedBy
+
+      let messageContainsContactMention = self.items[i].messageContainsMentions and self.items[i].mentionedUsersPks.anyIt(it == contactId)
+      let oldMessageText = self.items[i].messageText
+      let oldUnparsedText = self.items[i].unparsedText
+      let oldMessageContainsMentions = self.items[i].messageContainsMentions
+
+      let quotedAuthorMatches = self.items[i].quotedMessageAuthorDetails.dto.id == contactId
+      let oldQuotedMessageAuthorName = self.items[i].quotedMessageAuthorDetails.dto.name
+      let oldQuotedMessageAuthorDisplayName = self.items[i].quotedMessageAuthorDisplayName
+      let oldQuotedMessageAuthorAvatar = self.items[i].quotedMessageAuthorAvatar
+      let oldQuotedMessageAuthorEnsVerified = self.items[i].quotedMessageAuthorDetails.dto.ensVerified
+      let oldQuotedMessageAuthorIsContact = self.items[i].quotedMessageAuthorDetails.dto.isContact()
+
       yield self.items[i]
 
-      var roles: seq[int]
-      if(self.items[i].senderId == contactId):
-        roles = @[ModelRole.SenderDisplayName.int,
-          ModelRole.SenderOptionalName.int,
-          ModelRole.UsesDefaultName.int,
-          ModelRole.SenderIcon.int,
-          ModelRole.SenderIsAdded.int,
-          ModelRole.SenderTrustStatus.int,
-          ModelRole.SenderEnsVerified.int]
-      if(self.items[i].pinnedBy == contactId):
-        roles.add(ModelRole.PinnedBy.int)
-      if(self.items[i].messageContainsMentions):
-        roles.add(@[ModelRole.MessageText.int, ModelRole.UnparsedText.int, ModelRole.MessageContainsMentions.int])
+      var changedRoles: seq[int] = @[]
 
-      if (self.items[i].quotedMessageFrom == contactId):
-        roles.add(@[ModelRole.QuotedMessageAuthorName.int,
-          ModelRole.QuotedMessageAuthorDisplayName.int,
-          ModelRole.QuotedMessageAuthorThumbnailImage.int,
-          ModelRole.QuotedMessageAuthorEnsVerified.int,
-          ModelRole.QuotedMessageAuthorIsContact.int])
+      if senderMatches:
+        addChangedRole(changedRoles, oldSenderDisplayName, self.items[i].senderDisplayName, ModelRole.SenderDisplayName.int): discard
+        addChangedRole(changedRoles, oldSenderOptionalName, self.items[i].senderOptionalName, ModelRole.SenderOptionalName.int): discard
+        addChangedRole(changedRoles, oldSenderUsesDefaultName, self.items[i].senderUsesDefaultName, ModelRole.UsesDefaultName.int): discard
+        addChangedRole(changedRoles, oldSenderIcon, self.items[i].senderIcon, ModelRole.SenderIcon.int): discard
+        addChangedRole(changedRoles, oldSenderIsAdded, self.items[i].senderIsAdded, ModelRole.SenderIsAdded.int): discard
+        addChangedRole(changedRoles, oldSenderTrustStatus, self.items[i].senderTrustStatus, ModelRole.SenderTrustStatus.int): discard
+        addChangedRole(changedRoles, oldSenderEnsVerified, self.items[i].senderEnsVerified, ModelRole.SenderEnsVerified.int): discard
 
-      if(roles.len > 0):
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index, roles)
+      if pinnedByMatches:
+        addChangedRole(changedRoles, oldPinnedBy, self.items[i].pinnedBy, ModelRole.PinnedBy.int): discard
+
+      if messageContainsContactMention:
+        addChangedRole(changedRoles, oldMessageText, self.items[i].messageText, ModelRole.MessageText.int): discard
+        addChangedRole(changedRoles, oldUnparsedText, self.items[i].unparsedText, ModelRole.UnparsedText.int): discard
+        addChangedRole(changedRoles, oldMessageContainsMentions, self.items[i].messageContainsMentions, ModelRole.MessageContainsMentions.int): discard
+
+      if quotedAuthorMatches:
+        addChangedRole(changedRoles, oldQuotedMessageAuthorName, self.items[i].quotedMessageAuthorDetails.dto.name, ModelRole.QuotedMessageAuthorName.int): discard
+        addChangedRole(changedRoles, oldQuotedMessageAuthorDisplayName, self.items[i].quotedMessageAuthorDisplayName, ModelRole.QuotedMessageAuthorDisplayName.int): discard
+        addChangedRole(changedRoles, oldQuotedMessageAuthorAvatar, self.items[i].quotedMessageAuthorAvatar, ModelRole.QuotedMessageAuthorThumbnailImage.int): discard
+        addChangedRole(changedRoles, oldQuotedMessageAuthorEnsVerified, self.items[i].quotedMessageAuthorDetails.dto.ensVerified, ModelRole.QuotedMessageAuthorEnsVerified.int): discard
+        addChangedRole(changedRoles, oldQuotedMessageAuthorIsContact, self.items[i].quotedMessageAuthorDetails.dto.isContact(), ModelRole.QuotedMessageAuthorIsContact.int): discard
+
+      if(changedRoles.len > 0):
+        notifyRangeRolesChanged(i, i, changedRoles)
 
   proc setEditModeOn*(self: Model, messageId: string)  =
-    let ind = self.findIndexForMessageId(messageId)
-    if(ind == -1):
-      return
-
-    self.items[ind].editMode = true
-
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.EditMode.int])
+    updateItemRolesAndNotify self.findIndexForMessageId(messageId):
+      updateRoleWithValue(editMode, true)
 
   proc setEditModeOff*(self: Model, messageId: string)  =
-    let ind = self.findIndexForMessageId(messageId)
-    if(ind == -1):
-      return
-
-    self.items[ind].editMode = false
-
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.EditMode.int])
+    updateItemRolesAndNotify self.findIndexForMessageId(messageId):
+      updateRoleWithValue(editMode, false)
 
   proc updateEditedMsg*(
       self: Model,
@@ -689,54 +684,37 @@ QtObject:
       mentionedUsersPks: seq[string]
       ) =
     let ind = self.findIndexForMessageId(messageId)
-    if(ind == -1):
+    if ind == -1:
       return
 
-    self.items[ind].messageText = updatedMsg
-    self.items[ind].mentioned = mentioned
-    self.items[ind].messageContainsMentions = messageContainsMentions
-    self.items[ind].isEdited = true
-    self.items[ind].links = links
-    self.items[ind].mentionedUsersPks = mentionedUsersPks
-    self.items[ind].parsedText = updatedParsedText
+    updateRolesAndNotify:
+      updateRoleWithValue(messageText, updatedMsg)
+      updateRoleWithValue(unparsedText, updatedRawMsg)
+      updateRoleWithValue(mentioned, mentioned)
+      updateRoleWithValue(messageContainsMentions, messageContainsMentions)
+      updateRoleWithValue(isEdited, true)
+      updateRoleWithValue(links, links)
+      updateRoleWithValue(mentionedUsersPks, mentionedUsersPks)
 
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[
-      ModelRole.MessageText.int,
-      ModelRole.UnparsedText.int,
-      ModelRole.Mentioned.int,
-      ModelRole.MessageContainsMentions.int,
-      ModelRole.IsEdited.int,
-      ModelRole.Links.int,
-      ModelRole.MentionedUsersPks.int
-      ])
+      if self.items[ind].parsedText != updatedParsedText:
+        self.items[ind].parsedText = updatedParsedText
 
     # Update replied to messages if there are
-    for i in 0 ..< self.items.len:
-      if(self.items[i].responseToMessageWithId == messageId):
-        self.items[i].quotedMessageParsedText = updatedMsg
-        self.items[i].quotedMessageText = updatedRawMsg
-        self.items[i].quotedMessageContentType = contentType
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index, @[
-          ModelRole.QuotedMessageText.int,
-          ModelRole.QuotedMessageParsedText.int,
-          ModelRole.QuotedMessageContentType.int,
-        ])
+    let targetQuotedMessageParsedText = updatedMsg
+    let targetQuotedMessageText = updatedRawMsg
+    let targetQuotedMessageContentType = contentType
+    for ind in 0 ..< self.items.len:
+      if self.items[ind].responseToMessageWithId == messageId:
+        updateRolesAndNotify:
+          updateRoleWithValue(quotedMessageParsedText, targetQuotedMessageParsedText)
+          updateRoleWithValue(quotedMessageText, targetQuotedMessageText)
+          updateRoleWithValue(quotedMessageContentType, targetQuotedMessageContentType)
 
   proc clear*(self: Model) =
     self.beginResetModel()
     self.items = @[]
     self.endResetModel()
     self.countChanged()
-
-  proc refreshItemWithId*(self: Model, messageId: string) =
-    let ind = self.findIndexForMessageId(messageId)
-    if(ind == -1):
-      return
-    self.updateItemAtIndex(ind)
 
   proc setFirstUnseenMessageId*(self: Model, messageId: string) =
     self.firstUnseenMessageId = messageId
@@ -793,12 +771,7 @@ QtObject:
     if startIdx < 0 or endIdx < startIdx:
       return
 
-    let startIndex = self.createIndex(startIdx, 0, nil)
-    defer: startIndex.delete
-    let endIndex = self.createIndex(endIdx, 0, nil)
-    defer: endIndex.delete
-
-    self.dataChanged(startIndex, endIndex, @[ModelRole.Seen.int])
+    notifyRangeRolesChanged(startIdx, endIdx, @[ModelRole.Seen.int])
 
   proc markAllAsSeen*(self: Model) =
     var rangeStart = -1
@@ -821,14 +794,12 @@ QtObject:
   proc markMessageAsUnread*(self: Model, messageId: string) =
     self.setMessageMarker(messageId)
 
-    for i in 0 ..< self.items.len:
-      let item = self.items[i]
+    for ind in 0 ..< self.items.len:
+      let item = self.items[ind]
 
       if item.id == messageId and item.seen:
-        item.seen = false
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index, @[ModelRole.Seen.int])
+        updateRolesAndNotify:
+          updateRoleWithValue(seen, false)
         break
 
 
@@ -870,8 +841,8 @@ QtObject:
         return self.items[i].id
 
   proc updateAlbumIfExists*(self: Model, albumId: string, messageImage: string, messageId: string): bool =
-    for i in 0 ..< self.items.len:
-      let item = self.items[i]
+    for ind in 0 ..< self.items.len:
+      let item = self.items[ind]
       if item.albumId == albumId:
         # Check if message already in album
         for j in 0 ..< item.albumMessageIds.len:
@@ -881,12 +852,12 @@ QtObject:
         var albumMessagesIds = item.albumMessageIds
         albumMessagesIds.add(messageId)
         albumImages.add(messageImage)
-        item.albumMessageImages = albumImages
-        item.albumMessageIds = albumMessagesIds
-
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index, @[ModelRole.AlbumMessageImages.int])
+        let targetAlbumMessageImages = albumImages
+        let targetAlbumMessageIds = albumMessagesIds
+        updateRolesAndNotify:
+          updateRoleWithValue(albumMessageImages, targetAlbumMessageImages)
+          if self.items[ind].albumMessageIds != targetAlbumMessageIds:
+            self.items[ind].albumMessageIds = targetAlbumMessageIds
         return true
     return false
 

--- a/src/app/modules/shared_models/message_reaction_model.nim
+++ b/src/app/modules/shared_models/message_reaction_model.nim
@@ -81,6 +81,19 @@ QtObject:
       return ""
     return self.items[ind].getReactionId(userPublicKey)
 
+  proc notifyChangedReactionRoles(self: MessageReactionModel, ind: int, previousDidIReactWithThisEmoji: bool,
+    previousNumberOfReactions: int, previousJsonArrayOfUsersReactedWithThisEmoji: string) =
+    var changedRoles: seq[int] = @[]
+    addChangedRole(changedRoles, previousDidIReactWithThisEmoji, self.items[ind].didIReactWithThisEmoji,
+      ModelRole.DidIReactWithThisEmoji.int): discard
+    addChangedRole(changedRoles, previousNumberOfReactions, self.items[ind].numberOfReactions,
+      ModelRole.NumberOfReactions.int): discard
+    addChangedRole(changedRoles, previousJsonArrayOfUsersReactedWithThisEmoji, $self.items[ind].jsonArrayOfUsersReactedWithThisEmoji,
+      ModelRole.JsonArrayOfUsersReactedWithThisEmoji.int): discard
+
+    if changedRoles.len > 0:
+      notifyRangeRolesChanged(ind, ind, changedRoles)
+
   # This function is used when we optimistically have added a reaction and we received the real reactionID asyncly
   # Returns false if it was not updated. Then we can add the reaction with the normal path
   proc updateReactionId*(self: MessageReactionModel, emoji: string, userPublicKey: string, reactionId: string): bool =
@@ -97,10 +110,11 @@ QtObject:
       let ind = self.getIndexOfTheItemWithEmoji(emoji)
       if ind == -1:
         return
+      let previousDidIReactWithThisEmoji = self.items[ind].didIReactWithThisEmoji
+      let previousNumberOfReactions = self.items[ind].numberOfReactions
+      let previousJsonArrayOfUsersReactedWithThisEmoji = $self.items[ind].jsonArrayOfUsersReactedWithThisEmoji
       self.items[ind].addReaction(didIReactWithThisEmoji, userPublicKey, userDisplayName, reactionId)
-      let index = self.createIndex(ind, 0, nil)
-      defer: index.delete
-      self.dataChanged(index, index)
+      self.notifyChangedReactionRoles(ind, previousDidIReactWithThisEmoji, previousNumberOfReactions, previousJsonArrayOfUsersReactedWithThisEmoji)
     else:
       let parentModelIndex = newQModelIndex()
       defer: parentModelIndex.delete
@@ -116,6 +130,9 @@ QtObject:
     let ind = self.getIndexOfTheItemWithEmoji(emoji)
     if(ind == -1):
       return
+    let previousDidIReactWithThisEmoji = self.items[ind].didIReactWithThisEmoji
+    let previousNumberOfReactions = self.items[ind].numberOfReactions
+    let previousJsonArrayOfUsersReactedWithThisEmoji = $self.items[ind].jsonArrayOfUsersReactedWithThisEmoji
     self.items[ind].removeReaction(reactionId, didIRemoveThisReaction)
 
     if(self.items[ind].numberOfReactions() == 0):
@@ -127,9 +144,7 @@ QtObject:
       self.items.delete(ind)
       self.endRemoveRows()
     else:
-      let index = self.createIndex(ind, 0, nil)
-      defer: index.delete
-      self.dataChanged(index, index)
+      self.notifyChangedReactionRoles(ind, previousDidIReactWithThisEmoji, previousNumberOfReactions, previousJsonArrayOfUsersReactedWithThisEmoji)
 
   proc delete(self: MessageReactionModel) =
     self.QAbstractListModel.delete

--- a/src/app/modules/shared_models/model_utils.nim
+++ b/src/app/modules/shared_models/model_utils.nim
@@ -49,6 +49,14 @@ macro updateRoleWithValue*(propertyName: untyped, value: untyped): untyped =
       self.items[ind].`propertyName` = `value`
       roles.add(ModelRole.`roleName`.int)
 
+# Same as updateRoleWithValue, but for properties whose model role has a different name.
+# Eg: updateRoleWithValue(messageItem, item.messageItem, Message)
+macro updateRoleWithValue*(propertyName: untyped, value: untyped, roleName: untyped): untyped =
+  quote do:
+    if self.items[ind].`propertyName` != `value`:
+      self.items[ind].`propertyName` = `value`
+      roles.add(ModelRole.`roleName`.int)
+
 # Expands a list of item fields into updateRoleWithValue(field, item.field).
 # Example usage: updateRolesFromItem(item, name, memberRole, icon)
 macro updateRolesFromItem*(item: untyped, propertyNames: varargs[untyped]): untyped =
@@ -66,6 +74,17 @@ macro updateRolePreserveOnEmpty*(propertyName: untyped, roleName: untyped): unty
       self.items[ind].`propertyName` = `propertyName`
       roles.add(ModelRole.`roleName`.int)
 
+# Add a role to an existing roles list only when a computed value changed.
+# Useful when the model does not own the field being changed, or when the
+# setter lives outside of updateRole/updateRoleWithValue.
+# Example usage:
+#   addChangedRole(changedRoles, oldName, item.name(), ModelRole.Name.int):
+#     item.nameChanged()
+template addChangedRole*(roles: untyped, previousValue: untyped, currentValue: untyped, role: untyped, body: untyped) {.dirty.} =
+  if previousValue != currentValue:
+    roles.add(role)
+    body
+
 # Wrap one or more updateRole calls and notify the row at `ind` if any roles changed.
 # Example usage:
 #   updateRolesAndNotify:
@@ -76,12 +95,26 @@ template updateRolesAndNotify*(body: untyped) {.dirty.} =
 
   body
 
-  if roles.len == 0:
-    return
+  if roles.len > 0:
+    let modelIndex = self.createIndex(ind, 0, nil)
+    defer: modelIndex.delete
+    self.dataChanged(modelIndex, modelIndex, roles)
 
-  let modelIndex = self.createIndex(ind, 0, nil)
-  defer: modelIndex.delete
-  self.dataChanged(modelIndex, modelIndex, roles)
+# Same as updateRolesAndNotify, but also writes whether any roles changed.
+# Example usage:
+#   var rolesChanged = false
+#   updateRolesAndNotify rolesChanged:
+#     updateRole(name)
+template updateRolesAndNotify*(rolesChanged: untyped, body: untyped) {.dirty.} =
+  var roles: seq[int] = @[]
+
+  body
+
+  rolesChanged = roles.len > 0
+  if rolesChanged:
+    let modelIndex = self.createIndex(ind, 0, nil)
+    defer: modelIndex.delete
+    self.dataChanged(modelIndex, modelIndex, roles)
 
 # Like updateRolesAndNotify, but first resolves `ind` from a model-specific lookup expression.
 # Example usage:
@@ -94,3 +127,15 @@ template updateItemRolesAndNotify*(findIndex: untyped, body: untyped) {.dirty.} 
 
   updateRolesAndNotify:
     body
+
+# Notify a contiguous model row range when roles are computed outside of item
+# storage and cannot use updateRole/updateRoleWithValue.
+# Example usage:
+#   notifyRangeRolesChanged(0, self.rowCount() - 1, @[ModelRole.Visible.int])
+template notifyRangeRolesChanged*(firstRow: int, lastRow: int, changedRoles: untyped) {.dirty.} =
+  let firstIndex = self.createIndex(firstRow, 0, nil)
+  let lastIndex = self.createIndex(lastRow, 0, nil)
+  defer:
+    firstIndex.delete
+    lastIndex.delete
+  self.dataChanged(firstIndex, lastIndex, changedRoles)

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -274,17 +274,8 @@ QtObject:
     self.countChanged()
 
   proc setMuted*(self: SectionModel, id: string, muted: bool) = 
-    let index = self.getItemIndex(id)
-    if index == -1:
-      return
-
-    if self.items[index].muted == muted:
-      return
-
-    self.items[index].muted = muted 
-    let dataIndex = self.createIndex(index, 0, nil)
-    defer: dataIndex.delete
-    self.dataChanged(dataIndex, dataIndex, @[ModelRole.Muted.int])
+    updateItemRolesAndNotify self.getItemIndex(id):
+      updateRole(muted)
 
   proc editItem*(self: SectionModel, item: SectionItem) =
     updateItemRolesAndNotify self.getItemIndex(item.id):
@@ -378,32 +369,26 @@ QtObject:
     return not item.isEmpty() and item.enabled()
 
   proc setActiveSection*(self: SectionModel, id: string) =
-    for i in 0 ..< self.items.len:
-      if self.items[i].active:
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.items[i].active = false
-        self.dataChanged(index, index, @[ModelRole.Active.int])
+    for ind in 0 ..< self.items.len:
+      if self.items[ind].active:
+        let active = false
+        updateRolesAndNotify:
+          updateRole(active)
 
-      if self.items[i].id == id:
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.items[i].active = true
-
-        self.dataChanged(index, index, @[ModelRole.Active.int])
+      if self.items[ind].id == id:
+        let active = true
+        updateRolesAndNotify:
+          updateRole(active)
 
   proc sectionVisibilityUpdated*(self: SectionModel) {.signal.}
 
   proc enableDisableSection(self: SectionModel, sectionType: SectionType, value: bool) =
     if sectionType != SectionType.Community:
-      for i in 0 ..< self.items.len:
-        if self.items[i].sectionType == sectionType:
-          if self.items[i].enabled == value:
-            continue
-          let index = self.createIndex(i, 0, nil)
-          defer: index.delete
-          self.items[i].enabled = value
-          self.dataChanged(index, index, @[ModelRole.Enabled.int])
+      for ind in 0 ..< self.items.len:
+        if self.items[ind].sectionType == sectionType:
+          let enabled = value
+          updateRolesAndNotify:
+            updateRole(enabled)
     else:
       var topInd = -1
       var bottomInd = -1
@@ -415,11 +400,8 @@ QtObject:
 
           bottomInd = i
 
-      let topIndex = self.createIndex(topInd, 0, nil)
-      let bottomIndex = self.createIndex(bottomInd, 0, nil)
-      defer: topIndex.delete
-      defer: bottomIndex.delete
-      self.dataChanged(topIndex, bottomIndex, @[ModelRole.Enabled.int])
+      if topInd != -1:
+        notifyRangeRolesChanged(topInd, bottomInd, @[ModelRole.Enabled.int])
 
     # This signal is emitted to update buttons visibility in the left navigation bar,
     # `dataChanged` signal doesn't do the job because of `DelegateModel` used in `StatusAppNavBar` component
@@ -441,17 +423,8 @@ QtObject:
         result += item.notificationsCount
 
   proc updateIsPendingOwnershipRequest*(self: SectionModel, id: string, isPending: bool) =
-    for i in 0 ..< self.items.len:
-      if self.items[i].id == id:
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-
-        if self.items[i].isPendingOwnershipRequest == isPending:
-          return
-
-        self.items[i].setIsPendingOwnershipRequest(isPending)
-        self.dataChanged(index, index, @[ModelRole.IsPendingOwnershipRequest.int])
-        return
+    updateItemRolesAndNotify self.getItemIndex(id):
+      updateRoleWithValue(isPendingOwnershipRequest, isPending)
 
   proc updateNotifications*(self: SectionModel, id: string, hasNotification: bool, notificationsCount: int) =
     let ind = self.getItemIndex(id)
@@ -473,8 +446,6 @@ QtObject:
   proc appendCommunityToken*(self: SectionModel, id: string, item: TokenItem) =
     for i in 0 ..< self.items.len:
       if(self.items[i].id == id):
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].appendCommunityToken(item)
         return
 
@@ -533,27 +504,13 @@ QtObject:
     self.items[index].communityTokens.setItems(communityTokensItems)
 
   proc setMembersItems*(self: SectionModel, id: string, communityMembersItems: seq[MemberItem]) =
-    let index = self.getItemIndex(id)
-    if index == -1:
-      return
-
-    self.items[index].members.setItems(communityMembersItems)
-    self.items[index].membersLoaded = true
-
-    let dataIndex = self.createIndex(index, 0, nil)
-    defer: dataIndex.delete
-    self.dataChanged(dataIndex, dataIndex, @[ModelRole.MembersLoaded.int])
+    updateItemRolesAndNotify self.getItemIndex(id):
+      self.items[ind].members.setItems(communityMembersItems)
+      updateRoleWithValue(membersLoaded, true)
 
   proc setTokensLoading*(self: SectionModel, id: string, value: bool) =
-    let index = self.getItemIndex(id)
-    if index == -1 or self.items[index].tokensLoading == value:
-      return
-
-    self.items[index].tokensLoading = value
-
-    let dataIndex = self.createIndex(index, 0, nil)
-    defer: dataIndex.delete
-    self.dataChanged(dataIndex, dataIndex, @[ModelRole.TokensLoading.int])
+    updateItemRolesAndNotify self.getItemIndex(id):
+      updateRoleWithValue(tokensLoading, value)
 
   proc addMember*(self: SectionModel, communityId: string, memberItem: MemberItem) =
     let i = self.getItemIndex(communityId)

--- a/src/app/modules/shared_models/token_permission_chat_list_item.nim
+++ b/src/app/modules/shared_models/token_permission_chat_list_item.nim
@@ -24,3 +24,9 @@ proc getKey*(self: TokenPermissionChatListItem): string =
 proc getChannelName*(self: TokenPermissionChatListItem): string =
   return self.channelName
 
+proc channelName*(self: TokenPermissionChatListItem): string =
+  return self.channelName
+
+proc `channelName=`*(self: var TokenPermissionChatListItem, value: string) =
+  self.channelName = value
+

--- a/src/app/modules/shared_models/token_permission_chat_list_model.nim
+++ b/src/app/modules/shared_models/token_permission_chat_list_model.nim
@@ -45,6 +45,12 @@ QtObject:
       of ModelRole.ChannelName:
         result = newQVariant(item.getChannelName())
 
+  proc findIndexByKey(self: TokenPermissionChatListModel, key: string): int =
+    for i in 0 ..< self.items.len:
+      if self.items[i].getKey() == key:
+        return i
+    return -1
+
   proc addItem*(self: TokenPermissionChatListModel, item: TokenPermissionChatListItem) =
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
@@ -63,13 +69,8 @@ QtObject:
     return self.items
 
   proc renameChatById*(self: TokenPermissionChatListModel, chatId: string, newName: string) =
-    for i in 0 ..< self.items.len:
-      if self.items[i].getKey() == chatId:
-        self.items[i] = initTokenPermissionChatListItem(chatId, newName)
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index, @[ModelRole.ChannelName.int])
-        return
+    updateItemRolesAndNotify self.findIndexByKey(chatId):
+      updateRoleWithValue(channelName, newName)
 
   proc setup(self: TokenPermissionChatListModel) =
     self.QAbstractListModel.setup

--- a/src/app/modules/shared_models/token_permissions_model.nim
+++ b/src/app/modules/shared_models/token_permissions_model.nim
@@ -135,27 +135,16 @@ QtObject:
   proc tokenCriteriaUpdated(self: TokenPermissionsModel) {.signal.}
 
   proc updateItem*(self: TokenPermissionsModel, permissionId: string, item: TokenPermissionItem) =
-    let idx = self.findIndexById(permissionId)
-    if(idx == -1):
-      return
+    updateItemRolesAndNotify self.findIndexById(permissionId):
+      updateRoleWithValue(`type`, item.`type`)
+      self.items[ind].tokenCriteria.setItems(item.tokenCriteria.getItems())
+      roles.add(ModelRole.TokenCriteria.int)
+      self.items[ind].chatList.setItems(item.chatList.getItems())
+      roles.add(ModelRole.ChatList.int)
+      updateRoleWithValue(isPrivate, item.isPrivate)
+      updateRoleWithValue(tokenCriteriaMet, item.tokenCriteriaMet)
+      updateRoleWithValue(state, item.state)
 
-    self.items[idx].`type` = item.`type`
-    self.items[idx].tokenCriteria.setItems(item.tokenCriteria.getItems())
-    self.items[idx].chatList.setItems(item.chatList.getItems())
-    self.items[idx].isPrivate = item.isPrivate
-    self.items[idx].tokenCriteriaMet = item.tokenCriteriaMet
-    self.items[idx].state = item.state
-
-    let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[
-      ModelRole.Type.int,
-      ModelRole.TokenCriteria.int,
-      ModelRole.ChatList.int,
-      ModelRole.IsPrivate.int,
-      ModelRole.TokenCriteriaMet.int,
-      ModelRole.State.int
-    ])
     self.tokenCriteriaUpdated()
 
   proc setup(self: TokenPermissionsModel) =

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -267,28 +267,19 @@ QtObject:
   proc setName*(self: Model, pubKey: string, displayName: string,
       ensName: string, localNickname: string) =
     updateItemRolesAndNotify self.findIndexByPubKey(pubKey):
-      let preferredDisplayNameChanged =
-        resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias) !=
-        resolvePreferredDisplayName(localNickname, ensName, displayName, self.items[ind].alias)
+      let previousPreferredDisplayName = resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias)
+      let currentPreferredDisplayName = resolvePreferredDisplayName(localNickname, ensName, displayName, self.items[ind].alias)
 
       updateRole(displayName)
       updateRole(ensName)
       updateRole(localNickname)
 
-      if preferredDisplayNameChanged:
-        roles.add(ModelRole.PreferredDisplayName.int)
-        roles.add(ModelRole.UsesDefaultName.int)
+      addChangedRole(roles, previousPreferredDisplayName, currentPreferredDisplayName, ModelRole.PreferredDisplayName.int): discard
+      addChangedRole(roles, previousPreferredDisplayName, currentPreferredDisplayName, ModelRole.UsesDefaultName.int): discard
 
   proc setIcon*(self: Model, pubKey: string, icon: string) =
-    let ind = self.findIndexByPubKey(pubKey)
-    if(ind == -1):
-      return
-
-    self.items[ind].icon = icon
-
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.Icon.int])
+    updateItemRolesAndNotify self.findIndexByPubKey(pubKey):
+      updateRole(icon)
 
   proc updateItem*(
       self: Model,
@@ -314,11 +305,9 @@ QtObject:
       isRemoved: bool,
     ) =
     updateItemRolesAndNotify self.findIndexByPubKey(pubKey):
-      let preferredDisplayNameChanged =
-        resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias) !=
-        resolvePreferredDisplayName(localNickname, ensName, displayName, alias)
-
-      let trustStatusChanged = trustStatus != self.items[ind].trustStatus
+      let previousPreferredDisplayName = resolvePreferredDisplayName(self.items[ind].localNickname, self.items[ind].ensName, self.items[ind].displayName, self.items[ind].alias)
+      let currentPreferredDisplayName = resolvePreferredDisplayName(localNickname, ensName, displayName, alias)
+      let previousTrustStatus = self.items[ind].trustStatus
 
       updateRole(displayName)
       updateRole(ensName)
@@ -340,13 +329,10 @@ QtObject:
       updateRole(isContactRequestSent)
       updateRole(isRemoved)
 
-      if preferredDisplayNameChanged:
-        roles.add(ModelRole.PreferredDisplayName.int)
-        roles.add(ModelRole.UsesDefaultName.int)
-
-      if trustStatusChanged:
-        roles.add(ModelRole.IsUntrustworthy.int)
-        roles.add(ModelRole.IsVerified.int)
+      addChangedRole(roles, previousPreferredDisplayName, currentPreferredDisplayName, ModelRole.PreferredDisplayName.int): discard
+      addChangedRole(roles, previousPreferredDisplayName, currentPreferredDisplayName, ModelRole.UsesDefaultName.int): discard
+      addChangedRole(roles, previousTrustStatus, trustStatus, ModelRole.IsUntrustworthy.int): discard
+      addChangedRole(roles, previousTrustStatus, trustStatus, ModelRole.IsVerified.int): discard
 
   proc updateItem*(
       self: Model,
@@ -387,35 +373,18 @@ QtObject:
     )
 
   proc updateTrustStatus*(self: Model, pubKey: string, trustStatus: TrustStatus) =
-    let ind = self.findIndexByPubKey(pubKey)
-    if ind == -1:
-      return
+    updateItemRolesAndNotify self.findIndexByPubKey(pubKey):
+      let previousTrustStatus = self.items[ind].trustStatus
 
-    if self.items[ind].trustStatus == trustStatus:
-      return
+      updateRole(trustStatus)
 
-    self.items[ind].trustStatus = trustStatus
-
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.TrustStatus.int, ModelRole.IsUntrustworthy.int, ModelRole.IsVerified.int])
+      addChangedRole(roles, previousTrustStatus, trustStatus, ModelRole.IsUntrustworthy.int): discard
+      addChangedRole(roles, previousTrustStatus, trustStatus, ModelRole.IsVerified.int): discard
 
   proc setOnlineStatus*(self: Model, pubKey: string, onlineStatus: OnlineStatus) =
-    let ind = self.findIndexByPubKey(pubKey)
-    if ind == -1:
-      return
+    updateItemRolesAndNotify self.findIndexByPubKey(pubKey):
+      updateRole(onlineStatus)
 
-    if self.items[ind].onlineStatus == onlineStatus:
-      return
-
-    self.items[ind].onlineStatus = onlineStatus
-
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[ModelRole.OnlineStatus.int])
-
-
-# TODO: rename me to removeItemByPubkey
   proc removeItemById*(self: Model, pubKey: string) =
     let ind = self.findIndexByPubKey(pubKey)
     if(ind == -1):
@@ -423,7 +392,6 @@ QtObject:
 
     self.removeItemWithIndex(ind)
 
-# TODO: rename me to getItemsAsPubkeys
   proc getItemIds*(self: Model): seq[string] =
     return self.items.map(i => i.pubKey)
 

--- a/src/app/modules/shared_models/wallet_account_item.nim
+++ b/src/app/modules/shared_models/wallet_account_item.nim
@@ -94,9 +94,9 @@ QtObject:
   proc addressChanged*(self: WalletAccountItem) {.signal.}
   proc address*(self: WalletAccountItem): string {.slot.} =
     return self.address
-#  proc setAddress*(self: WalletAccountItem, value: string) {.slot.} =
-#    self.address = value
-#    self.addressChanged()
+  proc `address=`*(self: WalletAccountItem, value: string) {.inline.} =
+    self.address = value
+    self.addressChanged()
   QtProperty[string] address:
     read = address
     notify = addressChanged
@@ -104,6 +104,9 @@ QtObject:
   proc mixedcaseAddressChanged*(self: WalletAccountItem) {.signal.}
   proc mixedcaseAddress*(self: WalletAccountItem): string {.slot.} =
     return self.mixedcaseAddress
+  proc `mixedcaseAddress=`*(self: WalletAccountItem, value: string) {.inline.} =
+    self.mixedcaseAddress = value
+    self.mixedcaseAddressChanged()
 
   QtProperty[string] mixedcaseAddress:
     read = mixedcaseAddress
@@ -132,6 +135,9 @@ QtObject:
   proc walletTypeChanged*(self: WalletAccountItem) {.signal.}
   proc walletType*(self: WalletAccountItem): string {.slot.} =
     return self.walletType
+  proc `walletType=`*(self: WalletAccountItem, value: string) {.inline.} =
+    self.walletType = value
+    self.walletTypeChanged()
   QtProperty[string] walletType:
     read = walletType
     notify = walletTypeChanged
@@ -139,6 +145,9 @@ QtObject:
   proc pathChanged*(self: WalletAccountItem) {.signal.}
   proc path*(self: WalletAccountItem): string {.slot.} =
     return self.path
+  proc `path=`*(self: WalletAccountItem, value: string) {.inline.} =
+    self.path = value
+    self.pathChanged()
   QtProperty[string] path:
     read = path
     notify = pathChanged
@@ -146,6 +155,9 @@ QtObject:
   proc keyUidChanged*(self: WalletAccountItem) {.signal.}
   proc keyUid*(self: WalletAccountItem): string {.slot.} =
     return self.keyUid
+  proc `keyUid=`*(self: WalletAccountItem, value: string) {.inline.} =
+    self.keyUid = value
+    self.keyUidChanged()
   QtProperty[string] keyUid:
     read = keyUid
     notify = keyUidChanged
@@ -153,11 +165,19 @@ QtObject:
   proc migratedToColdWalletChanged*(self: WalletAccountItem) {.signal.}
   proc migratedToColdWallet*(self: WalletAccountItem): bool {.slot.} =
     return self.migratedToColdWallet
+  proc `migratedToColdWallet=`*(self: WalletAccountItem, value: bool) {.inline.} =
+    self.migratedToColdWallet = value
+    self.migratedToColdWalletChanged()
   QtProperty[bool] migratedToColdWallet:
     read = migratedToColdWallet
     notify = migratedToColdWalletChanged
 
   proc positionChanged*(self: WalletAccountItem) {.signal.}
+  proc position*(self: WalletAccountItem): int {.slot.} =
+    return self.position
+  proc `position=`*(self: WalletAccountItem, value: int) {.inline.} =
+    self.position = value
+    self.positionChanged()
   proc getPosition*(self: WalletAccountItem): int {.slot.} =
     return self.position
   proc setPosition*(self: WalletAccountItem, value: int) {.slot.} =

--- a/test/nim/curated_community_model_test.nim
+++ b/test/nim/curated_community_model_test.nim
@@ -1,0 +1,81 @@
+import unittest
+
+import app/modules/main/communities/models/[curated_community_model, curated_community_item]
+
+proc createTestCommunityItem(
+    id: string,
+    name: string = "Name",
+    description: string = "Description",
+    available: bool = true,
+    icon: string = "icon",
+    banner: string = "banner",
+    color: string = "#ffffff",
+    tags: string = "tag",
+    members: int = 10,
+    activeMembers: int = 5,
+    featured: bool = false,
+    amIBanned: bool = false,
+    joined: bool = false,
+    encrypted: bool = false,
+  ): CuratedCommunityItem =
+  return initCuratedCommunityItem(
+    id = id,
+    name = name,
+    description = description,
+    available = available,
+    icon = icon,
+    banner = banner,
+    color = color,
+    tags = tags,
+    members = members,
+    activeMembers = activeMembers,
+    featured = featured,
+    tokenPermissionsItems = @[],
+    amIBanned = amIBanned,
+    joined = joined,
+    encrypted = encrypted,
+  )
+
+suite "curated community model":
+  test "add item inserts a new row":
+    let model = newCuratedCommunityModel()
+    let item = createTestCommunityItem("community-a")
+
+    model.addItem(item)
+
+    check(model.rowCount() == 1)
+    check(model.getItemById("community-a").getName() == "Name")
+
+  test "add item updates existing row granularly":
+    let model = newCuratedCommunityModel()
+    let original = createTestCommunityItem(
+      id = "community-a",
+      name = "Original",
+      description = "Keep description",
+      icon = "keep-icon",
+      members = 10,
+      joined = false,
+    )
+    let replacement = createTestCommunityItem(
+      id = "community-a",
+      name = "Updated",
+      description = "Keep description",
+      icon = "keep-icon",
+      members = 42,
+      joined = true,
+    )
+
+    model.addItem(original)
+    let originalPermissionsModel = model.getItemById("community-a").getPermissionsModel()
+
+    model.addItem(replacement)
+
+    let updated = model.getItemById("community-a")
+    check(model.rowCount() == 1)
+    check(updated.getName() == "Updated")
+    check(updated.getMembers() == 42)
+    check(updated.getJoined() == true)
+    check(updated.getDescription() == "Keep description")
+    check(updated.getIcon() == "keep-icon")
+    check(updated.getPermissionsModel() != originalPermissionsModel)
+    check(updated.getPermissionsModel() == replacement.getPermissionsModel())

--- a/test/nim/network_route_model_test.nim
+++ b/test/nim/network_route_model_test.nim
@@ -1,0 +1,139 @@
+import unittest
+
+import app_service/service/network/types
+import app/modules/main/wallet_section/send/[network_route_model, network_route_item, suggested_route_item]
+import app/modules/shared_models/currency_amount
+
+proc createTokenBalance(amount: float64 = 1.0, symbol: string = "ETH"): CurrencyAmount =
+  return newCurrencyAmount(amount, symbol, symbol, 18, true)
+
+proc createNetworkRouteItem(
+    chainId: int,
+    layer: int = NETWORK_LAYER_1,
+    isRouteEnabled: bool = true,
+    isRoutePreferred: bool = true,
+    hasGas: bool = true,
+    tokenBalance: CurrencyAmount = createTokenBalance(),
+    amountIn: string = "",
+    amountOut: string = "",
+    toNetworks: seq[int] = @[],
+  ): NetworkRouteItem =
+  return initNetworkRouteItem(
+    chainId = chainId,
+    layer = layer,
+    isRouteEnabled = isRouteEnabled,
+    isRoutePreferred = isRoutePreferred,
+    hasGas = hasGas,
+    tokenBalance = tokenBalance,
+    amountIn = amountIn,
+    amountOut = amountOut,
+    toNetworks = toNetworks,
+  )
+
+proc createSuggestedRouteItem(
+    fromNetwork: int,
+    toNetwork: int,
+    amountIn: string = "100",
+    amountOut: string = "200",
+  ): SuggestedRouteItem =
+  return newSuggestedRouteItem(
+    fromNetwork = fromNetwork,
+    toNetwork = toNetwork,
+    amountIn = amountIn,
+    amountOut = amountOut,
+  )
+
+suite "network route model":
+  test "set items exposes row count and chain ids":
+    let model = newNetworkRouteModel()
+    model.setItems(@[
+      createNetworkRouteItem(1),
+      createNetworkRouteItem(10, layer = NETWORK_LAYER_2),
+    ])
+
+    check(model.rowCount() == 2)
+    check(model.getAllNetworksChainIds() == @[1, 10])
+
+  test "update from networks accumulates destinations and gas state":
+    let model = newNetworkRouteModel()
+    model.setItems(@[
+      createNetworkRouteItem(1),
+      createNetworkRouteItem(10),
+      createNetworkRouteItem(100),
+    ])
+
+    model.updateFromNetworks(createSuggestedRouteItem(fromNetwork = 1, toNetwork = 10, amountIn = "15"), hasGas = false)
+    model.updateFromNetworks(createSuggestedRouteItem(fromNetwork = 1, toNetwork = 100, amountIn = "20"), hasGas = true)
+
+    check(model.items[0].amountIn() == "20")
+    check(model.items[0].toNetworks() == "10:100")
+    check(model.items[0].hasGas() == true)
+    check(model.items[1].amountIn() == "")
+    check(model.items[1].toNetworks() == "")
+
+  test "update to networks sums amount out":
+    let model = newNetworkRouteModel()
+    model.setItems(@[
+      createNetworkRouteItem(1),
+      createNetworkRouteItem(10),
+    ])
+
+    model.updateToNetworks(createSuggestedRouteItem(fromNetwork = 1, toNetwork = 10, amountOut = "25"))
+    model.updateToNetworks(createSuggestedRouteItem(fromNetwork = 100, toNetwork = 10, amountOut = "75"))
+
+    check(model.items[0].amountOut() == "")
+    check(model.items[1].amountOut() == "100")
+
+  test "update token balance only changes matching chain":
+    let model = newNetworkRouteModel()
+    let originalBalance = createTokenBalance(1.0, "ETH")
+    let updatedBalance = createTokenBalance(5.0, "SNT")
+    model.setItems(@[
+      createNetworkRouteItem(1, tokenBalance = originalBalance),
+      createNetworkRouteItem(10, tokenBalance = originalBalance),
+    ])
+
+    model.updateTokenBalanceForSymbol(10, updatedBalance)
+
+    check(model.items[0].getTokenBalance() == originalBalance)
+    check(model.items[1].getTokenBalance() == updatedBalance)
+
+  test "preferred chains control enabled state":
+    let model = newNetworkRouteModel()
+    model.setItems(@[
+      createNetworkRouteItem(1, layer = NETWORK_LAYER_1),
+      createNetworkRouteItem(10, layer = NETWORK_LAYER_2),
+      createNetworkRouteItem(100, layer = NETWORK_LAYER_2),
+    ])
+
+    model.updateRoutePreferredChains("10")
+
+    check(model.items[0].isRoutePreferred() == false)
+    check(model.items[0].isRouteEnabled() == false)
+    check(model.items[1].isRoutePreferred() == true)
+    check(model.items[1].isRouteEnabled() == true)
+    check(model.items[2].isRoutePreferred() == false)
+    check(model.items[2].isRouteEnabled() == false)
+
+    model.enableRouteUnpreferredChains()
+    check(model.items[0].isRouteEnabled() == true)
+    check(model.items[2].isRouteEnabled() == true)
+
+    model.disableRouteUnpreferredChains()
+    check(model.items[0].isRouteEnabled() == false)
+    check(model.items[2].isRouteEnabled() == false)
+
+  test "reset clears path data and restores route flags":
+    let model = newNetworkRouteModel()
+    model.setItems(@[
+      createNetworkRouteItem(1, isRouteEnabled = false, isRoutePreferred = false, hasGas = false, amountIn = "10", amountOut = "20", toNetworks = @[10]),
+    ])
+
+    model.reset()
+
+    check(model.items[0].amountIn() == "")
+    check(model.items[0].amountOut() == "")
+    check(model.items[0].toNetworks() == "")
+    check(model.items[0].hasGas() == true)
+    check(model.items[0].isRouteEnabled() == true)
+    check(model.items[0].isRoutePreferred() == true)

--- a/test/nim/notifications_model_test.nim
+++ b/test/nim/notifications_model_test.nim
@@ -1,0 +1,105 @@
+import unittest
+
+import app_service/service/settings/dto/settings
+import app/modules/main/profile_section/notifications/[model, item]
+
+proc createNotificationItem(
+    id: string,
+    name: string = "Name",
+    image: string = "image",
+    color: string = "#ffffff",
+    joinedTimestamp: int64 = 1,
+    itemType: Type = Type.Community,
+    muteAllMessages: bool = false,
+    personalMentions: string = VALUE_NOTIF_SEND_ALERTS,
+    globalMentions: string = VALUE_NOTIF_SEND_ALERTS,
+    otherMessages: string = VALUE_NOTIF_TURN_OFF,
+  ): Item =
+  return initItem(
+    id = id,
+    name = name,
+    image = image,
+    color = color,
+    joinedTimestamp = joinedTimestamp,
+    itemType = itemType,
+    muteAllMessages = muteAllMessages,
+    personalMentions = personalMentions,
+    globalMentions = globalMentions,
+    otherMessages = otherMessages,
+  )
+
+suite "notifications model":
+  test "add and remove items by id":
+    let model = newModel()
+
+    model.addItem(createNotificationItem("community-a"))
+    model.addItem(createNotificationItem("community-b"))
+
+    check(model.rowCount() == 2)
+    check(model.findIndexForItemId("community-a") == 0)
+    check(model.findIndexForItemId("community-b") == 1)
+
+    model.removeItemById("community-a")
+
+    check(model.rowCount() == 1)
+    check(model.findIndexForItemId("community-a") == -1)
+    check(model.findIndexForItemId("community-b") == 0)
+
+  test "set items ignores empty replacement":
+    let model = newModel()
+    model.setItems(@[createNotificationItem("community-a")])
+
+    model.setItems(@[])
+
+    check(model.rowCount() == 1)
+    check(model.items[0].id == "community-a")
+
+  test "update name changes only matching item":
+    let model = newModel()
+    model.setItems(@[
+      createNotificationItem("community-a", name = "Old name"),
+      createNotificationItem("community-b", name = "Other name"),
+    ])
+
+    model.updateName("community-a", "New name")
+
+    check(model.items[0].name == "New name")
+    check(model.items[1].name == "Other name")
+
+  test "update item changes presentation fields":
+    let model = newModel()
+    model.setItems(@[createNotificationItem("community-a", name = "Old", image = "old-image", color = "old-color")])
+
+    model.updateItem("community-a", name = "New", image = "new-image", color = "new-color")
+
+    check(model.items[0].name == "New")
+    check(model.items[0].image == "new-image")
+    check(model.items[0].color == "new-color")
+
+  test "update exemptions updates notification settings and customized state":
+    let model = newModel()
+    model.setItems(@[createNotificationItem("community-a")])
+
+    check(model.items[0].customized == false)
+
+    model.updateExemptions(
+      id = "community-a",
+      muteAllMessages = true,
+      personalMentions = VALUE_NOTIF_TURN_OFF,
+      globalMentions = VALUE_NOTIF_SEND_ALERTS,
+      otherMessages = VALUE_NOTIF_SEND_ALERTS,
+    )
+
+    check(model.items[0].muteAllMessages == true)
+    check(model.items[0].personalMentions == VALUE_NOTIF_TURN_OFF)
+    check(model.items[0].globalMentions == VALUE_NOTIF_SEND_ALERTS)
+    check(model.items[0].otherMessages == VALUE_NOTIF_SEND_ALERTS)
+    check(model.items[0].customized == true)
+
+    model.updateExemptions("community-a")
+
+    check(model.items[0].muteAllMessages == false)
+    check(model.items[0].personalMentions == VALUE_NOTIF_SEND_ALERTS)
+    check(model.items[0].globalMentions == VALUE_NOTIF_SEND_ALERTS)
+    check(model.items[0].otherMessages == VALUE_NOTIF_TURN_OFF)
+    check(model.items[0].customized == false)


### PR DESCRIPTION
### What does the PR do

Fixes #21363

Refactored model update paths to use the shared model notification helpers instead of manually constructing indexes, collecting roles, and emitting `dataChanged`. The touched models now use `updateRolesAndNotify`, `updateItemRolesAndNotify`, `notifyRangeRolesChanged`, `updateRoleWithValue`, `updateRolesFromItem`, and `addChangedRole` where appropriate, so row updates only emit when relevant roles actually changed.

Also improved several computed-role updates so dependent roles are notified intentionally. Examples include preferred display name/default-name roles in member/user models, permission/visibility roles in chat models, curated community item updates becoming granular instead of replacing the whole item, and range notifications for roles that are computed outside direct item fields.

### Affected areas

Basically all models

### Impact on end user

The app should be a little faster. It should freeze less often too

### How to test

We need to test most of the app, since these changes touch most of the models

**Suggested Test Areas**

The best coverage is a mix of smoke testing model-backed screens and exercising updates that should change only specific roles. Since this refactor mostly changes notification plumbing, watch for stale UI, over-refreshing, rows not updating, and list order/category state getting stuck.

**Chat List And Messages**

- [x] Create or open a community with categories and channels.
- [x] Expand/collapse categories and confirm the opened state persists visually.
- [x] Reorder channels and categories if available.
- [x] Move channels into and out of categories.
- [x] Rename a channel/category/community and confirm only the relevant row updates.
- [x] Mute/unmute a category and verify channels under it update.
- [x] Switch active chats and confirm active/loader state updates correctly.
- [x] Send/edit/delete a message.
- [x] Delete a message that is quoted by another message and confirm the quoted preview updates as deleted.
- [x] Mark messages seen/unseen and confirm unread markers/counts update.
- [x] Update contact details for message authors/deleted-by users and confirm display names/icons refresh.
- [x] Check album/image messages still update when new album items arrive.

**Communities And Permissions**

- [x] Open the communities discovery/curated list and verify updated community metadata changes granularly: name, icon, banner, members, joined/banned/encrypted state.
- [x] Confirm selected counts and “has selected items” indicators update when toggling selections.
- [x] Create/edit token permissions that affect chat list and token criteria.
- [x] Confirm permission models refresh in QML when nested token criteria/chat list data changes.
- [x] Test permission check state transitions and private/public permission toggles.

**Wallet**

- [x] Add/remove/reorder wallet accounts.
- [x] Hide/unhide account from total balance.
- [x] Confirm account balance/loading state updates.
- [x] In send flow, switch route/network selections.
- [x] Confirm route amount in/out, gas availability, preferred/enabled routes, and token balance update correctly.
- [x] Test preferred-chain toggles and route enabling/disabling.
- [x] Load wallet activity list with pagination.
- [x] Trigger address/contact-name related refresh and confirm matching activity rows update.
- [x] Confirm updated NFT name/image/status changes still appear.

**Profile And Contacts**

- [x] Change community/chat notification settings.
- [x] Confirm mute/all mention/global/other message settings update.
- [x] Confirm “customized” state only changes when settings differ from defaults.
- [x] Rename contacts, set ENS/local nickname, update avatar, trust status, block/contact state.
- [x] Confirm preferred display name and default-name derived roles update.
- [x] In community members list, update member role, joined state, membership request state, and trust status.
- [x] Update linked devices names/enabled state.

**General Regression Checks**

- [x] Activity center notifications: mark read/unread, accept/decline membership requests, remove notifications.
- [x] Browser bookmarks: edit bookmark title/icon/url.
- [x] Stickers: install/remove/update sticker packs.
- [x] Market leaderboard and token groups: refresh market details/loading/visibility.
- [x] Collectibles: update ownership/collectible metadata and confirm rows refresh.

### Risk 

High
