### PR TITLE
fix(ProfileDialog): provide visual feedback when copying to clipboard

### DIFF
--- a/storybook/pages/StatusMenuPage.qml
+++ b/storybook/pages/StatusMenuPage.qml
@@ -211,3 +211,4 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
 }
 
 // category: Popups
+// status: good

--- a/ui/StatusQ/src/StatusQ/Popups/StatusSuccessAction.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusSuccessAction.qml
@@ -14,7 +14,7 @@ import StatusQ.Popups
    Success state is showed by changing action type to \c{Success}.
 
    \qml
-        StatusSuccessAction.qml {
+        StatusSuccessAction {
             text: qsTr("Copy details")
             successText: qsTr("Details copied")
         }
@@ -48,7 +48,7 @@ StatusMenuItem {
     property string successIconName: "tiny/checkmark"
     /*!
        \qmlproperty bool StatusSuccessAction::autoDismissMenu
-       This property enable menu closing on click.
+       This property enable menu closing on click after the \p timeout
     */
     property bool autoDismissMenu: false
     /*!

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -13256,6 +13256,10 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remove trusted mark</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -13333,6 +13333,10 @@ selhalo</translation>
         <translation>Kopírovat odkaz na profil</translation>
     </message>
     <message>
+        <source>Copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remove trusted mark</source>
         <translation>Odstranit značku důvěry</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -13271,6 +13271,10 @@ al cargar</translation>
         <translation>Copiar enlace al perfil</translation>
     </message>
     <message>
+        <source>Copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remove trusted mark</source>
         <translation>Eliminar marca de confianza</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -13210,6 +13210,10 @@ to load</source>
         <translation>프로필 링크 복사</translation>
     </message>
     <message>
+        <source>Copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remove trusted mark</source>
         <translation>신뢰 마크 제거</translation>
     </message>

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -313,8 +313,10 @@ Pane {
                         enabled: !d.isCurrentUser
                         onTriggered: Global.shareProfileDialogRequested(root.publicKey)
                     }
-                    StatusAction {
+                    StatusSuccessAction {
                         text: qsTr("Copy link to profile")
+                        successText: qsTr("Copied to clipboard")
+                        autoDismissMenu: true
                         icon.name: "copy"
                         onTriggered: ClipboardUtils.setText(d.linkToProfile)
                     }


### PR DESCRIPTION
### What does the PR do

- use `StatusSuccessAction` which provides the desired feedback

Fixes #20838

### Affected areas

ProfileDialog

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2870" height="2218" alt="image" src="https://github.com/user-attachments/assets/413c0f75-a84a-4756-a367-55137347a0b4" />


### Impact on end user

UX

### How to test

- open the Profile Dialog
- click the "Copy link to profile" menu item
- item changes to success state

### Risk 

low
