### PR TITLE
fix(CommunityColumnView): Persistent chat list context menu

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusLinkText.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusLinkText.qml
@@ -43,7 +43,7 @@ StatusBaseText {
     */
     readonly property alias containsMouse: textMouseArea.containsMouse
 
-    signal clicked()
+    signal clicked(var mouseEvent)
 
     maximumLineCount: 1
     elide: Text.ElideRight
@@ -57,6 +57,6 @@ StatusBaseText {
         anchors.fill: parent
         hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
-        onClicked: root.clicked()
+        onClicked: mouseEvent => root.clicked(mouseEvent)
     }
 }

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -149,54 +149,54 @@ Item {
             visible: !root.communitySectionModule.chatsLoaded
         }
 
-        StatusMenu {
-            id: adminPopupMenu
-            enabled: root.isSectionAdmin
-            hideDisabledItems: !showInviteButton
+        Component {
+            id: adminPopupMenuComp
+            StatusMenu {
+                hideDisabledItems: !showInviteButton
+                onClosed: destroy()
 
-            property bool showInviteButton: false
+                property bool showInviteButton
 
-            onClosed: adminPopupMenu.showInviteButton = false
+                StatusAction {
+                    objectName: "createCommunityChannelBtn"
+                    text: qsTr("Create channel")
+                    icon.name: "channel"
+                    onTriggered: Global.openPopup(createChannelPopup)
+                }
 
-            StatusAction {
-                objectName: "createCommunityChannelBtn"
-                text: qsTr("Create channel")
-                icon.name: "channel"
-                onTriggered: Global.openPopup(createChannelPopup)
-            }
+                // hidden as part of https://github.com/status-im/status-app/issues/17726
+                // StatusAction {
+                //     objectName: "importCommunityChannelBtn"
+                //     text: qsTr("Create channel via Discord import")
+                //     icon.name: "download"
+                //     enabled: !d.discordImportInProgress
+                //     onTriggered: {
+                //         Global.openPopup(createChannelPopup, {isDiscordImport: true, communityId: communityData.id})
+                //     }
+                // }
 
-            // hidden as part of https://github.com/status-im/status-app/issues/17726
-            // StatusAction {
-            //     objectName: "importCommunityChannelBtn"
-            //     text: qsTr("Create channel via Discord import")
-            //     icon.name: "download"
-            //     enabled: !d.discordImportInProgress
-            //     onTriggered: {
-            //         Global.openPopup(createChannelPopup, {isDiscordImport: true, communityId: communityData.id})
-            //     }
-            // }
+                StatusAction {
+                    objectName: "createCommunityCategoryBtn"
+                    text: qsTr("Create category")
+                    icon.name: "channel-category"
+                    onTriggered: Global.openPopup(createCategoryPopup)
+                }
 
-            StatusAction {
-                objectName: "createCommunityCategoryBtn"
-                text: qsTr("Create category")
-                icon.name: "channel-category"
-                onTriggered: Global.openPopup(createCategoryPopup)
-            }
+                StatusMenuSeparator {
+                    visible: invitePeopleBtn.enabled
+                }
 
-            StatusMenuSeparator {
-                visible: invitePeopleBtn.enabled
-            }
-
-            StatusAction {
-                id: invitePeopleBtn
-                text: qsTr("Invite people")
-                icon.name: "share-ios"
-                enabled: communityData.canManageUsers && adminPopupMenu.showInviteButton
-                objectName: "invitePeople"
-                onTriggered: {
-                    Global.openInviteFriendsToCommunityPopup(root.communityData,
-                                                             root.communitySectionModule,
-                                                             null)
+                StatusAction {
+                    id: invitePeopleBtn
+                    text: qsTr("Invite people")
+                    icon.name: "share-ios"
+                    enabled: communityData.canManageUsers && parent.showInviteButton
+                    objectName: "invitePeople"
+                    onTriggered: {
+                        Global.openInviteFriendsToCommunityPopup(root.communityData,
+                                                                 root.communitySectionModule,
+                                                                 null)
+                    }
                 }
             }
         }
@@ -258,45 +258,7 @@ Item {
 
                 onToggleCollapsedCommunityCategory: (categoryId, collapsed) => root.store.toggleCollapsedCommunityCategory(categoryId, collapsed)
 
-                popupMenu: StatusMenu {
-                    hideDisabledItems: false
-                    StatusAction {
-                        text: qsTr("Create channel")
-                        icon.name: "channel"
-                        enabled: root.isSectionAdmin
-                        onTriggered: Global.openPopup(createChannelPopup)
-                    }
-
-                    // hidden as part of https://github.com/status-im/status-app/issues/17726
-                    // StatusAction {
-                    //     objectName: "importCommunityChannelBtn"
-                    //     text: qsTr("Create channel via Discord import")
-                    //     icon.name: "download"
-                    //     enabled: !d.discordImportInProgress
-                    //     onTriggered: Global.openPopup(createChannelPopup, {isDiscordImport: true, communityId: root.communityData.id})
-                    // }
-
-                    StatusAction {
-                        text: qsTr("Create category")
-                        icon.name: "channel-category"
-                        enabled: root.isSectionAdmin
-                        onTriggered: Global.openPopup(createCategoryPopup)
-                    }
-
-                    StatusMenuSeparator {}
-
-                    StatusAction {
-                        text: qsTr("Invite people")
-                        icon.name: "share-ios"
-                        enabled: communityData.canManageUsers
-                        objectName: "invitePeople"
-                        onTriggered: {
-                            Global.openInviteFriendsToCommunityPopup(root.communityData,
-                                                                     root.communitySectionModule,
-                                                                     null)
-                        }
-                    }
-                }
+                popupMenu: adminPopupMenuComp
 
                 categoryPopupMenu: StatusMenu {
                     id: contextMenuCategory
@@ -485,38 +447,27 @@ Item {
 
             TapHandler {
                 enabled: root.isSectionAdmin
+                acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
                 acceptedButtons: Qt.RightButton
-                onTapped: function (eventPoint, button) {
-                    adminPopupMenu.showInviteButton = true
-                    adminPopupMenu.x = eventPoint.position.x + 4
-                    adminPopupMenu.y = eventPoint.position.y + 4
-                    adminPopupMenu.popup()
-                }
+                onTapped: adminPopupMenuComp.createObject(root, {showInviteButton: true}).popup()
             }
         }
 
         Loader {
             id: createChatOrCommunity
             Layout.alignment: Qt.AlignHCenter | Qt.AlignBottom
-            Layout.bottomMargin: Theme.padding
+            Layout.bottomMargin: Theme.bigPadding
             active: root.isSectionAdmin
             sourceComponent: Component {
                 StatusLinkText {
                     id: createChannelOrCategoryBtn
                     objectName: "createChannelOrCategoryBtn"
-                    height: visible ? implicitHeight : 0
+                    padding: Theme.halfPadding // enlarge the hitbox for easier touch handling
                     text: qsTr("Create channel or category")
                     font.underline: true
-
-                    StatusMouseArea {
-                        anchors.fill: parent
-                        cursorShape: Qt.PointingHandCursor
-                        onClicked: {
-                            adminPopupMenu.showInviteButton = false
-                            adminPopupMenu.popup()
-                            adminPopupMenu.y = Qt.binding(() => root.height - adminPopupMenu.height
-                                                          - createChannelOrCategoryBtn.height - 20)
-                        }
+                    onClicked: function(event) {
+                        const menu = adminPopupMenuComp.createObject(root)
+                        menu.popup(root.width/2 - menu.width/2, root.height - menu.height - createChannelOrCategoryBtn.height - 4)
                     }
                 }
             }


### PR DESCRIPTION
### What does the PR do

- deduplicate the context menu, wrap it in a Component, and create it on demand
- fix the right click handler to react to mouse events only
- fix `StatusLinkText` to emit the mouse event details too (needed for touch based event to position the menu properly)

Fixes #20938

### Affected areas

CommunityColumnView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Link:
<img width="2870" height="2218" alt="Snímek obrazovky z 2026-07-03 16-58-42" src="https://github.com/user-attachments/assets/24b94793-1943-473e-92e5-d195ad300549" />

RMB on empty space:
<img width="2870" height="2218" alt="image" src="https://github.com/user-attachments/assets/18da6be9-03f2-4418-a4d2-59e1a1f007ea" />

### Impact on end user

Better (mobile) UX

### How to test

- right click on empty space, or click/tap the "Create channel..." link to open the context menu
- the menu should open at the correct position, and close on clicking/tapping outside

### Risk 

low
