### PR TITLE
fix(AdvancedView): unbreak Chat scrolling switching

### DIFF
--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -494,9 +494,9 @@ SettingsContentBase {
             initialVelocity: root.advancedStore.scrollVelocity
             initialDeceleration: root.advancedStore.scrollDeceleration
             isCustomScrollingEnabled: root.advancedStore.isCustomScrollingEnabled
-            onVelocityChanged: root.advancedStore.setScrollVelocity(value)
-            onDecelerationChanged: root.advancedStore.setScrollDeceleration(value)
-            onCustomScrollingChanged: root.advancedStore.setCustomScrollingEnabled(enabled)
+            onVelocityChanged: value => root.advancedStore.setScrollVelocity(value)
+            onDecelerationChanged: value => root.advancedStore.setScrollDeceleration(value)
+            onCustomScrollingChanged: enabled => root.advancedStore.setCustomScrollingEnabled(enabled)
         }
 
         RPCStatsModal {

--- a/ui/app/AppLayouts/Profile/views/RPCStatsModal.qml
+++ b/ui/app/AppLayouts/Profile/views/RPCStatsModal.qml
@@ -53,10 +53,8 @@ StatusDialog {
         }
     }
 
-    ColumnLayout {
+    contentItem: ColumnLayout {
         id: contentColumn
-
-        anchors.fill: parent
 
         SearchBox {
             id: searchBox
@@ -77,6 +75,7 @@ StatusDialog {
             }
 
             header: StatusListItem {
+                width: ListView.view.width
                 title: qsTr("Total")
                 statusListItemTitle.customColor: Theme.palette.directColor1
                 statusListItemLabel.customColor: Theme.palette.directColor1
@@ -117,6 +116,7 @@ StatusDialog {
             }
 
             delegate: StatusListItem {
+                width: ListView.view.width
                 title: model.method
                 label: model.count
                 enabled: false

--- a/ui/app/AppLayouts/Profile/views/ScrollingModal.qml
+++ b/ui/app/AppLayouts/Profile/views/ScrollingModal.qml
@@ -17,8 +17,6 @@ import utils
 StatusDialog {
     id: root
 
-    destroyOnClose: false
-
     property bool isCustomScrollingEnabled: false
     property real initialVelocity
     property real initialDeceleration
@@ -27,9 +25,16 @@ StatusDialog {
     signal decelerationChanged(real value)
     signal customScrollingChanged(bool enabled)
 
-    footer.visible: false
+    footer: null
 
     implicitHeight: 610 // see contentColumn.height's comment
+
+    component CustomRadioSelector: StatusRadioButton {
+        Layout.fillWidth: true
+        implicitWidth: 448
+        LayoutMirroring.enabled: true
+        LayoutMirroring.childrenInherit: true
+    }
 
     ColumnLayout {
         id: contentColumn
@@ -42,26 +47,16 @@ StatusDialog {
 
         spacing: Theme.padding
 
-        ButtonGroup { id: scrollSettingsGroup }
-
-        RadioButtonSelector {
-            Layout.fillWidth: true
-            title: qsTr("System")
-            buttonGroup: scrollSettingsGroup
+        CustomRadioSelector {
+            text: qsTr("System")
             checked: !root.isCustomScrollingEnabled
-            onClicked: {
-                root.customScrollingChanged(false)
-            }
+            onToggled: root.customScrollingChanged(!checked)
         }
 
-        RadioButtonSelector {
-            Layout.fillWidth: true
-            title: qsTr("Custom")
-            buttonGroup: scrollSettingsGroup
+        CustomRadioSelector {
+            text: qsTr("Custom")
             checked: root.isCustomScrollingEnabled
-            onClicked: {
-                root.customScrollingChanged(true)
-            }
+            onToggled: root.customScrollingChanged(checked)
         }
 
         ColumnLayout {


### PR DESCRIPTION
### What does the PR do

- use a simple (inverted) `StatusRadioButton` in `ScrollingModal`
- also fix cutoff in RPCStatsModal; need to set the delegate widths

Fixes #20653

### Affected areas

Settings/Advanced

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Scrolling method:

https://github.com/user-attachments/assets/c2aca2b6-8a62-4e29-bbb6-c04808c8d3cc

RPC stats:

<img width="842" height="1738" alt="Snímek obrazovky z 2026-07-06 11-53-32" src="https://github.com/user-attachments/assets/e21cfc97-9d32-44a0-8f82-aa58dab7f3c0" />


### Impact on end user

Better UX

### How to test

- under Settings/Advanced, trying switching the "Chat scrolling" method by clicking either the whole item itself, or just the radio button selector on the right
- try opening the RPC stats dialog

### Risk 

low
