### PR TITLE
feat(SQ/StatusAdaptiveDialog): Introduce `StatusAdaptiveDialog` as the base for the dialog refactor. 

### DIFF
--- a/storybook/pages/CommunityRulesPopupPage.qml
+++ b/storybook/pages/CommunityRulesPopupPage.qml
@@ -1,0 +1,85 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import Storybook
+
+import StatusQ.Core.Theme
+
+import AppLayouts.Communities.popups
+
+SplitView {
+    id: root
+
+    Logs { id: logs }
+
+    readonly property string shortMessage: "Welcome to our community! Please read and follow the rules below."
+
+    readonly property string longMessage: "Welcome to our community! We're glad you're here.
+
+Please take a moment to read these rules carefully before participating.
+
+1. Be respectful. Treat all members with kindness and courtesy. Harassment, hate speech, or personal attacks of any kind will not be tolerated.
+
+2. Stay on topic. Keep discussions relevant to the community's focus. Off-topic content may be removed without notice.
+
+3. No spam or self-promotion. Do not post unsolicited advertisements, referral links, or repetitive messages.
+
+4. Protect privacy. Do not share personal information about yourself or others without explicit consent.
+
+5. Follow the law. Do not post content that is illegal in your jurisdiction or that violates the rights of others.
+
+6. Report issues. If you see behaviour that violates these rules, use the report function rather than engaging directly.
+
+Violations may result in a warning, temporary suspension, or permanent removal from the community at the discretion of the moderators."
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground { anchors.fill: parent }
+
+        CommunityRulesPopup {
+            visible: true
+            modal: false
+            closePolicy: Popup.NoAutoClose
+            parent: root.Overlay.overlay
+
+            name: communityName.text
+            introMessage: longMessageCheck.checked ? root.longMessage : root.shortMessage
+            image: ""
+            color: Theme.palette.primaryColor1
+
+            onClosed: logs.logEvent("CommunityRulesPopup::closed")
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.preferredWidth: 300
+        SplitView.fillHeight: true
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: Theme.halfPadding
+
+            Label { text: "Community name"; font.bold: true }
+
+            TextField {
+                id: communityName
+                Layout.fillWidth: true
+                text: "Status"
+            }
+
+            CheckBox {
+                id: longMessageCheck
+                text: "Long intro message (tests scroll)"
+                checked: true
+            }
+        }
+    }
+}
+
+// category: Popups
+// status: good

--- a/storybook/pages/ConfirmationDialogPage.qml
+++ b/storybook/pages/ConfirmationDialogPage.qml
@@ -1,0 +1,171 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import shared.popups
+
+import Storybook
+
+SplitView {
+    id: root
+
+    orientation: Qt.Horizontal
+
+    Logs {
+        id: logs
+    }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground {
+            anchors.fill: parent
+        }
+
+        Button {
+            anchors.centerIn: parent
+            text: "Reopen"
+            onClicked: popup.open()
+        }
+
+        ConfirmationDialog {
+            id: popup
+
+            modal: false
+            closeOnOverlayClick: closeOnOverlay.checked
+            escapeKeyCloses: escapeCloses.checked
+
+            headerSettings.title: titleInput.text
+            confirmationText: messageInput.text
+            confirmButtonLabel: confirmLabelInput.text
+            cancelButtonLabel: cancelLabelInput.text
+            showCancelButton: showCancel.checked
+            doNotShowAgainOptionVisible: doNotShowAgainVisible.checked
+            btnType: confirmDanger.checked ? "warn" : "normal"
+            cancelBtnType: cancelDanger.checked ? "warn" : "normal"
+
+            onConfirmButtonClicked: logs.logEvent("ConfirmationDialog::confirmButtonClicked doNotShowAgainChecked=" + doNotShowAgainChecked)
+            onCancelButtonClicked: logs.logEvent("ConfirmationDialog::cancelButtonClicked")
+            onClosed: logs.logEvent("ConfirmationDialog::closed")
+
+            Component.onCompleted: open()
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumWidth: 320
+        SplitView.preferredWidth: 360
+        SplitView.fillHeight: true
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            Layout.fillWidth: true
+
+            Label {
+                text: "Behavior"
+                font.bold: true
+            }
+
+            CheckBox {
+                id: closeOnOverlay
+
+                Layout.fillWidth: true
+                text: "Close on overlay click"
+                checked: true
+            }
+
+            CheckBox {
+                id: escapeCloses
+
+                Layout.fillWidth: true
+                text: "Close on Escape"
+                checked: true
+            }
+
+            CheckBox {
+                id: doNotShowAgainVisible
+
+                Layout.fillWidth: true
+                text: "Show do not show again"
+                checked: true
+            }
+
+            CheckBox {
+                id: showCancel
+
+                Layout.fillWidth: true
+                text: "Cancel button"
+                checked: true
+            }
+
+            Label {
+                text: "Content"
+                font.bold: true
+                Layout.topMargin: 12
+            }
+
+            TextField {
+                id: titleInput
+
+                Layout.fillWidth: true
+                text: "Confirm your action"
+                placeholderText: "Title"
+            }
+
+            TextArea {
+                id: messageInput
+
+                Layout.fillWidth: true
+                Layout.preferredHeight: 72
+                text: "Are you sure you want to do this?"
+                wrapMode: Text.WordWrap
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+
+                TextField {
+                    id: confirmLabelInput
+
+                    Layout.fillWidth: true
+                    text: "Confirm"
+                    placeholderText: "Confirm label"
+                }
+
+                TextField {
+                    id: cancelLabelInput
+
+                    Layout.fillWidth: true
+                    text: "Cancel"
+                    placeholderText: "Cancel label"
+                }
+            }
+
+            Label {
+                text: "Buttons"
+                font.bold: true
+                Layout.topMargin: 12
+            }
+
+            CheckBox {
+                id: confirmDanger
+
+                Layout.fillWidth: true
+                text: "Confirm danger"
+                checked: true
+            }
+
+            CheckBox {
+                id: cancelDanger
+
+                Layout.fillWidth: true
+                text: "Cancel danger"
+                checked: true
+            }
+        }
+    }
+}
+
+// category: Popups

--- a/storybook/pages/StatusAdaptiveDialogPage.qml
+++ b/storybook/pages/StatusAdaptiveDialogPage.qml
@@ -1,0 +1,537 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQml.Models
+
+import Storybook
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Components
+import StatusQ.Controls
+import StatusQ.Popups.Dialog
+
+import AppLayouts.Wallet.controls
+
+SplitView {
+    id: root
+
+    orientation: Qt.Horizontal
+
+    Logs {
+        id: logs
+    }
+
+    QtObject {
+        id: d
+
+        // Derived state used by the controls below to keep the dialog bindings compact.
+        readonly property bool longContent: contentMode.currentValue === "long"
+        readonly property bool dialogBottomSheet: dialog.width === root.width && dialog.y > root.height / 2
+
+        // Header presets: title/subtitle/image/action combinations can be mixed independently.
+        readonly property bool headerHasTitle: headerMode.currentValue !== "none"
+        readonly property bool headerHasSubtitle: headerMode.currentValue === "title-subtitle"
+                                             || headerMode.currentValue === "image-title-subtitle"
+        readonly property bool headerHasImage: headerMode.currentValue === "image-title"
+                                          || headerMode.currentValue === "image-title-subtitle"
+        readonly property bool headerHasCloseAction: headerActionsMode.currentValue === "close"
+                                                || headerActionsMode.currentValue === "both"
+                                                || headerActionsMode.currentValue === "close-custom"
+        readonly property bool headerHasInfoAction: headerActionsMode.currentValue === "info"
+                                               || headerActionsMode.currentValue === "both"
+        readonly property bool headerHasCustomActions: headerActionsMode.currentValue === "custom"
+                                                  || headerActionsMode.currentValue === "close-custom"
+        readonly property real controlsSectionSpacing: Math.max(Theme.halfPadding, 8)
+
+        // Footer presets: each mode resolves to the models consumed by StatusAdaptiveDialog.
+        readonly property var footerLeftModel: {
+            switch (footerButtonsMode.currentValue) {
+                case "back-done":
+                case "back-only":  return footerLeftButtonsModel
+                case "info-done":  return footerLeftInfoModel
+                default:           return null
+            }
+        }
+        readonly property var footerRightButtonsModel: {
+            switch (footerButtonsMode.currentValue) {
+                case "cancel-done": return footerRightButtonsCancelDoneModel
+                case "back-done":
+                case "info-done":
+                case "done-only":   return footerRightButtonsDoneModel
+                default:            return null
+            }
+        }
+        readonly property var footerErrorTagsModel: {
+            switch (footerErrorsMode.currentValue) {
+                case "one": return errorTagsOneModel
+                case "two": return errorTagsTwoModel
+                default: return null
+            }
+        }
+    }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground {
+            anchors.fill: parent
+
+            ColumnLayout {
+                anchors.centerIn: parent
+                width: Math.min(parent.width - 48, 420)
+                spacing: Theme.padding
+
+                StatusBaseText {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
+                    color: Theme.palette.baseColor1
+                    text: "Viewport: " + Math.round(root.width) + " x " + Math.round(root.height)
+                }
+
+                StatusButton {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: "Open adaptive dialog"
+                    onClicked: dialog.open()
+                }
+            }
+        }
+
+        StatusAdaptiveDialog {
+            id: dialog
+
+            // Presentation and behavior knobs.
+            maximumWidthOverride: customMaxWidth.checked ? maxWidthSlider.value : 0
+            maximumHeightOverride: heightCap.checked ? heightSlider.value : 0
+            closeOnOverlayClick: closeOnOverlay.checked
+            escapeKeyCloses: escapeCloses.checked
+            internalPopupComponent: internalPopupComponent
+
+            contentComponent: bodyComponent
+
+            // Header API: consumers configure data and actions, not the internal toolbar.
+            title: d.headerHasTitle ? "StatusAdaptiveDialog" : ""
+            subtitle: d.headerHasSubtitle ? (d.dialogBottomSheet ? "Bottom sheet" : "Centered") : ""
+            leftHeaderComponent: d.headerHasImage ? headerImageComponent : null
+            headerCustomButtons: d.headerHasCustomActions ? customActionsModel : null
+            headerActions.closeButton.visible: d.headerHasCloseAction
+            headerActions.infoButton.visible: d.headerHasInfoAction
+            headerActions.closeButton.onClicked: {
+                logs.logEvent("StatusAdaptiveDialog::closeButtonClicked")
+                dialog.close()
+            }
+            headerActions.infoButton.onClicked: {
+                logs.logEvent("StatusAdaptiveDialog::infoButtonClicked")
+                dialog.openInternalPopup()
+            }
+
+            // Footer API: left/right action groups and optional error tags.
+            footerLeftButtons: d.footerLeftModel
+            footerRightButtons: d.footerRightButtonsModel
+            errorTags: d.footerErrorTagsModel
+        }
+
+        // Extra header action used by the "custom" header action modes.
+        ObjectModel {
+            id: customActionsModel
+
+            StatusFlatRoundButton {
+                type: StatusFlatRoundButton.Type.Secondary
+                icon.name: "add"
+                icon.color: Theme.palette.directColor1
+                icon.width: 24
+                icon.height: 24
+                onClicked: {
+                    logs.logEvent("StatusAdaptiveDialog::customActionClicked")
+                    dialog.openInternalPopup()
+                }
+            }
+        }
+
+        Component {
+            id: bodyComponent
+
+            ColumnLayout {
+                spacing: Theme.halfPadding
+
+                Repeater {
+                    model: d.longContent ? 10 : 3
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        implicitHeight: index === 0 ? 88 : 52
+                        radius: 8
+                        color: index % 2 ? Theme.palette.baseColor5 : Theme.palette.baseColor4
+
+                        StatusBaseText {
+                            anchors.fill: parent
+                            anchors.margins: Theme.defaultPadding
+                            verticalAlignment: Text.AlignVCenter
+                            wrapMode: Text.WordWrap
+                            text: index === 0 ? "Base step: components, sizing and automatic presentation only." : "Content row " + index
+                        }
+                    }
+                }
+            }
+        }
+
+        Component {
+            id: headerImageComponent
+
+            // Mirrors the account/app icon style used by signing modals.
+            StatusSmartIdenticon {
+                asset.name: "filled-account"
+                asset.emoji: "S"
+                asset.color: Theme.palette.primaryColor1
+                asset.isLetterIdenticon: true
+                asset.bgWidth: 40
+                asset.bgHeight: 40
+
+                bridgeBadge.visible: true
+                bridgeBadge.border.width: 2
+                bridgeBadge.color: StatusColors.darkDesktopBlue10
+                bridgeBadge.image.source: Assets.svg("sign")
+            }
+        }
+
+        ObjectModel {
+            id: footerLeftButtonsModel
+
+            // Navigation-style left footer content.
+            StatusBackButton {
+                onClicked: {
+                    logs.logEvent("StatusAdaptiveDialog::backClicked")
+                    dialog.openInternalPopup()
+                }
+            }
+        }
+
+        ObjectModel {
+            id: footerLeftInfoModel
+
+            // Compact informational left footer content.
+            ColumnLayout {
+                Layout.alignment: Qt.AlignVCenter
+                spacing: 0
+
+                StatusBaseText {
+                    font.pixelSize: Theme.tertiaryTextFontSize
+                    color: Theme.palette.directColor5
+                    text: qsTr("Est. time")
+                }
+                StatusBaseText {
+                    font.pixelSize: Theme.primaryTextFontSize
+                    font.weight: Font.Medium
+                    color: Theme.palette.directColor1
+                    text: qsTr("~3 mins")
+                }
+            }
+
+            ColumnLayout {
+                Layout.alignment: Qt.AlignVCenter
+                spacing: 0
+
+                StatusBaseText {
+                    font.pixelSize: Theme.tertiaryTextFontSize
+                    color: Theme.palette.directColor5
+                    text: qsTr("Max fees")
+                }
+                StatusBaseText {
+                    font.pixelSize: Theme.primaryTextFontSize
+                    font.weight: Font.Medium
+                    color: Theme.palette.directColor1
+                    text: qsTr("$0.42")
+                }
+            }
+        }
+
+        // Right buttons vary by mode: "cancel-done" includes both, others just Done.
+        ObjectModel {
+            id: footerRightButtonsCancelDoneModel
+
+            StatusFlatButton {
+                text: qsTr("Cancel")
+                onClicked: dialog.close()
+            }
+
+            StatusButton {
+                text: qsTr("Done")
+                onClicked: {
+                    logs.logEvent("StatusAdaptiveDialog::doneClicked")
+                    dialog.close()
+                }
+            }
+        }
+
+        ObjectModel {
+            id: footerRightButtonsDoneModel
+
+            StatusButton {
+                text: qsTr("Done")
+                onClicked: {
+                    logs.logEvent("StatusAdaptiveDialog::doneClicked")
+                    dialog.close()
+                }
+            }
+        }
+
+        ObjectModel {
+            id: errorTagsOneModel
+
+            RouterErrorTag {
+                errorTitle: qsTr("Insufficient funds for send transaction")
+                buttonText: qsTr("Add ETH")
+                onButtonClicked: logs.logEvent("StatusAdaptiveDialog::errorTagButtonClicked")
+            }
+        }
+
+        ObjectModel {
+            id: errorTagsTwoModel
+
+            RouterErrorTag {
+                errorTitle: qsTr("Insufficient funds for send transaction")
+                buttonText: qsTr("Add ETH")
+                onButtonClicked: logs.logEvent("StatusAdaptiveDialog::errorTagButtonClicked")
+            }
+
+            RouterErrorTag {
+                errorTitle: qsTr("Not enough ETH to pay gas fees")
+                errorDetails: qsTr("This route requires more ETH than available in your wallet. Try a different route or add more ETH.")
+                buttonText: qsTr("Add ETH")
+                expandable: true
+                onButtonClicked: logs.logEvent("StatusAdaptiveDialog::errorTagButtonClicked")
+            }
+        }
+
+        Component {
+            id: internalPopupComponent
+
+            StatusAdaptiveDialog {
+                id: internalDialog
+
+                title: qsTr("Internal dialog")
+                subtitle: qsTr("This dialog is hosted inside the parent surface")
+                closeOnOverlayClick: false
+                escapeKeyCloses: true
+                contentComponent: Component {
+                    StatusBaseText {
+                        wrapMode: Text.WordWrap
+                        color: Theme.palette.directColor5
+                        text: qsTr("Lazy StatusAdaptiveDialog created and managed by the parent dialog's internal popup layer.")
+                    }
+                }
+                footerRightButtons: ObjectModel {
+                    StatusButton {
+                        text: qsTr("Close")
+                        onClicked: {
+                            logs.logEvent("StatusAdaptiveDialog::internalPopupCloseClicked")
+                            dialog.closeInternalPopup()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.preferredWidth: 320
+        SplitView.fillHeight: true
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            Layout.fillWidth: true
+
+            Label {
+                text: "Header"
+                font.bold: true
+            }
+
+            ComboBox {
+                id: headerMode
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    {
+                        text: "None",
+                        value: "none"
+                    },
+                    {
+                        text: "Title",
+                        value: "title"
+                    },
+                    {
+                        text: "Title + subtitle",
+                        value: "title-subtitle"
+                    },
+                    {
+                        text: "Image + title",
+                        value: "image-title"
+                    },
+                    {
+                        text: "Image + title + subtitle",
+                        value: "image-title-subtitle"
+                    }
+                ]
+                currentIndex: 2
+            }
+
+            ComboBox {
+                id: headerActionsMode
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    {
+                        text: "Close",
+                        value: "close"
+                    },
+                    {
+                        text: "Info",
+                        value: "info"
+                    },
+                    {
+                        text: "Close + info",
+                        value: "both"
+                    },
+                    {
+                        text: "Custom",
+                        value: "custom"
+                    },
+                    {
+                        text: "Close + custom",
+                        value: "close-custom"
+                    },
+                    {
+                        text: "None",
+                        value: "none"
+                    }
+                ]
+            }
+
+            Label {
+                text: "Footer"
+                font.bold: true
+                Layout.topMargin: d.controlsSectionSpacing
+            }
+
+            ComboBox {
+                id: footerButtonsMode
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Cancel + Done",    value: "cancel-done" },
+                    { text: "Back + Done",      value: "back-done" },
+                    { text: "Back only",        value: "back-only" },
+                    { text: "Info + Done",      value: "info-done" },
+                    { text: "Done only",        value: "done-only" },
+                    { text: "None",             value: "none" }
+                ]
+            }
+
+            ComboBox {
+                id: footerErrorsMode
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "No errors",           value: "none" },
+                    { text: "1 error",             value: "one" },
+                    { text: "2 errors (expandable)", value: "two" }
+                ]
+            }
+
+            Label {
+                text: "Content"
+                font.bold: true
+                Layout.topMargin: d.controlsSectionSpacing
+            }
+
+            ComboBox {
+                id: contentMode
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    {
+                        text: "Short content",
+                        value: "short"
+                    },
+                    {
+                        text: "Long content",
+                        value: "long"
+                    }
+                ]
+            }
+
+            Label {
+                text: "Sizing"
+                font.bold: true
+                Layout.topMargin: d.controlsSectionSpacing
+            }
+
+            Label {
+                text: "Max width override: " + (customMaxWidth.checked ? Math.round(maxWidthSlider.value) : "off")
+            }
+
+            CheckBox {
+                id: customMaxWidth
+                text: "Custom max width"
+            }
+
+            Slider {
+                id: maxWidthSlider
+                Layout.fillWidth: true
+                enabled: customMaxWidth.checked
+                from: 360
+                to: 720
+                stepSize: 20
+                value: 560
+            }
+
+            CheckBox {
+                id: heightCap
+                text: "Custom height cap"
+            }
+
+            Label {
+                text: "Height cap: " + Math.round(heightSlider.value)
+            }
+
+            Slider {
+                id: heightSlider
+                Layout.fillWidth: true
+                enabled: heightCap.checked
+                from: 220
+                to: 640
+                stepSize: 20
+                value: 420
+            }
+
+            Label {
+                text: "Mode: " + (d.dialogBottomSheet ? "bottom sheet" : "centered")
+            }
+
+            Label {
+                text: "Behavior"
+                font.bold: true
+                Layout.topMargin: d.controlsSectionSpacing
+            }
+
+            CheckBox {
+                id: closeOnOverlay
+                text: "Close on overlay click"
+                checked: true
+            }
+
+            CheckBox {
+                id: escapeCloses
+                text: "Escape closes"
+                checked: true
+            }
+        }
+    }
+}

--- a/storybook/pages/StatusAdaptiveDialogPage.qml
+++ b/storybook/pages/StatusAdaptiveDialogPage.qml
@@ -111,7 +111,7 @@ SplitView {
             id: dialog
 
             // Presentation and behavior knobs.
-            maximumWidthOverride: customMaxWidth.checked ? maxWidthSlider.value : 0
+            maximumWidthOverride: customMaxWidth.checked && !d.dialogBottomSheet ? maxWidthSlider.value : 0
             maximumHeightOverride: heightCap.checked ? heightSlider.value : 0
             closeOnOverlayClick: closeOnOverlay.checked
             escapeKeyCloses: escapeCloses.checked
@@ -599,18 +599,19 @@ SplitView {
                 }
 
                 Label {
-                    text: "Max width override: " + (customMaxWidth.checked ? Math.round(maxWidthSlider.value) : "off")
+                    text: "Max width override: " + (customMaxWidth.checked && !d.dialogBottomSheet ? Math.round(maxWidthSlider.value) : "off")
                 }
 
                 CheckBox {
                     id: customMaxWidth
                     text: "Custom max width"
+                    enabled: !d.dialogBottomSheet
                 }
 
                 Slider {
                     id: maxWidthSlider
                     Layout.fillWidth: true
-                    enabled: customMaxWidth.checked
+                    enabled: customMaxWidth.checked && !d.dialogBottomSheet
                     from: 360
                     to: 720
                     stepSize: 20

--- a/storybook/pages/StatusAdaptiveDialogPage.qml
+++ b/storybook/pages/StatusAdaptiveDialogPage.qml
@@ -27,7 +27,8 @@ SplitView {
 
         // Derived state used by the controls below to keep the dialog bindings compact.
         readonly property bool longContent: contentMode.currentValue === "long"
-        readonly property bool dialogBottomSheet: dialog.width === root.width && dialog.y > root.height / 2
+        readonly property var window: root.Window.window
+        readonly property bool dialogBottomSheet: !!window && dialog.width === window.width && dialog.y > window.height / 2
 
         // Header presets: title/subtitle/image/action combinations can be mixed independently.
         readonly property bool headerHasTitle: headerMode.currentValue !== "none"
@@ -43,7 +44,7 @@ SplitView {
         readonly property bool headerHasCustomActions: headerActionsMode.currentValue === "custom"
                                                   || headerActionsMode.currentValue === "close-custom"
         readonly property real controlsSectionSpacing: Math.max(Theme.halfPadding, 8)
-        readonly property var safeArea: dialog.contentItem ? dialog.contentItem.SafeArea : null
+        readonly property var safeArea: root.Overlay.overlay ? root.Overlay.overlay.SafeArea : null
         readonly property real artificialTopSafeArea: topSafeAreaEnabled.checked ? topSafeAreaSlider.value : 0
         readonly property real artificialBottomSafeArea: bottomSafeAreaEnabled.checked ? bottomSafeAreaSlider.value : 0
         readonly property real artificialLeftSafeArea: leftSafeAreaEnabled.checked ? leftSafeAreaSlider.value : 0
@@ -378,10 +379,7 @@ SplitView {
             sourceComponent: Component {
                 Item {
                     parent: root.Overlay.overlay
-                    x: dialog.x
-                    y: dialog.y
-                    width: dialog.width
-                    height: dialog.height
+                    anchors.fill: parent
                     z: 100
                     visible: dialog.opened
                     enabled: false

--- a/storybook/pages/StatusAdaptiveDialogPage.qml
+++ b/storybook/pages/StatusAdaptiveDialogPage.qml
@@ -43,6 +43,15 @@ SplitView {
         readonly property bool headerHasCustomActions: headerActionsMode.currentValue === "custom"
                                                   || headerActionsMode.currentValue === "close-custom"
         readonly property real controlsSectionSpacing: Math.max(Theme.halfPadding, 8)
+        readonly property var safeArea: dialog.contentItem ? dialog.contentItem.SafeArea : null
+        readonly property real artificialTopSafeArea: topSafeAreaEnabled.checked ? topSafeAreaSlider.value : 0
+        readonly property real artificialBottomSafeArea: bottomSafeAreaEnabled.checked ? bottomSafeAreaSlider.value : 0
+        readonly property real artificialLeftSafeArea: leftSafeAreaEnabled.checked ? leftSafeAreaSlider.value : 0
+        readonly property real artificialRightSafeArea: rightSafeAreaEnabled.checked ? rightSafeAreaSlider.value : 0
+        readonly property bool showSafeAreaOverlay: artificialTopSafeArea > 0
+                                                 || artificialBottomSafeArea > 0
+                                                 || artificialLeftSafeArea > 0
+                                                 || artificialRightSafeArea > 0
 
         // Footer presets: each mode resolves to the models consumed by StatusAdaptiveDialog.
         readonly property var footerLeftModel: {
@@ -332,6 +341,115 @@ SplitView {
                 }
             }
         }
+
+        Loader {
+            active: !!d.safeArea
+            sourceComponent: Component {
+                Item {
+                    Binding {
+                        target: d.safeArea
+                        property: "additionalMargins.top"
+                        value: d.artificialTopSafeArea
+                    }
+
+                    Binding {
+                        target: d.safeArea
+                        property: "additionalMargins.bottom"
+                        value: d.artificialBottomSafeArea
+                    }
+
+                    Binding {
+                        target: d.safeArea
+                        property: "additionalMargins.left"
+                        value: d.artificialLeftSafeArea
+                    }
+
+                    Binding {
+                        target: d.safeArea
+                        property: "additionalMargins.right"
+                        value: d.artificialRightSafeArea
+                    }
+                }
+            }
+        }
+
+        Loader {
+            active: d.showSafeAreaOverlay && !!d.safeArea
+            sourceComponent: Component {
+                Item {
+                    parent: root.Overlay.overlay
+                    x: dialog.x
+                    y: dialog.y
+                    width: dialog.width
+                    height: dialog.height
+                    z: 100
+                    visible: dialog.opened
+                    enabled: false
+
+                    Rectangle {
+                        anchors.top: parent.top
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        height: d.safeArea.margins.top
+                        visible: height > 0
+                        color: "#44FF0000"
+                        border.color: "red"
+
+                        Label {
+                            anchors.centerIn: parent
+                            text: "Header Safe Area"
+                        }
+                    }
+
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        height: d.safeArea.margins.bottom
+                        visible: height > 0
+                        color: "#44FF0000"
+                        border.color: "red"
+
+                        Label {
+                            anchors.centerIn: parent
+                            text: "Footer Safe Area"
+                        }
+                    }
+
+                    Rectangle {
+                        anchors.top: parent.top
+                        anchors.bottom: parent.bottom
+                        anchors.left: parent.left
+                        width: d.safeArea.margins.left
+                        visible: width > 0
+                        color: "#4400AAFF"
+                        border.color: "#0077CC"
+
+                        Label {
+                            anchors.centerIn: parent
+                            rotation: -90
+                            text: "Left Safe Area"
+                        }
+                    }
+
+                    Rectangle {
+                        anchors.top: parent.top
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        width: d.safeArea.margins.right
+                        visible: width > 0
+                        color: "#4400AAFF"
+                        border.color: "#0077CC"
+
+                        Label {
+                            anchors.centerIn: parent
+                            rotation: 90
+                            text: "Right Safe Area"
+                        }
+                    }
+                }
+            }
+        }
     }
 
     LogsAndControlsPanel {
@@ -340,197 +458,287 @@ SplitView {
 
         logsView.logText: logs.logText
 
-        ColumnLayout {
-            Layout.fillWidth: true
+        ScrollView {
+            id: controlsScrollView
 
-            Label {
-                text: "Header"
-                font.bold: true
-            }
+            anchors.fill: parent
+            clip: true
+            contentWidth: availableWidth
 
-            ComboBox {
-                id: headerMode
-                Layout.fillWidth: true
-                textRole: "text"
-                valueRole: "value"
-                model: [
-                    {
-                        text: "None",
-                        value: "none"
-                    },
-                    {
-                        text: "Title",
-                        value: "title"
-                    },
-                    {
-                        text: "Title + subtitle",
-                        value: "title-subtitle"
-                    },
-                    {
-                        text: "Image + title",
-                        value: "image-title"
-                    },
-                    {
-                        text: "Image + title + subtitle",
-                        value: "image-title-subtitle"
-                    }
-                ]
-                currentIndex: 2
-            }
+            ColumnLayout {
+                width: controlsScrollView.availableWidth
 
-            ComboBox {
-                id: headerActionsMode
-                Layout.fillWidth: true
-                textRole: "text"
-                valueRole: "value"
-                model: [
-                    {
-                        text: "Close",
-                        value: "close"
-                    },
-                    {
-                        text: "Info",
-                        value: "info"
-                    },
-                    {
-                        text: "Close + info",
-                        value: "both"
-                    },
-                    {
-                        text: "Custom",
-                        value: "custom"
-                    },
-                    {
-                        text: "Close + custom",
-                        value: "close-custom"
-                    },
-                    {
-                        text: "None",
-                        value: "none"
-                    }
-                ]
-            }
+                Label {
+                    text: "Header"
+                    font.bold: true
+                }
 
-            Label {
-                text: "Footer"
-                font.bold: true
-                Layout.topMargin: d.controlsSectionSpacing
-            }
+                ComboBox {
+                    id: headerMode
+                    Layout.fillWidth: true
+                    textRole: "text"
+                    valueRole: "value"
+                    model: [
+                        {
+                            text: "None",
+                            value: "none"
+                        },
+                        {
+                            text: "Title",
+                            value: "title"
+                        },
+                        {
+                            text: "Title + subtitle",
+                            value: "title-subtitle"
+                        },
+                        {
+                            text: "Image + title",
+                            value: "image-title"
+                        },
+                        {
+                            text: "Image + title + subtitle",
+                            value: "image-title-subtitle"
+                        }
+                    ]
+                    currentIndex: 2
+                }
 
-            ComboBox {
-                id: footerButtonsMode
-                Layout.fillWidth: true
-                textRole: "text"
-                valueRole: "value"
-                model: [
-                    { text: "Cancel + Done",    value: "cancel-done" },
-                    { text: "Back + Done",      value: "back-done" },
-                    { text: "Back only",        value: "back-only" },
-                    { text: "Info + Done",      value: "info-done" },
-                    { text: "Done only",        value: "done-only" },
-                    { text: "None",             value: "none" }
-                ]
-            }
+                ComboBox {
+                    id: headerActionsMode
+                    Layout.fillWidth: true
+                    textRole: "text"
+                    valueRole: "value"
+                    model: [
+                        {
+                            text: "Close",
+                            value: "close"
+                        },
+                        {
+                            text: "Info",
+                            value: "info"
+                        },
+                        {
+                            text: "Close + info",
+                            value: "both"
+                        },
+                        {
+                            text: "Custom",
+                            value: "custom"
+                        },
+                        {
+                            text: "Close + custom",
+                            value: "close-custom"
+                        },
+                        {
+                            text: "None",
+                            value: "none"
+                        }
+                    ]
+                }
 
-            ComboBox {
-                id: footerErrorsMode
-                Layout.fillWidth: true
-                textRole: "text"
-                valueRole: "value"
-                model: [
-                    { text: "No errors",           value: "none" },
-                    { text: "1 error",             value: "one" },
-                    { text: "2 errors (expandable)", value: "two" }
-                ]
-            }
+                Label {
+                    text: "Footer"
+                    font.bold: true
+                    Layout.topMargin: d.controlsSectionSpacing
+                }
 
-            Label {
-                text: "Content"
-                font.bold: true
-                Layout.topMargin: d.controlsSectionSpacing
-            }
+                ComboBox {
+                    id: footerButtonsMode
+                    Layout.fillWidth: true
+                    textRole: "text"
+                    valueRole: "value"
+                    model: [
+                        { text: "Cancel + Done",    value: "cancel-done" },
+                        { text: "Back + Done",      value: "back-done" },
+                        { text: "Back only",        value: "back-only" },
+                        { text: "Info + Done",      value: "info-done" },
+                        { text: "Done only",        value: "done-only" },
+                        { text: "None",             value: "none" }
+                    ]
+                }
 
-            ComboBox {
-                id: contentMode
-                Layout.fillWidth: true
-                textRole: "text"
-                valueRole: "value"
-                model: [
-                    {
-                        text: "Short content",
-                        value: "short"
-                    },
-                    {
-                        text: "Long content",
-                        value: "long"
-                    }
-                ]
-            }
+                ComboBox {
+                    id: footerErrorsMode
+                    Layout.fillWidth: true
+                    textRole: "text"
+                    valueRole: "value"
+                    model: [
+                        { text: "No errors",           value: "none" },
+                        { text: "1 error",             value: "one" },
+                        { text: "2 errors (expandable)", value: "two" }
+                    ]
+                }
 
-            Label {
-                text: "Sizing"
-                font.bold: true
-                Layout.topMargin: d.controlsSectionSpacing
-            }
+                Label {
+                    text: "Content"
+                    font.bold: true
+                    Layout.topMargin: d.controlsSectionSpacing
+                }
 
-            Label {
-                text: "Max width override: " + (customMaxWidth.checked ? Math.round(maxWidthSlider.value) : "off")
-            }
+                ComboBox {
+                    id: contentMode
+                    Layout.fillWidth: true
+                    textRole: "text"
+                    valueRole: "value"
+                    model: [
+                        {
+                            text: "Short content",
+                            value: "short"
+                        },
+                        {
+                            text: "Long content",
+                            value: "long"
+                        }
+                    ]
+                }
 
-            CheckBox {
-                id: customMaxWidth
-                text: "Custom max width"
-            }
+                Label {
+                    text: "Sizing"
+                    font.bold: true
+                    Layout.topMargin: d.controlsSectionSpacing
+                }
 
-            Slider {
-                id: maxWidthSlider
-                Layout.fillWidth: true
-                enabled: customMaxWidth.checked
-                from: 360
-                to: 720
-                stepSize: 20
-                value: 560
-            }
+                Label {
+                    text: "Max width override: " + (customMaxWidth.checked ? Math.round(maxWidthSlider.value) : "off")
+                }
 
-            CheckBox {
-                id: heightCap
-                text: "Custom height cap"
-            }
+                CheckBox {
+                    id: customMaxWidth
+                    text: "Custom max width"
+                }
 
-            Label {
-                text: "Height cap: " + Math.round(heightSlider.value)
-            }
+                Slider {
+                    id: maxWidthSlider
+                    Layout.fillWidth: true
+                    enabled: customMaxWidth.checked
+                    from: 360
+                    to: 720
+                    stepSize: 20
+                    value: 560
+                }
 
-            Slider {
-                id: heightSlider
-                Layout.fillWidth: true
-                enabled: heightCap.checked
-                from: 220
-                to: 640
-                stepSize: 20
-                value: 420
-            }
+                CheckBox {
+                    id: heightCap
+                    text: "Custom height cap"
+                }
 
-            Label {
-                text: "Mode: " + (d.dialogBottomSheet ? "bottom sheet" : "centered")
-            }
+                Label {
+                    text: "Height cap: " + Math.round(heightSlider.value)
+                }
 
-            Label {
-                text: "Behavior"
-                font.bold: true
-                Layout.topMargin: d.controlsSectionSpacing
-            }
+                Slider {
+                    id: heightSlider
+                    Layout.fillWidth: true
+                    enabled: heightCap.checked
+                    from: 220
+                    to: 640
+                    stepSize: 20
+                    value: 420
+                }
 
-            CheckBox {
-                id: closeOnOverlay
-                text: "Close on overlay click"
-                checked: true
-            }
+                Label {
+                    text: "Mode: " + (d.dialogBottomSheet ? "bottom sheet" : "centered")
+                }
 
-            CheckBox {
-                id: escapeCloses
-                text: "Escape closes"
-                checked: true
+                Label {
+                    text: "Behavior"
+                    font.bold: true
+                    Layout.topMargin: d.controlsSectionSpacing
+                }
+
+                CheckBox {
+                    id: closeOnOverlay
+                    text: "Close on overlay click"
+                    checked: true
+                }
+
+                CheckBox {
+                    id: escapeCloses
+                    text: "Escape closes"
+                    checked: true
+                }
+
+                Label {
+                    text: "Safe area"
+                    font.bold: true
+                    Layout.topMargin: d.controlsSectionSpacing
+                }
+
+                CheckBox {
+                    id: topSafeAreaEnabled
+                    text: "Top safe area"
+                }
+
+                Label {
+                    text: "Top: " + Math.round(topSafeAreaSlider.value)
+                }
+
+                Slider {
+                    id: topSafeAreaSlider
+                    Layout.fillWidth: true
+                    enabled: topSafeAreaEnabled.checked
+                    from: 0
+                    to: 160
+                    stepSize: 10
+                    value: 60
+                }
+
+                CheckBox {
+                    id: bottomSafeAreaEnabled
+                    text: "Bottom safe area"
+                }
+
+                Label {
+                    text: "Bottom: " + Math.round(bottomSafeAreaSlider.value)
+                }
+
+                Slider {
+                    id: bottomSafeAreaSlider
+                    Layout.fillWidth: true
+                    enabled: bottomSafeAreaEnabled.checked
+                    from: 0
+                    to: 160
+                    stepSize: 10
+                    value: 60
+                }
+
+                CheckBox {
+                    id: leftSafeAreaEnabled
+                    text: "Left safe area"
+                }
+
+                Label {
+                    text: "Left: " + Math.round(leftSafeAreaSlider.value)
+                }
+
+                Slider {
+                    id: leftSafeAreaSlider
+                    Layout.fillWidth: true
+                    enabled: leftSafeAreaEnabled.checked
+                    from: 0
+                    to: 120
+                    stepSize: 10
+                    value: 40
+                }
+
+                CheckBox {
+                    id: rightSafeAreaEnabled
+                    text: "Right safe area"
+                }
+
+                Label {
+                    text: "Right: " + Math.round(rightSafeAreaSlider.value)
+                }
+
+                Slider {
+                    id: rightSafeAreaSlider
+                    Layout.fillWidth: true
+                    enabled: rightSafeAreaEnabled.checked
+                    from: 0
+                    to: 120
+                    stepSize: 10
+                    value: 40
+                }
             }
         }
     }

--- a/storybook/pages/TokenListPopupPage.qml
+++ b/storybook/pages/TokenListPopupPage.qml
@@ -54,7 +54,7 @@ SplitView {
                     filters: ValueFilter {
                         id: keyFilter
 
-                        roleName: "key"
+                        roleName: "id"
                         value : uniswapBtn.checked ? "uniswap" : "status"
                     }
                 }
@@ -63,23 +63,22 @@ SplitView {
                     id: delegate
 
                     required property string name
-                    required property string image
+                    required property string logoUri
                     required property string source
                     required property string version
-                    required property double updatedAt
+                    required property double timestamp
 
                     readonly property TokenListPopup popup: TokenListPopup {
-                        parent: root
-
+                        parent: root.Overlay.overlay
                         visible: true
                         modal: false
                         closePolicy: Popup.NoAutoClose
 
                         title: qsTr("%1 Token List").arg(delegate.name)
-                        sourceImage: delegate.image
+                        sourceImage: delegate.logoUri
                         sourceUrl: delegate.source
                         sourceVersion: delegate.version
-                        updatedAt: delegate.updatedAt
+                        updatedAt: delegate.timestamp
 
                         tokensListModel: SortFilterProxyModel {
                             sourceModel: root.tokensProxyModel

--- a/storybook/qmlTests/tests/tst_CommunityRulesPopup.qml
+++ b/storybook/qmlTests/tests/tst_CommunityRulesPopup.qml
@@ -1,0 +1,72 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Communities.popups
+
+Item {
+    id: root
+
+    width: 1024
+    height: 768
+
+    Component {
+        id: componentUnderTest
+
+        CommunityRulesPopup {
+            destroyOnClose: false
+            name: "Status"
+            introMessage: "Welcome to the Status community."
+            image: ""
+            color: "#887af9"
+        }
+    }
+
+    property CommunityRulesPopup controlUnderTest: null
+
+    TestCase {
+        name: "CommunityRulesPopup"
+        when: windowShown
+
+        function init() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root);
+        }
+
+        function cleanup() {
+            if (controlUnderTest) {
+                controlUnderTest.close();
+                controlUnderTest.destroy();
+                controlUnderTest = null;
+            }
+        }
+
+        function openDialog() {
+            verify(!!controlUnderTest);
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+        }
+
+        function test_title_contains_community_name() {
+            openDialog();
+            verify(controlUnderTest.title.includes("Status"));
+        }
+
+        function test_done_button_closes_dialog() {
+            openDialog();
+
+            const doneButton = findChild(controlUnderTest, "communityRulesPopupDoneButton");
+            verify(!!doneButton);
+
+            mouseClick(doneButton);
+
+            tryCompare(controlUnderTest, "opened", false);
+        }
+
+        function test_content_host_is_present() {
+            openDialog();
+
+            const contentHost = findChild(controlUnderTest, "statusAdaptiveDialogContentHost");
+            verify(!!contentHost);
+            verify(contentHost.visible);
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_ConfirmationDialog.qml
+++ b/storybook/qmlTests/tests/tst_ConfirmationDialog.qml
@@ -1,0 +1,129 @@
+import QtQuick
+import QtTest
+
+import shared.popups
+
+Item {
+    id: root
+
+    width: 1024
+    height: 768
+
+    Component {
+        id: componentUnderTest
+
+        ConfirmationDialog {
+            confirmButtonObjectName: "confirmationDialogConfirmButton"
+            confirmationText: "Confirm the real flow"
+            confirmButtonLabel: "Confirm"
+            showCancelButton: true
+        }
+    }
+
+    Component {
+        id: deleteMessageComponentUnderTest
+
+        DeleteMessageConfirmationPopup {
+            messageId: "test-message-id"
+        }
+    }
+
+    property ConfirmationDialog controlUnderTest: null
+
+    SignalSpy {
+        id: confirmSpy
+        target: controlUnderTest
+        signalName: "confirmButtonClicked"
+    }
+
+    SignalSpy {
+        id: cancelSpy
+        target: controlUnderTest
+        signalName: "cancelButtonClicked"
+    }
+
+    TestCase {
+        name: "ConfirmationDialog"
+        when: windowShown
+
+        function init() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root);
+            confirmSpy.clear();
+            cancelSpy.clear();
+        }
+
+        function cleanup() {
+            if (controlUnderTest) {
+                controlUnderTest.close();
+                controlUnderTest.destroy();
+                controlUnderTest = null;
+            }
+            confirmSpy.clear();
+            cancelSpy.clear();
+        }
+
+        function openDialog() {
+            verify(!!controlUnderTest);
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+        }
+
+        function test_do_not_show_again_option_updates_state() {
+            compare(controlUnderTest.doNotShowAgainOptionVisible, false);
+            compare(controlUnderTest.doNotShowAgainChecked, false);
+
+            controlUnderTest.doNotShowAgainOptionVisible = true;
+            controlUnderTest.doNotShowAgainChecked = true;
+            openDialog();
+
+            const checkbox = findChild(controlUnderTest, "confirmationDialogDoNotShowAgainCheckBox");
+            verify(!!checkbox);
+            compare(checkbox.checked, true);
+
+            mouseClick(checkbox);
+
+            compare(controlUnderTest.doNotShowAgainChecked, false);
+        }
+
+        function test_confirm_button_emits_signal() {
+            openDialog();
+
+            const confirmButton = findChild(controlUnderTest, "confirmationDialogConfirmButton");
+            verify(!!confirmButton);
+
+            mouseClick(confirmButton);
+
+            compare(confirmSpy.count, 1);
+            compare(cancelSpy.count, 0);
+        }
+
+        function test_cancel_button_emits_signal() {
+            openDialog();
+
+            const cancelButton = findChild(controlUnderTest, "confirmationDialogCancelButton");
+            verify(!!cancelButton);
+
+            mouseClick(cancelButton);
+
+            compare(cancelSpy.count, 1);
+            compare(confirmSpy.count, 0);
+        }
+
+        function test_delete_message_confirmation_does_not_scroll_when_content_fits() {
+            const popup = createTemporaryObject(deleteMessageComponentUnderTest, root);
+            verify(!!popup);
+
+            popup.open();
+            tryCompare(popup, "opened", true);
+
+            const scrollFlickable = findChild(popup, "statusAdaptiveDialogScrollFlickable");
+            const scrollBar = findChild(popup, "statusAdaptiveDialogContentScrollBar");
+            verify(!!scrollFlickable);
+            verify(!!scrollBar);
+            verify(scrollFlickable.contentHeight <= scrollFlickable.height);
+            verify(!scrollBar.visible);
+
+            popup.close();
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
+++ b/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
@@ -476,6 +476,26 @@ Item {
             verify(contentScrollBar.x >= contentViewport.x + contentViewport.width);
         }
 
+        function test_content_scrollbar_drag_updates_content_position() {
+            controlUnderTest.destroy();
+            controlUnderTest = createTemporaryObject(tallRegularContentDialogComponent, testWindow.contentItem);
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            const scrollFlickable = findChild(controlUnderTest, "statusAdaptiveDialogScrollFlickable");
+            const contentScrollBar = findChild(controlUnderTest, "statusAdaptiveDialogContentScrollBar");
+            verify(!!scrollFlickable);
+            verify(!!contentScrollBar);
+            verify(contentScrollBar.visible);
+
+            const initialContentY = scrollFlickable.contentY;
+            mousePress(contentScrollBar, contentScrollBar.width / 2, 8);
+            mouseMove(contentScrollBar, contentScrollBar.width / 2, contentScrollBar.height / 2);
+            mouseRelease(contentScrollBar, contentScrollBar.width / 2, contentScrollBar.height / 2);
+
+            verify(scrollFlickable.contentY > initialContentY);
+        }
+
         function test_flickable_content_is_not_wrapped() {
             controlUnderTest.destroy();
             controlUnderTest = createTemporaryObject(flickableContentDialogComponent, testWindow.contentItem);

--- a/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
+++ b/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
@@ -433,6 +433,22 @@ Item {
             compare(controlUnderTest.modal, false);
         }
 
+        function test_destroy_on_close_destroys_dialog() {
+            const marker = createTemporaryQmlObject("import QtQuick; QtObject { property bool wasDestroyed: false }", root);
+
+            controlUnderTest.destroy();
+            controlUnderTest = createTemporaryObject(destroyOnCloseDialogComponent, root, {
+                "marker": marker
+            });
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            controlUnderTest.close();
+
+            tryCompare(marker, "wasDestroyed", true);
+            controlUnderTest = null;
+        }
+
         function test_regular_content_uses_internal_scroll_viewport() {
             controlUnderTest.destroy();
             controlUnderTest = createTemporaryObject(tallRegularContentDialogComponent, testWindow.contentItem);

--- a/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
+++ b/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
@@ -458,12 +458,21 @@ Item {
             const contentViewport = findChild(controlUnderTest, "statusAdaptiveDialogContentViewport");
             const scrollFlickable = findChild(controlUnderTest, "statusAdaptiveDialogScrollFlickable");
             const contentScrollBar = findChild(controlUnderTest, "statusAdaptiveDialogContentScrollBar");
+            const headerDivider = findChild(controlUnderTest, "statusAdaptiveDialogHeaderDivider");
+            const footerDivider = findChild(controlUnderTest, "statusAdaptiveDialogFooterDivider");
             verify(!!contentViewport);
             verify(!!scrollFlickable);
             verify(!!contentScrollBar);
+            verify(!!headerDivider);
+            verify(!!footerDivider);
             verify(scrollFlickable.visible);
             verify(scrollFlickable.enabled);
             verify(scrollFlickable.contentHeight > scrollFlickable.height);
+            compare(contentViewport.mapToItem(null, 0, 0).y,
+                    headerDivider.mapToItem(null, 0, headerDivider.height).y);
+            compare(contentViewport.mapToItem(null, 0, contentViewport.height).y,
+                    footerDivider.mapToItem(null, 0, 0).y);
+            compare(scrollFlickable.topMargin, Math.max(Theme.padding, 8));
             verify(contentScrollBar.x >= contentViewport.x + contentViewport.width);
         }
 
@@ -482,6 +491,7 @@ Item {
             compare(flickableContent.parent, contentViewport);
             compare(scrollFlickable.visible, false);
             verify(flickableContent.height <= contentViewport.height);
+            compare(flickableContent.topMargin, Math.max(Theme.padding, 8));
         }
 
     }

--- a/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
+++ b/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
@@ -448,6 +448,19 @@ Item {
             verify(controlUnderTest.y >= 0);
         }
 
+        function test_bottom_sheet_ignores_maximum_width_override() {
+            setTestWindowSize(d.mobileWindowWidth, d.mobileWindowHeight);
+            controlUnderTest.destroy();
+            controlUnderTest = createTemporaryObject(dialogComponent, testWindow.contentItem);
+
+            controlUnderTest.maximumWidthOverride = 240;
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            compare(controlUnderTest.width, d.mobileWindowWidth);
+            compare(controlUnderTest.x, 0);
+        }
+
         function test_safe_area_is_reserved_in_centered_mode() {
             controlUnderTest.open();
             tryCompare(controlUnderTest, "opened", true);

--- a/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
+++ b/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
@@ -245,6 +245,30 @@ Item {
             compare(popupLayer.popupObject.y, popupLayer.height - popupLayer.popupObject.height);
         }
 
+        function setDialogSafeArea(top, bottom, left, right) {
+            controlUnderTest.contentItem.SafeArea.additionalMargins.top = top;
+            controlUnderTest.contentItem.SafeArea.additionalMargins.bottom = bottom;
+            controlUnderTest.contentItem.SafeArea.additionalMargins.left = left;
+            controlUnderTest.contentItem.SafeArea.additionalMargins.right = right;
+        }
+
+        function verifyDialogSafeAreaLayout(top, bottom, left, right) {
+            const edgePadding = Math.max(Theme.padding, 8);
+            const header = findChild(controlUnderTest, "statusAdaptiveDialogHeader");
+            const footer = findChild(controlUnderTest, "statusAdaptiveDialogFooter");
+            verify(!!header);
+            verify(!!footer);
+
+            tryCompare(header, "x", edgePadding + left);
+            compare(header.y, edgePadding + top);
+            compare(header.width, controlUnderTest.width - 2 * edgePadding - left - right);
+
+            tryCompare(footer, "x", edgePadding + left);
+            compare(footer.width, controlUnderTest.width - 2 * edgePadding - left - right);
+            compare(footer.mapToItem(null, 0, footer.height).y,
+                    controlUnderTest.y + controlUnderTest.height - edgePadding - bottom);
+        }
+
         function test_centered_on_desktop() {
             controlUnderTest.open();
             tryCompare(controlUnderTest, "opened", true);
@@ -422,6 +446,25 @@ Item {
             compare(controlUnderTest.width, d.mobileWindowWidth);
             compare(controlUnderTest.x, 0);
             verify(controlUnderTest.y >= 0);
+        }
+
+        function test_safe_area_is_reserved_in_centered_mode() {
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            setDialogSafeArea(60, 60, 40, 30);
+            verifyDialogSafeAreaLayout(60, 60, 40, 30);
+        }
+
+        function test_safe_area_is_reserved_in_bottom_sheet_mode() {
+            setTestWindowSize(d.mobileWindowWidth, d.mobileWindowHeight);
+            controlUnderTest.destroy();
+            controlUnderTest = createTemporaryObject(adaptiveWidthDialogComponent, testWindow.contentItem);
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            setDialogSafeArea(60, 60, 40, 30);
+            verifyDialogSafeAreaLayout(60, 60, 40, 30);
         }
 
         function test_modal_can_be_overridden_from_outside() {

--- a/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
+++ b/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
@@ -1,0 +1,478 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Window
+import QtQml.Models
+import QtTest
+
+import StatusQ.Core.Theme
+import StatusQ.Controls
+import StatusQ.Popups.Dialog
+
+Item {
+    id: root
+
+    width: d.desktopWindowWidth
+    height: d.desktopWindowHeight
+
+    Window {
+        id: testWindow
+
+        width: d.desktopWindowWidth
+        height: d.desktopWindowHeight
+        visible: true
+    }
+
+    Component {
+        id: dialogComponent
+
+        StatusAdaptiveDialog {
+            objectName: "defaultDialog"
+            title: "Default dialog"
+            maximumWidthOverride: 420
+            contentComponent: Component {
+                Item {
+                    implicitHeight: 120
+                }
+            }
+            footerRightButtons: ObjectModel {
+                StatusButton {
+                    text: "Done"
+                }
+            }
+        }
+    }
+
+    Component {
+        id: modalOverrideDialogComponent
+
+        StatusAdaptiveDialog {
+            objectName: "modalOverrideDialog"
+            modal: false
+            contentComponent: Component {
+                Item {
+                    implicitHeight: 80
+                }
+            }
+        }
+    }
+
+    Component {
+        id: adaptiveWidthDialogComponent
+
+        StatusAdaptiveDialog {
+            objectName: "adaptiveWidthDialog"
+            title: "Adaptive width dialog"
+            contentComponent: Component {
+                Item {
+                    implicitHeight: 120
+                }
+            }
+            footerRightButtons: ObjectModel {
+                StatusButton {
+                    text: "Done"
+                }
+            }
+        }
+    }
+
+    Component {
+        id: destroyOnCloseDialogComponent
+
+        StatusAdaptiveDialog {
+            property QtObject marker
+
+            destroyOnClose: true
+            contentComponent: Component {
+                Item {
+                    implicitHeight: 80
+                }
+            }
+
+            Component.onDestruction: marker.wasDestroyed = true
+        }
+    }
+
+    Component {
+        id: tallRegularContentDialogComponent
+
+        StatusAdaptiveDialog {
+            maximumWidthOverride: 420
+            maximumHeightOverride: 260
+            title: "Tall content"
+            contentComponent: Component {
+                Item {
+                    objectName: "regularContent"
+                    implicitHeight: 600
+                }
+            }
+            footerRightButtons: ObjectModel {
+                StatusButton {
+                    text: "Done"
+                }
+            }
+        }
+    }
+
+    Component {
+        id: flickableContentDialogComponent
+
+        StatusAdaptiveDialog {
+            maximumWidthOverride: 420
+            maximumHeightOverride: 260
+            contentComponent: Component {
+                ListView {
+                    objectName: "flickableContent"
+                    implicitHeight: contentHeight
+                    model: 30
+                    delegate: Item {
+                        width: ListView.view.width
+                        height: 40
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: internalPopupComponent
+
+        StatusAdaptiveDialog {
+            objectName: "internalPopupContent"
+            maximumWidthOverride: 240
+            contentComponent: Component {
+                Item {
+                    implicitHeight: 120
+                }
+            }
+        }
+    }
+
+    Component {
+        id: tallInternalPopupComponent
+
+        StatusAdaptiveDialog {
+            objectName: "tallInternalPopupContent"
+            maximumWidthOverride: 240
+            contentComponent: Component {
+                Item {
+                    implicitHeight: 600
+                }
+            }
+        }
+    }
+
+    Component {
+        id: internalAdaptiveDialogComponent
+
+        StatusAdaptiveDialog {
+            objectName: "internalAdaptiveDialog"
+            title: "Internal dialog"
+            maximumWidthOverride: 240
+            contentComponent: Component {
+                Item {
+                    implicitHeight: 600
+                }
+            }
+        }
+    }
+
+    QtObject {
+        id: d
+
+        readonly property int desktopWindowWidth: ThemeUtils.portraitBreakpoint.width + 240
+        readonly property int desktopWindowHeight: ThemeUtils.portraitBreakpoint.height + 240
+        readonly property int mobileWindowWidth: ThemeUtils.portraitBreakpoint.width - 220
+        readonly property int mobileWindowHeight: ThemeUtils.portraitBreakpoint.height + 260
+    }
+
+    property StatusAdaptiveDialog controlUnderTest: null
+
+    TestCase {
+        name: "StatusAdaptiveDialog"
+        when: windowShown
+
+        function init() {
+            setTestWindowSize(d.desktopWindowWidth, d.desktopWindowHeight);
+            controlUnderTest = createTemporaryObject(dialogComponent, testWindow.contentItem);
+        }
+
+        function cleanup() {
+            if (controlUnderTest) {
+                controlUnderTest.close();
+                controlUnderTest.destroy();
+                controlUnderTest = null;
+            }
+            root.width = d.desktopWindowWidth;
+            root.height = d.desktopWindowHeight;
+            setTestWindowSize(d.desktopWindowWidth, d.desktopWindowHeight);
+        }
+
+        function setTestWindowSize(width, height) {
+            testWindow.width = width;
+            testWindow.height = height;
+            tryCompare(testWindow, "width", width);
+            tryCompare(testWindow, "height", height);
+            root.width = width;
+            root.height = height;
+        }
+
+        function findInternalPopupLayer() {
+            const popupLayer = findChild(controlUnderTest.Overlay.overlay, "statusAdaptiveDialogInternalPopupLayer");
+            verify(!!popupLayer);
+            return popupLayer;
+        }
+
+        function findInternalOverlay() {
+            const overlay = findChild(controlUnderTest.Overlay.overlay, "statusAdaptiveDialogInternalOverlay");
+            verify(!!overlay);
+            return overlay;
+        }
+
+        function verifyInternalLayerMatchesParent(popupLayer, overlay) {
+            tryCompare(popupLayer, "x", controlUnderTest.x);
+            tryCompare(popupLayer, "y", controlUnderTest.y);
+            tryCompare(popupLayer, "width", controlUnderTest.width);
+            tryCompare(popupLayer, "height", controlUnderTest.height);
+            compare(overlay.width, popupLayer.width);
+            compare(overlay.height, popupLayer.height);
+        }
+
+        function verifyInternalDialogBottomAligned(popupLayer) {
+            verify(!!popupLayer.popupObject);
+            tryCompare(popupLayer.popupObject, "opened", true);
+            tryCompare(popupLayer.popupObject, "width", popupLayer.width);
+            compare(popupLayer.popupObject.x, 0);
+            compare(popupLayer.popupObject.y, popupLayer.height - popupLayer.popupObject.height);
+        }
+
+        function test_centered_on_desktop() {
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            compare(controlUnderTest.width, 420);
+            verify(controlUnderTest.height > 0);
+            verify(controlUnderTest.x > 0);
+            verify(controlUnderTest.y > 0);
+        }
+
+        function test_default_header_uses_toolbar_with_parent_divider() {
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            const toolbar = findChild(controlUnderTest, "statusAdaptiveDialogHeader");
+            verify(!!toolbar);
+            compare(toolbar.objectName, "statusAdaptiveDialogHeader");
+            compare(controlUnderTest.title, "Default dialog");
+            const edgePadding = Math.max(Theme.padding, 8);
+            compare(toolbar.x, edgePadding);
+            compare(toolbar.y, edgePadding);
+            compare(toolbar.width, controlUnderTest.width - 2 * edgePadding);
+
+            const divider = findChild(controlUnderTest, "statusAdaptiveDialogHeaderDivider");
+            verify(!!divider);
+            tryCompare(divider, "visible", true);
+            compare(divider.height, 1);
+            compare(divider.width, controlUnderTest.width);
+            compare(divider.y, toolbar.height + 2 * edgePadding);
+        }
+
+        function test_default_footer_uses_toolbar_with_parent_divider() {
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            const toolbar = findChild(controlUnderTest, "statusAdaptiveDialogFooter");
+            verify(!!toolbar);
+            compare(toolbar.objectName, "statusAdaptiveDialogFooter");
+            const edgePadding = Math.max(Theme.padding, 8);
+            compare(toolbar.x, edgePadding);
+            compare(toolbar.width, controlUnderTest.width - 2 * edgePadding);
+
+            const divider = findChild(controlUnderTest, "statusAdaptiveDialogFooterDivider");
+            verify(!!divider);
+            tryCompare(divider, "visible", true);
+            compare(divider.height, 1);
+            compare(divider.width, controlUnderTest.width);
+        }
+
+        function test_internal_popup_opens_in_parent_overlay_and_closes_from_overlay() {
+            controlUnderTest.internalPopupComponent = internalPopupComponent;
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            controlUnderTest.openInternalPopup();
+
+            const popupLayer = findInternalPopupLayer();
+            const overlay = findInternalOverlay();
+            tryCompare(controlUnderTest, "internalPopupActive", true);
+            tryCompare(popupLayer, "visible", true);
+            verify(!!popupLayer.popupObject);
+            compare(popupLayer.popupObject.objectName, "internalPopupContent");
+            tryCompare(popupLayer.popupObject, "opened", true);
+            verifyInternalLayerMatchesParent(popupLayer, overlay);
+
+            mouseClick(overlay, overlay.width / 2, Theme.padding);
+
+            tryCompare(controlUnderTest, "internalPopupActive", false);
+            verify(!popupLayer.popupObject);
+        }
+
+        function test_internal_popup_is_reset_when_parent_dialog_closes() {
+            controlUnderTest.internalPopupComponent = internalPopupComponent;
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            controlUnderTest.openInternalPopup();
+            tryCompare(controlUnderTest, "internalPopupActive", true);
+
+            controlUnderTest.close();
+
+            tryCompare(controlUnderTest, "opened", false);
+            tryCompare(controlUnderTest, "internalPopupActive", false);
+        }
+
+        function test_internal_popup_height_is_capped_by_parent_dialog() {
+            controlUnderTest.internalPopupComponent = tallInternalPopupComponent;
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            controlUnderTest.openInternalPopup();
+
+            const popupLayer = findInternalPopupLayer();
+            verify(!!popupLayer.popupObject);
+            tryCompare(popupLayer.popupObject, "opened", true);
+            compare(popupLayer.popupObject.maximumHeightOverride, Math.floor(controlUnderTest.height * 0.8));
+            verify(popupLayer.popupObject.height <= Math.floor(controlUnderTest.height * 0.8));
+        }
+
+        function test_internal_adaptive_dialog_component_is_created_lazily_and_capped() {
+            controlUnderTest.internalPopupComponent = internalAdaptiveDialogComponent;
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            const hiddenPopupLayer = findChild(controlUnderTest.Overlay.overlay, "statusAdaptiveDialogInternalPopupLayer");
+            verify(!hiddenPopupLayer || !hiddenPopupLayer.visible);
+            verify(!hiddenPopupLayer || !hiddenPopupLayer.popupObject);
+
+            controlUnderTest.openInternalPopup();
+
+            const popupLayer = findInternalPopupLayer();
+            verify(!!popupLayer.popupObject);
+            compare(popupLayer.popupObject.objectName, "internalAdaptiveDialog");
+            tryCompare(popupLayer.popupObject, "opened", true);
+            compare(popupLayer.popupObject.maximumWidthOverride, controlUnderTest.width);
+            compare(popupLayer.popupObject.width, controlUnderTest.width);
+            compare(popupLayer.popupObject.maximumHeightOverride, Math.floor(controlUnderTest.height * 0.8));
+            verify(popupLayer.popupObject.height <= Math.floor(controlUnderTest.height * 0.8));
+            compare(popupLayer.popupObject.x, 0);
+            compare(popupLayer.popupObject.y, controlUnderTest.height - popupLayer.popupObject.height);
+        }
+
+        function test_internal_adaptive_dialog_tracks_parent_geometry_after_resize() {
+            controlUnderTest.destroy();
+            controlUnderTest = createTemporaryObject(adaptiveWidthDialogComponent, testWindow.contentItem);
+            controlUnderTest.internalPopupComponent = internalAdaptiveDialogComponent;
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            controlUnderTest.openInternalPopup();
+
+            const popupLayer = findInternalPopupLayer();
+            const overlay = findInternalOverlay();
+            verify(!!popupLayer.popupObject);
+            tryCompare(popupLayer.popupObject, "opened", true);
+
+            setTestWindowSize(d.mobileWindowWidth, d.mobileWindowHeight);
+
+            tryCompare(controlUnderTest, "width", d.mobileWindowWidth);
+            tryCompare(controlUnderTest, "x", 0);
+            verifyInternalLayerMatchesParent(popupLayer, overlay);
+            verifyInternalDialogBottomAligned(popupLayer);
+        }
+
+        function test_internal_adaptive_dialog_tracks_parent_geometry_from_mobile_to_desktop() {
+            setTestWindowSize(d.mobileWindowWidth, d.mobileWindowHeight);
+            controlUnderTest.destroy();
+            controlUnderTest = createTemporaryObject(adaptiveWidthDialogComponent, testWindow.contentItem);
+            controlUnderTest.internalPopupComponent = internalAdaptiveDialogComponent;
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            controlUnderTest.openInternalPopup();
+
+            const popupLayer = findInternalPopupLayer();
+            const overlay = findInternalOverlay();
+            tryCompare(popupLayer.popupObject, "opened", true);
+
+            setTestWindowSize(d.desktopWindowWidth, d.desktopWindowHeight);
+
+            tryCompare(controlUnderTest, "width", 560);
+            tryVerify(() => controlUnderTest.x > 0);
+            verifyInternalLayerMatchesParent(popupLayer, overlay);
+            verifyInternalDialogBottomAligned(popupLayer);
+        }
+
+        function test_bottom_sheet_on_mobile() {
+            setTestWindowSize(d.mobileWindowWidth, d.mobileWindowHeight);
+            controlUnderTest.destroy();
+            controlUnderTest = createTemporaryObject(adaptiveWidthDialogComponent, testWindow.contentItem);
+
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            compare(controlUnderTest.width, d.mobileWindowWidth);
+            compare(controlUnderTest.x, 0);
+            verify(controlUnderTest.y >= 0);
+        }
+
+        function test_modal_can_be_overridden_from_outside() {
+            controlUnderTest.destroy();
+            controlUnderTest = createTemporaryObject(modalOverrideDialogComponent, testWindow.contentItem);
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            compare(controlUnderTest.modal, false);
+        }
+
+        function test_regular_content_uses_internal_scroll_viewport() {
+            controlUnderTest.destroy();
+            controlUnderTest = createTemporaryObject(tallRegularContentDialogComponent, testWindow.contentItem);
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            const contentViewport = findChild(controlUnderTest, "statusAdaptiveDialogContentViewport");
+            const scrollFlickable = findChild(controlUnderTest, "statusAdaptiveDialogScrollFlickable");
+            const contentScrollBar = findChild(controlUnderTest, "statusAdaptiveDialogContentScrollBar");
+            verify(!!contentViewport);
+            verify(!!scrollFlickable);
+            verify(!!contentScrollBar);
+            verify(scrollFlickable.visible);
+            verify(scrollFlickable.enabled);
+            verify(scrollFlickable.contentHeight > scrollFlickable.height);
+            verify(contentScrollBar.x >= contentViewport.x + contentViewport.width);
+        }
+
+        function test_flickable_content_is_not_wrapped() {
+            controlUnderTest.destroy();
+            controlUnderTest = createTemporaryObject(flickableContentDialogComponent, testWindow.contentItem);
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+
+            const contentViewport = findChild(controlUnderTest, "statusAdaptiveDialogContentViewport");
+            const scrollFlickable = findChild(controlUnderTest, "statusAdaptiveDialogScrollFlickable");
+            const flickableContent = findChild(controlUnderTest, "flickableContent");
+            verify(!!contentViewport);
+            verify(!!scrollFlickable);
+            verify(!!flickableContent);
+            compare(flickableContent.parent, contentViewport);
+            compare(scrollFlickable.visible, false);
+            verify(flickableContent.height <= contentViewport.height);
+        }
+
+    }
+
+    Component {
+        id: signalSpyComponent
+
+        SignalSpy {}
+    }
+}

--- a/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
+++ b/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
@@ -202,6 +202,7 @@ Item {
                 controlUnderTest.destroy();
                 controlUnderTest = null;
             }
+            setDialogSafeArea(0, 0, 0, 0);
             root.width = d.desktopWindowWidth;
             root.height = d.desktopWindowHeight;
             setTestWindowSize(d.desktopWindowWidth, d.desktopWindowHeight);
@@ -246,10 +247,10 @@ Item {
         }
 
         function setDialogSafeArea(top, bottom, left, right) {
-            controlUnderTest.contentItem.SafeArea.additionalMargins.top = top;
-            controlUnderTest.contentItem.SafeArea.additionalMargins.bottom = bottom;
-            controlUnderTest.contentItem.SafeArea.additionalMargins.left = left;
-            controlUnderTest.contentItem.SafeArea.additionalMargins.right = right;
+            testWindow.contentItem.Overlay.overlay.SafeArea.additionalMargins.top = top;
+            testWindow.contentItem.Overlay.overlay.SafeArea.additionalMargins.bottom = bottom;
+            testWindow.contentItem.Overlay.overlay.SafeArea.additionalMargins.left = left;
+            testWindow.contentItem.Overlay.overlay.SafeArea.additionalMargins.right = right;
         }
 
         function verifyDialogSafeAreaLayout(top, bottom, left, right) {
@@ -466,7 +467,9 @@ Item {
             tryCompare(controlUnderTest, "opened", true);
 
             setDialogSafeArea(60, 60, 40, 30);
-            verifyDialogSafeAreaLayout(60, 60, 40, 30);
+            verifyDialogSafeAreaLayout(0, 0, 0, 0);
+            compare(controlUnderTest.x, 40 + (testWindow.width - 40 - 30 - controlUnderTest.width) / 2);
+            compare(controlUnderTest.y, 60 + (testWindow.height - 60 - 60 - controlUnderTest.height) / 2);
         }
 
         function test_safe_area_is_reserved_in_bottom_sheet_mode() {
@@ -477,7 +480,7 @@ Item {
             tryCompare(controlUnderTest, "opened", true);
 
             setDialogSafeArea(60, 60, 40, 30);
-            verifyDialogSafeAreaLayout(60, 60, 40, 30);
+            verifyDialogSafeAreaLayout(0, 60, 40, 30);
         }
 
         function test_modal_can_be_overridden_from_outside() {

--- a/storybook/qmlTests/tests/tst_TokenListPopup.qml
+++ b/storybook/qmlTests/tests/tst_TokenListPopup.qml
@@ -1,0 +1,117 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Profile.popups
+
+Item {
+    id: root
+
+    width: 1024
+    height: 768
+
+    ListModel {
+        id: tokensModel
+
+        ListElement {
+            name: "Ether"
+            symbol: "ETH"
+            image: ""
+            chainId: 1
+            chainName: "Ethereum"
+            address: "0x0000000000000000000000000000000000000000"
+            blockExplorerURL: "https://etherscan.io"
+            isTest: false
+        }
+        ListElement {
+            name: "USDC"
+            symbol: "USDC"
+            image: ""
+            chainId: 1
+            chainName: "Ethereum"
+            address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+            blockExplorerURL: "https://etherscan.io"
+            isTest: false
+        }
+    }
+
+    Component {
+        id: componentUnderTest
+
+        TokenListPopup {
+            destroyOnClose: false
+            title: "Uniswap Token List"
+            sourceImage: ""
+            sourceUrl: "https://tokens.uniswap.org"
+            sourceVersion: "11.6.0"
+            updatedAt: 1710538948
+            tokensListModel: tokensModel
+        }
+    }
+
+    property TokenListPopup controlUnderTest: null
+
+    SignalSpy {
+        id: linkClickedSpy
+        target: controlUnderTest
+        signalName: "linkClicked"
+    }
+
+    TestCase {
+        name: "TokenListPopup"
+        when: windowShown
+
+        function init() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root);
+            linkClickedSpy.clear();
+        }
+
+        function cleanup() {
+            if (controlUnderTest) {
+                controlUnderTest.close();
+                controlUnderTest.destroy();
+                controlUnderTest = null;
+            }
+            linkClickedSpy.clear();
+        }
+
+        function openDialog() {
+            verify(!!controlUnderTest);
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+        }
+
+        function test_subtitle_shows_token_count() {
+            openDialog();
+            verify(controlUnderTest.subtitle.includes("2"));
+        }
+
+        function test_done_button_closes_dialog() {
+            openDialog();
+
+            const doneButton = findChild(controlUnderTest, "tokenListPopupDoneButton");
+            verify(!!doneButton);
+
+            mouseClick(doneButton);
+
+            tryCompare(controlUnderTest, "opened", false);
+        }
+
+        function test_content_host_is_present() {
+            openDialog();
+
+            const contentHost = findChild(controlUnderTest, "statusAdaptiveDialogContentHost");
+            verify(!!contentHost);
+            verify(contentHost.visible);
+        }
+
+        function test_link_clicked_signal_emitted() {
+            openDialog();
+
+            controlUnderTest.linkClicked("https://etherscan.io/token/0x0000000000000000000000000000000000000000");
+
+            compare(linkClickedSpy.count, 1);
+            compare(linkClickedSpy.signalArguments[0][0],
+                    "https://etherscan.io/token/0x0000000000000000000000000000000000000000");
+        }
+    }
+}

--- a/test/e2e/gui/components/delete_popup.py
+++ b/test/e2e/gui/components/delete_popup.py
@@ -1,3 +1,6 @@
+import allure
+
+import configs
 from gui.elements.button import Button
 from gui.elements.object import QObject
 from gui.objects_map import names
@@ -10,6 +13,10 @@ class ConfirmationPopup(QObject):
         self.confirmation_dialog = QObject(names.confirmationDialog)
         self.delete_button = Button(names.delete_StatusButton)
 
+    @allure.step('Wait until appears {0}')
+    def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+        self.delete_button.wait_until_appears(timeout_msec)
+        return self
 
 
 class ConfirmationCategoryPopup(ConfirmationPopup):
@@ -18,12 +25,22 @@ class ConfirmationCategoryPopup(ConfirmationPopup):
         super().__init__()
         self.confirm_button = Button(names.confirm_StatusButton)
 
+    @allure.step('Wait until appears {0}')
+    def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+        self.confirm_button.wait_until_appears(timeout_msec)
+        return self
+
 
 class ConfirmationPermissionPopup(ConfirmationPopup):
 
     def __init__(self):
         super().__init__()
         self.confirm_delete_button = Button(names.confirm_permission_delete_StatusButton)
+
+    @allure.step('Wait until appears {0}')
+    def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+        self.confirm_delete_button.wait_until_appears(timeout_msec)
+        return self
 
 
 class ConfirmationMessagePopup(QObject):

--- a/test/e2e/gui/components/messaging/clear_chat_history_popup.py
+++ b/test/e2e/gui/components/messaging/clear_chat_history_popup.py
@@ -19,5 +19,7 @@ class ClearChatHistoryPopup(QObject):
 
     @allure.step("Confirm clearing chat")
     def confirm_clearing_chat(self):
+        self._clear_button.wait_until_appears()
+        self._clear_button.wait_until_enabled()
         self._clear_button.click()
         self._clear_button.wait_until_hidden()

--- a/test/e2e/gui/components/messaging/close_chat_popup.py
+++ b/test/e2e/gui/components/messaging/close_chat_popup.py
@@ -19,5 +19,7 @@ class CloseChatPopup(QObject):
 
     @allure.step("Confirm closing chat")
     def confirm_closing_chat(self):
+        self._close_chat_button.wait_until_appears()
+        self._close_chat_button.wait_until_enabled()
         self._close_chat_button.click()
         self._close_chat_button.wait_until_hidden()

--- a/test/e2e/gui/components/messaging/leave_group_popup.py
+++ b/test/e2e/gui/components/messaging/leave_group_popup.py
@@ -1,5 +1,6 @@
 import allure
 
+import configs
 from gui.elements.button import Button
 from gui.elements.object import QObject
 from gui.objects_map import names
@@ -11,8 +12,15 @@ class LeaveGroupPopup(QObject):
         super().__init__(names.confirmationDialog)
         self.leave_button = Button(names.leave_StatusButton)
 
+    @allure.step('Wait until appears {0}')
+    def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+        self.leave_button.wait_until_appears(timeout_msec)
+        return self
+
     @allure.step("Confirm leaving group")
     def confirm_leaving(self):
+        self.leave_button.wait_until_appears()
+        self.leave_button.wait_until_enabled()
         self.leave_button.click()
-        self.wait_until_hidden()
+        self.leave_button.wait_until_hidden()
 

--- a/test/e2e/gui/components/settings/unpair_confirmation_popup.py
+++ b/test/e2e/gui/components/settings/unpair_confirmation_popup.py
@@ -12,6 +12,6 @@ class UnpairDeviceConfirmationPopup(QObject):
 
     @allure.step('Confirm unpairing')
     def confirm_unpairing(self):
+        self.unpair_button.wait_until_enabled()
         self.unpair_button.click()
         return self
-    

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -598,7 +598,8 @@ delete_StatusButton = {"container": statusDesktop_mainWindow_overlay,
 confirm_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
                         "objectName": "confirmDeleteCategoryButton", "type": "StatusButton", "visible": True}
 confirm_permission_delete_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
-                                          "id": "confirmButton", "type": "StatusButton", "unnamed": 1, "visible": True}
+                                          "objectName": "confirmDeletePermissionButton", "type": "StatusButton",
+                                          "visible": True}
 confirm_delete_message_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
                                        "objectName": "chatButtonsPanelConfirmDeleteMessageButton", "text": "Confirm",
                                        "type": "StatusButton", "visible": True}

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -602,11 +602,12 @@ confirm_permission_delete_StatusButton = {"checkable": False, "container": statu
 confirm_delete_message_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay,
                                        "objectName": "chatButtonsPanelConfirmDeleteMessageButton", "text": "Confirm",
                                        "type": "StatusButton", "visible": True}
-confirmationDialog = {"container": statusDesktop_mainWindow_overlay, "objectName": "ConfirmationDialog",
-                      "type": "PopupItem", "visible": True}
+confirmationDialog = {"container": statusDesktop_mainWindow_overlay, "objectName": "ConfirmationDialog", "visible": True}
 confirmationDeleteMessagePopup = {"container": statusDesktop_mainWindow_overlay,
                                   "objectName": "DeleteMessageConfirmationPopup", "type": "PopupItem", "visible": True}
-unpairButton =  {"container": statusDesktop_mainWindow_overlay, "id": "confirmButton", "type": "StatusButton", "unnamed": 1, "visible": True}
+unpairButton = {"container": statusDesktop_mainWindow_overlay,
+                "objectName": "unpairDeviceConfirmationDialogUnpairButton", "type": "StatusButton",
+                "visible": True}
 
 # Education popup
 educationPopup = {"container": statusDesktop_mainWindow_overlay, "objectName": "NavigationEducationDialog", "type": "PopupItem", "visible": True}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
@@ -219,6 +219,8 @@ Dialog {
         }
     }
 
+    enabled: opened && !enterTransition.running
+
     exit: Transition {
         ParallelAnimation {
             NumberAnimation {

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
@@ -114,19 +114,16 @@ Dialog {
         readonly property bool bottomSheet: windowWidth <= ThemeUtils.portraitBreakpoint.width
                                             && windowHeight > windowWidth
 
-        // Safe-area insets for bottom-sheet mode, read from the Window so the values
-        // are stable physical constants rather than position-dependent computed values.
-        readonly property real headerSafeArea: bottomSheet
-            ? (root.contentItem.Window.window?.SafeArea.margins.top ?? 0) : 0
-        readonly property real footerSafeArea: bottomSheet
-            ? (root.contentItem.Window.window?.SafeArea.margins.bottom ?? 0) : 0
-        readonly property real leftSafeArea: bottomSheet
-            ? (root.contentItem.Window.window?.SafeArea.margins.left ?? 0) : 0
-        readonly property real rightSafeArea: bottomSheet
-            ? (root.contentItem.Window.window?.SafeArea.margins.right ?? 0) : 0
-        // Vertical padding owned by the content host. When the content is the last visible
-        // section in a bottom sheet, bottom padding also absorbs the home-indicator safe area.
-        readonly property real contentTopPadding: edgePadding
+        // Safe-area insets for the dialog surface. The dialog reads them from its
+        // content host so tests and hosted dialogs can override them locally
+        // without changing the whole window.
+        readonly property real headerSafeArea: root.contentItem.SafeArea.margins.top
+        readonly property real footerSafeArea: root.contentItem.SafeArea.margins.bottom
+        readonly property real leftSafeArea: root.contentItem.SafeArea.margins.left
+        readonly property real rightSafeArea: root.contentItem.SafeArea.margins.right
+        // Vertical padding owned by the content host. When content is the first or
+        // last visible section, it also absorbs the corresponding safe area.
+        readonly property real contentTopPadding: edgePadding + (hasHeader ? 0 : headerSafeArea)
         readonly property real contentBottomPadding: edgePadding + (hasFooterSection ? 0 : footerSafeArea)
         readonly property real contentLeftPadding: edgePadding + leftSafeArea
         readonly property real contentRightPadding: edgePadding + rightSafeArea
@@ -258,7 +255,7 @@ Dialog {
             id: headerToolbarItem
 
             Layout.fillWidth: true
-            Layout.topMargin: d.edgePadding
+            Layout.topMargin: d.edgePadding + d.headerSafeArea
             Layout.leftMargin: d.edgePadding + d.leftSafeArea
             Layout.rightMargin: d.edgePadding + d.rightSafeArea
             visible: d.hasHeader

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
@@ -283,8 +283,10 @@ Dialog {
         contentComponent: root.contentComponent
         leftPadding: d.contentLeftPadding
         rightPadding: d.contentRightPadding
-        topPadding: d.contentTopPadding
-        bottomPadding: d.contentBottomPadding
+        topPadding: 0
+        bottomPadding: 0
+        flickableTopPadding: d.contentTopPadding
+        flickableBottomPadding: d.contentBottomPadding
     }
 
     // Footer contract:

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
@@ -1,0 +1,486 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
+import QtQml.Models
+
+import StatusQ.Core.Theme
+
+// Base dialog container that owns presentation, sizing and interaction rules.
+//
+// The dialog automatically chooses one of two modes:
+// - bottom sheet on narrow portrait windows
+// - centered dialog on wider or landscape windows
+//
+// Consumers configure the header data/actions and provide content/footer components.
+// Layout decisions such as mode selection, size caps, positioning and overlay behavior
+// stay centralized here so individual dialogs do not duplicate geometry rules. Content
+// hosting is also resolved by the base dialog: it decides whether to reuse a provided
+// Flickable (Strategy A) or wrap regular content in an internal scroll container (Strategy B).
+// When Strategy A applies, the dialog owns the scrollbar — the content item must disable any
+// built-in scrollbar it carries to avoid duplicates (e.g. StatusListView.ScrollBar.vertical: null).
+//
+// The dialog can also host one nested StatusAdaptiveDialog inside its own surface.
+// This is intended for secondary steps that must dim and cover the current dialog
+// header/content/footer without opening a full-window modal. The internal dialog is
+// loaded lazily, sized within the parent dialog bounds, and closed automatically with
+// the parent dialog.
+Dialog {
+    id: root
+
+    // Header related properties:
+    property alias subtitle: headerToolbarItem.subtitle
+    property alias leftHeaderComponent: headerToolbarItem.leftComponent
+    readonly property alias headerActions: headerToolbarItem.actions
+    property alias headerCustomButtons: headerToolbarItem.actions.customButtons
+
+    property Component contentComponent
+
+    // Footer related properties:
+    property ObjectModel footerLeftButtons
+    property ObjectModel footerRightButtons
+    property ObjectModel errorTags
+
+    // StatusAdaptiveDialog component used by openInternalPopup(). It is configured
+    // as a modeless child of the parent dialog's internal popup layer.
+    property Component internalPopupComponent
+    // Color used by the internal overlay that covers the parent dialog while the
+    // internal popup is active.
+    property color internalOverlayColor: Theme.palette.backdropColor
+    // Whether the internal dialog layer is currently open. It may be hidden for a
+    // parent-close frame while still finishing the nested dialog lifecycle.
+    readonly property bool internalPopupActive: internalPopupLayer.active
+
+    // Whether pressing outside the dialog closes it.
+    property bool closeOnOverlayClick: true
+    // Whether pressing Escape closes the dialog.
+    property bool escapeKeyCloses: !d.bottomSheet
+
+    // Exceptional override. Leave 0 to let the dialog resolve its own width.
+    property int maximumWidthOverride: 0
+    // Exceptional override. Leave 0 to let the dialog resolve its own height.
+    property int maximumHeightOverride: 0
+    // Whether to show the divider between the header toolbar and content.
+    property bool showHeaderDivider: true
+    // Whether to show the divider between the content and footer.
+    property bool showFooterDivider: true
+
+    function openInternalPopup() {
+        internalPopupLayer.open()
+    }
+
+    function closeInternalPopup() {
+        internalPopupLayer.close()
+    }
+
+    // Internal: used when this dialog is hosted as another StatusAdaptiveDialog's
+    // internal dialog. Consumers should create/open dialogs normally.
+    function setHostSurface(surface) {
+        d.hostSurface = surface
+    }
+
+    QtObject {
+        id: d
+
+        property Item hostSurface: null
+
+        // NB: must be set in onAboutToShow, not declaratively — contentItem.Window.width/height
+        // is 0 before the popup is attached to a window (the attached property always exists
+        // but carries no dimensions until then).
+        property int windowWidth: Screen.width
+        property int windowHeight: Screen.height
+
+        readonly property bool hasHeader: !!root.title || !!root.subtitle
+        readonly property bool hasContent: !!root.contentComponent
+        readonly property bool hasFooter: !!root.footerLeftButtons || !!root.footerRightButtons
+        readonly property bool hasErrorTags: !!root.errorTags
+        // Footer section is visible when either action buttons or error tags are present.
+        // The bottom safe area is applied to whichever visible section sits at the sheet bottom.
+        readonly property bool hasFooterSection: hasFooter || hasErrorTags
+        readonly property real headerHeight: headerSection.implicitHeight
+        readonly property real footerHeight: footerSection.implicitHeight
+
+        // Internal spacing between the dialog edge and each visible component.
+        readonly property real edgePadding: Math.max(root.Theme.padding, 8)
+
+        readonly property bool bottomSheet: windowWidth <= ThemeUtils.portraitBreakpoint.width
+                                            && windowHeight > windowWidth
+
+        // Safe-area insets for bottom-sheet mode, read from the Window so the values
+        // are stable physical constants rather than position-dependent computed values.
+        readonly property real headerSafeArea: bottomSheet
+            ? (root.contentItem.Window.window?.SafeArea.margins.top ?? 0) : 0
+        readonly property real footerSafeArea: bottomSheet
+            ? (root.contentItem.Window.window?.SafeArea.margins.bottom ?? 0) : 0
+        // Vertical padding owned by the content host. When the content is the last visible
+        // section in a bottom sheet, bottom padding also absorbs the home-indicator safe area.
+        readonly property real contentTopPadding: edgePadding
+        readonly property real contentBottomPadding: edgePadding + (bottomSheet && !hasFooterSection ? footerSafeArea : 0)
+
+        // Internal max width for centered dialogs.
+        readonly property real centeredMaxWidth: 560
+        // Centered dialogs can use up to this fraction of the window height.
+        readonly property real centeredHeightRatio: 0.8
+        // Total horizontal space reserved around centered dialogs.
+        readonly property real centeredHorizontalMargin: 2 * Theme.bigPadding
+        // Width used by centered dialogs after applying margins and the exceptional override, if any.
+        readonly property real resolvedCenteredWidth: Math.min(root.maximumWidthOverride > 0 ? root.maximumWidthOverride : centeredMaxWidth,
+                                                               Math.max(root.implicitWidth, windowWidth - centeredHorizontalMargin))
+        // Height cap used by centered dialogs after applying the exceptional override, if any.
+        readonly property real resolvedCenteredMaxHeight: root.maximumHeightOverride > 0 ? Math.min(root.maximumHeightOverride, windowHeight)
+                                                                                         : windowHeight * centeredHeightRatio
+
+        // Width used by bottom sheets after applying the exceptional override, if any.
+        readonly property real resolvedBottomSheetWidth: root.maximumWidthOverride > 0 ? Math.min(root.maximumWidthOverride, windowWidth)
+                                                                                       : windowWidth
+        // Bottom sheets can use up to this fraction of the window height.
+        readonly property real bottomSheetHeightRatio: 0.9
+        // Height cap for bottom sheets. The ratio is applied to the usable height
+        // (window minus top safe area) so the visible gap above the dialog is
+        // consistent regardless of notch/status-bar size. footerSafeArea is then
+        // added back so the home-indicator padding does not reduce the content area.
+        readonly property real resolvedBottomSheetMaxHeight: (root.maximumHeightOverride > 0
+            ? Math.min(root.maximumHeightOverride, windowHeight)
+            : (windowHeight - headerSafeArea) * bottomSheetHeightRatio) + footerSafeArea
+
+        // Height ratio selected by the active presentation mode. Reused by internal
+        // popup hosting so nested surfaces follow the same cap as their parent mode.
+        readonly property real resolvedHeightRatio: bottomSheet ? bottomSheetHeightRatio : centeredHeightRatio
+        // Final width after choosing the presentation mode.
+        readonly property real resolvedWidth: bottomSheet ? resolvedBottomSheetWidth : resolvedCenteredWidth
+        // Final height cap after choosing the presentation mode.
+        readonly property real resolvedMaxHeight: bottomSheet ? resolvedBottomSheetMaxHeight : resolvedCenteredMaxHeight
+        // Natural dialog height before cap: fixed header + content natural height + fixed footer.
+        readonly property real naturalHeight: headerHeight
+                                              + contentHost.implicitHeight
+                                              + footerHeight
+        // Final vertical position: anchored to bottom of host surface, window bottom for sheets, centered otherwise.
+        // Note: for hosted dialogs the parent is internalPopupLayer, so y is in its local coordinate space.
+        readonly property real resolvedY: hostSurface
+            ? hostSurface.height - root.height
+            : bottomSheet ? windowHeight - root.height
+                          : (windowHeight - root.height) / 2
+        // Make the loaded component root follow the area owned by the dialog layout.
+        function bindLoadedItemToContentArea(item, contentArea) {
+            if (!item)
+                return;
+
+            item.width = Qt.binding(() => contentArea.width);
+            item.height = Qt.binding(() => contentArea.height);
+        }
+    }
+
+    parent: Overlay.overlay
+    modal: true
+    padding: 0
+    leftPadding: 0
+    rightPadding: 0
+    topPadding: 0
+    bottomPadding: 0
+    spacing: 0
+    // TODO: Verify if bottom sheets still need the legacy -1 margin adjustment.
+    margins: d.bottomSheet ? -1 : 0
+    closePolicy: (root.escapeKeyCloses ? Popup.CloseOnEscape : Popup.NoAutoClose)
+                 | (root.closeOnOverlayClick ? Popup.CloseOnPressOutside : Popup.NoAutoClose)
+
+    Overlay.modal: overlayBackgroundComponent
+    Overlay.modeless: overlayBackgroundComponent
+
+    width: d.resolvedWidth
+    height: Math.min(d.naturalHeight, d.resolvedMaxHeight)
+
+    x: d.hostSurface ? 0
+                     : d.bottomSheet ? 0 : (d.windowWidth - root.width) / 2
+
+    enter: Transition {
+        id: enterTransition
+
+        ParallelAnimation {
+            NumberAnimation {
+                property: "opacity"
+                from: 0
+                to: 1
+                duration: ThemeUtils.AnimationDuration.Fast
+            }
+            NumberAnimation {
+                property: "y"
+                from: d.hostSurface ? d.hostSurface.height
+                                    : (root.parent ? root.parent.height : d.windowHeight)
+                to: d.resolvedY
+                duration: ThemeUtils.AnimationDuration.Fast
+                easing.type: Easing.OutCubic
+            }
+        }
+    }
+
+    exit: Transition {
+        ParallelAnimation {
+            NumberAnimation {
+                property: "opacity"
+                from: 1
+                to: 0
+                duration: ThemeUtils.AnimationDuration.Fast
+                easing.type: Easing.OutQuint
+            }
+            NumberAnimation {
+                property: "y"
+                from: root.y
+                to: d.hostSurface ? d.hostSurface.height
+                                  : (root.parent ? root.parent.height : d.windowHeight)
+                duration: ThemeUtils.AnimationDuration.Fast
+                easing.type: Easing.OutCubic
+            }
+        }
+    }
+
+    background: StatusDialogBackground {}
+
+    // Header contract:
+    // - Uses Dialog.header so the native Dialog layout owns section placement.
+    // - The toolbar receives top/horizontal edge padding; the divider is full width.
+    // - Consumers configure data/actions through the dialog API, not by replacing
+    //   the internal toolbar.
+    header: ColumnLayout {
+        id: headerSection
+
+        visible: root.visible
+        spacing: d.edgePadding
+
+        StatusAdaptiveDialogHeader {
+            id: headerToolbarItem
+
+            Layout.fillWidth: true
+            Layout.topMargin: d.edgePadding
+            Layout.leftMargin: d.edgePadding
+            Layout.rightMargin: d.edgePadding
+            visible: d.hasHeader
+            title: root.title
+            actions.closeButton.onClicked: mouse => root.close()
+        }
+
+        StatusDialogDivider {
+            id: headerDivider
+
+            objectName: "statusAdaptiveDialogHeaderDivider"
+            Layout.fillWidth: true
+            visible: root.showHeaderDivider && d.hasHeader && d.hasContent
+        }
+    }
+
+    contentItem: StatusAdaptiveDialogContentHost {
+        id: contentHost
+
+        implicitHeight: visible ? naturalHeight + d.contentTopPadding + d.contentBottomPadding : 0
+        visible: root.visible && d.hasContent
+        contentComponent: root.contentComponent
+        contentMargin: d.edgePadding
+        contentTopMargin: d.contentTopPadding
+        contentBottomMargin: d.contentBottomPadding
+    }
+
+    // Footer contract:
+    // - Uses Dialog.footer so the native Dialog layout owns section placement.
+    // - The divider is full width; error tags and toolbar content receive edge padding.
+    // - Consumers provide button/error models while the dialog owns footer layout.
+    footer: ColumnLayout {
+        id: footerSection
+
+        visible: root.visible && d.hasFooterSection
+        spacing: 0
+
+        StatusDialogDivider {
+            objectName: "statusAdaptiveDialogFooterDivider"
+            Layout.fillWidth: true
+            visible: root.showFooterDivider && d.hasContent
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.topMargin: d.hasErrorTags ? d.edgePadding : 0
+            Layout.bottomMargin: d.hasFooter ? 0 : d.edgePadding + d.footerSafeArea
+            Layout.leftMargin: d.edgePadding
+            Layout.rightMargin: d.edgePadding
+            spacing: Math.max(Theme.halfPadding, 8)
+            visible: d.hasErrorTags
+
+            Repeater {
+                model: root.errorTags
+                onItemAdded: (_, item) => item.Layout.fillWidth = true
+            }
+        }
+
+        StatusAdaptiveDialogFooter {
+            id: footerToolbarItem
+
+            Layout.fillWidth: true
+            Layout.topMargin: d.hasErrorTags ? Math.max(Theme.halfPadding, 8) : d.edgePadding
+            Layout.bottomMargin: d.edgePadding + d.footerSafeArea
+            Layout.leftMargin: d.edgePadding
+            Layout.rightMargin: d.edgePadding
+            visible: d.hasFooter
+
+            leftButtons: root.footerLeftButtons
+            rightButtons: root.footerRightButtons
+        }
+    }
+
+    onAboutToShow: {
+        d.windowWidth = Qt.binding(() => root.contentItem.Window ? root.contentItem.Window.width : Screen.width)
+        d.windowHeight = Qt.binding(() => root.contentItem.Window ? root.contentItem.Window.height : Screen.height)
+    }
+
+    onAboutToHide: internalPopupLayer.hideDuringParentClose()
+    onClosed: closeInternalPopup()
+
+    Item {
+        id: internalPopupLayer
+
+        objectName: "statusAdaptiveDialogInternalPopupLayer"
+        parent: null
+        x: hiddenDuringParentClose ? frozenX : root.x
+        y: hiddenDuringParentClose ? frozenY : root.y
+        z: root.z + 1
+        width: hiddenDuringParentClose ? frozenWidth : root.width
+        height: hiddenDuringParentClose ? frozenHeight : root.height
+        visible: active && !hiddenDuringParentClose
+        enabled: visible
+
+        property bool active: false
+        property bool hiddenDuringParentClose: false
+        readonly property var popupObject: popupLoader.item
+        readonly property bool hasPopupObject: !!popupObject
+        property bool closeOnOverlayClick: true
+        // Snapshot used only while the parent dialog is closing. During normal
+        // operation the layer follows root geometry so resize/orientation changes
+        // propagate to the internal dialog.
+        property real frozenX: root.x
+        property real frozenY: root.y
+        property real frozenWidth: root.width
+        property real frozenHeight: root.height
+        readonly property real maximumPopupHeightRatio: d.resolvedHeightRatio
+        readonly property int maximumPopupHeight: Math.floor(height * maximumPopupHeightRatio)
+
+        function open() {
+            if (!root.internalPopupComponent)
+                return;
+
+            parent = root.Overlay.overlay;
+            hiddenDuringParentClose = false;
+            closeOnOverlayClick = true;
+            active = true;
+        }
+
+        function close() {
+            if (popupObject && popupObject.opened) {
+                popupObject.close();
+                return;
+            }
+
+            deactivate();
+        }
+
+        function deactivate() {
+            active = false;
+            hiddenDuringParentClose = false;
+            closeOnOverlayClick = true;
+            parent = null;
+        }
+
+        function hideDuringParentClose() {
+            frozenX = root.x;
+            frozenY = root.y;
+            frozenWidth = root.width;
+            frozenHeight = root.height;
+            hiddenDuringParentClose = true;
+        }
+
+        function configurePopupObject(dialog) {
+            if (!dialog)
+                return;
+
+            dialog.parent = internalPopupLayer;
+            internalPopupLayer.closeOnOverlayClick = dialog.closeOnOverlayClick;
+            dialog.closeOnOverlayClick = false;
+            dialog.setHostSurface(internalPopupLayer);
+            dialog.open();
+        }
+
+        Binding {
+            target: internalPopupLayer.popupObject
+            property: "modal"
+            value: false
+            when: internalPopupLayer.hasPopupObject
+        }
+
+        Binding {
+            target: internalPopupLayer.popupObject
+            property: "dim"
+            value: false
+            when: internalPopupLayer.hasPopupObject
+        }
+
+        Binding {
+            target: internalPopupLayer.popupObject
+            property: "z"
+            value: internalPopupLayer.z + 1
+            when: internalPopupLayer.hasPopupObject
+        }
+
+        Binding {
+            target: internalPopupLayer.popupObject
+            property: "maximumWidthOverride"
+            value: internalPopupLayer.width
+            when: internalPopupLayer.hasPopupObject
+        }
+
+        Binding {
+            target: internalPopupLayer.popupObject
+            property: "maximumHeightOverride"
+            value: internalPopupLayer.maximumPopupHeight
+            when: internalPopupLayer.hasPopupObject
+        }
+
+        Loader {
+            id: popupLoader
+
+            active: internalPopupLayer.active
+            sourceComponent: internalPopupLayer.active ? root.internalPopupComponent : null
+            onLoaded: internalPopupLayer.configurePopupObject(item)
+        }
+
+        Connections {
+            target: internalPopupLayer.popupObject
+            function onClosed() {
+                internalPopupLayer.deactivate()
+            }
+        }
+
+        Rectangle {
+            id: internalOverlay
+
+            objectName: "statusAdaptiveDialogInternalOverlay"
+            anchors.fill: parent
+            radius: d.bottomSheet ? 0 : Theme.radius
+            color: root.internalOverlayColor
+
+            MouseArea {
+                anchors.fill: parent
+                anchors.bottomMargin: internalPopupLayer.popupObject ? internalPopupLayer.popupObject.height : 0
+                onClicked: if (internalPopupLayer.closeOnOverlayClick) root.closeInternalPopup()
+            }
+        }
+    }
+
+    Binding on y {
+        when: !enterTransition.running
+        value: d.resolvedY
+    }
+
+    Component {
+        id: overlayBackgroundComponent
+
+        Rectangle {
+            color: Theme.palette.backdropColor
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
@@ -14,11 +14,9 @@ import StatusQ.Core.Theme
 //
 // Consumers configure the header data/actions and provide content/footer components.
 // Layout decisions such as mode selection, size caps, positioning and overlay behavior
-// stay centralized here so individual dialogs do not duplicate geometry rules. Content
-// hosting is also resolved by the base dialog: it decides whether to reuse a provided
-// Flickable (Strategy A) or wrap regular content in an internal scroll container (Strategy B).
-// When Strategy A applies, the dialog owns the scrollbar — the content item must disable any
-// built-in scrollbar it carries to avoid duplicates (e.g. StatusListView.ScrollBar.vertical: null).
+// stay centralized here so individual dialogs do not duplicate geometry rules.
+// Content hosting is also resolved by the base dialog: it configures either regular
+// content or a Flickable/ListView body and owns the visible scrollbar.
 //
 // The dialog can also host one nested StatusAdaptiveDialog inside its own surface.
 // This is intended for secondary steps that must dim and cover the current dialog
@@ -34,6 +32,13 @@ Dialog {
     readonly property alias headerActions: headerToolbarItem.actions
     property alias headerCustomButtons: headerToolbarItem.actions.customButtons
 
+    // Dialog body supplied by consumers. The component should describe only the
+    // content itself; StatusAdaptiveDialog owns sizing, padding/insets and scroll
+    // hosting. Flickable/ListView bodies are detected from the root item or its
+    // contentItem. If that body has its own vertical scrollbar, expose it as:
+    //   readonly property alias statusAdaptiveDialogContentVerticalScrollBar: <bar>
+    // That property describes the loaded root only; the base dialog still owns
+    // the vertical scrollbar and contentY/interactive policy.
     property Component contentComponent
 
     // Footer related properties:
@@ -75,8 +80,9 @@ Dialog {
         internalPopupLayer.close()
     }
 
-    // Internal: used when this dialog is hosted as another StatusAdaptiveDialog's
-    // internal dialog. Consumers should create/open dialogs normally.
+    // Internal bridge used only when another StatusAdaptiveDialog hosts this instance.
+    // It stays on root because the parent dialog configures the loaded child instance.
+    // Consumers should create/open dialogs normally.
     function setHostSurface(surface) {
         d.hostSurface = surface
     }
@@ -114,10 +120,16 @@ Dialog {
             ? (root.contentItem.Window.window?.SafeArea.margins.top ?? 0) : 0
         readonly property real footerSafeArea: bottomSheet
             ? (root.contentItem.Window.window?.SafeArea.margins.bottom ?? 0) : 0
+        readonly property real leftSafeArea: bottomSheet
+            ? (root.contentItem.Window.window?.SafeArea.margins.left ?? 0) : 0
+        readonly property real rightSafeArea: bottomSheet
+            ? (root.contentItem.Window.window?.SafeArea.margins.right ?? 0) : 0
         // Vertical padding owned by the content host. When the content is the last visible
         // section in a bottom sheet, bottom padding also absorbs the home-indicator safe area.
         readonly property real contentTopPadding: edgePadding
-        readonly property real contentBottomPadding: edgePadding + (bottomSheet && !hasFooterSection ? footerSafeArea : 0)
+        readonly property real contentBottomPadding: edgePadding + (hasFooterSection ? 0 : footerSafeArea)
+        readonly property real contentLeftPadding: edgePadding + leftSafeArea
+        readonly property real contentRightPadding: edgePadding + rightSafeArea
 
         // Internal max width for centered dialogs.
         readonly property real centeredMaxWidth: 560
@@ -162,14 +174,6 @@ Dialog {
             ? hostSurface.height - root.height
             : bottomSheet ? windowHeight - root.height
                           : (windowHeight - root.height) / 2
-        // Make the loaded component root follow the area owned by the dialog layout.
-        function bindLoadedItemToContentArea(item, contentArea) {
-            if (!item)
-                return;
-
-            item.width = Qt.binding(() => contentArea.width);
-            item.height = Qt.binding(() => contentArea.height);
-        }
     }
 
     parent: Overlay.overlay
@@ -253,8 +257,8 @@ Dialog {
 
             Layout.fillWidth: true
             Layout.topMargin: d.edgePadding
-            Layout.leftMargin: d.edgePadding
-            Layout.rightMargin: d.edgePadding
+            Layout.leftMargin: d.edgePadding + d.leftSafeArea
+            Layout.rightMargin: d.edgePadding + d.rightSafeArea
             visible: d.hasHeader
             title: root.title
             actions.closeButton.onClicked: mouse => root.close()
@@ -275,9 +279,10 @@ Dialog {
         implicitHeight: visible ? naturalHeight + d.contentTopPadding + d.contentBottomPadding : 0
         visible: root.visible && d.hasContent
         contentComponent: root.contentComponent
-        contentMargin: d.edgePadding
-        contentTopMargin: d.contentTopPadding
-        contentBottomMargin: d.contentBottomPadding
+        leftPadding: d.contentLeftPadding
+        rightPadding: d.contentRightPadding
+        topPadding: d.contentTopPadding
+        bottomPadding: d.contentBottomPadding
     }
 
     // Footer contract:
@@ -300,8 +305,8 @@ Dialog {
             Layout.fillWidth: true
             Layout.topMargin: d.hasErrorTags ? d.edgePadding : 0
             Layout.bottomMargin: d.hasFooter ? 0 : d.edgePadding + d.footerSafeArea
-            Layout.leftMargin: d.edgePadding
-            Layout.rightMargin: d.edgePadding
+            Layout.leftMargin: d.edgePadding + d.leftSafeArea
+            Layout.rightMargin: d.edgePadding + d.rightSafeArea
             spacing: Math.max(Theme.halfPadding, 8)
             visible: d.hasErrorTags
 
@@ -317,8 +322,8 @@ Dialog {
             Layout.fillWidth: true
             Layout.topMargin: d.hasErrorTags ? Math.max(Theme.halfPadding, 8) : d.edgePadding
             Layout.bottomMargin: d.edgePadding + d.footerSafeArea
-            Layout.leftMargin: d.edgePadding
-            Layout.rightMargin: d.edgePadding
+            Layout.leftMargin: d.edgePadding + d.leftSafeArea
+            Layout.rightMargin: d.edgePadding + d.rightSafeArea
             visible: d.hasFooter
 
             leftButtons: root.footerLeftButtons
@@ -341,6 +346,10 @@ Dialog {
     Item {
         id: internalPopupLayer
 
+        // Hosts a secondary StatusAdaptiveDialog over the current dialog surface.
+        // The layer tracks root geometry during normal use, paints the local dimmer,
+        // and freezes its bounds for the parent-close frame so both exit animations
+        // can complete without the nested dialog jumping back to window coordinates.
         objectName: "statusAdaptiveDialogInternalPopupLayer"
         parent: null
         x: hiddenDuringParentClose ? frozenX : root.x
@@ -472,7 +481,8 @@ Dialog {
             MouseArea {
                 anchors.fill: parent
                 anchors.bottomMargin: internalPopupLayer.popupObject ? internalPopupLayer.popupObject.height : 0
-                onClicked: if (internalPopupLayer.closeOnOverlayClick) root.closeInternalPopup()
+                onClicked: if (internalPopupLayer.closeOnOverlayClick)
+                    root.closeInternalPopup()
             }
         }
     }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
@@ -118,13 +118,12 @@ Dialog {
         // adjustments there. Centered dialogs use these values only as outer
         // bounds; bottom sheets use bottom/horizontal values as internal padding.
         readonly property var surfaceSafeArea: root.parent ? root.parent.SafeArea : root.contentItem.SafeArea
-        readonly property real headerSafeArea: 0
         readonly property real footerSafeArea: bottomSheet ? surfaceSafeArea.margins.bottom : 0
         readonly property real leftSafeArea: bottomSheet ? surfaceSafeArea.margins.left : 0
         readonly property real rightSafeArea: bottomSheet ? surfaceSafeArea.margins.right : 0
         // Vertical padding owned by the content host. When content is the first or
         // last visible section, it also absorbs the corresponding safe area.
-        readonly property real contentTopPadding: edgePadding + (hasHeader ? 0 : headerSafeArea)
+        readonly property real contentTopPadding: edgePadding
         readonly property real contentBottomPadding: edgePadding + (hasFooterSection ? 0 : footerSafeArea)
         readonly property real contentLeftPadding: edgePadding + leftSafeArea
         readonly property real contentRightPadding: edgePadding + rightSafeArea
@@ -134,7 +133,7 @@ Dialog {
         // Centered dialogs can use up to this fraction of the window height.
         readonly property real centeredHeightRatio: 0.8
         // Total horizontal space reserved around centered dialogs.
-        readonly property real centeredHorizontalMargin: 2 * Theme.bigPadding
+        readonly property real centeredHorizontalMargin: 2 * root.Theme.bigPadding
         // Width used by centered dialogs after applying margins and the exceptional override, if any.
         readonly property real resolvedCenteredAvailableWidth: windowWidth - surfaceSafeArea.margins.left - surfaceSafeArea.margins.right
         readonly property real resolvedCenteredAvailableHeight: windowHeight - surfaceSafeArea.margins.top - surfaceSafeArea.margins.bottom
@@ -183,7 +182,6 @@ Dialog {
     topPadding: 0
     bottomPadding: 0
     spacing: 0
-    // TODO: Verify if bottom sheets still need the legacy -1 margin adjustment.
     margins: d.bottomSheet ? -1 : 0
     closePolicy: (root.escapeKeyCloses ? Popup.CloseOnEscape : Popup.NoAutoClose)
                  | (root.closeOnOverlayClick ? Popup.CloseOnPressOutside : Popup.NoAutoClose)
@@ -257,7 +255,7 @@ Dialog {
             id: headerToolbarItem
 
             Layout.fillWidth: true
-            Layout.topMargin: d.edgePadding + d.headerSafeArea
+            Layout.topMargin: d.edgePadding
             Layout.leftMargin: d.edgePadding + d.leftSafeArea
             Layout.rightMargin: d.edgePadding + d.rightSafeArea
             visible: d.hasHeader

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
@@ -141,9 +141,8 @@ Dialog {
         readonly property real resolvedCenteredMaxHeight: root.maximumHeightOverride > 0 ? Math.min(root.maximumHeightOverride, windowHeight)
                                                                                          : windowHeight * centeredHeightRatio
 
-        // Width used by bottom sheets after applying the exceptional override, if any.
-        readonly property real resolvedBottomSheetWidth: root.maximumWidthOverride > 0 ? Math.min(root.maximumWidthOverride, windowWidth)
-                                                                                       : windowWidth
+        // Bottom sheets always span the full window width.
+        readonly property real resolvedBottomSheetWidth: windowWidth
         // Bottom sheets can use up to this fraction of the window height.
         readonly property real bottomSheetHeightRatio: 0.9
         // Height cap for bottom sheets. The ratio is applied to the usable height

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
@@ -114,13 +114,14 @@ Dialog {
         readonly property bool bottomSheet: windowWidth <= ThemeUtils.portraitBreakpoint.width
                                             && windowHeight > windowWidth
 
-        // Safe-area insets for the dialog surface. The dialog reads them from its
-        // content host so tests and hosted dialogs can override them locally
-        // without changing the whole window.
-        readonly property real headerSafeArea: root.contentItem.SafeArea.margins.top
-        readonly property real footerSafeArea: root.contentItem.SafeArea.margins.bottom
-        readonly property real leftSafeArea: root.contentItem.SafeArea.margins.left
-        readonly property real rightSafeArea: root.contentItem.SafeArea.margins.right
+        // Use the overlay item because Android applies keyboard/safe-area
+        // adjustments there. Centered dialogs use these values only as outer
+        // bounds; bottom sheets use bottom/horizontal values as internal padding.
+        readonly property var surfaceSafeArea: root.parent ? root.parent.SafeArea : root.contentItem.SafeArea
+        readonly property real headerSafeArea: 0
+        readonly property real footerSafeArea: bottomSheet ? surfaceSafeArea.margins.bottom : 0
+        readonly property real leftSafeArea: bottomSheet ? surfaceSafeArea.margins.left : 0
+        readonly property real rightSafeArea: bottomSheet ? surfaceSafeArea.margins.right : 0
         // Vertical padding owned by the content host. When content is the first or
         // last visible section, it also absorbs the corresponding safe area.
         readonly property real contentTopPadding: edgePadding + (hasHeader ? 0 : headerSafeArea)
@@ -135,11 +136,13 @@ Dialog {
         // Total horizontal space reserved around centered dialogs.
         readonly property real centeredHorizontalMargin: 2 * Theme.bigPadding
         // Width used by centered dialogs after applying margins and the exceptional override, if any.
+        readonly property real resolvedCenteredAvailableWidth: windowWidth - surfaceSafeArea.margins.left - surfaceSafeArea.margins.right
+        readonly property real resolvedCenteredAvailableHeight: windowHeight - surfaceSafeArea.margins.top - surfaceSafeArea.margins.bottom
         readonly property real resolvedCenteredWidth: Math.min(root.maximumWidthOverride > 0 ? root.maximumWidthOverride : centeredMaxWidth,
-                                                               Math.max(root.implicitWidth, windowWidth - centeredHorizontalMargin))
+                                                               Math.max(root.implicitWidth, resolvedCenteredAvailableWidth - centeredHorizontalMargin))
         // Height cap used by centered dialogs after applying the exceptional override, if any.
-        readonly property real resolvedCenteredMaxHeight: root.maximumHeightOverride > 0 ? Math.min(root.maximumHeightOverride, windowHeight)
-                                                                                         : windowHeight * centeredHeightRatio
+        readonly property real resolvedCenteredMaxHeight: root.maximumHeightOverride > 0 ? Math.min(root.maximumHeightOverride, resolvedCenteredAvailableHeight)
+                                                                                         : resolvedCenteredAvailableHeight * centeredHeightRatio
 
         // Bottom sheets always span the full window width.
         readonly property real resolvedBottomSheetWidth: windowWidth
@@ -151,7 +154,7 @@ Dialog {
         // added back so the home-indicator padding does not reduce the content area.
         readonly property real resolvedBottomSheetMaxHeight: (root.maximumHeightOverride > 0
             ? Math.min(root.maximumHeightOverride, windowHeight)
-            : (windowHeight - headerSafeArea) * bottomSheetHeightRatio) + footerSafeArea
+            : (windowHeight - surfaceSafeArea.margins.top) * bottomSheetHeightRatio) + footerSafeArea
 
         // Height ratio selected by the active presentation mode. Reused by internal
         // popup hosting so nested surfaces follow the same cap as their parent mode.
@@ -169,7 +172,7 @@ Dialog {
         readonly property real resolvedY: hostSurface
             ? hostSurface.height - root.height
             : bottomSheet ? windowHeight - root.height
-                          : (windowHeight - root.height) / 2
+                          : surfaceSafeArea.margins.top + (resolvedCenteredAvailableHeight - root.height) / 2
     }
 
     parent: Overlay.overlay
@@ -192,7 +195,7 @@ Dialog {
     height: Math.min(d.naturalHeight, d.resolvedMaxHeight)
 
     x: d.hostSurface ? 0
-                     : d.bottomSheet ? 0 : (d.windowWidth - root.width) / 2
+                     : d.bottomSheet ? 0 : d.surfaceSafeArea.margins.left + (d.resolvedCenteredAvailableWidth - root.width) / 2
 
     enter: Transition {
         id: enterTransition

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
@@ -55,6 +55,8 @@ Dialog {
     property bool closeOnOverlayClick: true
     // Whether pressing Escape closes the dialog.
     property bool escapeKeyCloses: !d.bottomSheet
+    // Whether the dialog object should destroy itself after it is closed.
+    property bool destroyOnClose: false
 
     // Exceptional override. Leave 0 to let the dialog resolve its own width.
     property int maximumWidthOverride: 0
@@ -330,7 +332,11 @@ Dialog {
     }
 
     onAboutToHide: internalPopupLayer.hideDuringParentClose()
-    onClosed: closeInternalPopup()
+    onClosed: {
+        closeInternalPopup()
+        if (root.destroyOnClose)
+            root.destroy()
+    }
 
     Item {
         id: internalPopupLayer

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
@@ -1,129 +1,125 @@
 import QtQuick
 import QtQuick.Controls
 
-import StatusQ.Core.Theme
 import StatusQ.Controls
 
 // Hosts the dialog content component and applies the scroll rules from the dialog spec.
-//
-// Strategy A — content IS a Flickable (ListView, GridView, …):
-//   The item is placed directly in the viewport and given the full content area
-//   size. This host owns the visible ScrollBar; the content item must disable any
-//   built-in scrollbar it carries (e.g. StatusListView.ScrollBar.vertical: null)
-//   to avoid showing two overlapping bars.
-//
-// Strategy B — content is NOT a Flickable (ColumnLayout, Item, …):
-//   The content is placed inside an internal Flickable managed by this host.
-//   Scrolling activates automatically when the content's implicit height exceeds
-//   the available area.
-Item {
+// Consumers provide the body only; the base dialog sets this control's paddings/insets.
+// The host owns the single visible scrollbar and configures scroll behavior, whether
+// the loaded body is regular content or resolves to a Flickable/ListView viewport.
+Control {
     id: root
 
     required property Component contentComponent
-
-    // Space around the content component. The vertical scrollbar is placed in the right margin.
-    property real contentMargin: 0
-    // Vertical space above the content component. Defaults to contentMargin.
-    property real contentTopMargin: contentMargin
-    // Vertical space below the content component. Defaults to contentMargin and may include bottom safe area.
-    property real contentBottomMargin: contentMargin
 
     // Natural height requested by the loaded content before the dialog applies its max-height cap.
     readonly property real naturalHeight: d.loadedContentNaturalHeight
 
     objectName: "statusAdaptiveDialogContentHost"
     clip: true
+    padding: 0
 
     QtObject {
         id: d
 
         readonly property var loadedContentItem: contentLoader.item
-        readonly property bool contentIsFlickable: loadedContentItem instanceof Flickable
-        readonly property real loadedContentNaturalHeight: loadedContentItem
-                                                           ? Math.max(loadedContentItem.implicitHeight,
-                                                                      contentIsFlickable ? loadedContentItem.contentHeight : 0)
-                                                           : 0
-        readonly property bool contentOverflows: loadedContentNaturalHeight > contentArea.height
+        readonly property var contentFlickable: resolveFlickable(loadedContentItem)
+        readonly property bool contentIsFlickable: !!contentFlickable
+        readonly property var activeFlickable: contentIsFlickable ? contentFlickable : scrollFlickable
+        readonly property var contentVerticalScrollBar: loadedContentItem
+                                                        && loadedContentItem.statusAdaptiveDialogContentVerticalScrollBar
+                                                        ? loadedContentItem.statusAdaptiveDialogContentVerticalScrollBar
+                                                        : null
+        readonly property real loadedContentImplicitHeight: loadedContentItem ? loadedContentItem["implicitHeight"] ?? 0 : 0
+        readonly property real loadedContentHeight: contentFlickable ? contentFlickable.contentHeight : 0
+        readonly property real loadedContentNaturalHeight: loadedContentItem ? Math.max(loadedContentImplicitHeight, contentIsFlickable ? loadedContentHeight : 0) : 0
+        readonly property bool contentOverflows: activeFlickable ? activeFlickable.contentHeight > activeFlickable.height : false
+
+        function resolveFlickable(item) {
+            if (!item)
+                return null;
+
+            if (item instanceof Flickable)
+                return item;
+
+            if (item.contentItem instanceof Flickable)
+                return item.contentItem;
+
+            return null;
+        }
     }
 
-    Loader {
-        id: contentLoader
+    contentItem: Item {
+        id: contentViewport
 
-        active: !!root.contentComponent
-        sourceComponent: root.contentComponent
-        visible: false
+        objectName: "statusAdaptiveDialogContentViewport"
+        clip: true
 
-        onLoaded: {
-            item.x = 0;
-            item.y = 0;
+        Flickable {
+            id: scrollFlickable
 
-            if (d.contentIsFlickable) {
-                item.parent = contentArea;
-                item.width = Qt.binding(() => contentArea.width);
-                item.height = Qt.binding(() => contentArea.height);
-                item.boundsBehavior = Flickable.StopAtBounds;
-                item.flickableDirection = Flickable.VerticalFlick;
-                item.contentWidth = Qt.binding(() => contentArea.width);
-            } else {
-                item.parent = scrollFlickable.contentItem;
-                item.width = Qt.binding(() => scrollFlickable.width);
-                item.height = Qt.binding(() => Math.max(item.implicitHeight, scrollFlickable.height));
+            objectName: "statusAdaptiveDialogScrollFlickable"
+            anchors.fill: parent
+            boundsBehavior: Flickable.StopAtBounds
+            clip: true
+            contentWidth: width
+            contentHeight: d.contentIsFlickable ? 0 : d.loadedContentNaturalHeight
+            flickableDirection: Flickable.VerticalFlick
+            visible: !!d.loadedContentItem && !d.contentIsFlickable
+            enabled: visible
+            interactive: visible && d.contentOverflows
+        }
+
+        Loader {
+            id: contentLoader
+
+            active: !!root.contentComponent
+            sourceComponent: root.contentComponent
+            visible: false
+
+            onLoaded: {
+                item.x = 0;
+                item.y = 0;
+
+                if (d.contentIsFlickable) {
+                    const flickable = d.contentFlickable;
+
+                    item.parent = contentViewport;
+                    item.width = Qt.binding(() => contentViewport.width);
+                    item.height = Qt.binding(() => contentViewport.height);
+                    flickable.boundsBehavior = Flickable.StopAtBounds;
+                    flickable.flickableDirection = Flickable.VerticalFlick;
+                    flickable.contentWidth = Qt.binding(() => contentViewport.width);
+                    flickable.interactive = Qt.binding(() => d.contentOverflows);
+                    if (d.contentVerticalScrollBar)
+                        d.contentVerticalScrollBar.policy = ScrollBar.AlwaysOff;
+                } else {
+                    item.parent = scrollFlickable.contentItem;
+                    item.width = Qt.binding(() => scrollFlickable.width);
+                    item.height = Qt.binding(() => Math.max(d.loadedContentImplicitHeight, scrollFlickable.height));
+                }
             }
         }
     }
 
-    Item {
-        id: contentArea
-
-        objectName: "statusAdaptiveDialogContentViewport"
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        anchors.leftMargin: root.contentMargin
-        anchors.rightMargin: root.contentMargin
-        anchors.topMargin: root.contentTopMargin
-        anchors.bottomMargin: root.contentBottomMargin
-        clip: true
-    }
-
-    Flickable {
-        id: scrollFlickable
-
-        objectName: "statusAdaptiveDialogScrollFlickable"
-        anchors.fill: contentArea
-        boundsBehavior: Flickable.StopAtBounds
-        clip: true
-        contentWidth: width
-        contentHeight: d.contentIsFlickable ? 0 : d.loadedContentNaturalHeight
-        flickableDirection: Flickable.VerticalFlick
-        visible: !!d.loadedContentItem && !d.contentIsFlickable
-        enabled: visible
-        interactive: visible && d.contentOverflows
-    }
-
     StatusScrollBar {
-        id: contentScrollBar
-
         objectName: "statusAdaptiveDialogContentScrollBar"
 
-        readonly property var flickable: d.contentIsFlickable && contentLoader.item instanceof Flickable ? contentLoader.item : scrollFlickable
-
-        width: Math.max(root.Theme.halfPadding, 8)
-        anchors.top: contentArea.top
-        anchors.right: parent.right
-        anchors.rightMargin: Math.max(0, (root.contentMargin - width) / 2)
-        anchors.bottom: contentArea.bottom
+        width: Math.max(root.rightPadding / 2, 8)
+        anchors.top: contentViewport.top
+        anchors.bottom: contentViewport.bottom
+        anchors.right: root.right
+        anchors.rightMargin: Math.max(0, (root.rightPadding - width) / 2)
         orientation: Qt.Vertical
         policy: ScrollBar.AsNeeded
-        position: flickable ? flickable.visibleArea.yPosition : 0
-        size: flickable ? flickable.visibleArea.heightRatio : 1
-        active: flickable && flickable.moving
-        visible: flickable && flickable.visible && resolveVisibility(policy, flickable.height, flickable.contentHeight)
+        position: d.activeFlickable ? d.activeFlickable.visibleArea.yPosition : 0
+        size: d.activeFlickable ? d.activeFlickable.visibleArea.heightRatio : 1
+        active: d.activeFlickable && d.activeFlickable.moving
+        visible: d.activeFlickable && resolveVisibility(policy, d.activeFlickable.height, d.activeFlickable.contentHeight)
 
         onPositionChanged: {
-            if (pressed && flickable)
-                flickable.contentY = position * Math.max(0, flickable.contentHeight - flickable.height);
+            if (pressed && d.activeFlickable)
+                d.activeFlickable.contentY = position * Math.max(0, d.activeFlickable.contentHeight - d.activeFlickable.height);
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
@@ -115,7 +115,16 @@ Control {
     }
 
     StatusScrollBar {
+        id: contentScrollBar
+
         objectName: "statusAdaptiveDialogContentScrollBar"
+
+        function syncPositionFromFlickable() {
+            if (!pressed) {
+                const newPosition = d.activeFlickable ? d.activeFlickable.visibleArea.yPosition : 0;
+                position = isNaN(newPosition) ? 0 : newPosition;
+            }
+        }
 
         width: Math.max(root.rightPadding / 2, 8)
         anchors.top: contentViewport.top
@@ -124,15 +133,43 @@ Control {
         anchors.rightMargin: Math.max(0, (root.rightPadding - width) / 2)
         orientation: Qt.Vertical
         policy: ScrollBar.AsNeeded
-        position: d.activeFlickable ? d.activeFlickable.visibleArea.yPosition : 0
-        size: d.activeFlickable ? d.activeFlickable.visibleArea.heightRatio : 1
-        active: d.activeFlickable && d.activeFlickable.moving
-        visible: d.activeFlickable && resolveVisibility(policy, d.activeFlickable.height, d.activeContentExtent)
+        position: 0
+        size: d.activeFlickable && d.activeFlickable.visibleArea.heightRatio >= 0
+              ? d.activeFlickable.visibleArea.heightRatio : 1
+        active: !!d.activeFlickable && d.activeFlickable.moving
+        visible: !!d.activeFlickable && resolveVisibility(policy, d.activeFlickable.height, d.activeContentExtent)
 
+        Component.onCompleted: syncPositionFromFlickable()
+        onPressedChanged: syncPositionFromFlickable()
         onPositionChanged: {
             if (pressed && d.activeFlickable)
                 d.activeFlickable.contentY = -d.activeFlickable.topMargin
                                              + position * Math.max(0, d.activeContentExtent - d.activeFlickable.height);
+        }
+    }
+
+    Connections {
+        target: d
+
+        function onActiveFlickableChanged() {
+            contentScrollBar.syncPositionFromFlickable();
+        }
+    }
+
+    Connections {
+        target: d.activeFlickable
+        ignoreUnknownSignals: true
+
+        function onContentYChanged() {
+            contentScrollBar.syncPositionFromFlickable();
+        }
+
+        function onContentHeightChanged() {
+            contentScrollBar.syncPositionFromFlickable();
+        }
+
+        function onHeightChanged() {
+            contentScrollBar.syncPositionFromFlickable();
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
@@ -1,0 +1,129 @@
+import QtQuick
+import QtQuick.Controls
+
+import StatusQ.Core.Theme
+import StatusQ.Controls
+
+// Hosts the dialog content component and applies the scroll rules from the dialog spec.
+//
+// Strategy A — content IS a Flickable (ListView, GridView, …):
+//   The item is placed directly in the viewport and given the full content area
+//   size. This host owns the visible ScrollBar; the content item must disable any
+//   built-in scrollbar it carries (e.g. StatusListView.ScrollBar.vertical: null)
+//   to avoid showing two overlapping bars.
+//
+// Strategy B — content is NOT a Flickable (ColumnLayout, Item, …):
+//   The content is placed inside an internal Flickable managed by this host.
+//   Scrolling activates automatically when the content's implicit height exceeds
+//   the available area.
+Item {
+    id: root
+
+    required property Component contentComponent
+
+    // Space around the content component. The vertical scrollbar is placed in the right margin.
+    property real contentMargin: 0
+    // Vertical space above the content component. Defaults to contentMargin.
+    property real contentTopMargin: contentMargin
+    // Vertical space below the content component. Defaults to contentMargin and may include bottom safe area.
+    property real contentBottomMargin: contentMargin
+
+    // Natural height requested by the loaded content before the dialog applies its max-height cap.
+    readonly property real naturalHeight: d.loadedContentNaturalHeight
+
+    objectName: "statusAdaptiveDialogContentHost"
+    clip: true
+
+    QtObject {
+        id: d
+
+        readonly property var loadedContentItem: contentLoader.item
+        readonly property bool contentIsFlickable: loadedContentItem instanceof Flickable
+        readonly property real loadedContentNaturalHeight: loadedContentItem
+                                                           ? Math.max(loadedContentItem.implicitHeight,
+                                                                      contentIsFlickable ? loadedContentItem.contentHeight : 0)
+                                                           : 0
+        readonly property bool contentOverflows: loadedContentNaturalHeight > contentArea.height
+    }
+
+    Loader {
+        id: contentLoader
+
+        active: !!root.contentComponent
+        sourceComponent: root.contentComponent
+        visible: false
+
+        onLoaded: {
+            item.x = 0;
+            item.y = 0;
+
+            if (d.contentIsFlickable) {
+                item.parent = contentArea;
+                item.width = Qt.binding(() => contentArea.width);
+                item.height = Qt.binding(() => contentArea.height);
+                item.boundsBehavior = Flickable.StopAtBounds;
+                item.flickableDirection = Flickable.VerticalFlick;
+                item.contentWidth = Qt.binding(() => contentArea.width);
+            } else {
+                item.parent = scrollFlickable.contentItem;
+                item.width = Qt.binding(() => scrollFlickable.width);
+                item.height = Qt.binding(() => Math.max(item.implicitHeight, scrollFlickable.height));
+            }
+        }
+    }
+
+    Item {
+        id: contentArea
+
+        objectName: "statusAdaptiveDialogContentViewport"
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.leftMargin: root.contentMargin
+        anchors.rightMargin: root.contentMargin
+        anchors.topMargin: root.contentTopMargin
+        anchors.bottomMargin: root.contentBottomMargin
+        clip: true
+    }
+
+    Flickable {
+        id: scrollFlickable
+
+        objectName: "statusAdaptiveDialogScrollFlickable"
+        anchors.fill: contentArea
+        boundsBehavior: Flickable.StopAtBounds
+        clip: true
+        contentWidth: width
+        contentHeight: d.contentIsFlickable ? 0 : d.loadedContentNaturalHeight
+        flickableDirection: Flickable.VerticalFlick
+        visible: !!d.loadedContentItem && !d.contentIsFlickable
+        enabled: visible && d.contentOverflows
+        interactive: enabled
+    }
+
+    StatusScrollBar {
+        id: contentScrollBar
+
+        objectName: "statusAdaptiveDialogContentScrollBar"
+
+        readonly property var flickable: d.contentIsFlickable && contentLoader.item instanceof Flickable ? contentLoader.item : scrollFlickable
+
+        width: Math.max(root.Theme.halfPadding, 8)
+        anchors.top: contentArea.top
+        anchors.right: parent.right
+        anchors.rightMargin: Math.max(0, (root.contentMargin - width) / 2)
+        anchors.bottom: contentArea.bottom
+        orientation: Qt.Vertical
+        policy: ScrollBar.AsNeeded
+        position: flickable ? flickable.visibleArea.yPosition : 0
+        size: flickable ? flickable.visibleArea.heightRatio : 1
+        active: flickable && flickable.moving
+        visible: flickable && flickable.visible && resolveVisibility(policy, flickable.height, flickable.contentHeight)
+
+        onPositionChanged: {
+            if (pressed && flickable)
+                flickable.contentY = position * Math.max(0, flickable.contentHeight - flickable.height);
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
@@ -11,6 +11,8 @@ Control {
     id: root
 
     required property Component contentComponent
+    property real flickableTopPadding: 0
+    property real flickableBottomPadding: 0
 
     // Natural height requested by the loaded content before the dialog applies its max-height cap.
     readonly property real naturalHeight: d.loadedContentNaturalHeight
@@ -33,7 +35,10 @@ Control {
         readonly property real loadedContentImplicitHeight: loadedContentItem ? loadedContentItem["implicitHeight"] ?? 0 : 0
         readonly property real loadedContentHeight: contentFlickable ? contentFlickable.contentHeight : 0
         readonly property real loadedContentNaturalHeight: loadedContentItem ? Math.max(loadedContentImplicitHeight, contentIsFlickable ? loadedContentHeight : 0) : 0
-        readonly property bool contentOverflows: activeFlickable ? activeFlickable.contentHeight > activeFlickable.height : false
+        readonly property real activeContentExtent: activeFlickable ? activeFlickable.contentHeight
+                                                                      + activeFlickable.topMargin
+                                                                      + activeFlickable.bottomMargin : 0
+        readonly property bool contentOverflows: activeFlickable ? activeContentExtent > activeFlickable.height : false
 
         function resolveFlickable(item) {
             if (!item)
@@ -64,6 +69,8 @@ Control {
             clip: true
             contentWidth: width
             contentHeight: d.contentIsFlickable ? 0 : d.loadedContentNaturalHeight
+            topMargin: root.flickableTopPadding
+            bottomMargin: root.flickableBottomPadding
             flickableDirection: Flickable.VerticalFlick
             visible: !!d.loadedContentItem && !d.contentIsFlickable
             enabled: visible
@@ -90,13 +97,18 @@ Control {
                     flickable.boundsBehavior = Flickable.StopAtBounds;
                     flickable.flickableDirection = Flickable.VerticalFlick;
                     flickable.contentWidth = Qt.binding(() => contentViewport.width);
+                    flickable.topMargin = Qt.binding(() => root.flickableTopPadding);
+                    flickable.bottomMargin = Qt.binding(() => root.flickableBottomPadding);
                     flickable.interactive = Qt.binding(() => d.contentOverflows);
                     if (d.contentVerticalScrollBar)
                         d.contentVerticalScrollBar.policy = ScrollBar.AlwaysOff;
                 } else {
                     item.parent = scrollFlickable.contentItem;
                     item.width = Qt.binding(() => scrollFlickable.width);
-                    item.height = Qt.binding(() => Math.max(d.loadedContentImplicitHeight, scrollFlickable.height));
+                    item.height = Qt.binding(() => Math.max(d.loadedContentImplicitHeight,
+                                                            scrollFlickable.height
+                                                            - root.flickableTopPadding
+                                                            - root.flickableBottomPadding));
                 }
             }
         }
@@ -115,11 +127,12 @@ Control {
         position: d.activeFlickable ? d.activeFlickable.visibleArea.yPosition : 0
         size: d.activeFlickable ? d.activeFlickable.visibleArea.heightRatio : 1
         active: d.activeFlickable && d.activeFlickable.moving
-        visible: d.activeFlickable && resolveVisibility(policy, d.activeFlickable.height, d.activeFlickable.contentHeight)
+        visible: d.activeFlickable && resolveVisibility(policy, d.activeFlickable.height, d.activeContentExtent)
 
         onPositionChanged: {
             if (pressed && d.activeFlickable)
-                d.activeFlickable.contentY = position * Math.max(0, d.activeFlickable.contentHeight - d.activeFlickable.height);
+                d.activeFlickable.contentY = -d.activeFlickable.topMargin
+                                             + position * Math.max(0, d.activeContentExtent - d.activeFlickable.height);
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
@@ -32,7 +32,7 @@ Control {
                                                         && loadedContentItem.statusAdaptiveDialogContentVerticalScrollBar
                                                         ? loadedContentItem.statusAdaptiveDialogContentVerticalScrollBar
                                                         : null
-        readonly property real loadedContentImplicitHeight: loadedContentItem ? loadedContentItem["implicitHeight"] ?? 0 : 0
+        readonly property real loadedContentImplicitHeight: loadedContentItem ? loadedContentItem.implicitHeight : 0
         readonly property real loadedContentHeight: contentFlickable ? contentFlickable.contentHeight : 0
         readonly property real loadedContentNaturalHeight: loadedContentItem ? Math.max(loadedContentImplicitHeight, contentIsFlickable ? loadedContentHeight : 0) : 0
         readonly property real activeContentExtent: activeFlickable ? activeFlickable.contentHeight

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
@@ -98,8 +98,8 @@ Item {
         contentHeight: d.contentIsFlickable ? 0 : d.loadedContentNaturalHeight
         flickableDirection: Flickable.VerticalFlick
         visible: !!d.loadedContentItem && !d.contentIsFlickable
-        enabled: visible && d.contentOverflows
-        interactive: enabled
+        enabled: visible
+        interactive: visible && d.contentOverflows
     }
 
     StatusScrollBar {

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml
@@ -18,7 +18,6 @@ Control {
     readonly property real naturalHeight: d.loadedContentNaturalHeight
 
     objectName: "statusAdaptiveDialogContentHost"
-    clip: true
     padding: 0
 
     QtObject {
@@ -66,7 +65,6 @@ Control {
             objectName: "statusAdaptiveDialogScrollFlickable"
             anchors.fill: parent
             boundsBehavior: Flickable.StopAtBounds
-            clip: true
             contentWidth: width
             contentHeight: d.contentIsFlickable ? 0 : d.loadedContentNaturalHeight
             topMargin: root.flickableTopPadding

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogFooter.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogFooter.qml
@@ -32,6 +32,7 @@ Control {
 
     visible: !!leftButtons || !!rightButtons
     padding: 0
+    spacing: Theme.defaultHalfPadding
 
     background: StatusDialogBackground {
         color: root.color
@@ -42,7 +43,7 @@ Control {
     }
 
     contentItem: RowLayout {
-        spacing: Theme.defaultHalfPadding
+        spacing: root.spacing
 
         Repeater {
             model: root.leftButtons

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogFooter.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogFooter.qml
@@ -1,0 +1,59 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQml.Models
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+
+// Footer action surface for StatusAdaptiveDialog.
+//
+// Renders two ObjectModel slots in a horizontal row: leftButtons on the left
+// (navigation controls, contextual info) and rightButtons on the right (primary
+// and secondary actions). Visibility is automatic — the component hides itself
+// when both slots are empty.
+//
+// The parent dialog owns external margins, dividers, safe-area spacing and
+// section visibility. This component owns only the painted surface and the
+// button row inside it.
+Control {
+    id: root
+
+    objectName: "statusAdaptiveDialogFooter"
+
+    // Typically navigation controls (e.g. StatusBackButton in multi-step flows) or
+    // informational content (e.g. estimated time, fees).
+    property ObjectModel leftButtons
+    // Typically the primary and secondary actions (e.g. Cancel + Confirm).
+    property ObjectModel rightButtons
+
+    property color color: Theme.palette.statusModal.backgroundColor
+    property int radius: Theme.radius
+
+    visible: !!leftButtons || !!rightButtons
+    padding: 0
+
+    background: StatusDialogBackground {
+        color: root.color
+        bottomLeftRadius: root.radius
+        bottomRightRadius: root.radius
+        topLeftRadius: 0
+        topRightRadius: 0
+    }
+
+    contentItem: RowLayout {
+        spacing: Theme.defaultHalfPadding
+
+        Repeater {
+            model: root.leftButtons
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+
+        Repeater {
+            model: root.rightButtons
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogHeader.qml
@@ -1,0 +1,78 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Controls.Universal
+import QtQuick.Layouts
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+
+// Header surface for StatusAdaptiveDialog.
+//
+// Renders a title/subtitle row with an optional left component (e.g. a back
+// button) and a right actions area (close button, overflow menu). Visibility
+// is automatic — the component hides itself when both title and subtitle are
+// empty.
+//
+// The parent dialog owns external margins, dividers and section visibility.
+// This component owns only the painted surface and the internal row layout.
+// Consumers configure it through StatusAdaptiveDialog's header aliases rather
+// than depending on this component directly.
+Control {
+    id: root
+
+    objectName: "statusAdaptiveDialogHeader"
+
+    readonly property alias headline: headline
+    readonly property alias actions: actions
+    property alias title: headline.title
+    property alias subtitle: headline.subtitle
+    property alias leftComponent: leftComponentLoader.sourceComponent
+
+    property color color: Theme.palette.statusModal.backgroundColor
+    property int radius: Theme.radius
+
+    visible: !!headline.title || !!headline.subtitle
+    padding: 0
+
+    background: StatusDialogBackground {
+        color: root.color
+        topLeftRadius: root.radius
+        topRightRadius: root.radius
+        bottomLeftRadius: 0
+        bottomRightRadius: 0
+    }
+
+    contentItem: RowLayout {
+        id: layout
+
+        spacing: Theme.halfPadding
+
+        Item {
+            id: leftComponentHost
+
+            Layout.fillHeight: true
+            Layout.preferredWidth: visible ? leftComponentLoader.implicitWidth : 0
+            Layout.rightMargin: visible ? Math.max(Theme.padding, 8) - layout.spacing : 0
+            visible: leftComponentLoader.sourceComponent
+
+            Loader {
+                id: leftComponentLoader
+
+                anchors.centerIn: parent
+            }
+        }
+
+        StatusTitleSubtitle {
+            id: headline
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+
+        StatusHeaderActions {
+            id: actions
+
+            Layout.alignment: Qt.AlignTop
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogHeader.qml
@@ -33,6 +33,7 @@ Control {
 
     visible: !!headline.title || !!headline.subtitle
     padding: 0
+    spacing: Theme.halfPadding
 
     background: StatusDialogBackground {
         color: root.color
@@ -45,14 +46,14 @@ Control {
     contentItem: RowLayout {
         id: layout
 
-        spacing: Theme.halfPadding
+        spacing: root.spacing
 
         Item {
             id: leftComponentHost
 
             Layout.fillHeight: true
             Layout.preferredWidth: visible ? leftComponentLoader.implicitWidth : 0
-            Layout.rightMargin: visible ? Math.max(Theme.padding, 8) - layout.spacing : 0
+            Layout.rightMargin: visible ? Math.max(Theme.padding, 8) - root.spacing : 0
             visible: leftComponentLoader.sourceComponent
 
             Loader {

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusHeaderActions.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusHeaderActions.qml
@@ -30,7 +30,7 @@ Item {
 
         Repeater {
             model: root.customButtons
-            onItemAdded: {
+            onItemAdded: function(index, item) {
                 item.Layout.fillHeight = true
                 item.Layout.preferredHeight = d.buttonSize
                 item.Layout.preferredWidth = d.buttonSize

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/qmldir
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/qmldir
@@ -1,6 +1,10 @@
 module StatusQ.Popups.Dialog
 
 StatusDialog 0.1 StatusDialog.qml
+StatusAdaptiveDialog 0.1 StatusAdaptiveDialog.qml
+StatusAdaptiveDialogContentHost 0.1 StatusAdaptiveDialogContentHost.qml
+StatusAdaptiveDialogFooter 0.1 StatusAdaptiveDialogFooter.qml
+StatusAdaptiveDialogHeader 0.1 StatusAdaptiveDialogHeader.qml
 StatusDialogBackground 0.1 StatusDialogBackground.qml
 StatusDialogDivider 0.1 StatusDialogDivider.qml
 StatusDialogFooter 0.1 StatusDialogFooter.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -234,6 +234,10 @@
         <file>StatusQ/Platform/StatusMacNotification.qml</file>
         <file>StatusQ/Platform/qmldir</file>
         <file>StatusQ/Popups/Dialog/StatusDialog.qml</file>
+        <file>StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml</file>
+        <file>StatusQ/Popups/Dialog/StatusAdaptiveDialogContentHost.qml</file>
+        <file>StatusQ/Popups/Dialog/StatusAdaptiveDialogFooter.qml</file>
+        <file>StatusQ/Popups/Dialog/StatusAdaptiveDialogHeader.qml</file>
         <file>StatusQ/Popups/Dialog/StatusDialogBackground.qml</file>
         <file>StatusQ/Popups/Dialog/StatusDialogDivider.qml</file>
         <file>StatusQ/Popups/Dialog/StatusDialogFooter.qml</file>

--- a/ui/app/AppLayouts/Communities/popups/CommunityRulesPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CommunityRulesPopup.qml
@@ -8,58 +8,47 @@ import StatusQ.Controls
 import StatusQ.Popups.Dialog
 import StatusQ.Core.Theme
 
-StatusDialog {
+StatusAdaptiveDialog {
     id: root
 
     required property string name
     required property string introMessage
     required property string image
     required property string color
-    
 
-    implicitWidth: 640 // design
     title: qsTr("%1 community rules").arg(root.name)
+    destroyOnClose: true
 
-    onClosed: destroy()
+    contentComponent: ColumnLayout {
+        spacing: 24
 
-    contentItem: StatusScrollView {
-        id: scrollView
-        contentWidth: availableWidth
-        padding: 0
+        StatusSmartIdenticon {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.topMargin: 1
+            Layout.bottomMargin: 1
+            name: asset.isImage ? "" : root.name
+            asset.isImage: root.image !== ""
+            asset.name: root.image
+            asset.isLetterIdenticon: !asset.isImage
+            asset.color: root.color
+            asset.charactersLen: 1
+            asset.useAcronymForLetterIdenticon: false
+            asset.width: 64
+            asset.height: 64
+        }
 
-        ColumnLayout {
-            width: scrollView.availableWidth
-            spacing: 24
-
-            StatusSmartIdenticon {
-                Layout.alignment: Qt.AlignHCenter
-                name: asset.isImage ? "" : root.name
-                asset.isImage: root.image !== ""
-                asset.name: root.image
-                asset.isLetterIdenticon: !asset.isImage
-                asset.color: root.color
-                asset.charactersLen: 1
-                asset.useAcronymForLetterIdenticon: false
-                asset.width: 64
-                asset.height: 64
-            }
-
-            StatusBaseText {
-                text: root.introMessage
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                wrapMode: Text.WordWrap
-            }
+        StatusBaseText {
+            text: root.introMessage
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
         }
     }
 
-    footer: StatusDialogFooter {
-        bottomPadding: Theme.padding + root.parent.SafeArea.margins.bottom
-        rightButtons: ObjectModel {
-            StatusButton {
-                text: qsTr("Done")
-                onClicked: root.close()
-            }
+    footerRightButtons: ObjectModel {
+        StatusButton {
+            objectName: "communityRulesPopupDoneButton"
+            text: qsTr("Done")
+            onClicked: root.close()
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/views/PermissionsView.qml
+++ b/ui/app/AppLayouts/Communities/views/PermissionsView.qml
@@ -185,6 +185,7 @@ ColumnLayout {
     ConfirmationDialog {
         id: declineAllDialog
 
+        confirmButtonObjectName: "confirmDeletePermissionButton"
         headerSettings.title: qsTr("Sure you want to delete permission")
         confirmationText: qsTr("If you delete this permission, any of your community members who rely on this permission will lose the access this permission gives them.")
 

--- a/ui/app/AppLayouts/Profile/popups/TokenListPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/TokenListPopup.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQml.Models
 
 import StatusQ.Core
 import StatusQ.Controls
@@ -15,7 +16,7 @@ import shared.panels
 
 import QtModelsToolkit
 
-StatusDialog {
+StatusAdaptiveDialog {
     id: root
 
     required property string sourceImage
@@ -29,24 +30,21 @@ StatusDialog {
     QtObject {
         id: d
 
-        readonly property int symbolColumnWidth: 90
-        readonly property int addressColumnWidth: 106
+        readonly property real symbolColumnFraction: 1 / 6
+        readonly property real addressColumnFraction: 1 / 5
         readonly property int externalLinkBtnWidth: 32
-        readonly property int maxTokenListBodyHeight: 420
     }
 
-    width: 521 // by design
-    padding: 0
-    horizontalPadding: Theme.padding
-    fillHeightOnBottomSheet: true    
+    subtitle: qsTr("%n token(s)", "", root.tokensListModel.ModelCount.count)
+    leftHeaderComponent: StatusSmartIdenticon {
+        asset.name: root.sourceImage
+        asset.isImage: !!asset.name
+    }
 
-    contentItem: StatusListView {
+    contentComponent: StatusListView {
         id: list
 
-        topMargin: Theme.padding
-        bottomMargin: Theme.padding
-        // Cap ListView implicit height so delegates recycle instead of laying out the full list
-        implicitHeight: Math.min(d.maxTokenListBodyHeight, contentHeight + topMargin + bottomMargin)
+        ScrollBar.vertical: null
 
         model: root.tokensListModel
 
@@ -64,7 +62,7 @@ StatusDialog {
             CustomHeaderDelegate {}
         }
         delegate: CustomDelegate {
-            width: contentItem.width
+            width: ListView.view.width
             height: 64
 
             name: model.name
@@ -77,18 +75,13 @@ StatusDialog {
         }
     }
 
-    header: StatusDialogHeader {
-        headline.title: root.title
-        headline.subtitle: qsTr("%n token(s)", "", root.tokensListModel.ModelCount.count)
-        actions.closeButton.onClicked: root.close()
-        leftComponent: StatusSmartIdenticon {
-            asset.name: root.sourceImage
-            asset.isImage: !!asset.name
+    footerRightButtons: ObjectModel {
+        StatusButton {
+            objectName: "tokenListPopupDoneButton"
+            text: qsTr("Done")
+            onClicked: root.close()
         }
     }
-
-    standardButtons: Dialog.Ok
-    okButtonText: qsTr("Done")
 
     component CustomTextBlock: ColumnLayout {
         id: textBlock
@@ -153,8 +146,10 @@ StatusDialog {
     }
 
     component CustomHeaderDelegate: RowLayout {
+        id: headerDelegate
+
         height: 34
-        width: contentItem.width
+        width: ListView.view ? ListView.view.width : 0
         spacing: 0
 
         StatusBaseText {
@@ -167,7 +162,7 @@ StatusDialog {
 
         StatusBaseText {
             Layout.leftMargin: Theme.padding
-            Layout.preferredWidth: d.symbolColumnWidth - Layout.leftMargin
+            Layout.preferredWidth: headerDelegate.width * d.symbolColumnFraction - Layout.leftMargin
             Layout.alignment: Qt.AlignLeft
 
             text: qsTr("Symbol")
@@ -176,7 +171,7 @@ StatusDialog {
 
         StatusBaseText {
             Layout.leftMargin: Theme.padding
-            Layout.preferredWidth: d.addressColumnWidth - Layout.leftMargin
+            Layout.preferredWidth: headerDelegate.width * d.addressColumnFraction - Layout.leftMargin
             Layout.alignment: Qt.AlignLeft
 
             text: qsTr("Address")
@@ -249,7 +244,7 @@ StatusDialog {
 
             StatusBaseText {
                 Layout.leftMargin: Theme.padding
-                Layout.preferredWidth: d.symbolColumnWidth - Layout.leftMargin
+                Layout.preferredWidth: customDelegate.width * d.symbolColumnFraction - Layout.leftMargin
                 Layout.alignment: Qt.AlignLeft
 
                 text: customDelegate.symbol
@@ -258,7 +253,7 @@ StatusDialog {
 
             StatusBaseText {
                 Layout.leftMargin: Theme.padding
-                Layout.preferredWidth: d.addressColumnWidth - Layout.leftMargin
+                Layout.preferredWidth: customDelegate.width * d.addressColumnFraction - Layout.leftMargin
                 Layout.alignment: Qt.AlignLeft
 
                 text: customDelegate.address

--- a/ui/app/AppLayouts/Profile/popups/TokenListPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/TokenListPopup.qml
@@ -46,6 +46,7 @@ StatusAdaptiveDialog {
 
         ScrollBar.vertical: null
 
+        implicitHeight: contentHeight
         model: root.tokensListModel
 
         header: ColumnLayout {
@@ -54,7 +55,6 @@ StatusAdaptiveDialog {
 
             CustomSourceInfoComponent {
                 Layout.fillWidth: true
-                Layout.margins: Theme.padding
             }
 
             Separator {}

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -331,6 +331,7 @@ SettingsContentBase {
                 headerSettings.title: qsTr("Unpair Device")
                 confirmationText: qsTr("Are you sure you want to unpair this device?")
                 confirmButtonLabel: qsTr("Unpair")
+                confirmButtonObjectName: "unpairDeviceConfirmationDialogUnpairButton"
                 onConfirmButtonClicked: {
                     const error = devicesStore.devicesModule.unpairDevice(installationId)
                     if (error) {

--- a/ui/imports/shared/popups/ConfirmationDialog.qml
+++ b/ui/imports/shared/popups/ConfirmationDialog.qml
@@ -8,7 +8,7 @@ import StatusQ.Core.Theme
 import StatusQ.Controls
 import StatusQ.Popups.Dialog
 
-StatusDialog {
+StatusAdaptiveDialog {
     id: root
 
     property var executeConfirm
@@ -19,29 +19,26 @@ StatusDialog {
     property string cancelButtonLabel: qsTr("Cancel")
     property string confirmationText: qsTr("Are you sure you want to do this?")
     property bool showCancelButton: false
-    property alias checkbox: checkbox
+    property bool doNotShowAgainOptionVisible: false
+    property bool doNotShowAgainChecked: false
 
     property StatusModalHeaderSettings headerSettings: StatusModalHeaderSettings {
         title: qsTr("Confirm your action")
     }
 
-    width: 480
-    margins: contentItem.Theme.padding
-
     title: headerSettings.title
     focus: visible
-    standardButtons: Dialog.NoButton
 
     signal confirmButtonClicked()
     signal cancelButtonClicked()
 
-    contentItem: ColumnLayout {
+    contentComponent: ColumnLayout {
         spacing: Theme.padding
 
         StatusBaseText {
             Layout.fillWidth: true
             Layout.topMargin: Theme.padding
-            Layout.bottomMargin: checkbox.visible ? 0: Theme.padding
+            Layout.bottomMargin: root.doNotShowAgainOptionVisible ? 0 : Theme.padding
 
             text: root.confirmationText
             font.pixelSize: Theme.primaryTextFontSize
@@ -50,43 +47,41 @@ StatusDialog {
         }
 
         StatusCheckBox {
-            id: checkbox
-            visible: false
+            id: doNotShowAgainCheckBox
+
+            objectName: "confirmationDialogDoNotShowAgainCheckBox"
 
             Layout.fillWidth: true
             Layout.bottomMargin: Theme.padding
-
+            visible: root.doNotShowAgainOptionVisible
+            checked: root.doNotShowAgainChecked
             text: qsTr("Do not show this again")
+            onToggled: root.doNotShowAgainChecked = checked
         }
     }
 
-    footer: StatusDialogFooter {
-        rightButtons: ObjectModel {
-            StatusFlatButton {
-                id: cancelButton
-                visible: root.showCancelButton
-                text: root.cancelButtonLabel
-                type: root.cancelBtnType === "warn"
-                      ? StatusBaseButton.Type.Danger
-                      : StatusBaseButton.Type.Normal
-                onClicked: root.cancelButtonClicked()
-            }
-            StatusButton {
-                id: confirmButton
-                objectName: root.confirmButtonObjectName
-                Layout.maximumWidth: root.availableWidth / 2
-                type: root.btnType === "warn"
-                      ? StatusBaseButton.Type.Danger
-                      : StatusBaseButton.Type.Normal
-                text: root.confirmButtonLabel
-                focus: true
-                Keys.onReturnPressed: confirmButton.clicked()
-                onClicked: {
-                    if (root.executeConfirm
-                            && typeof root.executeConfirm === "function")
-                        root.executeConfirm()
-                    root.confirmButtonClicked()
-                }
+    footerRightButtons: ObjectModel {
+        StatusFlatButton {
+            id: cancelButton
+
+            objectName: "confirmationDialogCancelButton"
+            visible: root.showCancelButton
+            text: root.cancelButtonLabel
+            type: root.cancelBtnType === "warn" ? StatusBaseButton.Type.Danger : StatusBaseButton.Type.Normal
+            onClicked: root.cancelButtonClicked()
+        }
+        StatusButton {
+            id: confirmButton
+            objectName: root.confirmButtonObjectName
+            Layout.maximumWidth: root.width / 2
+            type: root.btnType === "warn" ? StatusBaseButton.Type.Danger : StatusBaseButton.Type.Normal
+            text: root.confirmButtonLabel
+            focus: true
+            Keys.onReturnPressed: confirmButton.clicked()
+            onClicked: {
+                if (root.executeConfirm && typeof root.executeConfirm === "function")
+                    root.executeConfirm()
+                root.confirmButtonClicked()
             }
         }
     }

--- a/ui/imports/shared/popups/ConfirmationDialog.qml
+++ b/ui/imports/shared/popups/ConfirmationDialog.qml
@@ -11,6 +11,8 @@ import StatusQ.Popups.Dialog
 StatusAdaptiveDialog {
     id: root
 
+    objectName: "ConfirmationDialog"
+
     property var executeConfirm
     property string confirmButtonObjectName: ""
     property string btnType: "warn"

--- a/ui/imports/shared/popups/DeleteMessageConfirmationPopup.qml
+++ b/ui/imports/shared/popups/DeleteMessageConfirmationPopup.qml
@@ -10,12 +10,11 @@ ConfirmationDialog {
 
     headerSettings.title: qsTr("Confirm deleting this message")
     confirmationText: qsTr("Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.")
-    height: 260
-    checkbox.visible: true
+    doNotShowAgainOptionVisible: true
     confirmButtonObjectName: "chatButtonsPanelConfirmDeleteMessageButton"
 
     executeConfirm: () => {
-        if (checkbox.checked) {
+        if (doNotShowAgainChecked) {
             localAccountSensitiveSettings.showDeleteMessageWarning = false
         }
         close()


### PR DESCRIPTION
Part of #20128
Closes https://github.com/status-im/status-app/issues/21656

# Summary

This PR introduces `StatusAdaptiveDialog`, a new base dialog component for StatusQ.

The goal is to centralise common dialog behaviour, including:

- presentation mode
- sizing
- scrolling
- safe-area handling
- header, content and footer composition

This avoids duplicating geometry and layout logic across individual dialogs.

The PR also includes a few pilot migrations from `StatusDialog` / `StatusModal` to validate the new API before starting the bulk migration.

---

# What does the PR do

## New components

Location:

```text
StatusQ/Popups/Dialog/
```

## `StatusAdaptiveDialog`

New base dialog component.

It handles:

- Automatic presentation mode:
  - bottom sheet on narrow portrait windows
  - centered popup otherwise
  - updates reactively on orientation changes

- Sizing:
  - bottom sheets are capped at 90% of the usable window height
  - centered dialogs are capped at 80%
  - exceptional cases can override the default limits with:
    - `maximumWidthOverride`
    - `maximumHeightOverride`

- Safe-area handling:
  - reads safe-area insets from the `Window`
  - avoids relying on `Overlay` values
  - keeps top and bottom insets stable
  - includes bottom safe-area padding in footer spacing and max-height calculation

- Scrolling:
  - if the content is already a `Flickable`, it is used directly
  - otherwise, the content is wrapped in an internal `Flickable`
  - scrolling is enabled only when the content exceeds the available space

- Composition slots:
  - `title`
  - `subtitle`
  - `leftHeaderComponent`
  - `headerActions`
  - `contentComponent`
  - `footerLeftButtons`
  - `footerRightButtons`
  - `errorTags`

- Internal popup support:
  - `internalPopupComponent`
  - `openInternalPopup()`
  - `closeInternalPopup()`
  - `internalPopupActive`

- Behaviour options:
  - `closeOnOverlayClick`
  - `consumeFirstOutsideClick`
  - `escapeKeyCloses`
  - `destroyOnClose`

- Animations:
  - slide animation for bottom sheets
  - fade animation for centered dialogs

---

## `StatusAdaptiveDialogHeader`

Header component backed by a plain `Control`.

It intentionally does not use `ToolBar`, because `ToolBar` with `position: Top` on iOS can inject position-dependent safe-area padding and cause layout instability.

It supports:

- title
- subtitle
- optional left component
- optional right actions

The header hides itself when empty.

---

## `StatusAdaptiveDialogFooter`

Footer component backed by a plain `Control`.

It provides two button areas:

- left side for navigation or info actions
- right side for primary and secondary actions

The footer hides itself when empty.

---

## `StatusAdaptiveDialogContentHost`

Content host responsible for:

- applying the automatic scroll strategy
- managing the shared `ScrollBar`

---

# Pilot migrations

| Dialog | Location | Notes |
|---|---|---|
| `ConfirmationDialog` | `ui/imports/shared/popups/` | High-impact migration. Around 14 call sites inherit the new base automatically. |
| `DeleteMessageConfirmationPopup` | `ui/imports/shared/popups/` | Extends `ConfirmationDialog`. Only API adjustment needed: `checkbox.visible` → `doNotShowAgainOptionVisible`. |
| `TokenListPopup` | `ui/app/AppLayouts/Profile/popups/` | Representative scrollable list content. |
| `CommunityRulesPopup` | `ui/app/AppLayouts/Communities/popups/` | Representative static content with optional scroll. |

---

# Storybook and tests

| Page | Test |
|---|---|
| `StatusAdaptiveDialogPage` | `tst_StatusAdaptiveDialog` |
| `ConfirmationDialogPage` | `tst_ConfirmationDialog` |
| `TokenListPopupPage` | `tst_TokenListPopup` |
| `CommunityRulesPopupPage` | `tst_CommunityRulesPopup` |

`StatusAdaptiveDialogPage` covers:

- basic dialog
- internal popup
- footer error tags

---

# Out of scope

The following items are intentionally not handled in this PR.

## Keyboard avoidance

The dialog does not yet reflow when the on-screen keyboard appears on iOS or Android.

This will be handled in follow-up work.

## Multi-step wizard flows

`StatusStackModal` is not migrated in this PR.

The internal popup layer supports one level of nesting, but not a full navigation stack pattern yet.

Wizard dialogs such as Keycard and onboarding will need a dedicated migration approach.

## Bulk migration

Around 65 dialogs still extend `StatusDialog` or `StatusModal`.

They will be migrated in separate PRs, likely in batches:

1. Simple confirmations
2. Forms
3. Complex flows

## Deprecation of old bases

The old bases will only be deprecated and removed after the bulk migration is complete:

- `StatusDialog`
- `StatusModal`
- `StatusStackModal`

# Affected areas

Already described before

# Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

# Screencapture of the functionality

https://github.com/user-attachments/assets/5dad51b4-6098-46cb-8005-fdb15be98454

https://github.com/user-attachments/assets/7d5d954a-6cf8-4914-af70-6fab356c143b

**ANDROID - NAV BAR**

<img width="398" height="875" alt="Screenshot 2026-07-06 at 16 29 01" src="https://github.com/user-attachments/assets/2c46a486-e94f-484c-901f-d9e142ca91fa" />


<img width="398" height="875" alt="Screenshot 2026-07-06 at 16 29 12" src="https://github.com/user-attachments/assets/879c8f58-1406-45f9-93bb-e602f87ac23d" />

**ANDROID GESTURES**

<img width="398" height="875" alt="Screenshot 2026-07-06 at 16 29 27" src="https://github.com/user-attachments/assets/d52280ef-1918-4ce6-ad50-3e7a4d0b6943" />

<img width="398" height="875" alt="Screenshot 2026-07-06 at 16 29 39" src="https://github.com/user-attachments/assets/b749f403-19cb-46cb-beda-d9b62595a157" />

**IOS**

<img width="398" height="875" alt="Screenshot 2026-07-06 at 16 29 50" src="https://github.com/user-attachments/assets/4dca8f22-91ed-440a-ae90-453af5670b38" />

# Impact on end user

Better and consistent dialogs UX

## How to test

- Test migrated dialogs in different sizes / layouts and devices. 
- Use Storybook to test the base component.

## Risk 

Medium
