### PR TITLE
fix(ContactsColumnView): better placeholder "Search" text

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -123,7 +123,7 @@ Item {
             Layout.preferredHeight: 40
             KeyNavigation.tab: channelList
             Keys.onEscapePressed: searchBtn.checked = false
-            placeholderText: qsTr("Search chats...")
+            placeholderText: qsTr("Search contacts and groups...")
             visible: searchBtn.checked
             onVisibleChanged: {
                 clear()

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -4202,7 +4202,7 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Search chats...</source>
+        <source>Search contacts and groups...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -4221,7 +4221,7 @@ Zůstanete přihlášeni a vaše obnovovací fráze bude zcela ve vašich rukou.
         <translation type="unfinished">Hledat</translation>
     </message>
     <message>
-        <source>Search chats...</source>
+        <source>Search contacts and groups...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -4207,7 +4207,7 @@ Permanecerás conectado y tu frase de recuperación estará completamente en tus
         <translation type="unfinished">Buscar</translation>
     </message>
     <message>
-        <source>Search chats...</source>
+        <source>Search contacts and groups...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -4192,7 +4192,7 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation type="unfinished">검색</translation>
     </message>
     <message>
-        <source>Search chats...</source>
+        <source>Search contacts and groups...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
### What does the PR do

- replace "Search chats..." with a more descriptive "Search contacts and groups..." placeholder text

Fixes #20833

### Affected areas

ContactsColumnView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2674" height="2086" alt="image" src="https://github.com/user-attachments/assets/6a600a11-937a-4930-8797-cb9fc0e83248" />

### Impact on end user

Nicer UX

### How to test

- activate the "Search" field

### Risk 

low
