### PR TITLE
fix(EmptyChatPanel): invoke the Share dialog directly

### DIFF
--- a/storybook/pages/EmptyChatPanelPage.qml
+++ b/storybook/pages/EmptyChatPanelPage.qml
@@ -15,7 +15,7 @@ Item {
 
         EmptyChatPanel {
             anchors.fill: parent
-            onShareChatKeyClicked: console.log("EmptyChatPanel::onShareChatKeyClicked")
+            onShareChatKeyClicked: console.info("EmptyChatPanel::onShareChatKeyClicked")
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -296,7 +296,7 @@ Item {
     EmptyChatPanel {
         anchors.fill: parent
         visible: root.activeChatId === "" || root.chatsCount == 0
-        onShareChatKeyClicked: Global.openProfilePopup(userProfile.pubKey);
+        onShareChatKeyClicked: Global.shareProfileDialogRequested(userProfile.pubKey)
     }
 
     // This is kind of a solution for applying backend refactored changes with the minimal qml changes.


### PR DESCRIPTION
### What does the PR do

- instead of 2 clicks (going thru the Profile dialog)

Fixes #20823

### Affected areas

EmptyChatPanel

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2578" height="1694" alt="Snímek obrazovky z 2026-07-06 18-55-49" src="https://github.com/user-attachments/assets/18705c6c-f166-446d-85dc-a275e805a8a3" />

### Impact on end user

Easier UX for new users

### How to test

- have an empty chat list
- click the "Share your profile..." link

### Risk 

low
