### PR TITLE
test(e2e-mobile): wallet-send smoke

### DIFF
--- a/test/e2e_appium/locators/settings/wallet_settings_locators.py
+++ b/test/e2e_appium/locators/settings/wallet_settings_locators.py
@@ -20,6 +20,24 @@ class WalletSettingsLocators(BaseLocators):
 
     # Wallet settings menu items
     NETWORKS_ITEM = BaseLocators.resource_id_contains("networksItem")
+
+    # Networks view — testnet mode toggle + its confirmation popup. The
+    # popup title repeats the accept-button text, so prefer the Button class
+    # and keep the plain text match as fallback.
+    TESTNET_MODE_SWITCH = BaseLocators.tid("testnetModeSwitch")
+    TESTNET_CONFIRM_BUTTON = BaseLocators.xpath(
+        "//android.widget.Button[@text='Turn on testnet mode'"
+        " or contains(@content-desc, 'Turn on testnet mode')]"
+    )
+    # [last()]: the popup title repeats the button text and precedes it in
+    # document order; the accept control is the final match. @clickable
+    # keeps non-actionable echoes of the text (title, toast) out of the
+    # candidate set so [last()] cannot land on one rendered after the button.
+    TESTNET_CONFIRM_BUTTON_FALLBACK = BaseLocators.xpath(
+        "(//*[(contains(@text, 'Turn on testnet mode')"
+        " or contains(@content-desc, 'Turn on testnet mode'))"
+        " and @clickable='true'])[last()]"
+    )
     ACCOUNT_ORDER_ITEM = BaseLocators.resource_id_contains("accountOrderItem")
     MANAGE_TOKENS_ITEM = BaseLocators.resource_id_contains("manageTokensItem")
     SAVED_ADDRESSES_ITEM = BaseLocators.resource_id_contains("savedAddressesItem")

--- a/test/e2e_appium/locators/wallet/send_locators.py
+++ b/test/e2e_appium/locators/wallet/send_locators.py
@@ -1,0 +1,34 @@
+from ..base_locators import BaseLocators
+
+
+class SimpleSendModalLocators(BaseLocators):
+    RECIPIENT_INPUT = BaseLocators.resource_id_contains(
+        "RecipientView_SendRecipientInput"
+    )
+    RECIPIENT_FILLED = BaseLocators.resource_id_contains(
+        "RecipientView_RecipientViewDelegate"
+    )
+    AMOUNT_INPUT = BaseLocators.resource_id_contains("amountToSend_textField")
+    TOKEN_SELECTOR = BaseLocators.tid("tokenSelectorButton")
+    # AssetView_TokenListItem_* belongs to the wallet page BEHIND the modal —
+    # matching it "selects" nothing. The modal's own picker (a StatusDropdown
+    # tokenSelectorPanel) names its rows tokenSelectorAssetDelegate_<Asset>.
+    ETH_TOKEN_ITEM = BaseLocators.tid("AssetView_TokenListItem_ETH")
+    ETH_TOKEN_ITEM_PICKER = BaseLocators.resource_id_contains(
+        "tokenSelectorAssetDelegate_Ethereum"
+    )
+    REVIEW_SEND_BUTTON = BaseLocators.tid("transactionModalFooterButton")
+    REVIEW_SEND_BUTTON_FALLBACK = BaseLocators.content_desc_contains("Review Send")
+    SCROLL_VIEW = BaseLocators.resource_id_contains("scrollView")
+
+
+class SendSignModalLocators(BaseLocators):
+    SEND_ASSET_VALUE_TID = "sendAssetBoxValue"
+    NETWORK_VALUE_TID = "networkBoxValue"
+    RECIPIENT_DELEGATE_TID = "recipientDelegate"
+    SEND_ASSET_VALUE = BaseLocators.tid(SEND_ASSET_VALUE_TID)
+    NETWORK_VALUE = BaseLocators.tid(NETWORK_VALUE_TID)
+    RECIPIENT_DELEGATE = BaseLocators.tid(RECIPIENT_DELEGATE_TID)
+    SIGN_BUTTON = BaseLocators.tid("signButton")
+    REJECT_BUTTON = BaseLocators.tid("rejectButton")
+    HEADER_CLOSE_BUTTON = BaseLocators.resource_id_contains("headerActionsCloseButton")

--- a/test/e2e_appium/pages/base_page.py
+++ b/test/e2e_appium/pages/base_page.py
@@ -219,6 +219,25 @@ class BasePage:
         self.dump_page_source(f"click_failure_{locator_desc}")
         raise ElementInteractionError(message, str(locators[0] if locators else ""), "click")
 
+    def try_click(
+        self,
+        locator: tuple,
+        *,
+        timeout: int | None = None,
+        fallback_locators: list[tuple] | None = None,
+        max_attempts: int = 3,
+    ) -> bool:
+        """safe_click that returns False instead of raising on exhaustion."""
+        try:
+            return self.safe_click(
+                locator,
+                timeout=timeout,
+                fallback_locators=fallback_locators,
+                max_attempts=max_attempts,
+            )
+        except ElementInteractionError:
+            return False
+
     def find_element_safe(self, locator: tuple, timeout: int | None = None) -> WebElement | None:
         """Find element and return None instead of raising on failure."""
         try:
@@ -283,6 +302,28 @@ class BasePage:
             except Exception as exc:
                 self.logger.debug("scroll_to_element swipe failed: %s", exc)
         return self.is_element_visible(locator, timeout=timeout)
+
+    def wait_for_painted(
+        self, locator: tuple, timeout: int = 10
+    ) -> WebElement | None:
+        """Wait until the element exists AND reports non-zero bounds.
+
+        Qt/QML nodes can sit in the a11y tree with bounds [0,0][0,0] before
+        first paint or right after a view transition (stale tree); tapping
+        them dispatches at (0,0). Returns the painted element, or None.
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            element = self.find_element_safe(locator, timeout=1)
+            if element is not None:
+                try:
+                    rect = element.rect
+                    if rect.get("width", 0) > 0 and rect.get("height", 0) > 0:
+                        return element
+                except Exception:
+                    pass
+            time.sleep(0.3)
+        return None
 
     def qt_safe_input(
         self,

--- a/test/e2e_appium/pages/settings/wallet_settings_page.py
+++ b/test/e2e_appium/pages/settings/wallet_settings_page.py
@@ -242,6 +242,44 @@ class WalletSettingsPage(BasePage):
 
         return True
 
+    def open_networks(self, timeout: int = 10) -> bool:
+        """Open Settings → Wallet → Networks.
+
+        Returns True once the networks view is displayed (testnet switch
+        visible in its title row).
+        """
+        if not self._scroll_until_visible(self.locators.NETWORKS_ITEM):
+            self.logger.error("Networks item not visible in wallet settings")
+            return False
+        if not self.try_click(self.locators.NETWORKS_ITEM, timeout=timeout):
+            self.logger.error("Failed to click Networks item")
+            return False
+        return self.is_element_visible(
+            self.locators.TESTNET_MODE_SWITCH, timeout=timeout
+        )
+
+    def enable_testnet_mode(self, timeout: int = 10) -> bool:
+        """Turn on testnet mode from the Networks view (no-op if already on)."""
+        if not self.is_element_visible(self.locators.TESTNET_MODE_SWITCH, timeout=timeout):
+            self.logger.error("Testnet mode switch not visible")
+            return False
+        if self._is_element_checked(self.locators.TESTNET_MODE_SWITCH):
+            self.logger.info("Testnet mode already enabled")
+            return True
+        if not self.try_click(self.locators.TESTNET_MODE_SWITCH, timeout=timeout):
+            self.logger.error("Failed to tap testnet mode switch")
+            return False
+        if not self.try_click(
+            self.locators.TESTNET_CONFIRM_BUTTON,
+            fallback_locators=[self.locators.TESTNET_CONFIRM_BUTTON_FALLBACK],
+            timeout=timeout,
+        ):
+            self.logger.error("Failed to confirm testnet mode popup")
+            return False
+        return self.wait_for_element_checked(
+            self.locators.TESTNET_MODE_SWITCH, timeout=15
+        )
+
     def account_exists(self, name: str, timeout: int = 5) -> bool:
         """Check if an account with the given name exists.
         

--- a/test/e2e_appium/pages/wallet/send_modal.py
+++ b/test/e2e_appium/pages/wallet/send_modal.py
@@ -1,0 +1,303 @@
+import re
+import time
+from typing import Optional
+
+from selenium.common.exceptions import InvalidSessionIdException
+
+from ..base_page import BasePage
+from locators.wallet.send_locators import (
+    SendSignModalLocators,
+    SimpleSendModalLocators,
+)
+
+
+class SimpleSendModal(BasePage):
+    """Page object for the send modal (recipient, token, amount, Review Send)."""
+
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locators = SimpleSendModalLocators()
+
+    def is_displayed(self, timeout: int = 15) -> bool:
+        return self.is_element_visible(self.locators.RECIPIENT_INPUT, timeout=timeout)
+
+    def _scroll_into_view(self, locator: tuple) -> bool:
+        if self.is_element_visible(locator, timeout=2):
+            return True
+        return self.scroll_to_element(
+            locator,
+            container_locator=self.locators.SCROLL_VIEW,
+            max_swipes=3,
+            timeout=2,
+        )
+
+    def _log_send_resource_ids(self) -> None:
+        """Log every on-screen resource-id containing 'Send' for triage."""
+        try:
+            source = self.driver.page_source or ""
+            ids = sorted(set(re.findall(r'resource-id="([^"]*Send[^"]*)"', source)))
+            self.logger.error(
+                "Send-related resource-ids on screen: %s", ids or "none"
+            )
+        except Exception as exc:
+            self.logger.debug("page-source diagnostic failed: %s", exc)
+
+    def enter_recipient(self, address: str) -> bool:
+        if not self._scroll_into_view(self.locators.RECIPIENT_INPUT):
+            self.logger.error("Recipient input not visible in send modal")
+            self._log_send_resource_ids()
+            return False
+        if self.wait_for_painted(self.locators.RECIPIENT_INPUT, timeout=10) is None:
+            self.logger.error(
+                "Recipient input present but never painted (zero bounds)"
+            )
+            self._log_send_resource_ids()
+            return False
+        if not self.qt_safe_input(self.locators.RECIPIENT_INPUT, address):
+            # A resolved recipient replaces the input with a delegate chip, so
+            # the input "vanishing" after typing is the success state.
+            if self.find_element_safe(self.locators.RECIPIENT_FILLED, timeout=3):
+                return True
+            self._log_send_resource_ids()
+            return False
+        self.hide_keyboard()
+        return True
+
+    def ensure_eth_selected(self, timeout: int = 10) -> bool:
+        """Select ETH in the token picker, or accept an existing selection.
+
+        The picker list may already be open, the selector may already show
+        ETH, or the selector may not be rendered at all (preselected asset).
+        """
+        selector = self.find_element_safe(self.locators.TOKEN_SELECTOR, timeout=3)
+        if selector is None:
+            if self.is_element_visible(self.locators.ETH_TOKEN_ITEM_PICKER, timeout=2):
+                return self.try_click(
+                    self.locators.ETH_TOKEN_ITEM_PICKER, timeout=timeout
+                )
+            self.logger.info("No token selector rendered — assuming preselected asset")
+            return True
+
+        current = ""
+        for attr in ("content-desc", "text"):
+            try:
+                current += selector.get_attribute(attr) or ""
+            except Exception:
+                pass
+        # Word-boundary match: "stETH"/"wETH" must not pass as ETH.
+        if re.search(r"\bETH\b", current):
+            self.logger.info("Token selector already shows ETH")
+            return True
+
+        # The picker list may already be open (stray tap, retried click)
+        # while the selector button is still in the a11y tree — clicking the
+        # selector then would toggle the list closed.
+        if self.is_element_visible(self.locators.ETH_TOKEN_ITEM_PICKER, timeout=2):
+            return self.try_click(self.locators.ETH_TOKEN_ITEM_PICKER, timeout=timeout)
+
+        if not self.try_click(self.locators.TOKEN_SELECTOR, timeout=timeout):
+            self.logger.error("Failed to open token selector")
+            return False
+        if not self.is_element_visible(
+            self.locators.ETH_TOKEN_ITEM_PICKER, timeout=timeout
+        ):
+            self.logger.error("ETH item not visible in token picker")
+            self.dump_page_source("token_picker_no_eth")
+            self.take_screenshot("token_picker_no_eth")
+            return False
+        return self.try_click(self.locators.ETH_TOKEN_ITEM_PICKER, timeout=timeout)
+
+    def enter_amount(self, amount: str) -> bool:
+        if not self._scroll_into_view(self.locators.AMOUNT_INPUT):
+            self.logger.error("Amount input not visible in send modal")
+            self.dump_page_source("send_amount_missing")
+            self.take_screenshot("send_amount_missing")
+            return False
+        element = self.wait_for_painted(self.locators.AMOUNT_INPUT, timeout=10)
+        if element is None:
+            self.logger.error("Amount input present but never painted (zero bounds)")
+            self.dump_page_source("send_amount_unpainted")
+            return False
+        # Qt fields do not reliably expose their text for readback, so type
+        # without verification; wait_for_route_ready is the success oracle.
+        element.click()
+        try:
+            element.send_keys(amount)
+        except Exception:
+            self.driver.execute_script(
+                "mobile: type", {"text": amount}
+            )
+        self.hide_keyboard()
+        return True
+
+    def wait_for_route_ready(self, timeout: int = 60) -> bool:
+        """Wait until Review Send enables (route + fee estimation done)."""
+        return self.wait_for_element_enabled(
+            self.locators.REVIEW_SEND_BUTTON, timeout=timeout
+        )
+
+    def click_review_send(self, timeout: int = 10) -> Optional["SendSignModal"]:
+        if not self.try_click(
+            self.locators.REVIEW_SEND_BUTTON,
+            fallback_locators=[self.locators.REVIEW_SEND_BUTTON_FALLBACK],
+            timeout=timeout,
+        ):
+            self.logger.error("Failed to click Review Send")
+            return None
+        modal = SendSignModal(self.driver)
+        if modal.is_displayed(timeout=30):
+            return modal
+        self.logger.error("Sign modal did not appear after Review Send")
+        self.dump_page_source("sign_modal_missing")
+        self.take_screenshot("sign_modal_missing")
+        return None
+
+
+class SendSignModal(BasePage):
+    """Page object for the send/sign confirmation modal (SendSignModal.qml)."""
+
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locators = SendSignModalLocators()
+
+    def is_displayed(self, timeout: int = 30) -> bool:
+        # Anchor on the modal chrome: the value boxes' a11y exposure is
+        # intermittent, the footer sign button is not.
+        return self.is_element_visible(self.locators.SIGN_BUTTON, timeout=timeout)
+
+    def asset_value(self) -> Optional[str]:
+        return self._read_value(self.locators.SEND_ASSET_VALUE_TID)
+
+    def network_value(self) -> Optional[str]:
+        return self._read_value(self.locators.NETWORK_VALUE_TID)
+
+    def recipient_value(self) -> Optional[str]:
+        """Read the To-box recipient text.
+
+        Both the From and To boxes render a ``recipientDelegate``; document
+        order is From first, so the recipient is the last match. min_matches=2
+        refuses the read when only one delegate is reachable — taking a lone
+        match risks reading the From box and passing vacuously.
+        """
+        return self._read_value(
+            self.locators.RECIPIENT_DELEGATE_TID, last=True, min_matches=2
+        )
+
+    def _read_value(
+        self, tid: str, last: bool = False, min_matches: int = 1, timeout: int = 30
+    ) -> Optional[str]:
+        """Read a value box's a11y text by test-id, polling until it appears.
+
+        Value boxes below the modal's scroll fold keep zero bounds even after
+        swiping, and UiAutomator2 prunes such nodes from element queries and
+        page source unless allowInvisibleElements is on — enable it for the
+        read and restore the session's prior setting after, so waits elsewhere
+        keep their expected semantics.
+
+        The value nodes also join the a11y tree a beat after the modal
+        chrome renders, so a single read races the exposure — poll the full
+        read until timeout and only then report the value absent. A dead
+        session is not "value not there yet": InvalidSessionIdException
+        propagates instead of burning the timeout.
+        """
+        prior_allow = False
+        try:
+            prior_allow = bool(
+                (self.driver.get_settings() or {}).get("allowInvisibleElements", False)
+            )
+            self.driver.update_settings({"allowInvisibleElements": True})
+        except InvalidSessionIdException:
+            raise
+        except Exception as exc:
+            self.logger.debug("allowInvisibleElements toggle failed: %s", exc)
+        try:
+            deadline = time.monotonic() + timeout
+            attempt = 0
+            while True:
+                attempt += 1
+                value = self._value_from_page_source(tid, last, min_matches)
+                if value:
+                    if attempt > 1:
+                        self.logger.info(
+                            "Value %s appeared on read attempt %d", tid, attempt
+                        )
+                    return value
+                if time.monotonic() >= deadline:
+                    self.logger.error(
+                        "Value %s absent after %d reads over %ds",
+                        tid,
+                        attempt,
+                        timeout,
+                    )
+                    return None
+                time.sleep(1)
+        finally:
+            try:
+                self.driver.update_settings({"allowInvisibleElements": prior_allow})
+            except Exception:
+                pass
+
+    def _value_from_page_source(
+        self, tid: str, last: bool, min_matches: int
+    ) -> Optional[str]:
+        try:
+            source = self.driver.page_source or ""
+        except InvalidSessionIdException:
+            raise
+        except Exception as exc:
+            self.logger.debug("page_source failed: %s", exc)
+            return None
+        # Test-ids surface either as "VALUE [tid:NAME]" in content-desc
+        # (legacy) or as the resource-id leaf with the value in text or
+        # content-desc (current convention). Appium page source tags are
+        # class names (<android.widget.TextView ...>), and the resource-id
+        # may be the bare tid or a dotted/slashed path ending in it.
+        leaf = re.compile(r'resource-id="(?:[^"]*[./])?%s"' % re.escape(tid))
+        values = []
+        for node_match in re.finditer(r"<[A-Za-z][^>]*>", source):
+            node = node_match.group(0)
+            if f"[tid:{tid}]" not in node and not leaf.search(node):
+                continue
+            raw = ""
+            for attr in ("content-desc", "text"):
+                m = re.search(r'%s="([^"]*)"' % attr, node)
+                if m and m.group(1):
+                    raw = m.group(1)
+                    break
+            # Every matched node counts toward min_matches (mirroring the
+            # element path); only the chosen node's text must be non-empty.
+            values.append(raw.split(" [tid:")[0].strip())
+        if len(values) < min_matches:
+            return None
+        value = values[-1] if last else values[0]
+        return value or None
+
+    def close_without_signing(self, timeout: int = 10) -> bool:
+        """Dismiss the sign modal without touching the sign button.
+
+        On phones the modal renders as a bottom sheet which hides Reject and
+        shows the header close instead; the header close button objectName is
+        shared with any dialog beneath, so tap the last (top-most) match.
+
+        Dismissal is verified on the sign button — the chrome is_displayed
+        anchored on, so it was provably visible before the close. The value
+        boxes can be legitimately absent, which would make their
+        invisibility pass vacuously on a failed close.
+        """
+        if self.is_element_visible(self.locators.REJECT_BUTTON, timeout=2):
+            if not self.try_click(self.locators.REJECT_BUTTON, timeout=timeout):
+                return False
+        else:
+            try:
+                closers = self.driver.find_elements(
+                    *self.locators.HEADER_CLOSE_BUTTON
+                )
+            except Exception as exc:
+                self.logger.error("Header close lookup failed: %s", exc)
+                return False
+            if not closers:
+                self.logger.error("No close button found on sign modal")
+                return False
+            if not self.gestures.element_tap(closers[-1]):
+                return False
+        return self.wait_for_invisibility(self.locators.SIGN_BUTTON, timeout=10)

--- a/test/e2e_appium/pages/wallet/wallet_left_panel.py
+++ b/test/e2e_appium/pages/wallet/wallet_left_panel.py
@@ -11,6 +11,7 @@ from .add_edit_account_modal import AddEditAccountModal
 from .keycard_auth_modal import KeycardAuthenticationModal
 from .receive_modal import ReceiveModal
 from .remove_account_modal import RemoveAccountConfirmationModal
+from .send_modal import SimpleSendModal
 
 
 class WalletLeftPanel(BasePage):
@@ -158,6 +159,49 @@ class WalletLeftPanel(BasePage):
         self.logger.error("Receive modal did not appear after clicking receive button")
         return None
 
+    def open_send_modal(self, timeout: int | None = 10) -> SimpleSendModal | None:
+        """Open the send modal from the wallet footer.
+
+        Like Receive, the Send button is only rendered when a specific
+        account is selected, and it can sit below the fold reporting zero
+        bounds until painted — scroll to it before tapping.
+        """
+        fallback = self.locators.content_desc_contains(
+            "[tid:walletFooterSendButton]"
+        )
+
+        # The button is known to report bounds [0,0][0,0] until the account
+        # view paints — require a painted element before tapping.
+        button = self.wait_for_painted(self.locators.FOOTER_SEND, timeout=5)
+        if button is None:
+            self.logger.debug("Send button not painted; scrolling to find it")
+            self.scroll_to_element(
+                self.locators.FOOTER_SEND, max_swipes=3, timeout=2,
+            )
+            button = (
+                self.wait_for_painted(self.locators.FOOTER_SEND, timeout=5)
+                or self.wait_for_painted(fallback, timeout=3)
+            )
+        if button is None:
+            self.logger.error(
+                "Send footer button absent or never painted (zero bounds)"
+            )
+            return None
+
+        if not self.try_click(
+            self.locators.FOOTER_SEND,
+            fallback_locators=[fallback],
+            timeout=timeout,
+        ):
+            self.logger.error("Failed to click send button in wallet footer")
+            return None
+
+        modal = SimpleSendModal(self.driver)
+        if modal.is_displayed(timeout=15):
+            return modal
+        self.logger.error("Send modal did not appear after clicking send button")
+        return None
+
     def open_add_account_popup(self) -> AddEditAccountModal | None:
         try:
             self.safe_click(self.locators.ADD_ACCOUNT_BUTTON, timeout=5)
@@ -197,6 +241,42 @@ class WalletLeftPanel(BasePage):
             return False
 
         return True
+
+    def click_account_row(self, index: int = 0) -> bool:
+        """Click an account row only once it reports non-zero bounds.
+
+        Unpainted rows sit in the a11y tree at [0,0][0,0] and a click on
+        them lands at the screen origin. Scroll/retry once, then fail.
+        """
+        for attempt in range(2):
+            rows = self.account_rows()
+            if len(rows) > index:
+                try:
+                    rect = rows[index].rect
+                except Exception:
+                    rect = {}
+                if rect.get("width", 0) > 0 and rect.get("height", 0) > 0:
+                    # Gesture first: native click silently no-ops on QML nodes
+                    # exposing clickable="false".
+                    if self.gestures.element_tap(rows[index]):
+                        return True
+                    try:
+                        rows[index].click()
+                        return True
+                    except Exception as exc:
+                        self.logger.debug("Account row click failed: %s", exc)
+            if attempt == 0:
+                self.logger.debug(
+                    "Account row %d missing or unpainted; scrolling once", index
+                )
+                self.scroll_to_element(
+                    self.locators.ACCOUNT_ROW_ANY, max_swipes=2, timeout=2,
+                )
+        self.logger.error(
+            "Account row %d never painted (zero bounds) — cannot select account",
+            index,
+        )
+        return False
 
     def account_rows(self) -> list[WebElement]:
         try:

--- a/test/e2e_appium/tests/test_wallet_send_smoke.py
+++ b/test/e2e_appium/tests/test_wallet_send_smoke.py
@@ -1,0 +1,217 @@
+import os
+import time
+
+import pytest
+
+from utils.timeouts import ONBOARDING_SCREEN_TRANSITION_TIMEOUT_SECONDS
+from pages.onboarding import (
+    WelcomePage,
+    CreateProfilePage,
+    SeedPhraseInputPage,
+    PasswordPage,
+    SplashScreen,
+)
+from pages.onboarding.biometrics_page import BiometricsPage
+from pages.onboarding.push_notifications_page import PushNotificationsPage
+from locators.base_locators import BaseLocators
+from pages.app import App
+from pages.base_page import BasePage
+from pages.settings.settings_page import SettingsPage
+from pages.wallet.wallet_left_panel import WalletLeftPanel
+from utils.generators import get_wallet_address_from_mnemonic
+from utils.gestures import Gestures
+from utils.multi_device_helpers import StepMixin
+
+SEED_ENV_VAR = "WALLET_TEST_USER_SEED"
+FUNDED_WALLET_ADDRESS = "0x81e5872aC91b2D8C770d997fF1524A3Cb28fe3A0"
+SEND_AMOUNT = "0.001"
+TESTNET_NETWORK_NAME = "Hoodi"
+
+
+def elide_address(address: str) -> str:
+    """Mirror StatusQUtils.elideText(address, 6, 4) used by the sign screen."""
+    return address[:6] + "…" + address[-4:]
+
+
+@pytest.mark.flaky(reruns=1, reruns_delay=5)
+class TestWalletSendSmoke(StepMixin):
+    async def _onboard_with_seed(
+        self, driver, seed_phrase: str, password: str,
+    ) -> None:
+        """Onboard via seed-phrase import (same flow as the import-seed test)."""
+        async with self.step(self.device, "Complete welcome screen"):
+            try:
+                Gestures(driver).activation_tap()
+                time.sleep(1)
+            except Exception:
+                pass
+
+            welcome = WelcomePage(driver)
+            assert welcome.is_screen_displayed(timeout=30), (
+                "Welcome screen should be visible"
+            )
+            assert welcome.click_create_profile(), "Failed to click Create profile"
+
+        async with self.step(self.device, "Select recovery phrase import"):
+            create = CreateProfilePage(driver)
+            assert create.is_screen_displayed(
+                timeout=ONBOARDING_SCREEN_TRANSITION_TIMEOUT_SECONDS,
+            ), "Create profile screen should be visible"
+            assert create.click_use_recovery_phrase(), (
+                "Failed to click Use a recovery phrase"
+            )
+
+        async with self.step(self.device, "Import seed phrase"):
+            seed_page = SeedPhraseInputPage(driver, flow_type="create")
+            assert seed_page.is_screen_displayed(
+                timeout=ONBOARDING_SCREEN_TRANSITION_TIMEOUT_SECONDS,
+            ), "Seed phrase input (create) should be visible"
+            assert seed_page.import_seed_phrase(seed_phrase), "Failed to import seed phrase"
+
+        async with self.step(self.device, "Create password"):
+            password_page = PasswordPage(driver)
+            assert password_page.is_screen_displayed(
+                timeout=ONBOARDING_SCREEN_TRANSITION_TIMEOUT_SECONDS,
+            ), "Password screen should be visible"
+            assert password_page.create_password(password), "Failed to create password"
+
+        async with self.step(self.device, "Dismiss biometrics prompt if present"):
+            biometrics = BiometricsPage(driver)
+            if biometrics.is_screen_displayed(timeout=10):
+                assert biometrics.select_maybe_later(), "Failed to dismiss biometrics"
+
+        async with self.step(self.device, "Wait for app loading"):
+            splash = SplashScreen(driver)
+            assert splash.wait_for_loading_completion(), (
+                "App did not finish loading"
+            )
+
+        async with self.step(self.device, "Dismiss post-onboarding overlays"):
+            PushNotificationsPage(driver).dismiss_if_present(timeout=15)
+            nav_edu = ("xpath",
+                "//*[contains(@resource-id,'NavigationEducationDialog')]"
+                "//*[contains(@resource-id,'headerActionsCloseButton')]")
+            base_for_edu = BasePage(driver)
+            if base_for_edu.is_element_visible(nav_edu, timeout=5):
+                base_for_edu.safe_click(nav_edu, timeout=5)
+            PushNotificationsPage(driver).dismiss_if_present(timeout=5)
+
+    @pytest.mark.smoke
+    @pytest.mark.wallet
+    @pytest.mark.raw_devices
+    @pytest.mark.timeout(900)
+    async def test_send_eth_review_matches_input(self):
+        """Send-flow smoke: reviewed amount/recipient/network match the input.
+
+        Onboards the funded test profile, enables testnet mode, builds a
+        0.001 ETH send to the profile's own address, and asserts the sign
+        screen shows the entered amount, network and recipient. Stops at the
+        sign screen — nothing is signed or broadcast.
+        """
+        seed_phrase = os.getenv(SEED_ENV_VAR, "").strip()
+        if not seed_phrase:
+            pytest.skip(
+                f"{SEED_ENV_VAR} not set — requires the seed phrase of the "
+                f"funded test profile ({FUNDED_WALLET_ADDRESS})"
+            )
+
+        derived_address = get_wallet_address_from_mnemonic(seed_phrase)
+        assert derived_address.lower() == FUNDED_WALLET_ADDRESS.lower(), (
+            f"{SEED_ENV_VAR} derives '{derived_address}', expected the funded "
+            f"test address '{FUNDED_WALLET_ADDRESS}'"
+        )
+
+        driver = self.device.driver
+        await self._onboard_with_seed(driver, seed_phrase, "TestPassword123!")
+
+        app = App(driver)
+
+        async with self.step(self.device, "Enable testnet mode"):
+            assert app.click_settings_button(), "Failed to navigate to Settings"
+            settings = SettingsPage(driver)
+            assert settings.is_loaded(timeout=10), "Settings page not loaded"
+            wallet_settings = settings.open_wallet_settings()
+            assert wallet_settings is not None, "Failed to open Settings → Wallet"
+            assert wallet_settings.open_networks(), (
+                "Failed to open Networks in wallet settings"
+            )
+            assert wallet_settings.enable_testnet_mode(), (
+                "Failed to enable testnet mode"
+            )
+
+        async with self.step(self.device, "Leave settings"):
+            # Unwind Networks → Wallet → Settings root before opening the
+            # drawer: click_wallet_button can early-exit on a stale tree
+            # read straight out of a settings sub-view.
+            base = BasePage(driver)
+            back_button = BaseLocators.tid("toolBarBackButton")
+            for _ in range(4):
+                if not base.is_element_visible(back_button, timeout=2):
+                    break
+                try:
+                    base.safe_click(back_button, timeout=3, max_attempts=1)
+                except Exception:
+                    break
+                time.sleep(0.3)
+
+        async with self.step(self.device, "Navigate to wallet account"):
+            assert app.click_wallet_button(), "Failed to navigate to Wallet"
+            panel = WalletLeftPanel(driver)
+            assert panel.is_loaded(timeout=20), "Wallet left panel not visible"
+            assert panel.wait_for_painted(
+                panel.locators.ADD_ACCOUNT_BUTTON, timeout=15
+            ) is not None, (
+                "Wallet panel landmark present but never painted (zero bounds) "
+                "— navigation likely landed on another section"
+            )
+            assert panel.click_account_row(0), (
+                "First account row not clickable (missing or unpainted)"
+            )
+
+        async with self.step(self.device, "Open send modal"):
+            PushNotificationsPage(driver).dismiss_if_present(timeout=3)
+            send_modal = panel.open_send_modal()
+            assert send_modal is not None, "Send modal did not open from wallet footer"
+
+        async with self.step(self.device, "Enter recipient address"):
+            assert send_modal.enter_recipient(FUNDED_WALLET_ADDRESS), (
+                "Failed to enter recipient address"
+            )
+
+        async with self.step(self.device, "Select ETH"):
+            assert send_modal.ensure_eth_selected(), (
+                "Failed to select ETH in token picker"
+            )
+
+        async with self.step(self.device, "Enter amount"):
+            assert send_modal.enter_amount(SEND_AMOUNT), "Failed to enter send amount"
+
+        async with self.step(self.device, "Wait for route and review"):
+            assert send_modal.wait_for_route_ready(timeout=60), (
+                "Review Send did not become enabled — no route/fee estimate"
+            )
+            sign_modal = send_modal.click_review_send()
+            assert sign_modal is not None, "Sign modal did not appear after Review Send"
+
+        async with self.step(self.device, "Verify reviewed values match input"):
+            asset_value = sign_modal.asset_value()
+            assert asset_value and f"{SEND_AMOUNT} ETH" in asset_value, (
+                f"Sign screen asset should show '{SEND_AMOUNT} ETH', got: '{asset_value}'"
+            )
+
+            network_value = sign_modal.network_value()
+            assert network_value and TESTNET_NETWORK_NAME in network_value, (
+                f"Sign screen network should show '{TESTNET_NETWORK_NAME}', "
+                f"got: '{network_value}'"
+            )
+
+            recipient_value = sign_modal.recipient_value()
+            expected_elided = elide_address(FUNDED_WALLET_ADDRESS)
+            normalized = (recipient_value or "").replace("×", "x").lower()
+            assert expected_elided.lower() in normalized, (
+                f"Sign screen recipient should show '{expected_elided}', "
+                f"got: '{recipient_value}'"
+            )
+
+        async with self.step(self.device, "Close sign modal without signing"):
+            assert sign_modal.close_without_signing(), "Failed to close sign modal"


### PR DESCRIPTION
Adds a wallet-send smoke test: onboard by seed, enable a testnet, send on it, and assert the send-sign modal shows the expected asset, amount, network, and recipient, then close without signing (nothing is broadcast). Verified on device (Samsung A36).

Stacked on #21392, which exposes the sign-confirm values to accessibility — this diff is test-only against that branch. Re-target to master once #21392 merges.

Runs in the nightly `smoke` set only (not the per-PR gate). Requires the funded test seed (`WALLET_TEST_USER_SEED`, the same credential desktop uses, already funded on Hoodi); skips cleanly when unset. The CI credential binding will follow separately.