### PR TITLE
chore(@ci): if benchmark child job fails, show it is as failed in combined job

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -116,17 +116,18 @@ pipeline {
                 }
               }
               steps {
-                script {
-                  benchmark_windows_e2e = build(
-                    job: 'status-app/e2e/nightly-benchmark-windows-master',
-                    propagate: false,
-                    parameters: jenkins.mapToParams([
-                      BUILD_SOURCE:      windows_x86_64.fullProjectName,
-                      TESTRAIL_RUN_NAME: utils.pkgFilename(),
-                      TEST_SCOPE_FLAG:   utils.isReleaseBuild() ? '-m=critical' : '',
-                      GIT_REF:           env.BRANCH_NAME
-                    ]),
-                  )
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                  script {
+                    benchmark_windows_e2e = build(
+                      job: 'status-app/e2e/nightly-benchmark-windows-master',
+                      parameters: jenkins.mapToParams([
+                        BUILD_SOURCE:      windows_x86_64.fullProjectName,
+                        TESTRAIL_RUN_NAME: utils.pkgFilename(),
+                        TEST_SCOPE_FLAG:   utils.isReleaseBuild() ? '-m=critical' : '',
+                        GIT_REF:           env.BRANCH_NAME
+                      ]),
+                    )
+                  }
                 }
               }
             }


### PR DESCRIPTION
### What does the PR do

Fix current misleading behavior - when child benchmark job is failed, it is still shown as passed in combined nightly job which led me to fail impression that tests are working

<img width="819" height="506" alt="image" src="https://github.com/user-attachments/assets/a7781ec9-6a07-4c91-b4df-300ec7c418d1" />

<img width="1356" height="230" alt="image" src="https://github.com/user-attachments/assets/bcfe7ddd-03f2-4aa5-98da-480cf968c908" />

<img width="947" height="928" alt="image" src="https://github.com/user-attachments/assets/d9c06a80-8d14-497a-865e-99bf274bffde" />

After this fix, if benchmark job fails, it should appear as failed step in nightly job as well