### PR TITLE
feat(StatusEmojiPopup): add keyboard navigation

### DIFF
--- a/storybook/pages/StatusEmojiPopupPage.qml
+++ b/storybook/pages/StatusEmojiPopupPage.qml
@@ -66,6 +66,10 @@ SplitView {
                 d.lastSelectedEmoji = emoji
                 d.lastSelectedEmojiHexcode = hexcode
             }
+            onSetSkinColorRequested: function(skinColor) {
+                logs.logEvent("onSetSkinColorRequested", ["skinColor"], arguments)
+                settings.skinColor = skinColor
+            }
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml
@@ -41,8 +41,8 @@ Flow {
                 listOfUsers.push(qsTr("%1 more").arg(extraCount)) // "a, b, ... and N more"
             }
 
-            // Create a simple comma-separated list without using QLocale.createSeparatedList (not available in QML)
-            return qsTr("%1 reacted with %2").arg(listOfUsers.join(", ")).arg(StatusQUtils.Emoji.fromCodePoint(emoji))
+            const authors = Qt.locale(Qt.uiLanguage).createSeparatedList(listOfUsers) // "a, b, c and d"
+            return qsTr("%1 reacted with %2").arg(authors).arg(StatusQUtils.Emoji.fromCodePoint(emoji))
         }
 
         // design values

--- a/ui/StatusQ/src/StatusQ/Controls/StatusToolTip.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusToolTip.qml
@@ -21,10 +21,10 @@ ToolTip {
     property alias arrow: arrow
     property color color: StatusColors.black
 
-    implicitWidth: Math.min(maxWidth,
-                            Math.max(implicitBackgroundWidth + leftInset + rightInset,
-                                     implicitContentWidth + leftPadding + rightPadding)
-                            )
+    implicitWidth: Math.ceil(Math.min(maxWidth,
+                                      Math.max(implicitBackgroundWidth + leftInset + rightInset,
+                                               implicitContentWidth + leftPadding + rightPadding)
+                                      ))
     horizontalPadding: Theme.padding
     verticalPadding: Theme.halfPadding
     margins: Theme.halfPadding

--- a/ui/imports/shared/status/StatusEmojiPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiPopup.qml
@@ -97,6 +97,7 @@ StatusDropdown {
     onOpened: {
         if (!StatusQUtils.Utils.isMobile)
             searchBox.forceActiveFocus()
+        emojiGrid.currentIndex = 0
         emojiGrid.positionViewAtBeginning()
     }
 
@@ -135,6 +136,8 @@ StatusDropdown {
                 anchors.left: parent.left
                 anchors.leftMargin: d.headerMargin
                 height: 36
+                KeyNavigation.tab: emojiGrid
+                KeyNavigation.down: emojiGrid
             }
 
             Row {
@@ -224,26 +227,36 @@ StatusDropdown {
                 policy: ScrollBar.AsNeeded
             }
 
-            delegate: Item {
+            delegate: ItemDelegate {
                 readonly property string category: model.category
+
+                required property int index
+                required property var model
 
                 width: emojiGrid.cellWidth
                 height: emojiGrid.cellHeight
-
-                StatusEmoji {
+                padding: d.imageMargin
+                highlighted: emojiGrid.activeFocus && index === emojiGrid.currentIndex
+                background: Rectangle {
+                    radius: Theme.radius
+                    color: hovered ? Theme.palette.backgroundHover : StatusColors.transparent
+                    border.width: 1
+                    border.color: visualFocus || highlighted ? Theme.palette.primaryColor1 : StatusColors.transparent
+                }
+                contentItem: StatusEmoji {
                     objectName: "statusEmoji_" + model.shortname.replace(/:/g, "")
                     Accessible.role: Accessible.StaticText
                     Accessible.name: model.emoji
-                    anchors.centerIn: parent
-                    width: d.imageWidth
-                    height: d.imageWidth
                     emojiId: model.unicode
-
-                    StatusMouseArea {
-                        cursorShape: Qt.PointingHandCursor
-                        anchors.fill: parent
-                        onClicked: root.addEmoji(model.unicode)
-                    }
+                }
+                onClicked: root.addEmoji(model.unicode)
+                HoverHandler {
+                    cursorShape: hovered ? Qt.PointingHandCursor : undefined
+                }
+                StatusToolTip {
+                    text: model.shortname
+                    visible: hovered && !!text
+                    y: -height
                 }
             }
         }


### PR DESCRIPTION
### What does the PR do

- add standard keyboard navigation (down/up/tab/backtab) between the search field and the emoji grid
- make the emoji grid delegate a proper ItemDelegate, draw a focus rectangle around it
- add a tooltip to the individual emojis (showing the `:shortname:`)
- minor fixes to StatusMessageEmojiReactions and StatusToolTip

Fixes #20826

### Affected areas

StatusEmojiPopup

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality


https://github.com/user-attachments/assets/b93332fa-e3a1-4d16-be52-d4b116741709

Emoji tooltip:
<img width="2706" height="1694" alt="image" src="https://github.com/user-attachments/assets/252972f9-816a-4b4c-943a-d5d88a0fad03" />



### Impact on end user

Better keyboard UX

### How to test

- open Emoji popup
- press tab/backtab/up/down to move between the search field and the emoji grid
- press Enter/Space to confirm

### Risk 

low
