### PR TITLE
fix: StatusModal header has no contentHeight

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
@@ -197,6 +197,7 @@ StatusDialog {
 
     header: ToolBar {
         position: ToolBar.Top
+        contentHeight: headerImpl.implicitHeight
         background: StatusDialogBackground {
             implicitHeight: headerImpl.implicitHeight
         }


### PR DESCRIPTION
### What does the PR do

Closes #[21436](https://github.com/status-im/status-app/issues/21436)

https://github.com/user-attachments/assets/819fbb10-fdb9-4a7a-8ed4-0c93ce2aaab5


