### PR TITLE
feat(StatusMessage): implement copying selected text

### DIFF
--- a/storybook/pages/MessageContextMenuViewPage.qml
+++ b/storybook/pages/MessageContextMenuViewPage.qml
@@ -44,6 +44,7 @@ SplitView {
                 amIChatAdmin: ctrlChatAdmin.checked
                 canPin: true
                 pinnedMessage: ctrlPinned.checked
+                selectedText: ctrlSelectedText.checked ? "Dolor ipsum sit amet" : ""
 
                 onPinMessage: logs.logEvent(`onPinMessage: ${messageContextMenuView.messageId}`)
                 onUnpinMessage: logs.logEvent(`onUnpinMessage: ${messageContextMenuView.messageId}`)
@@ -92,6 +93,12 @@ SplitView {
             CheckBox {
                 id: ctrlPinned
                 text: "Pinned message?"
+            }
+
+            CheckBox {
+                id: ctrlSelectedText
+                text: "Selected text?"
+                checked: true
             }
         }
     }

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -80,6 +80,7 @@ Control {
     property string hoveredLink: ""
     property bool linkAddressAndEnsName
     property string disabledTooltipText
+    readonly property string selectedText: d.selectedText
 
     property bool isMobile: Utils.isMobile
 
@@ -407,6 +408,11 @@ Control {
         }
     }
 
+    QtObject {
+        id: d
+        property string selectedText
+    }
+
     component StatusTextMessageCommon: StatusTextMessage {
         objectName: "StatusMessage_textMessage"
         messageDetails: root.messageDetails
@@ -420,5 +426,6 @@ Control {
         onLinkActivated: link => root.linkActivated(link)
         onHoveredLinkChanged: root.hoveredLink = hoveredLink
         onContextMenuRequested: pos => root.contextMenuRequested(pos)
+        onSelectedTextChanged: d.selectedText = selectedText
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -13,6 +13,8 @@ Item {
     id: root
 
     readonly property alias hoveredLink: chatTextLoader.hoveredLink
+    readonly property string selectedText: chatTextLoader.item && chatTextLoader.sourceComponent === chatTextDesktopComp ? chatTextLoader.item.selectedText
+                                                                                                                         : ""
 
     property string highlightedLink: ""
     property bool linkAddressAndEnsName

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -10898,6 +10898,10 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Copy message</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -10963,6 +10963,10 @@ selhalo</translation>
         <translation>Upravit zprávu</translation>
     </message>
     <message>
+        <source>Copy</source>
+        <translation type="unfinished">Kopírovat</translation>
+    </message>
+    <message>
         <source>Copy message</source>
         <translation>Kopírovar zprávu</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -10911,6 +10911,10 @@ al cargar</translation>
         <translation>Editar mensaje</translation>
     </message>
     <message>
+        <source>Copy</source>
+        <translation type="unfinished">Copiar</translation>
+    </message>
+    <message>
         <source>Copy message</source>
         <translation>Copiar mensaje</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -10860,6 +10860,10 @@ to load</source>
         <translation>메시지 편집</translation>
     </message>
     <message>
+        <source>Copy</source>
+        <translation type="unfinished">클립보드로 복사</translation>
+    </message>
+    <message>
         <source>Copy message</source>
         <translation>메시지 복사</translation>
     </message>

--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -769,7 +769,7 @@ Control {
                         Shortcut {
                             enabled: messageInputField.activeFocus
                             sequences: ["Ctrl+Meta+Space", "Ctrl+E"]
-                            onActivated: toolBar.emojiButton.clicked(null)
+                            onActivated: toolBar.emojiButton.click()
                         }
 
                         StatusChatInputSelectionMarker {

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -25,6 +25,7 @@ StatusMenu {
     property string unparsedText: ""
     property string messageSenderId: ""
     property int messageContentType: Constants.messageContentType.unknownContentType
+    property string selectedText
 
     property bool pinMessageAllowedForMembers: false
     property bool isDebugEnabled: false
@@ -88,11 +89,20 @@ StatusMenu {
         id: editMessageAction
         objectName: "messageContextMenu_edit"
         text: qsTr("Edit message")
-        onTriggered: editClicked()
+        onTriggered: root.editClicked()
         icon.name: "edit"
         enabled: root.isMyMessage &&
                  !root.editRestricted &&
                  !root.disabledForChat
+    }
+
+    StatusAction {
+        id: copySelectedTextItem
+        objectName: "messageContextMenu_copySelection"
+        text: qsTr("Copy")
+        icon.name: "copy"
+        enabled: !!root.selectedText
+        onTriggered: root.copyToClipboard(root.selectedText)
     }
 
     StatusAction {
@@ -102,6 +112,8 @@ StatusMenu {
         icon.name: "copy"
         onTriggered: root.copyToClipboard(root.unparsedText)
         enabled: (root.messageContentType === Constants.messageContentType.messageType ||
+                  root.messageContentType === Constants.messageContentType.contactRequestType ||
+                  root.messageContentType === Constants.messageContentType.bridgeMessageType ||
                 (root.messageContentType === Constants.messageContentType.imageType && root.unparsedText != "")) &&
                 replyToMenuItem.enabled
     }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -247,7 +247,7 @@ Loader {
         profileContextMenuComponent.createObject(root, params).popup(x, y)
     }
 
-    function openMessageContextMenu(point) {
+    function openMessageContextMenu(point, selectedText = "") {
         if (isViewMemberMessagesePopup || placeholderMessage || !root.joined)
             return
 
@@ -272,6 +272,7 @@ Loader {
             pinnedMessage: root.pinnedMessage,
             canPin: !!root.messageStore && root.messageStore.getNumberOfPinnedMessages() < Constants.maxNumberOfPins,
             editRestricted: root.editRestricted,
+            selectedText
         }
 
         d.preventVirtualKeyboardOpening()
@@ -939,17 +940,17 @@ Loader {
                     root.messageStore.resendMessage(root.messageId)
                 }
 
-                onContextMenuRequested: pos => root.openMessageContextMenu(pos) // for StatusTextMessage which would eat the press events internally
+                onContextMenuRequested: pos => root.openMessageContextMenu(pos, delegate.selectedText) // for StatusTextMessage which would eat the press events internally
                 TapHandler {
                     gesturePolicy: TapHandler.ReleaseWithinBounds // exclusive grab on press
                     acceptedDevices: PointerDevice.TouchScreen
-                    onLongPressed: root.openMessageContextMenu(point.position)
+                    onLongPressed: root.openMessageContextMenu(point.position, delegate.selectedText)
                 }
 
                 TapHandler {
                     acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
                     acceptedButtons: Qt.RightButton
-                    onTapped: (point, button) => root.openMessageContextMenu(point.position)
+                    onTapped: (point, button) => root.openMessageContextMenu(point.position, delegate.selectedText)
                 }
 
                 messageDetails: StatusMessageDetails {


### PR DESCRIPTION
### What does the PR do

- add a "Copy" action to the MessageContextMenuView when the message contains some selected text
- enable the "Copy message" action also for other text-based content types
- adjust the SB pages

Fixes #20825

### Affected areas

StatusMessage

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

No selection:
<img width="2718" height="1616" alt="image" src="https://github.com/user-attachments/assets/5747cf0f-2dc8-473a-bd54-2e78bd2d03be" />

Selected text:
<img width="2718" height="1616" alt="image" src="https://github.com/user-attachments/assets/0fdc832f-07fc-4b28-9af9-7db2c8762f58" />

### Impact on end user

Better mouse UX

### How to test

- right click a message
- choose "Copy message" or "Copy" to copy the text to clipboard

### Risk 

- low
