### PR TITLE
fix(LinksMessageView): enable GIF unfurling directly

### DIFF
--- a/storybook/pages/LinksMessageViewPage.qml
+++ b/storybook/pages/LinksMessageViewPage.qml
@@ -36,12 +36,18 @@ SplitView {
 
             senderName: "Alice"
 
-            gifUnfurlingEnabled: false
+            gifUnfurlingEnabled: d.gifUnfurlingEnabled
+            onSetGifUnfurlingEnabled: d.gifUnfurlingEnabled = true
             canAskToUnfurlGifs: true
             onImageClicked: {
                 console.log("image clicked")
             }
         }
+    }
+
+    QtObject {
+        id: d
+        property bool gifUnfurlingEnabled
     }
 
     Pane {
@@ -56,8 +62,8 @@ SplitView {
                 }
                 CheckBox {
                     text: qsTr("Enabled")
-                    checked: linksMessageView.gifUnfurlingEnabled
-                    onToggled: linksMessageView.gifUnfurlingEnabled = !linksMessageView.gifUnfurlingEnabled
+                    checked: d.gifUnfurlingEnabled
+                    onToggled: d.gifUnfurlingEnabled = !d.gifUnfurlingEnabled
                 }
                 CheckBox {
                     text: qsTr("Can ask about GIF unfurling")

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -9907,7 +9907,7 @@ corruption, loss of your Status profile and the inability to restart Status.</so
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable in Settings</source>
+        <source>Always Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -9958,8 +9958,8 @@ corruption, loss of your Status profile and the inability to restart Status.</so
         <translation>Po povolení mohou odkazy zveřejněné v chatu sdílet vaše metadata s jejich vlastníky</translation>
     </message>
     <message>
-        <source>Enable in Settings</source>
-        <translation>Povolit v Nastavení</translation>
+        <source>Always Enable</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Don&apos;t ask me again</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -9919,8 +9919,8 @@ corruption, loss of your Status profile and the inability to restart Status.</so
         <translation>Una vez habilitado, los enlaces publicados en el chat pueden compartir tus metadatos con sus propietarios</translation>
     </message>
     <message>
-        <source>Enable in Settings</source>
-        <translation>Habilitar en Configuración</translation>
+        <source>Always Enable</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Don&apos;t ask me again</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -9881,8 +9881,8 @@ corruption, loss of your Status profile and the inability to restart Status.</so
         <translation>활성화하면, 채팅에 올린 링크가 해당 사이트/소유자에게 메타데이터를 공유할 수 있습니다</translation>
     </message>
     <message>
-        <source>Enable in Settings</source>
-        <translation>설정에서 사용 설정</translation>
+        <source>Always Enable</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Don&apos;t ask me again</source>

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -13,8 +13,8 @@ QtObject {
     property real volume: !!appSettingsInst ? appSettingsInst.volume * 0.01 : 0.5
 
     property bool notificationSoundsEnabled: !!appSettingsInst ? appSettingsInst.notificationSoundsEnabled : true
-    property bool neverAskAboutUnfurlingAgain: !!accountSensitiveSettings ? accountSensitiveSettings.neverAskAboutUnfurlingAgain : false
-    property bool gifUnfurlingEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.gifUnfurlingEnabled : false
+    readonly property bool neverAskAboutUnfurlingAgain: !!accountSensitiveSettings ? accountSensitiveSettings.neverAskAboutUnfurlingAgain : false
+    readonly property bool gifUnfurlingEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.gifUnfurlingEnabled : false
 
     required property CurrenciesStore currencyStore
 

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -45,6 +45,7 @@ Flow {
     signal imageClicked(var image, var mouse, string imageSource, string url)
     signal openContextMenu(var item, string url, string domain)
     signal setNeverAskAboutUnfurlingAgain(bool neverAskAgain)
+    signal setGifUnfurlingEnabled
     signal paymentRequestClicked(int index)
 
     function resetLocalAskAboutUnfurling() {
@@ -207,15 +208,11 @@ Flow {
             StatusFlatButton {
                 id: enableBtn
                 objectName: "LinksMessageView_enableBtn"
-                text: qsTr("Enable in Settings")
-                onClicked: {
-                    Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.messaging);
-                }
+                text: qsTr("Always Enable")
+                onClicked: root.setGifUnfurlingEnabled()
                 width: parent.width
                 anchors.top: sep1.bottom
-                Component.onCompleted: {
-                    background.radius = 0
-                }
+                radius: 0
             }
             Separator {
                 id: sep2
@@ -232,8 +229,8 @@ Flow {
                 onClicked: root.setNeverAskAboutUnfurlingAgain(true)
                 Component.onCompleted: {
                     background.radius = 0
-                    background.bottomRightRadius = Theme.padding
-                    background.bottomRightRadius = Theme.padding
+                    background.bottomLeftRadius = enableLinkRoot.radius
+                    background.bottomRightRadius = enableLinkRoot.radius
                 }
             }
         }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -1129,6 +1129,7 @@ Loader {
                         }
                         onHoveredLinkChanged: delegate.highlightedLink = linksMessageView.hoveredLink
                         gifUnfurlingEnabled: root.gifUnfurlingEnabled
+                        onSetGifUnfurlingEnabled: localAccountSensitiveSettings.gifUnfurlingEnabled = true
                         canAskToUnfurlGifs: !root.neverAskAboutUnfurlingAgain
                         onSetNeverAskAboutUnfurlingAgain: root.setNeverAskAboutUnfurlingAgain(neverAskAgain)
                         onPaymentRequestClicked: (index) => {


### PR DESCRIPTION
### What does the PR do

- when clicking on the "Enable" button, instead of sending the user to Settings
- update the SB page and TS files

Fixes #20832

### Affected areas

Messaging/GIFs

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality


https://github.com/user-attachments/assets/c4e5b933-ae6e-4adb-8145-d9ea0f28066e



### Impact on end user

More streamlined messaging UX

### How to test

- receive a GIF (link)
- click the Enable (unfurling) button
- see the GIF rendered straight away

### Risk 

low
