### PR TITLE
feat(Notifications): implement the badge notification count

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -120,7 +120,7 @@
 [submodule "vendor/nim-seaqt"]
 	path = vendor/nim-seaqt
 	url = https://github.com/seaqt/nim-seaqt.git
-	branch = qt-6.4
+	branch = qt-6.8
 [submodule "vendor/nimqml-seaqt"]
 	path = vendor/nimqml-seaqt
 	url = https://github.com/seaqt/nimqml-seaqt.git

--- a/nim-status.desktop
+++ b/nim-status.desktop
@@ -4,5 +4,4 @@ Name=Status Desktop
 Exec=nim_status_client
 Icon=status
 Comment=Desktop client for the Status Network
-Terminal=true
 Categories=Network;

--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -173,8 +173,8 @@ QtObject:
     sectionId: sectionId)
     self.processNotification(title, message, details)
 
-  proc onMeMentionedIconBadgeNotification(self: NotificationsManager, allMentions: int) {.slot.} =
-    self.osNotification.showIconBadgeNotification(allMentions)
+  proc onNotificationsCountChanged(self: NotificationsManager, count: int) {.slot.} =
+    self.osNotification.showIconBadgeNotification(count)
 
   proc onShowCommunityMemberKickedNotification*(self: NotificationsManager, title: string, message: string, sectionId: string) {.slot.} =
     let details = NotificationDetails(notificationType: NotificationType.CommunityMemberKicked, sectionId: sectionId, isCommunitySection: true)
@@ -201,7 +201,7 @@ QtObject:
     discard QObject.connect(singletonInstance.globalEvents, newCommunityMembershipRequestNotification, self, onNewCommunityMembershipRequestNotification, ConnectionType.QueuedConnection)
     discard QObject.connect(singletonInstance.globalEvents, myRequestToJoinCommunityAcccepted, self, onMyRequestToJoinCommunityAcccepted, ConnectionType.QueuedConnection)
     discard QObject.connect(singletonInstance.globalEvents, myRequestToJoinCommunityRejected, self, onMyRequestToJoinCommunityRejected, ConnectionType.QueuedConnection)
-    discard QObject.connect(singletonInstance.globalEvents, meMentionedIconBadgeNotification, self, onMeMentionedIconBadgeNotification, ConnectionType.QueuedConnection)
+    discard QObject.connect(singletonInstance.globalEvents, notificationsCountChanged, self, onNotificationsCountChanged, ConnectionType.QueuedConnection)
     discard QObject.connect(singletonInstance.globalEvents, showCommunityTokenPermissionCreatedNotification, self, onShowCommunityTokenPermissionCreatedNotification, ConnectionType.QueuedConnection)
     discard QObject.connect(singletonInstance.globalEvents, showCommunityTokenPermissionUpdatedNotification, self, onShowCommunityTokenPermissionUpdatedNotification, ConnectionType.QueuedConnection)
     discard QObject.connect(singletonInstance.globalEvents, showCommunityTokenPermissionDeletedNotification, self, onShowCommunityTokenPermissionDeletedNotification, ConnectionType.QueuedConnection)

--- a/src/app/global/global_events.nim
+++ b/src/app/global/global_events.nim
@@ -51,7 +51,7 @@ QtObject:
   proc myRequestToJoinCommunityRejected*(self: GlobalEvents, title: string, message: string,
     sectionId: string) {.signal.}
 
-  proc meMentionedIconBadgeNotification*(self: GlobalEvents, allMentions: int) {.signal.}
+  proc notificationsCountChanged*(self: GlobalEvents, count: int) {.signal.}
 
   proc showCommunityMemberKickedNotification*(self: GlobalEvents, sectionId: string, title: string, message: string) {.signal.}
 

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -247,9 +247,6 @@ method newCommunityMembershipRequestReceived*(self: AccessInterface, membershipR
 method communityMembershipRequestCanceled*(self: AccessInterface, communityId: string, requestId: string, pubKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method meMentionedCountChanged*(self: AccessInterface, allMentions: int) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method onPlayNotificationSound*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1632,9 +1632,6 @@ method newCommunityMembershipRequestReceived*[T](self: Module[T], membershipRequ
 method communityMembershipRequestCanceled*[T](self: Module[T], communityId: string, requestId: string, pubKey: string) =
   self.view.model().removeMember(communityId, pubKey)
 
-method meMentionedCountChanged*[T](self: Module[T], allMentions: int) =
-  singletonInstance.globalEvents.meMentionedIconBadgeNotification(allMentions)
-
 method displayEphemeralNotification*[T](
     self: Module[T],
     title: string,

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -28,9 +28,6 @@ QtObject:
 
   proc delete*(self: View)
 
-  proc onNotificationsCountChanged*(self: View) {.slot.} =
-    self.delegate.meMentionedCountChanged(self.model.allMentionsCount())
-
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -45,8 +42,6 @@ QtObject:
     result.ephemeralNotificationModel = ephemeralNotification_model.newModel()
     result.ephemeralNotificationModelVariant = newQVariant(result.ephemeralNotificationModel)
     result.mainLoaded = false
-
-    discard QObject.connect(result.model, notificationsCountChanged, result, onNotificationsCountChanged, ConnectionType.QueuedConnection)
 
   proc load*(self: View) =
     # In some point, here, we will setup some exposed main module related things.

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -6,6 +6,7 @@ import section_item, member_model, member_item
 import ../main/communities/tokens/models/[token_item, token_model]
 import model_utils
 import ../../../app_service/common/types
+import app/global/global_singleton
 
 type
   ModelRole {.pure.} = enum
@@ -393,8 +394,6 @@ QtObject:
 
   proc sectionVisibilityUpdated*(self: SectionModel) {.signal.}
 
-  proc notificationsCountChanged*(self: SectionModel) {.signal.}
-
   proc enableDisableSection(self: SectionModel, sectionType: SectionType, value: bool) =
     if sectionType != SectionType.Community:
       for i in 0 ..< self.items.len:
@@ -463,7 +462,7 @@ QtObject:
       updateRole(hasNotification)
       updateRole(notificationsCount)
 
-    self.notificationsCountChanged()
+    singletonInstance.globalEvents.notificationsCountChanged(notificationsCount)
 
   proc isThereASectionWithUnreadMessages*(self: SectionModel): bool =
     for item in self.items:

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -22,7 +22,6 @@ when defined(qmldebug):
   import seaqt/qqmldebuggingenabler
 
 import app/global/global_singleton
-import app/global/local_app_settings
 import app/global/app_lifecycle
 import app/boot/app_controller
 
@@ -185,7 +184,7 @@ proc enableHDPI(uiScaleFilePath: string) =
     echo "[Warning] ", scaleEnvVar, " already set, will NOT enable custom Status scaling"
     return
 
-  QGuiApplication.setHighDpiScaleFactorRoundingPolicy(5) # Qt.HighDpiScaleFactorRoundingPolicy.PassThrough enumerator not exported by seaqt :/
+  QGuiApplication.setHighDpiScaleFactorRoundingPolicy(HighDpiScaleFactorRoundingPolicyEnum.PassThrough)
 
   if fileExists(uiScaleFilePath):
     # Reads the file and strips any trailing/leading whitespace (like newlines)
@@ -245,8 +244,6 @@ proc mainProc() =
 
   # Enable HDPI (replaces dos_qguiapplication_enable_hdpi)
   let uiScaleFilePath = joinPath(DATADIR, "ui-scale")
-  gen_qguiapplication.QGuiApplication.setHighDpiScaleFactorRoundingPolicy(
-    cint(HighDpiScaleFactorRoundingPolicyEnum.PassThrough))
   enableHDPI(uiScaleFilePath)
 
   # Enable threaded renderer (replaces dos_qguiapplication_try_enable_threaded_renderer)
@@ -268,8 +265,14 @@ proc mainProc() =
     defaultConfig.setCaCertificates(certList)
     QSslConfiguration.setDefaultConfiguration(defaultConfig)
 
+  # static qApp setup
+  QCoreApplication.setApplicationName("Status Desktop")
+  QCoreApplication.setOrganizationName("Status")
+  QCoreApplication.setOrganizationDomain("status.app")
+  QCoreApplication.setApplicationVersion(APP_VERSION)
+  QGuiApplication.setDesktopFileName("nim-status")
+
   let app = newQGuiApplication()
-  gen_qcoreapplication.QCoreApplication.setApplicationName("Status")
   singletonInstance.setApplication(app)
 
   when defined(qmldebug):

--- a/ui/StatusQ/include/StatusQ/osnotification.h
+++ b/ui/StatusQ/include/StatusQ/osnotification.h
@@ -1,5 +1,4 @@
-#ifndef STATUSQ_OS_NOTIFICATION_H
-#define STATUSQ_OS_NOTIFICATION_H
+#pragma once
 
 #include <QObject>
 #include <QString>
@@ -24,7 +23,7 @@ namespace Status
         void showIconBadgeNotification(int notificationsCount);
 
     signals:
-        void notificationClicked(QString identifier);
+        void notificationClicked(const QString& identifier);
 
 #ifdef Q_OS_WIN
     public:
@@ -39,10 +38,7 @@ namespace Status
     private:
         void initNotificationMacOs();
         void showNotificationMacOs(QString title, QString message, QString identifier);
-        void showIconBadgeNotificationMacOs(int notificationsCount);
         void* m_delegate = nullptr; // StatusQNotificationDelegate* (opaque to C++)
 #endif
     };
 }
-
-#endif // STATUSQ_OS_NOTIFICATION_H

--- a/ui/StatusQ/src/osnotification.cpp
+++ b/ui/StatusQ/src/osnotification.cpp
@@ -1,3 +1,5 @@
+#include <QGuiApplication>
+
 #include "StatusQ/osnotification.h"
 
 #ifdef Q_OS_WIN
@@ -148,9 +150,5 @@ void OSNotification::showNotification(const QString& title,
 
 void OSNotification::showIconBadgeNotification(int notificationsCount)
 {
-#ifdef Q_OS_MACOS
-    showIconBadgeNotificationMacOs(notificationsCount);
-#else
-    Q_UNUSED(notificationsCount)
-#endif
+    qGuiApp->setBadgeNumber(notificationsCount);
 }

--- a/ui/StatusQ/src/osnotification_apple.mm
+++ b/ui/StatusQ/src/osnotification_apple.mm
@@ -68,16 +68,6 @@ void OSNotification::showNotificationMacOs(QString title, QString message, QStri
     [content release];
 }
 
-void OSNotification::showIconBadgeNotificationMacOs(int notificationsCount)
-{
-    QString s; // empty clears the badge
-    if (notificationsCount > 0 && notificationsCount < 10)
-        s = QString::number(notificationsCount);
-    else if (notificationsCount >= 10)
-        s = "9+";
-    [[NSApp dockTile] setBadgeLabel:s.toNSString()];
-}
-
 // Destructor lives here so it can release the Obj-C delegate (non-ARC).
 OSNotification::~OSNotification()
 {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -92,12 +92,7 @@ Window {
     objectName: "mainWindow"
     color: Theme.palette.background
     title: {
-        // Set application settings
-        Qt.application.name = "Status Desktop"
         Qt.application.displayName = d.macOSWindowed ? "" : qsTr("Status Desktop")
-        Qt.application.organization = "Status"
-        Qt.application.domain = "status.im"
-        Qt.application.version = aboutModule.getCurrentVersion()
         return Qt.application.displayName
     }
 


### PR DESCRIPTION
### What does the PR do

- tied to the global AC notifications count
- use the `QGuiApplication::setBadgeNumber(int num)` everywhere to set the actual value
- fixup and move the qApp static initialization to NIM, simplify the global signal code path/propagation
- bump `vendor/nim-seaqt` to the Qt 6.8 branch

Fixes #20872

### Affected areas

Chat/App

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

TBD

### Impact on end user

UI/UX

### How to test

- get yourself @mentioned in the chat
- the dock icon should have a number badge on it (depending on the OS impl/support)

### Risk 

low
