### PR TITLE
fix(tokens): stops RPC flood from spam/scam tokens

### DIFF
--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -44,6 +44,10 @@ type
 type
   AsyncRefreshTokensTaskArg = ref object of QObjectTaskArg
     requestId: int
+    # When false, the full token catalogue (~3MB) is NOT fetched and "allTokens" stays
+    # empty, so the main-thread slot keeps the existing cache and skips the heavy decode.
+    # Only init / token-lists-updated set this to true.
+    fetchAllTokens: bool
 
 proc asyncRefreshTokensTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncRefreshTokensTaskArg](argEncoded)
@@ -68,16 +72,18 @@ proc asyncRefreshTokensTask*(argEncoded: string) {.gcsafe, nimcall.} =
   except Exception as e:
     output["error"] = %* fmt"Error refreshing tokens: {e.msg}"
 
-  # fetch all tokens for the group-key index
-  try:
-    var allTokensResponse: JsonNode
-    let allTokensErr = status_go_tokens.getAllTokens(allTokensResponse)
-    if allTokensErr.len > 0:
-      warn "asyncRefreshTokensTask: getAllTokens failed", err = allTokensErr
-    else:
-      output["allTokens"] = if allTokensResponse.isNil: newJArray() else: allTokensResponse
-  except Exception as e:
-    warn "asyncRefreshTokensTask: getAllTokens exception", err = e.msg
+  # fetch all tokens for the group-key index only when the catalogue may have changed.
+  # Skipping this on routine refreshes avoids shipping+decoding ~3MB on the main thread.
+  if arg.fetchAllTokens:
+    try:
+      var allTokensResponse: JsonNode
+      let allTokensErr = status_go_tokens.getAllTokens(allTokensResponse)
+      if allTokensErr.len > 0:
+        warn "asyncRefreshTokensTask: getAllTokens failed", err = allTokensErr
+      else:
+        output["allTokens"] = if allTokensResponse.isNil: newJArray() else: allTokensResponse
+    except Exception as e:
+      warn "asyncRefreshTokensTask: getAllTokens exception", err = e.msg
 
   arg.finish(output)
 

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -1,4 +1,4 @@
-import nimqml, tables, json, std/sequtils, chronicles, strutils, sugar, algorithm
+import nimqml, tables, json, std/sequtils, chronicles, strutils, sugar, algorithm, std/sets
 
 import web3/eth_api_types
 import backend/backend as backend
@@ -66,6 +66,9 @@ QtObject:
     hasPriceValuesCache: bool
     tokenListUpdatedAt: int64
     refreshTokensRequestId: int
+    # Negative cache: token keys that status-go could not resolve. Prevents re-hitting
+    # wallet_getTokensByKeys for the same unknown key on every lookup. Cleared on token refresh.
+    notFoundKeys: HashSet[string]
 
   # Forward declaration
   proc getCurrency*(self: Service): string
@@ -111,6 +114,7 @@ QtObject:
     result.tokensMarketDetailsLoading = true
     result.hasMarketDetailsCache = false
     result.hasPriceValuesCache = false
+    result.notFoundKeys = initHashSet[string]()
 
 
   include service_tokens

--- a/src/app_service/service/token/service_main.nim
+++ b/src/app_service/service/token/service_main.nim
@@ -67,6 +67,10 @@ proc prefetchParaswapSupportRetrieved(self: Service, response: string) {.slot.} 
 proc applyRefreshTokensData(self: Service, tokenDtos: seq[TokenDtoSafe], allTokenDtos: seq[TokenDtoSafe], tokenPrefsNode: JsonNode) =
   let tokens = tokenDtos.map(t => createTokenItem(t))
 
+  # Token catalogue changed -> previously-unresolvable keys may now resolve.
+  if tokenDtos.len > 0 or allTokenDtos.len > 0:
+    self.notFoundKeys.clear()
+
   if tokens.len > 0 or self.groupsOfInterestByKey.len == 0:
     self.tokensOfInterestByKey.clear()
     self.groupsOfInterestByKey.clear()
@@ -286,6 +290,8 @@ proc getTokenByKey*(self: Service, key: string): TokenItem =
     return nil
   if self.tokensOfInterestByKey.hasKey(key):
     return self.tokensOfInterestByKey[key]
+  if self.notFoundKeys.contains(key):
+    return nil
   let tokens = getTokensByKeys(@[key])
   if tokens.len > 0:
     # add newly found tokens to the groups of interest
@@ -293,6 +299,7 @@ proc getTokenByKey*(self: Service, key: string): TokenItem =
 
     self.tokensOfInterestByKey[key] = tokens[0]
     return self.tokensOfInterestByKey[key]
+  self.notFoundKeys.incl(key)
   return nil
 
 proc getTokenByChainAddress*(self: Service, chainId: int, address: string): TokenItem =

--- a/src/app_service/service/token/service_main.nim
+++ b/src/app_service/service/token/service_main.nim
@@ -132,13 +132,16 @@ proc onAsyncFetchAllTokenListsDone(self: Service, response: string) {.slot.} =
   except Exception as e:
     error "error processing async fetch all token lists", msg = e.msg
 
-proc asyncRefreshTokens(self: Service) =
+# fetchAllTokens must be true only when the full catalogue can change (init /
+# token-lists-updated); routine refreshes skip the ~3MB getAllTokens fetch+decode.
+proc asyncRefreshTokens(self: Service, fetchAllTokens: bool = false) =
   inc self.refreshTokensRequestId
   let arg = AsyncRefreshTokensTaskArg(
     tptr: asyncRefreshTokensTask,
     vptr: cast[uint](self.vptr),
     slot: "onAsyncRefreshTokensDone",
     requestId: self.refreshTokensRequestId,
+    fetchAllTokens: fetchAllTokens,
   )
   self.threadpool.start(arg)
 
@@ -171,7 +174,7 @@ proc init*(self: Service) =
         self.rebuildMarketData()
   # update and populate internal list and then emit signal when new custom token detected?
   self.events.on(SignalType.WalletTokensListsUpdated.event) do(e:Args):
-    self.asyncRefreshTokens()
+    self.asyncRefreshTokens(fetchAllTokens = true)
     self.asyncFetchAllTokenLists()
 
   self.events.on(SIGNAL_NETWORK_MODE_UPDATED) do(e:Args):
@@ -181,7 +184,7 @@ proc init*(self: Service) =
   self.events.on(SIGNAL_CURRENCY_UPDATED) do(e:Args):
     self.rebuildMarketData()
 
-  self.asyncRefreshTokens()
+  self.asyncRefreshTokens(fetchAllTokens = true)
   self.prefetchParaswapSupport()
 
 proc getMandatoryTokenGroupKeys*(self: Service): seq[string] =


### PR DESCRIPTION
* Cache unresolvable token keys 
* Skip the full fetch on refreshes



examples of uresolvable(delisted) tokens :

| Key | Chain | Token | Type |
|---|---|---|---|
| `1-0x05cd8430…edfc4f` | Ethereum | Royal Doge (DOGE) | ERC-20 spam |
| `1-0x180af131…ebb3451` | Ethereum | Slop Sato (SATO) | ERC-20 spam |
| `1-0xeb1a8184…8f4339` | Ethereum | Royal King (KING) | ERC-20 spam |
| `10-0x06f42645…806a5cd` | Optimism | www.base1.cfd airdrop | ERC-20 scam |
| `10-0x6042174f…2354279` | Optimism | www.base1.cfd airdrop (dup) | ERC-20 scam |
| `10-0x036b3b9a…afbcf9` | Optimism | evmhub | ERC-721 NFT ⚠️ |