### PR TITLE
Makefile: linker flags adjusted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ ifneq ($(mkspecs),win32)
 
  else
   NIM_PARAMS += --passL:"-L$(QT_LIBDIR)"
+  NIM_PARAMS += --passL:"-Wl,-rpath-link,$(QT_LIBDIR)"
  endif
  QT_SEAQT_EXTRA_LIBS = $(shell PKG_CONFIG_PATH="$(QT_PCFILEDIR)" PKG_CONFIG_PREFIX_OVERRIDE="Qt*=$(QT_PC_PREFIX)" $(QT_PC_PKGCONFIG) --libs Qt"$(QT_MAJOR_VERSION)"Core Qt"$(QT_MAJOR_VERSION)"Qml Qt"$(QT_MAJOR_VERSION)"Gui Qt"$(QT_MAJOR_VERSION)"Quick Qt"$(QT_MAJOR_VERSION)"QuickControls2 Qt"$(QT_MAJOR_VERSION)"Widgets Qt"$(QT_MAJOR_VERSION)"Svg Qt"$(QT_MAJOR_VERSION)"Multimedia Qt"$(QT_MAJOR_VERSION)"WebView Qt"$(QT_MAJOR_VERSION)"WebChannel)
 else


### PR DESCRIPTION
### What does the PR do

Linker flags adjusted to avoid linking problem of QtWebEngineQuick::initialize on some linux envs.

### Affected areas
`Makefile`
