### PR TITLE
feat(browser): cleanup browser profiles 

### DIFF
--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -1,7 +1,13 @@
 -include ./scripts/EnvVariables.mk
 -include ./scripts/Common.mk
 
+# iOS device and simulator are both arm64 but produce incompatible objects,
+# so the sentinel key must include the SDK (iphoneos vs iphonesimulator).
+ifeq ($(OS),ios)
+PLATFORM_TARGET := $(OS)-$(ARCH)-$(IPHONE_SDK)
+else
 PLATFORM_TARGET := $(OS)-$(ARCH)
+endif
 
 # FLAG_KEYCARD_ENABLED: Controls NFC/Keycard support
 # - iOS: Default 1 (enabled) - Build with NFC support, works with free Apple Developer account

--- a/mobile/android/qt6/build.gradle
+++ b/mobile/android/qt6/build.gradle
@@ -27,8 +27,9 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     //noinspection GradleDependency
     implementation 'androidx.core:core:1.16.0'
-    // Required for WebViewFeature / addDocumentStartJavaScript
-    implementation 'androidx.webkit:webkit:1.12.1'
+    // Required for WebViewFeature / addDocumentStartJavaScript / DELETE_BROWSING_DATA
+    // (clearSiteData). DELETE_BROWSING_DATA + WebStorageCompat need >= 1.13.
+    implementation 'androidx.webkit:webkit:1.13.0'
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.core:core-splashscreen:1.0.1'
     implementation 'com.google.android.material:material:1.12.0'

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -408,6 +408,10 @@ target_link_libraries(StatusQ PRIVATE
 if(NOT (IOS OR ANDROID))
     find_package(Qt${QT_VERSION_MAJOR} COMPONENTS WebEngineQuick QUIET)
     if(TARGET Qt::WebEngineQuick)
+        target_sources(StatusQ PRIVATE
+            include/StatusQ/browserprofileutils.h
+            src/browserprofileutils.cpp
+        )
         target_link_libraries(StatusQ PRIVATE Qt::WebEngineQuick)
         target_compile_definitions(StatusQ PRIVATE STATUSQ_HAS_QTWEBENGINE=1)
     endif()

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -328,7 +328,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG b1917e84037ccae2acce76a5f4f60e989a8310f5
+      GIT_TAG 5ba81a30992c11b1f1a38383c011a794f1fe57b7
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -328,7 +328,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG 126213ed270264ff29e675d86836e1a51582bb9b
+      GIT_TAG 92a4c62212702048715c69a85c82fd87fab47666
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -328,7 +328,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG d8e2856688c5217c50ec02f1a9fc4e92750f544f
+      GIT_TAG 126213ed270264ff29e675d86836e1a51582bb9b
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -328,7 +328,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG 5ba81a30992c11b1f1a38383c011a794f1fe57b7
+      GIT_TAG d8e2856688c5217c50ec02f1a9fc4e92750f544f
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)

--- a/ui/StatusQ/include/StatusQ/browserprofileutils.h
+++ b/ui/StatusQ/include/StatusQ/browserprofileutils.h
@@ -1,17 +1,31 @@
 #pragma once
 
+#include <QHash>
 #include <QObject>
 #include <QUrl>
 
 // Desktop-only helper exposing WebEngineProfile clearing that the QML
 // WebEngineProfile type does not expose (cookie store). Registered only when
 // StatusQ is built with Qt WebEngine (STATUSQ_HAS_QTWEBENGINE).
+//
+// Note: this singleton keeps a small live cookie-name index per profile store
+// because Qt 6 cannot enumerate cookies for per-site clear (loadAllCookies does
+// not re-emit via cookieAdded). Prefer keeping the index here over scattering
+// store subscriptions across QML.
 class BrowserProfileUtils : public QObject
 {
     Q_OBJECT
 
 public:
     explicit BrowserProfileUtils(QObject *parent = nullptr);
+    ~BrowserProfileUtils() override;
+
+    // Subscribe to cookieAdded on the profile's cookie store and keep a live
+    // set of cookie names. Must be called once when the profile is created
+    // (before first navigation). Names are kept across overwrites (Qt reports
+    // overwrite as cookieRemoved only). Persistent cookies restored from disk
+    // are not indexed until they are (re)set in the current session.
+    Q_INVOKABLE void trackProfile(QObject *profile);
 
     // Clears profile-wide browsing data: HTTP cache and all cookies.
     // `profile` must be a QML WebEngineProfile (QQuickWebEngineProfile);
@@ -21,13 +35,22 @@ public:
     // public API and are therefore left untouched.
     Q_INVOKABLE void clearBrowsingData(QObject *profile);
 
-    // Clears cookies that belong to `siteUrl`'s host (including Domain-scoped
-    // cookies that cover it, e.g. .example.com for www.example.com). Emits
-    // clearSiteDataCompleted when the cookie store load+delete settles.
-    // Pair with injected site_utils.js on the page for DOM storage; WebEngine
-    // has no public per-site HTTP cache / DOM storage API in C++.
+    // Clears cookies that belong to `siteUrl`'s host using the live name index
+    // from trackProfile (DeleteCookies is URL-scoped). Emits
+    // clearSiteDataCompleted when deletes settle (or immediately if there is
+    // nothing to clear / profile untracked). Pair with injected site_utils.js
+    // on the page for DOM storage; WebEngine has no public per-site HTTP cache
+    // / DOM storage API in C++.
     Q_INVOKABLE void clearSiteData(QObject *profile, const QUrl &siteUrl);
 
 signals:
     void clearSiteDataCompleted();
+
+private:
+    struct TrackedStore;
+
+    TrackedStore *trackedStoreFor(QObject *profile) const;
+
+    // Keyed by cookie store pointer; owned.
+    QHash<quintptr, TrackedStore *> m_tracked;
 };

--- a/ui/StatusQ/include/StatusQ/browserprofileutils.h
+++ b/ui/StatusQ/include/StatusQ/browserprofileutils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QUrl>
 
 // Desktop-only helper exposing WebEngineProfile clearing that the QML
 // WebEngineProfile type does not expose (cookie store). Registered only when
@@ -19,4 +20,14 @@ public:
     // Note: global DOM storage / visited links are not clearable via Qt's
     // public API and are therefore left untouched.
     Q_INVOKABLE void clearBrowsingData(QObject *profile);
+
+    // Clears cookies that belong to `siteUrl`'s host (including Domain-scoped
+    // cookies that cover it, e.g. .example.com for www.example.com). Emits
+    // clearSiteDataCompleted when the cookie store load+delete settles.
+    // Pair with injected site_utils.js on the page for DOM storage; WebEngine
+    // has no public per-site HTTP cache / DOM storage API in C++.
+    Q_INVOKABLE void clearSiteData(QObject *profile, const QUrl &siteUrl);
+
+signals:
+    void clearSiteDataCompleted();
 };

--- a/ui/StatusQ/include/StatusQ/browserprofileutils.h
+++ b/ui/StatusQ/include/StatusQ/browserprofileutils.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QObject>
+
+// Desktop-only helper exposing WebEngineProfile clearing that the QML
+// WebEngineProfile type does not expose (cookie store). Registered only when
+// StatusQ is built with Qt WebEngine (STATUSQ_HAS_QTWEBENGINE).
+class BrowserProfileUtils : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit BrowserProfileUtils(QObject *parent = nullptr);
+
+    // Clears profile-wide browsing data: HTTP cache and all cookies.
+    // `profile` must be a QML WebEngineProfile (QQuickWebEngineProfile);
+    // no-op with a warning otherwise. The profile's clearHttpCacheCompleted
+    // signal still fires, so QML can drive completion/reload handling.
+    // Note: global DOM storage / visited links are not clearable via Qt's
+    // public API and are therefore left untouched.
+    Q_INVOKABLE void clearBrowsingData(QObject *profile);
+};

--- a/ui/StatusQ/include/StatusQ/browserprofileutils.h
+++ b/ui/StatusQ/include/StatusQ/browserprofileutils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QHash>
+#include <QJSValue>
 #include <QObject>
 #include <QUrl>
 
@@ -29,22 +30,18 @@ public:
 
     // Clears profile-wide browsing data: HTTP cache and all cookies.
     // `profile` must be a QML WebEngineProfile (QQuickWebEngineProfile);
-    // no-op with a warning otherwise. The profile's clearHttpCacheCompleted
-    // signal still fires, so QML can drive completion/reload handling.
+    // no-op with a warning otherwise. Invokes `callback` when clearHttpCache
+    // completes (or after a short timeout fallback).
     // Note: global DOM storage / visited links are not clearable via Qt's
     // public API and are therefore left untouched.
-    Q_INVOKABLE void clearBrowsingData(QObject *profile);
+    Q_INVOKABLE void clearBrowsingData(QObject *profile, QJSValue callback = {});
 
     // Clears cookies that belong to `siteUrl`'s host using the live name index
-    // from trackProfile (DeleteCookies is URL-scoped). Emits
-    // clearSiteDataCompleted(requester) when deletes settle so only the
-    // initiating WebViewAdapter finishes. Pair with injected site_utils.js
-    // on the page for DOM storage.
+    // from trackProfile (DeleteCookies is URL-scoped). Invokes `callback` when
+    // deletes settle (sentinel barrier) so the initiating WebViewAdapter can
+    // wipe DOM storage / reload. Pair with injected site_utils.js on the page.
     Q_INVOKABLE void clearSiteData(QObject *profile, const QUrl &siteUrl,
-                                   QObject *requester = nullptr);
-
-signals:
-    void clearSiteDataCompleted(QObject *requester);
+                                   QJSValue callback = {});
 
 private:
     struct TrackedStore;

--- a/ui/StatusQ/include/StatusQ/browserprofileutils.h
+++ b/ui/StatusQ/include/StatusQ/browserprofileutils.h
@@ -37,14 +37,14 @@ public:
 
     // Clears cookies that belong to `siteUrl`'s host using the live name index
     // from trackProfile (DeleteCookies is URL-scoped). Emits
-    // clearSiteDataCompleted when deletes settle (or immediately if there is
-    // nothing to clear / profile untracked). Pair with injected site_utils.js
-    // on the page for DOM storage; WebEngine has no public per-site HTTP cache
-    // / DOM storage API in C++.
-    Q_INVOKABLE void clearSiteData(QObject *profile, const QUrl &siteUrl);
+    // clearSiteDataCompleted(requester) when deletes settle so only the
+    // initiating WebViewAdapter finishes. Pair with injected site_utils.js
+    // on the page for DOM storage.
+    Q_INVOKABLE void clearSiteData(QObject *profile, const QUrl &siteUrl,
+                                   QObject *requester = nullptr);
 
 signals:
-    void clearSiteDataCompleted();
+    void clearSiteDataCompleted(QObject *requester);
 
 private:
     struct TrackedStore;

--- a/ui/StatusQ/src/browserprofileutils.cpp
+++ b/ui/StatusQ/src/browserprofileutils.cpp
@@ -1,0 +1,26 @@
+#include "StatusQ/browserprofileutils.h"
+
+#include <QtWebEngineQuick/qquickwebengineprofile.h>
+#include <QtWebEngineCore/QWebEngineCookieStore>
+
+#include <QLoggingCategory>
+
+BrowserProfileUtils::BrowserProfileUtils(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void BrowserProfileUtils::clearBrowsingData(QObject *profile)
+{
+    auto *webProfile = qobject_cast<QQuickWebEngineProfile*>(profile);
+    if (!webProfile) {
+        qWarning("BrowserProfileUtils::clearBrowsingData: expected a WebEngineProfile");
+        return;
+    }
+
+    if (auto *cookieStore = webProfile->cookieStore())
+        cookieStore->deleteAllCookies();
+
+    // Async; the profile emits clearHttpCacheCompleted when done.
+    webProfile->clearHttpCache();
+}

--- a/ui/StatusQ/src/browserprofileutils.cpp
+++ b/ui/StatusQ/src/browserprofileutils.cpp
@@ -10,6 +10,27 @@
 
 #include <functional>
 
+namespace {
+
+bool hostMatchesCookieDomain(const QString &host, QString domain)
+{
+    if (domain.startsWith(QLatin1Char('.')))
+        domain.remove(0, 1);
+    if (domain.isEmpty() || host.isEmpty())
+        return false;
+    return host.compare(domain, Qt::CaseInsensitive) == 0
+        || host.endsWith(QLatin1Char('.') + domain, Qt::CaseInsensitive);
+}
+
+bool cookieMatchesHost(const QNetworkCookie &cookie, const QString &host)
+{
+    const QString domain = cookie.domain();
+    // Empty domain = host-only cookie for the delete origin.
+    return domain.isEmpty() || hostMatchesCookieDomain(host, domain);
+}
+
+} // namespace
+
 struct BrowserProfileUtils::TrackedStore
 {
     QPointer<QWebEngineCookieStore> store;
@@ -23,9 +44,10 @@ struct BrowserProfileUtils::TrackedStore
 
 namespace {
 
-// One-shot: deleteCookie(name, siteUrl) for each known name → wait / timeout → notify.
+// One-shot: deleteCookie(name, siteUrl) for each known name → settle / timeout → notify.
 // Chromium's DeleteCookies filter scopes by URL, so same-named cookies on other
-// hosts are not removed.
+// hosts are not removed. cookieRemoved is filtered by host so unrelated
+// same-named cookies do not end the wait early.
 class SiteCookieClearOp : public QObject
 {
 public:
@@ -38,9 +60,15 @@ public:
         , m_store(store)
         , m_names(std::move(names))
         , m_siteUrl(std::move(siteUrl))
+        , m_host(m_siteUrl.host())
         , m_onDone(std::move(onDone))
+        , m_settle(this)
         , m_timeout(this)
     {
+        m_settle.setSingleShot(true);
+        m_settle.setInterval(100);
+        connect(&m_settle, &QTimer::timeout, this, [this]() { finish(); });
+
         m_timeout.setSingleShot(true);
         m_timeout.setInterval(1000);
         connect(&m_timeout, &QTimer::timeout, this, [this]() { finish(); });
@@ -48,7 +76,7 @@ public:
 
     void start()
     {
-        if (!m_store || m_siteUrl.host().isEmpty() || m_names.isEmpty()) {
+        if (!m_store || m_host.isEmpty() || m_names.isEmpty()) {
             done();
             return;
         }
@@ -60,11 +88,16 @@ public:
             &QWebEngineCookieStore::cookieRemoved,
             this,
             [this](const QNetworkCookie &cookie) {
+                if (!cookieMatchesHost(cookie, m_host))
+                    return;
+                if (!m_pendingNames.contains(cookie.name()))
+                    return;
                 m_pendingNames.remove(cookie.name());
+                // After every expected name has been seen, briefly settle so
+                // same-name multi-path deletes can finish before notifying QML.
                 if (m_pendingNames.isEmpty())
-                    finish();
+                    m_settle.start();
             });
-
         for (const QByteArray &name : std::as_const(m_names)) {
             QNetworkCookie cookie(name);
             m_store->deleteCookie(cookie, m_siteUrl);
@@ -81,6 +114,7 @@ private:
         m_finished = true;
         if (m_removedConn)
             disconnect(m_removedConn);
+        m_settle.stop();
         m_timeout.stop();
         done();
     }
@@ -95,8 +129,10 @@ private:
     QPointer<QWebEngineCookieStore> m_store;
     QSet<QByteArray> m_names;
     QUrl m_siteUrl;
+    QString m_host;
     QSet<QByteArray> m_pendingNames;
     QMetaObject::Connection m_removedConn;
+    QTimer m_settle;
     QTimer m_timeout;
     std::function<void()> m_onDone;
     bool m_finished = false;
@@ -195,18 +231,19 @@ void BrowserProfileUtils::clearBrowsingData(QObject *profile)
     webProfile->clearHttpCache();
 }
 
-void BrowserProfileUtils::clearSiteData(QObject *profile, const QUrl &siteUrl)
+void BrowserProfileUtils::clearSiteData(QObject *profile, const QUrl &siteUrl,
+                                        QObject *requester)
 {
     auto *webProfile = qobject_cast<QQuickWebEngineProfile *>(profile);
     if (!webProfile) {
         qWarning("BrowserProfileUtils::clearSiteData: expected a WebEngineProfile");
-        emit clearSiteDataCompleted();
+        emit clearSiteDataCompleted(requester);
         return;
     }
 
     if (siteUrl.host().isEmpty()) {
         qWarning("BrowserProfileUtils::clearSiteData: empty host; ignoring");
-        emit clearSiteDataCompleted();
+        emit clearSiteDataCompleted(requester);
         return;
     }
 
@@ -214,15 +251,18 @@ void BrowserProfileUtils::clearSiteData(QObject *profile, const QUrl &siteUrl)
     if (!tracked || !tracked->store) {
         qWarning("BrowserProfileUtils::clearSiteData: profile not tracked "
                  "(call trackProfile at profile creation); ignoring");
-        emit clearSiteDataCompleted();
+        emit clearSiteDataCompleted(requester);
         return;
     }
 
+    // Hold a QPointer so a destroyed adapter does not leave a dangling
+    // requester in the async completion path.
+    const QPointer<QObject> requesterGuard(requester);
     auto *op = new SiteCookieClearOp(
         tracked->store,
         tracked->cookieNames,
         siteUrl,
-        [this]() { emit clearSiteDataCompleted(); },
+        [this, requesterGuard]() { emit clearSiteDataCompleted(requesterGuard.data()); },
         this);
     op->start();
 }

--- a/ui/StatusQ/src/browserprofileutils.cpp
+++ b/ui/StatusQ/src/browserprofileutils.cpp
@@ -3,7 +3,103 @@
 #include <QtWebEngineQuick/qquickwebengineprofile.h>
 #include <QtWebEngineCore/QWebEngineCookieStore>
 
-#include <QLoggingCategory>
+#include <QList>
+#include <QNetworkCookie>
+#include <QPointer>
+#include <QTimer>
+
+#include <functional>
+
+namespace {
+
+bool hostMatchesCookieDomain(const QString &host, QString domain)
+{
+    if (domain.startsWith(QLatin1Char('.')))
+        domain.remove(0, 1);
+    if (domain.isEmpty() || host.isEmpty())
+        return false;
+    return host.compare(domain, Qt::CaseInsensitive) == 0
+        || host.endsWith(QLatin1Char('.') + domain, Qt::CaseInsensitive);
+}
+
+// One-shot: loadAllCookies → collect matches → deleteCookie → notify.
+// No Q_OBJECT / moc: lambdas + QTimer are enough.
+class SiteCookieClearOp : public QObject
+{
+public:
+    SiteCookieClearOp(QWebEngineCookieStore *store,
+                      QUrl siteUrl,
+                      std::function<void()> onDone,
+                      QObject *parent = nullptr)
+        : QObject(parent)
+        , m_store(store)
+        , m_siteUrl(std::move(siteUrl))
+        , m_host(m_siteUrl.host())
+        , m_onDone(std::move(onDone))
+        , m_settle(this)
+    {
+        m_settle.setSingleShot(true);
+        m_settle.setInterval(100);
+        QObject::connect(&m_settle, &QTimer::timeout, this, [this]() { finish(); });
+    }
+
+    void start()
+    {
+        if (!m_store || m_host.isEmpty()) {
+            done();
+            return;
+        }
+
+        m_conn = QObject::connect(
+            m_store,
+            &QWebEngineCookieStore::cookieAdded,
+            this,
+            [this](const QNetworkCookie &cookie) { onCookieAdded(cookie); });
+
+        m_store->loadAllCookies();
+        // Complete even when the store has no cookies (no cookieAdded flood).
+        m_settle.start();
+    }
+
+private:
+    void onCookieAdded(const QNetworkCookie &cookie)
+    {
+        const QString domain = cookie.domain();
+        // Empty domain = host-only cookie; deleteCookie(..., siteUrl) scopes it.
+        if (domain.isEmpty() || hostMatchesCookieDomain(m_host, domain))
+            m_pending.append(cookie);
+        m_settle.start();
+    }
+
+    void finish()
+    {
+        if (m_conn)
+            QObject::disconnect(m_conn);
+
+        if (m_store) {
+            for (const QNetworkCookie &cookie : std::as_const(m_pending))
+                m_store->deleteCookie(cookie, m_siteUrl);
+        }
+        done();
+    }
+
+    void done()
+    {
+        if (m_onDone)
+            m_onDone();
+        deleteLater();
+    }
+
+    QPointer<QWebEngineCookieStore> m_store;
+    QUrl m_siteUrl;
+    QString m_host;
+    QList<QNetworkCookie> m_pending;
+    QMetaObject::Connection m_conn;
+    QTimer m_settle;
+    std::function<void()> m_onDone;
+};
+
+} // namespace
 
 BrowserProfileUtils::BrowserProfileUtils(QObject *parent)
     : QObject(parent)
@@ -23,4 +119,28 @@ void BrowserProfileUtils::clearBrowsingData(QObject *profile)
 
     // Async; the profile emits clearHttpCacheCompleted when done.
     webProfile->clearHttpCache();
+}
+
+void BrowserProfileUtils::clearSiteData(QObject *profile, const QUrl &siteUrl)
+{
+    auto *webProfile = qobject_cast<QQuickWebEngineProfile*>(profile);
+    if (!webProfile) {
+        qWarning("BrowserProfileUtils::clearSiteData: expected a WebEngineProfile");
+        emit clearSiteDataCompleted();
+        return;
+    }
+
+    auto *cookieStore = webProfile->cookieStore();
+    if (!cookieStore || siteUrl.host().isEmpty()) {
+        qWarning("BrowserProfileUtils::clearSiteData: no cookie store or empty host; ignoring");
+        emit clearSiteDataCompleted();
+        return;
+    }
+
+    auto *op = new SiteCookieClearOp(
+        cookieStore,
+        siteUrl,
+        [this]() { emit clearSiteDataCompleted(); },
+        this);
+    op->start();
 }

--- a/ui/StatusQ/src/browserprofileutils.cpp
+++ b/ui/StatusQ/src/browserprofileutils.cpp
@@ -3,83 +3,85 @@
 #include <QtWebEngineQuick/qquickwebengineprofile.h>
 #include <QtWebEngineCore/QWebEngineCookieStore>
 
-#include <QList>
 #include <QNetworkCookie>
 #include <QPointer>
+#include <QSet>
 #include <QTimer>
 
 #include <functional>
 
+struct BrowserProfileUtils::TrackedStore
+{
+    QPointer<QWebEngineCookieStore> store;
+    // Cookie names observed via cookieAdded. Qt 6 reports overwrites
+    // (e.g. JS cookie replaced by HttpOnly Set-Cookie) as cookieRemoved only,
+    // so we never drop names on removal — stale names make deleteCookie a no-op.
+    QSet<QByteArray> cookieNames;
+    QMetaObject::Connection addedConn;
+    QMetaObject::Connection destroyedConn;
+};
+
 namespace {
 
-bool hostMatchesCookieDomain(const QString &host, QString domain)
-{
-    if (domain.startsWith(QLatin1Char('.')))
-        domain.remove(0, 1);
-    if (domain.isEmpty() || host.isEmpty())
-        return false;
-    return host.compare(domain, Qt::CaseInsensitive) == 0
-        || host.endsWith(QLatin1Char('.') + domain, Qt::CaseInsensitive);
-}
-
-// One-shot: loadAllCookies → collect matches → deleteCookie → notify.
-// No Q_OBJECT / moc: lambdas + QTimer are enough.
+// One-shot: deleteCookie(name, siteUrl) for each known name → wait / timeout → notify.
+// Chromium's DeleteCookies filter scopes by URL, so same-named cookies on other
+// hosts are not removed.
 class SiteCookieClearOp : public QObject
 {
 public:
     SiteCookieClearOp(QWebEngineCookieStore *store,
+                      QSet<QByteArray> names,
                       QUrl siteUrl,
                       std::function<void()> onDone,
                       QObject *parent = nullptr)
         : QObject(parent)
         , m_store(store)
+        , m_names(std::move(names))
         , m_siteUrl(std::move(siteUrl))
-        , m_host(m_siteUrl.host())
         , m_onDone(std::move(onDone))
-        , m_settle(this)
+        , m_timeout(this)
     {
-        m_settle.setSingleShot(true);
-        m_settle.setInterval(100);
-        QObject::connect(&m_settle, &QTimer::timeout, this, [this]() { finish(); });
+        m_timeout.setSingleShot(true);
+        m_timeout.setInterval(1000);
+        connect(&m_timeout, &QTimer::timeout, this, [this]() { finish(); });
     }
 
     void start()
     {
-        if (!m_store || m_host.isEmpty()) {
+        if (!m_store || m_siteUrl.host().isEmpty() || m_names.isEmpty()) {
             done();
             return;
         }
 
-        m_conn = QObject::connect(
-            m_store,
-            &QWebEngineCookieStore::cookieAdded,
-            this,
-            [this](const QNetworkCookie &cookie) { onCookieAdded(cookie); });
+        m_pendingNames = m_names;
 
-        m_store->loadAllCookies();
-        // Complete even when the store has no cookies (no cookieAdded flood).
-        m_settle.start();
+        m_removedConn = connect(
+            m_store,
+            &QWebEngineCookieStore::cookieRemoved,
+            this,
+            [this](const QNetworkCookie &cookie) {
+                m_pendingNames.remove(cookie.name());
+                if (m_pendingNames.isEmpty())
+                    finish();
+            });
+
+        for (const QByteArray &name : std::as_const(m_names)) {
+            QNetworkCookie cookie(name);
+            m_store->deleteCookie(cookie, m_siteUrl);
+        }
+
+        m_timeout.start();
     }
 
 private:
-    void onCookieAdded(const QNetworkCookie &cookie)
-    {
-        const QString domain = cookie.domain();
-        // Empty domain = host-only cookie; deleteCookie(..., siteUrl) scopes it.
-        if (domain.isEmpty() || hostMatchesCookieDomain(m_host, domain))
-            m_pending.append(cookie);
-        m_settle.start();
-    }
-
     void finish()
     {
-        if (m_conn)
-            QObject::disconnect(m_conn);
-
-        if (m_store) {
-            for (const QNetworkCookie &cookie : std::as_const(m_pending))
-                m_store->deleteCookie(cookie, m_siteUrl);
-        }
+        if (m_finished)
+            return;
+        m_finished = true;
+        if (m_removedConn)
+            disconnect(m_removedConn);
+        m_timeout.stop();
         done();
     }
 
@@ -91,12 +93,13 @@ private:
     }
 
     QPointer<QWebEngineCookieStore> m_store;
+    QSet<QByteArray> m_names;
     QUrl m_siteUrl;
-    QString m_host;
-    QList<QNetworkCookie> m_pending;
-    QMetaObject::Connection m_conn;
-    QTimer m_settle;
+    QSet<QByteArray> m_pendingNames;
+    QMetaObject::Connection m_removedConn;
+    QTimer m_timeout;
     std::function<void()> m_onDone;
+    bool m_finished = false;
 };
 
 } // namespace
@@ -106,16 +109,87 @@ BrowserProfileUtils::BrowserProfileUtils(QObject *parent)
 {
 }
 
+BrowserProfileUtils::~BrowserProfileUtils()
+{
+    for (TrackedStore *tracked : std::as_const(m_tracked)) {
+        if (tracked->addedConn)
+            disconnect(tracked->addedConn);
+        if (tracked->destroyedConn)
+            disconnect(tracked->destroyedConn);
+        delete tracked;
+    }
+    m_tracked.clear();
+}
+
+BrowserProfileUtils::TrackedStore *BrowserProfileUtils::trackedStoreFor(QObject *profile) const
+{
+    auto *webProfile = qobject_cast<QQuickWebEngineProfile *>(profile);
+    if (!webProfile)
+        return nullptr;
+    auto *store = webProfile->cookieStore();
+    if (!store)
+        return nullptr;
+    return m_tracked.value(reinterpret_cast<quintptr>(store), nullptr);
+}
+
+void BrowserProfileUtils::trackProfile(QObject *profile)
+{
+    auto *webProfile = qobject_cast<QQuickWebEngineProfile *>(profile);
+    if (!webProfile) {
+        qWarning("BrowserProfileUtils::trackProfile: expected a WebEngineProfile");
+        return;
+    }
+
+    auto *store = webProfile->cookieStore();
+    if (!store) {
+        qWarning("BrowserProfileUtils::trackProfile: no cookie store");
+        return;
+    }
+
+    const quintptr key = reinterpret_cast<quintptr>(store);
+    if (m_tracked.contains(key))
+        return;
+
+    auto *tracked = new TrackedStore;
+    tracked->store = store;
+
+    tracked->addedConn = connect(
+        store,
+        &QWebEngineCookieStore::cookieAdded,
+        this,
+        [tracked](const QNetworkCookie &cookie) {
+            tracked->cookieNames.insert(cookie.name());
+        });
+
+    tracked->destroyedConn = connect(
+        store,
+        &QObject::destroyed,
+        this,
+        [this, key]() {
+            TrackedStore *gone = m_tracked.take(key);
+            if (!gone)
+                return;
+            if (gone->addedConn)
+                disconnect(gone->addedConn);
+            delete gone;
+        });
+
+    m_tracked.insert(key, tracked);
+}
+
 void BrowserProfileUtils::clearBrowsingData(QObject *profile)
 {
-    auto *webProfile = qobject_cast<QQuickWebEngineProfile*>(profile);
+    auto *webProfile = qobject_cast<QQuickWebEngineProfile *>(profile);
     if (!webProfile) {
         qWarning("BrowserProfileUtils::clearBrowsingData: expected a WebEngineProfile");
         return;
     }
 
-    if (auto *cookieStore = webProfile->cookieStore())
+    if (auto *cookieStore = webProfile->cookieStore()) {
         cookieStore->deleteAllCookies();
+        if (TrackedStore *tracked = trackedStoreFor(profile))
+            tracked->cookieNames.clear();
+    }
 
     // Async; the profile emits clearHttpCacheCompleted when done.
     webProfile->clearHttpCache();
@@ -123,22 +197,30 @@ void BrowserProfileUtils::clearBrowsingData(QObject *profile)
 
 void BrowserProfileUtils::clearSiteData(QObject *profile, const QUrl &siteUrl)
 {
-    auto *webProfile = qobject_cast<QQuickWebEngineProfile*>(profile);
+    auto *webProfile = qobject_cast<QQuickWebEngineProfile *>(profile);
     if (!webProfile) {
         qWarning("BrowserProfileUtils::clearSiteData: expected a WebEngineProfile");
         emit clearSiteDataCompleted();
         return;
     }
 
-    auto *cookieStore = webProfile->cookieStore();
-    if (!cookieStore || siteUrl.host().isEmpty()) {
-        qWarning("BrowserProfileUtils::clearSiteData: no cookie store or empty host; ignoring");
+    if (siteUrl.host().isEmpty()) {
+        qWarning("BrowserProfileUtils::clearSiteData: empty host; ignoring");
+        emit clearSiteDataCompleted();
+        return;
+    }
+
+    TrackedStore *tracked = trackedStoreFor(profile);
+    if (!tracked || !tracked->store) {
+        qWarning("BrowserProfileUtils::clearSiteData: profile not tracked "
+                 "(call trackProfile at profile creation); ignoring");
         emit clearSiteDataCompleted();
         return;
     }
 
     auto *op = new SiteCookieClearOp(
-        cookieStore,
+        tracked->store,
+        tracked->cookieNames,
         siteUrl,
         [this]() { emit clearSiteDataCompleted(); },
         this);

--- a/ui/StatusQ/src/browserprofileutils.cpp
+++ b/ui/StatusQ/src/browserprofileutils.cpp
@@ -8,26 +8,164 @@
 #include <QSet>
 #include <QTimer>
 
-#include <functional>
-
 namespace {
 
-bool hostMatchesCookieDomain(const QString &host, QString domain)
+// Written after deletes so cookieAdded(sentinel) means the store has applied
+// every prior deleteCookie for this host (Mojo IPC is ordered per store).
+constexpr char kClearBarrierCookieName[] = "__status_clear_barrier";
+
+void invokeCallback(QJSValue callback)
 {
-    if (domain.startsWith(QLatin1Char('.')))
-        domain.remove(0, 1);
-    if (domain.isEmpty() || host.isEmpty())
-        return false;
-    return host.compare(domain, Qt::CaseInsensitive) == 0
-        || host.endsWith(QLatin1Char('.') + domain, Qt::CaseInsensitive);
+    if (!callback.isCallable())
+        return;
+    const QJSValue result = callback.call();
+    if (result.isError())
+        qWarning("BrowserProfileUtils: clear callback threw: %s",
+                 qPrintable(result.toString()));
 }
 
-bool cookieMatchesHost(const QNetworkCookie &cookie, const QString &host)
+// One-shot: deleteCookie(name, siteUrl) for each known name, then set a sentinel
+// cookie and wait for cookieAdded(sentinel) before notifying. No pending-name
+// counters — Mojo ordering guarantees deletes are applied before the add.
+class SiteCookieClearOp : public QObject
 {
-    const QString domain = cookie.domain();
-    // Empty domain = host-only cookie for the delete origin.
-    return domain.isEmpty() || hostMatchesCookieDomain(host, domain);
-}
+public:
+    SiteCookieClearOp(QWebEngineCookieStore *store,
+                      QSet<QByteArray> names,
+                      QUrl siteUrl,
+                      QJSValue callback,
+                      QObject *parent = nullptr)
+        : QObject(parent)
+        , m_store(store)
+        , m_names(std::move(names))
+        , m_siteUrl(std::move(siteUrl))
+        , m_callback(std::move(callback))
+        , m_timeout(this)
+    {
+        m_timeout.setSingleShot(true);
+        m_timeout.setInterval(2000);
+        connect(&m_timeout, &QTimer::timeout, this, [this]() { finish(); });
+    }
+
+    void start()
+    {
+        if (!m_store || m_siteUrl.host().isEmpty()) {
+            done();
+            return;
+        }
+
+        m_names.remove(QByteArray(kClearBarrierCookieName));
+
+        m_addedConn = connect(
+            m_store,
+            &QWebEngineCookieStore::cookieAdded,
+            this,
+            [this](const QNetworkCookie &cookie) {
+                if (cookie.name() != QByteArray(kClearBarrierCookieName))
+                    return;
+                // Drop the sentinel so it does not linger on the site.
+                m_store->deleteCookie(cookie, m_siteUrl);
+                finish();
+            });
+
+        for (const QByteArray &name : std::as_const(m_names)) {
+            QNetworkCookie cookie(name);
+            m_store->deleteCookie(cookie, m_siteUrl);
+        }
+
+        QNetworkCookie barrier(QByteArray(kClearBarrierCookieName),
+                               QByteArrayLiteral("1"));
+        barrier.setPath(QStringLiteral("/"));
+        m_store->setCookie(barrier, m_siteUrl);
+
+        m_timeout.start();
+    }
+
+private:
+    void finish()
+    {
+        if (m_finished)
+            return;
+        m_finished = true;
+        if (m_addedConn)
+            disconnect(m_addedConn);
+        m_timeout.stop();
+        done();
+    }
+
+    void done()
+    {
+        invokeCallback(m_callback);
+        deleteLater();
+    }
+
+    QPointer<QWebEngineCookieStore> m_store;
+    QSet<QByteArray> m_names;
+    QUrl m_siteUrl;
+    QJSValue m_callback;
+    QMetaObject::Connection m_addedConn;
+    QTimer m_timeout;
+    bool m_finished = false;
+};
+
+// One-shot: wait for clearHttpCacheCompleted (or timeout), then invoke callback.
+class BrowsingDataClearOp : public QObject
+{
+public:
+    BrowsingDataClearOp(QQuickWebEngineProfile *profile,
+                        QJSValue callback,
+                        QObject *parent = nullptr)
+        : QObject(parent)
+        , m_profile(profile)
+        , m_callback(std::move(callback))
+        , m_timeout(this)
+    {
+        m_timeout.setSingleShot(true);
+        m_timeout.setInterval(2000);
+        connect(&m_timeout, &QTimer::timeout, this, [this]() { finish(); });
+    }
+
+    void start()
+    {
+        if (!m_profile) {
+            done();
+            return;
+        }
+
+        m_cacheConn = connect(
+            m_profile,
+            &QQuickWebEngineProfile::clearHttpCacheCompleted,
+            this,
+            [this]() { finish(); });
+
+        m_profile->clearHttpCache();
+        m_timeout.start();
+    }
+
+private:
+    void finish()
+    {
+        if (m_finished)
+            return;
+        m_finished = true;
+        if (m_cacheConn)
+            disconnect(m_cacheConn);
+        m_timeout.stop();
+        done();
+    }
+
+    void done()
+    {
+        invokeCallback(m_callback);
+        deleteLater();
+    }
+
+    QPointer<QQuickWebEngineProfile> m_profile;
+    QJSValue m_callback;
+    QMetaObject::Connection m_cacheConn;
+    QTimer m_timeout;
+    bool m_finished = false;
+};
 
 } // namespace
 
@@ -41,104 +179,6 @@ struct BrowserProfileUtils::TrackedStore
     QMetaObject::Connection addedConn;
     QMetaObject::Connection destroyedConn;
 };
-
-namespace {
-
-// One-shot: deleteCookie(name, siteUrl) for each known name → settle / timeout → notify.
-// Chromium's DeleteCookies filter scopes by URL, so same-named cookies on other
-// hosts are not removed. cookieRemoved is filtered by host so unrelated
-// same-named cookies do not end the wait early.
-class SiteCookieClearOp : public QObject
-{
-public:
-    SiteCookieClearOp(QWebEngineCookieStore *store,
-                      QSet<QByteArray> names,
-                      QUrl siteUrl,
-                      std::function<void()> onDone,
-                      QObject *parent = nullptr)
-        : QObject(parent)
-        , m_store(store)
-        , m_names(std::move(names))
-        , m_siteUrl(std::move(siteUrl))
-        , m_host(m_siteUrl.host())
-        , m_onDone(std::move(onDone))
-        , m_settle(this)
-        , m_timeout(this)
-    {
-        m_settle.setSingleShot(true);
-        m_settle.setInterval(100);
-        connect(&m_settle, &QTimer::timeout, this, [this]() { finish(); });
-
-        m_timeout.setSingleShot(true);
-        m_timeout.setInterval(1000);
-        connect(&m_timeout, &QTimer::timeout, this, [this]() { finish(); });
-    }
-
-    void start()
-    {
-        if (!m_store || m_host.isEmpty() || m_names.isEmpty()) {
-            done();
-            return;
-        }
-
-        m_pendingNames = m_names;
-
-        m_removedConn = connect(
-            m_store,
-            &QWebEngineCookieStore::cookieRemoved,
-            this,
-            [this](const QNetworkCookie &cookie) {
-                if (!cookieMatchesHost(cookie, m_host))
-                    return;
-                if (!m_pendingNames.contains(cookie.name()))
-                    return;
-                m_pendingNames.remove(cookie.name());
-                // After every expected name has been seen, briefly settle so
-                // same-name multi-path deletes can finish before notifying QML.
-                if (m_pendingNames.isEmpty())
-                    m_settle.start();
-            });
-        for (const QByteArray &name : std::as_const(m_names)) {
-            QNetworkCookie cookie(name);
-            m_store->deleteCookie(cookie, m_siteUrl);
-        }
-
-        m_timeout.start();
-    }
-
-private:
-    void finish()
-    {
-        if (m_finished)
-            return;
-        m_finished = true;
-        if (m_removedConn)
-            disconnect(m_removedConn);
-        m_settle.stop();
-        m_timeout.stop();
-        done();
-    }
-
-    void done()
-    {
-        if (m_onDone)
-            m_onDone();
-        deleteLater();
-    }
-
-    QPointer<QWebEngineCookieStore> m_store;
-    QSet<QByteArray> m_names;
-    QUrl m_siteUrl;
-    QString m_host;
-    QSet<QByteArray> m_pendingNames;
-    QMetaObject::Connection m_removedConn;
-    QTimer m_settle;
-    QTimer m_timeout;
-    std::function<void()> m_onDone;
-    bool m_finished = false;
-};
-
-} // namespace
 
 BrowserProfileUtils::BrowserProfileUtils(QObject *parent)
     : QObject(parent)
@@ -194,6 +234,8 @@ void BrowserProfileUtils::trackProfile(QObject *profile)
         &QWebEngineCookieStore::cookieAdded,
         this,
         [tracked](const QNetworkCookie &cookie) {
+            if (cookie.name() == QByteArray(kClearBarrierCookieName))
+                return;
             tracked->cookieNames.insert(cookie.name());
         });
 
@@ -213,11 +255,12 @@ void BrowserProfileUtils::trackProfile(QObject *profile)
     m_tracked.insert(key, tracked);
 }
 
-void BrowserProfileUtils::clearBrowsingData(QObject *profile)
+void BrowserProfileUtils::clearBrowsingData(QObject *profile, QJSValue callback)
 {
     auto *webProfile = qobject_cast<QQuickWebEngineProfile *>(profile);
     if (!webProfile) {
         qWarning("BrowserProfileUtils::clearBrowsingData: expected a WebEngineProfile");
+        invokeCallback(callback);
         return;
     }
 
@@ -227,23 +270,23 @@ void BrowserProfileUtils::clearBrowsingData(QObject *profile)
             tracked->cookieNames.clear();
     }
 
-    // Async; the profile emits clearHttpCacheCompleted when done.
-    webProfile->clearHttpCache();
+    auto *op = new BrowsingDataClearOp(webProfile, std::move(callback), this);
+    op->start();
 }
 
 void BrowserProfileUtils::clearSiteData(QObject *profile, const QUrl &siteUrl,
-                                        QObject *requester)
+                                        QJSValue callback)
 {
     auto *webProfile = qobject_cast<QQuickWebEngineProfile *>(profile);
     if (!webProfile) {
         qWarning("BrowserProfileUtils::clearSiteData: expected a WebEngineProfile");
-        emit clearSiteDataCompleted(requester);
+        invokeCallback(callback);
         return;
     }
 
     if (siteUrl.host().isEmpty()) {
         qWarning("BrowserProfileUtils::clearSiteData: empty host; ignoring");
-        emit clearSiteDataCompleted(requester);
+        invokeCallback(callback);
         return;
     }
 
@@ -251,18 +294,15 @@ void BrowserProfileUtils::clearSiteData(QObject *profile, const QUrl &siteUrl,
     if (!tracked || !tracked->store) {
         qWarning("BrowserProfileUtils::clearSiteData: profile not tracked "
                  "(call trackProfile at profile creation); ignoring");
-        emit clearSiteDataCompleted(requester);
+        invokeCallback(callback);
         return;
     }
 
-    // Hold a QPointer so a destroyed adapter does not leave a dangling
-    // requester in the async completion path.
-    const QPointer<QObject> requesterGuard(requester);
     auto *op = new SiteCookieClearOp(
         tracked->store,
         tracked->cookieNames,
         siteUrl,
-        [this, requesterGuard]() { emit clearSiteDataCompleted(requesterGuard.data()); },
+        std::move(callback),
         this);
     op->start();
 }

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -34,6 +34,10 @@
 #include "MobileWebView/mobilewebviewbackend.h"
 #endif
 
+#if defined(STATUSQ_HAS_QTWEBENGINE)
+#include "StatusQ/browserprofileutils.h"
+#endif
+
 // Forward declare platform-specific registration functions
 // These are implemented in the respective platform files
 #if defined(Q_OS_IOS) || defined(Q_OS_ANDROID) || defined(Q_OS_MACOS)
@@ -160,6 +164,13 @@ void registerStatusQTypes() {
 
 #if defined(STATUSQ_HAS_MOBILEWEBVIEW)
     qmlRegisterType<MobileWebViewBackend>("StatusQ.CustomWebView", 1, 0, "MobileWebViewBackend");
+#endif
+
+#if defined(STATUSQ_HAS_QTWEBENGINE)
+    qmlRegisterSingletonType<BrowserProfileUtils>(
+        "StatusQ.Internal", 0, 1, "BrowserProfileUtils", [](QQmlEngine*, QJSEngine*) {
+            return new BrowserProfileUtils;
+        });
 #endif
     // Register NativeSwipeHandler + NativeIndicator (native on iOS/Android/macOS)
 #if defined(Q_OS_IOS) || defined(Q_OS_ANDROID) || defined(Q_OS_MACOS)

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -66,6 +66,24 @@ StatusSectionLayout {
         webViewContext.reloadCurrent()
     }
 
+    // Drive the current tab from Storybook / automation (web content is not in AX).
+    function runJsOnCurrentTab(script, callback) {
+        const wv = _internal.currentWebView
+        if (!wv || typeof wv.runJavaScript !== "function")
+            return
+        if (typeof wv.ensureLoaded === "function")
+            wv.ensureLoaded()
+        wv.runJavaScript(script, callback)
+    }
+
+    function clearSiteDataOnCurrentTab() {
+        webViewContext.clearSiteDataCurrent()
+    }
+
+    function clearBrowsingDataOnCurrentTab() {
+        webViewContext.clearBrowsingDataCurrent()
+    }
+
     function applyIncognitoMode(checked) {
         webViewContext.setIncognitoCurrent(checked)
         if (!checked && root.connectorController)

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -650,11 +650,11 @@ StatusSectionLayout {
         incognitoMode: _internal.currentTabIncognito
         zoomFactor: _internal.currentWebView?.zoomFactor ?? 1
         browserSettings: localAccountSensitiveSettings
-        clearingCache: _internal.currentWebView?.clearing ?? false
+        clearingBrowsingData: _internal.currentWebView?.clearing ?? false
         clearSiteDataSupported: _internal.currentWebView?.clearSiteDataSupported ?? true
         onForceReload: webViewContext.forceReloadCurrent()
         onClearSiteData: webViewContext.clearSiteDataCurrent()
-        onClearCache: webViewContext.clearCacheCurrent()
+        onClearBrowsingData: webViewContext.clearBrowsingDataCurrent()
         onAddNewTab: _internal.addNewEmptyTab()
         onAddNewDownloadTab: _internal.addNewDownloadTab()
         onGoIncognito: (checked) => root.applyIncognitoMode(checked)
@@ -697,7 +697,7 @@ StatusSectionLayout {
         clearing: _internal.currentWebView?.clearing ?? false
         onForceReload: webViewContext.forceReloadCurrent()
         onClearSiteData: webViewContext.clearSiteDataCurrent()
-        onClearCache: webViewContext.clearCacheCurrent()
+        onClearBrowsingData: webViewContext.clearBrowsingDataCurrent()
 
         onGoIncognito: checked => root.applyIncognitoMode(checked)
         onSettingsRequested: Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.browserSettings)

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -695,9 +695,19 @@ StatusSectionLayout {
 
         clearSiteDataSupported: _internal.currentWebView?.clearSiteDataSupported ?? false
         clearing: _internal.currentWebView?.clearing ?? false
+        compatibilityMode: localAccountSensitiveSettings.compatibilityMode
         onForceReload: webViewContext.forceReloadCurrent()
         onClearSiteData: webViewContext.clearSiteDataCurrent()
         onClearBrowsingData: webViewContext.clearBrowsingDataCurrent()
+        onToggleCompatibilityMode: function(checked) {
+            for (let i = 0; i < tabs.count; ++i) {
+                webViewContext.getWebView(i).stop()
+            }
+            localAccountSensitiveSettings.compatibilityMode = checked
+            for (let i = 0; i < tabs.count; ++i) {
+                webViewContext.getWebView(i).reload()
+            }
+        }
 
         onGoIncognito: checked => root.applyIncognitoMode(checked)
         onSettingsRequested: Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.browserSettings)

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -662,17 +662,7 @@ StatusSectionLayout {
         onZoomOut: webViewContext.changeZoomCurrent(-0.1)
         onResetZoomFactor: webViewContext.resetZoomCurrent()
         onLaunchFindBar: _internal.showFindBar()
-        onToggleCompatibilityMode: function(checked) {
-            for (let i = 0; i < tabs.count; ++i){
-                webViewContext.getWebView(i).stop() // Stop all loading tabs
-            }
-
-            localAccountSensitiveSettings.compatibilityMode = checked;
-
-            for (let i = 0; i < tabs.count; ++i){
-                webViewContext.getWebView(i).reload() // Reload them with new user agent
-            }
-        }
+        onToggleCompatibilityMode: (checked) => webViewContext.setCompatibilityMode(checked)
         onLaunchBrowserSettings: {
             Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.browserSettings);
         }
@@ -699,15 +689,7 @@ StatusSectionLayout {
         onForceReload: webViewContext.forceReloadCurrent()
         onClearSiteData: webViewContext.clearSiteDataCurrent()
         onClearBrowsingData: webViewContext.clearBrowsingDataCurrent()
-        onToggleCompatibilityMode: function(checked) {
-            for (let i = 0; i < tabs.count; ++i) {
-                webViewContext.getWebView(i).stop()
-            }
-            localAccountSensitiveSettings.compatibilityMode = checked
-            for (let i = 0; i < tabs.count; ++i) {
-                webViewContext.getWebView(i).reload()
-            }
-        }
+        onToggleCompatibilityMode: (checked) => webViewContext.setCompatibilityMode(checked)
 
         onGoIncognito: checked => root.applyIncognitoMode(checked)
         onSettingsRequested: Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.browserSettings)

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -650,6 +650,11 @@ StatusSectionLayout {
         incognitoMode: _internal.currentTabIncognito
         zoomFactor: _internal.currentWebView?.zoomFactor ?? 1
         browserSettings: localAccountSensitiveSettings
+        clearingCache: _internal.currentWebView?.clearing ?? false
+        clearSiteDataSupported: _internal.currentWebView?.clearSiteDataSupported ?? true
+        onForceReload: webViewContext.forceReloadCurrent()
+        onClearSiteData: webViewContext.clearSiteDataCurrent()
+        onClearCache: webViewContext.clearCacheCurrent()
         onAddNewTab: _internal.addNewEmptyTab()
         onAddNewDownloadTab: _internal.addNewDownloadTab()
         onGoIncognito: (checked) => root.applyIncognitoMode(checked)
@@ -687,6 +692,12 @@ StatusSectionLayout {
 
         supportsFind: _internal.currentTabSupportsFindInPage
         onLaunchFindBar: _internal.showFindBar()
+
+        clearSiteDataSupported: _internal.currentWebView?.clearSiteDataSupported ?? false
+        clearing: _internal.currentWebView?.clearing ?? false
+        onForceReload: webViewContext.forceReloadCurrent()
+        onClearSiteData: webViewContext.clearSiteDataCurrent()
+        onClearCache: webViewContext.clearCacheCurrent()
 
         onGoIncognito: checked => root.applyIncognitoMode(checked)
         onSettingsRequested: Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.browserSettings)

--- a/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
+++ b/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
@@ -122,7 +122,7 @@ Item {
     function clearSiteData() { console.warn("AbstractWebView: clearSiteData not implemented") }
 
     // Clear browsing data (profile-wide cache, cookies, DOM storage), then reload.
-    function clearCache() { console.warn("AbstractWebView: clearCache not implemented") }
+    function clearBrowsingData() { console.warn("AbstractWebView: clearBrowsingData not implemented") }
 
     function findText(text, flags) {}
     function showFindPanel() {}

--- a/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
+++ b/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
@@ -124,6 +124,9 @@ Item {
     // Clear browsing data (profile-wide cache, cookies, DOM storage), then reload.
     function clearBrowsingData() { console.warn("AbstractWebView: clearBrowsingData not implemented") }
 
+    // Run JS in the current page. Optional callback receives the result (WebEngine).
+    function runJavaScript(script, callback) { console.warn("AbstractWebView: runJavaScript not implemented") }
+
     function findText(text, flags) {}
     function showFindPanel() {}
     function hideFindPanel() {}

--- a/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
+++ b/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
@@ -31,6 +31,9 @@ Item {
     readonly property bool htmlPageLoaded: false
     readonly property var scrollPosition: Qt.point(0, 0)
 
+    // True while at least one data-clearing operation is in flight (see CONTEXT: Clearing).
+    property bool clearing: false
+
     // === Capability Flags ===
     required property bool supportsZoom
     required property bool supportsDevTools
@@ -38,6 +41,10 @@ Item {
     required property bool supportsIncognito
     required property bool supportsHistory
     required property bool hasNativeFindPanel
+
+    // Whether "clear current site data" is available on this platform/backend.
+    // Desktop: always true (JS path). Mobile: reflects native capability.
+    property bool clearSiteDataSupported: false
 
     // Mobile-only: pauses native webview updates (no-op on desktop)
     property bool freeze: false
@@ -105,6 +112,17 @@ Item {
     function goBackOrForward(offset) { console.warn("AbstractWebView: goBackOrForward not implemented") }
     function reload() { console.warn("AbstractWebView: reload not implemented") }
     function stop() { console.warn("AbstractWebView: stop not implemented") }
+
+    // Force reload: refetch every resource from the network for this navigation,
+    // bypassing (not evicting) the cache (see CONTEXT: Force reload).
+    function forceReload() { console.warn("AbstractWebView: forceReload not implemented") }
+
+    // Clear current site data: wipe the current tab's site data, then reload.
+    // The implementation reloads itself; callers must not reload afterwards.
+    function clearSiteData() { console.warn("AbstractWebView: clearSiteData not implemented") }
+
+    // Clear browsing data (profile-wide cache, cookies, DOM storage), then reload.
+    function clearCache() { console.warn("AbstractWebView: clearCache not implemented") }
 
     function findText(text, flags) {}
     function showFindPanel() {}

--- a/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
@@ -19,12 +19,14 @@ AbstractWebView {
     // WARN: needs to remain a var to avoid mixing platform-specific types
     property var profileManager: null
 
-    supportsZoom:       loader.item ? loader.item.supportsZoom       : false
-    supportsDevTools:   loader.item ? loader.item.supportsDevTools   : false
-    supportsFindInPage: loader.item ? loader.item.supportsFindInPage : false
-    supportsIncognito:  loader.item ? loader.item.supportsIncognito  : false
-    supportsHistory:    loader.item ? loader.item.supportsHistory    : false
-    hasNativeFindPanel: loader.item ? loader.item.hasNativeFindPanel : false
+    supportsZoom:           loader.item ? loader.item.supportsZoom           : false
+    supportsDevTools:       loader.item ? loader.item.supportsDevTools       : false
+    supportsFindInPage:     loader.item ? loader.item.supportsFindInPage     : false
+    supportsIncognito:      loader.item ? loader.item.supportsIncognito      : false
+    supportsHistory:        loader.item ? loader.item.supportsHistory        : false
+    hasNativeFindPanel:     loader.item ? loader.item.hasNativeFindPanel     : false
+    clearSiteDataSupported: loader.item ? loader.item.clearSiteDataSupported : false
+    clearing:               loader.item ? loader.item.clearing               : false
 
     property string title: ""
     property url icon: ""
@@ -89,6 +91,21 @@ AbstractWebView {
             loader.item.reload()
     }
     function stop()               { if (loader.item) loader.item.stop() }
+    function forceReload() {
+        ensureLoaded()
+        if (loader.item)
+            loader.item.forceReload()
+    }
+    function clearSiteData() {
+        ensureLoaded()
+        if (loader.item)
+            loader.item.clearSiteData()
+    }
+    function clearCache() {
+        ensureLoaded()
+        if (loader.item)
+            loader.item.clearCache()
+    }
     function findText(text, flags){ if (loader.item) loader.item.findText(text, flags) }
     function showFindPanel()      { if (loader.item) loader.item.showFindPanel() }
     function hideFindPanel()      { if (loader.item) loader.item.hideFindPanel() }

--- a/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
@@ -101,10 +101,10 @@ AbstractWebView {
         if (loader.item)
             loader.item.clearSiteData()
     }
-    function clearCache() {
+    function clearBrowsingData() {
         ensureLoaded()
         if (loader.item)
-            loader.item.clearCache()
+            loader.item.clearBrowsingData()
     }
     function findText(text, flags){ if (loader.item) loader.item.findText(text, flags) }
     function showFindPanel()      { if (loader.item) loader.item.showFindPanel() }

--- a/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
@@ -106,6 +106,11 @@ AbstractWebView {
         if (loader.item)
             loader.item.clearBrowsingData()
     }
+    function runJavaScript(script, callback) {
+        ensureLoaded()
+        if (loader.item)
+            loader.item.runJavaScript(script, callback)
+    }
     function findText(text, flags){ if (loader.item) loader.item.findText(text, flags) }
     function showFindPanel()      { if (loader.item) loader.item.showFindPanel() }
     function hideFindPanel()      { if (loader.item) loader.item.hideFindPanel() }

--- a/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
@@ -27,6 +27,8 @@ AbstractWebView {
     supportsIncognito: true
     supportsHistory: true
     hasNativeFindPanel: backend.hasNativeFindPanel
+    clearSiteDataSupported: backend.clearSiteDataSupported
+    clearing: backend.clearing
 
     MobileWebViewBackend {
         id: backend
@@ -60,6 +62,9 @@ AbstractWebView {
 
         function onHistoryItemsChanged() { root.rebuildHistoryModel() }
         function onCurrentHistoryIndexChanged() { root.rebuildHistoryModel() }
+
+        // clearSiteData reloads natively (cache-bypass); clearProfileData does not.
+        function onClearProfileDataCompleted() { backend.reload() }
     }
 
     function rebuildHistoryModel() {
@@ -98,6 +103,22 @@ AbstractWebView {
 
     function stop() {
         backend.stop()
+    }
+
+    function forceReload() {
+        backend.reloadAndBypassCache()
+    }
+
+    // Full native per-site wipe (cookies + cache + storage + SW); backend
+    // reloads with cache-bypass on completion (mobilewebview ADR 0004).
+    function clearSiteData() {
+        backend.clearSiteData()
+    }
+
+    // Profile-wide "clear browsing data": HTTP cache + cookies + DOM storage.
+    // Reloads the current view once clearProfileDataCompleted fires.
+    function clearCache() {
+        backend.clearProfileData()
     }
 
     function findText(text, flags) {

--- a/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
@@ -117,7 +117,7 @@ AbstractWebView {
 
     // Profile-wide "clear browsing data": HTTP cache + cookies + DOM storage.
     // Reloads the current view once clearProfileDataCompleted fires.
-    function clearCache() {
+    function clearBrowsingData() {
         backend.clearProfileData()
     }
 

--- a/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
@@ -121,6 +121,13 @@ AbstractWebView {
         backend.clearProfileData()
     }
 
+    function runJavaScript(script, callback) {
+        // Mobile backend has no result callback; fire-and-forget.
+        // Do not invent a completion value — callers must not rely on callback.
+        backend.runJavaScript(script)
+        void callback
+    }
+
     function findText(text, flags) {
         if (!text) {
             backend.stopFind()

--- a/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/MobileWebViewAdapter.qml
@@ -40,7 +40,7 @@ AbstractWebView {
 
         offTheRecord: root.profileParams.offTheRecord
         storageName: root.profileParams.storageName
-        // TODO(mobile): profileParams.userAgent is not applied — no native backend API.
+        httpUserAgent: root.profileParams.userAgent
     }
 
     Connections {

--- a/ui/app/AppLayouts/Browser/adapters/ProfileManager.qml
+++ b/ui/app/AppLayouts/Browser/adapters/ProfileManager.qml
@@ -1,6 +1,8 @@
 import QtQuick
 import QtWebEngine
 
+import StatusQ.Internal
+
 QtObject {
     id: root
     property var profiles: ({})
@@ -53,6 +55,9 @@ QtObject {
                 profileParams.offTheRecord,
                 key)
             p = prototype.instance()
+            // Live cookie index for per-site clear (Qt 6 loadAllCookies is a no-op
+            // for re-emitting existing cookies — see BrowserProfileUtils).
+            BrowserProfileUtils.trackProfile(p)
             if (!root.defaultHttpUserAgent)
                 root.defaultHttpUserAgent = p.httpUserAgent
             root.profiles[key] = p

--- a/ui/app/AppLayouts/Browser/adapters/ProfileManager.qml
+++ b/ui/app/AppLayouts/Browser/adapters/ProfileManager.qml
@@ -4,6 +4,9 @@ import QtWebEngine
 QtObject {
     id: root
     property var profiles: ({})
+    // Chromium default UA (same for all profiles in a Qt build). Snapshot before
+    // Binding override — httpUserAgent="" does not restore navigator.userAgent.
+    property string defaultHttpUserAgent: ""
 
     function _key(userUID, offTheRecord) {
         return userUID + "::" + (offTheRecord ? "otr" : "default")
@@ -50,6 +53,8 @@ QtObject {
                 profileParams.offTheRecord,
                 key)
             p = prototype.instance()
+            if (!root.defaultHttpUserAgent)
+                root.defaultHttpUserAgent = p.httpUserAgent
             root.profiles[key] = p
         }
 

--- a/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
@@ -36,7 +36,7 @@ AbstractWebView {
     supportsIncognito: true
     supportsHistory: true
     hasNativeFindPanel: false
-    // WebEngine can clear the current origin's web storage via injected JS (site_utils.js).
+    // Cookies (incl. HttpOnly) via BrowserProfileUtils; DOM storage via site_utils.js.
     clearSiteDataSupported: true
 
     // Override functions
@@ -47,16 +47,28 @@ AbstractWebView {
     function reload() { webView.reload() }
     function stop() { webView.stop() }
     function forceReload() { webView.triggerWebAction(WebEngineView.ReloadAndBypassCache) }
-    // Per-origin web storage clear via injected site_utils.js, which reloads on completion.
-    // WebEngine has no honest per-site cookie/cache primitive (see mobilewebview ADR 0004).
+
+    // Native per-site cookies, then site_utils.js for current-origin DOM + reload.
+    property bool _clearingSiteData: false
     function clearSiteData() {
-        webView.runJavaScript("window.StatusSiteUtils && window.StatusSiteUtils.clearSiteDataAndReload()")
+        if (root._clearingSiteData || !root.profile)
+            return
+        const siteUrl = webView.url
+        if (!siteUrl.toString())
+            return
+        root._clearingSiteData = true
+        _clearSiteDataFallbackTimer.restart()
+        BrowserProfileUtils.clearSiteData(root.profile, siteUrl)
     }
-    // Profile-wide "clear browsing data": HTTP cache + cookies, via the native
-    // BrowserProfileUtils (the QML WebEngineProfile exposes no cookie API).
-    // Global DOM storage isn't clearable via Qt's public API, so after the
-    // profile clear completes we also wipe the *current origin* via
-    // StatusSiteUtils (see CONTEXT: Clear browsing data) and reload once.
+    function _finishClearSiteData() {
+        if (!root._clearingSiteData)
+            return
+        root._clearingSiteData = false
+        _clearSiteDataFallbackTimer.stop()
+        root._wipeCurrentOriginDomAndReload()
+    }
+
+    // Profile-wide cookies + HTTP cache, then current-origin DOM via site_utils.js.
     function clearBrowsingData() {
         if (root.clearing || !root.profile)
             return
@@ -69,13 +81,14 @@ AbstractWebView {
             return
         _clearBrowsingDataFallbackTimer.stop()
         root.clearing = false
-        // One reload: StatusSiteUtils.clearSiteDataAndReload wipes current-origin
-        // DOM storage then reloads. Fall back to a plain reload if missing.
+        root._wipeCurrentOriginDomAndReload()
+    }
+    function _wipeCurrentOriginDomAndReload() {
         webView.runJavaScript(
             "(function(){ if (window.StatusSiteUtils) { window.StatusSiteUtils.clearSiteDataAndReload(); return true; } return false; })()",
             function(ok) {
                 if (!ok)
-                    webView.reload()
+                    webView.triggerWebAction(WebEngineView.ReloadAndBypassCache)
             }
         )
     }
@@ -246,12 +259,24 @@ AbstractWebView {
         function onClearHttpCacheCompleted() { root._finishClearBrowsingData() }
     }
 
+    Connections {
+        target: BrowserProfileUtils
+        function onClearSiteDataCompleted() { root._finishClearSiteData() }
+    }
+
     // Fallback in case clearHttpCacheCompleted doesn't fire (e.g. empty cache).
     Timer {
         id: _clearBrowsingDataFallbackTimer
         interval: 1000
         repeat: false
         onTriggered: root._finishClearBrowsingData()
+    }
+
+    Timer {
+        id: _clearSiteDataFallbackTimer
+        interval: 1000
+        repeat: false
+        onTriggered: root._finishClearSiteData()
     }
 
     WebEngineView {
@@ -268,7 +293,9 @@ AbstractWebView {
     }
 
     Binding {
-        when: !!(root.profile && root.profileParams && root.profileParams.userAgent)
+        // Always apply, including "". Empty must clear a previous override;
+        // gating on truthy userAgent leaves the last Chrome UA stuck on the profile.
+        when: !!(root.profile && root.profileParams)
         target: root.profile
         property: "httpUserAgent"
         value: root.profileParams.userAgent
@@ -280,6 +307,10 @@ AbstractWebView {
         root.profile.userScripts.collection = root.profileManager.scriptListForParams(root.profileParams)
     }
 
+    // Qt does not emit *Changed for the initial property value — only for later
+    // changes. Without onCompleted, userScripts (site_utils, dapp injectors) are
+    // never installed when profile is already set at construction time.
+    Component.onCompleted: applyProfileScripts()
     onProfileChanged: applyProfileScripts()
 
     Connections {

--- a/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
@@ -3,6 +3,7 @@ import QtQml
 import QtWebEngine
 
 import StatusQ.Core.Theme
+import StatusQ.Internal
 
 import AppLayouts.Browser.views
 
@@ -51,20 +52,23 @@ AbstractWebView {
     function clearSiteData() {
         webView.runJavaScript("window.StatusSiteUtils && window.StatusSiteUtils.clearSiteDataAndReload()")
     }
-    // Profile-wide "clear browsing data": HTTP cache, cookies and visited links.
-    function clearCache() {
+    // Profile-wide "clear browsing data": HTTP cache + cookies, via the native
+    // BrowserProfileUtils (the QML WebEngineProfile exposes no cookie API).
+    // Global DOM storage isn't clearable via Qt's public API, so it's left as-is
+    // (unlike mobile's clearProfileData). The profile's clearHttpCacheCompleted
+    // drives _finishClearBrowsingData(); start the fallback timer first so `clearing`
+    // can never stick if the call fails.
+    function clearBrowsingData() {
         if (root.clearing || !root.profile)
             return
         root.clearing = true
-        root.profile.cookieStore.deleteAllCookies()
-        root.profile.clearAllVisitedLinks()
-        root.profile.clearHttpCache() // async; completion drives _finishClearCache()
-        _clearCacheFallbackTimer.restart()
+        _clearBrowsingDataFallbackTimer.restart()
+        BrowserProfileUtils.clearBrowsingData(root.profile)
     }
-    function _finishClearCache() {
+    function _finishClearBrowsingData() {
         if (!root.clearing)
             return
-        _clearCacheFallbackTimer.stop()
+        _clearBrowsingDataFallbackTimer.stop()
         root.clearing = false
         webView.reload()
     }
@@ -232,15 +236,15 @@ AbstractWebView {
                 return
             root.downloadRequested(download)
         }
-        function onClearHttpCacheCompleted() { root._finishClearCache() }
+        function onClearHttpCacheCompleted() { root._finishClearBrowsingData() }
     }
 
     // Fallback in case clearHttpCacheCompleted doesn't fire (e.g. empty cache).
     Timer {
-        id: _clearCacheFallbackTimer
+        id: _clearBrowsingDataFallbackTimer
         interval: 1000
         repeat: false
-        onTriggered: root._finishClearCache()
+        onTriggered: root._finishClearBrowsingData()
     }
 
     WebEngineView {

--- a/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
@@ -39,6 +39,15 @@ AbstractWebView {
     // Cookies (incl. HttpOnly) via BrowserProfileUtils; DOM storage via site_utils.js.
     clearSiteDataSupported: true
 
+    // Unified clear lifecycle (see CONTEXT: Clearing). Mutual exclusion + nav guard.
+    readonly property int _clearIdle: 0
+    readonly property int _clearSite: 1
+    readonly property int _clearProfile: 2
+    readonly property int _clearAwaitingReload: 3
+    property int _clearState: _clearIdle
+    property url _clearingUrl
+    clearing: _clearState !== _clearIdle
+
     // Override functions
     function loadUrl(newUrl) { webView.url = newUrl }
     function goBack() { webView.goBack() }
@@ -48,32 +57,58 @@ AbstractWebView {
     function stop() { webView.stop() }
     function forceReload() { webView.triggerWebAction(WebEngineView.ReloadAndBypassCache) }
 
+    function _sameOrigin(a, b) {
+        if (!a || !b || !a.toString() || !b.toString())
+            return false
+        return a.scheme === b.scheme && a.host === b.host && a.port === b.port
+    }
+
+    function _endClear() {
+        root._clearState = root._clearIdle
+        root._clearingUrl = ""
+        _clearFallbackTimer.stop()
+    }
+
+    function _beginAwaitingReloadWipe() {
+        // Do not wipe DOM / reload a different origin than the one we cleared.
+        if (!root._sameOrigin(webView.url, root._clearingUrl)) {
+            root._endClear()
+            return
+        }
+        root._clearState = root._clearAwaitingReload
+        _clearFallbackTimer.restart()
+        root._wipeCurrentOriginDomAndReload()
+    }
+
     // Native per-site cookies, then site_utils.js for current-origin DOM + reload.
-    property bool _clearingSiteData: false
     function clearSiteData() {
-        if (root._clearingSiteData || !root.profile)
+        if (root._clearState !== root._clearIdle || !root.profile)
             return
         const siteUrl = webView.url
         if (!siteUrl.toString())
             return
-        root._clearingSiteData = true
-        _clearSiteDataFallbackTimer.restart()
-        BrowserProfileUtils.clearSiteData(root.profile, siteUrl)
+        root._clearState = root._clearSite
+        root._clearingUrl = siteUrl
+        _clearFallbackTimer.restart()
+        // Pass `root` so only this adapter reacts to clearSiteDataCompleted.
+        BrowserProfileUtils.clearSiteData(root.profile, siteUrl, root)
     }
-    function _finishClearSiteData() {
-        if (!root._clearingSiteData)
+
+    function _onNativeSiteClearDone(requester) {
+        if (requester !== root)
             return
-        root._clearingSiteData = false
-        _clearSiteDataFallbackTimer.stop()
-        root._wipeCurrentOriginDomAndReload()
+        if (root._clearState !== root._clearSite)
+            return
+        root._beginAwaitingReloadWipe()
     }
 
     // Profile-wide cookies + HTTP cache, then current-origin DOM via site_utils.js.
     function clearBrowsingData() {
-        if (root.clearing || !root.profile)
+        if (root._clearState !== root._clearIdle || !root.profile)
             return
-        root.clearing = true
-        _clearBrowsingDataFallbackTimer.restart()
+        root._clearState = root._clearProfile
+        root._clearingUrl = webView.url
+        _clearFallbackTimer.restart()
         BrowserProfileUtils.clearBrowsingData(root.profile)
     }
 
@@ -83,22 +118,29 @@ AbstractWebView {
         else
             webView.runJavaScript(script, callback)
     }
-    function _finishClearBrowsingData() {
-        if (!root.clearing)
+
+    function _onNativeBrowsingClearDone() {
+        // Profile signal fans out to every tab; only the initiator finishes.
+        if (root._clearState !== root._clearProfile)
             return
-        _clearBrowsingDataFallbackTimer.stop()
-        root.clearing = false
-        root._wipeCurrentOriginDomAndReload()
+        root._beginAwaitingReloadWipe()
     }
+
     function _wipeCurrentOriginDomAndReload() {
+        const expected = root._clearingUrl
         webView.runJavaScript(
             "(function(){ if (window.StatusSiteUtils) { window.StatusSiteUtils.clearSiteDataAndReload(); return true; } return false; })()",
             function(ok) {
+                if (root._clearState !== root._clearAwaitingReload)
+                    return
+                if (!root._sameOrigin(webView.url, expected)) {
+                    root._endClear()
+                    return
+                }
                 if (!ok) {
                     // GET navigate — ReloadAndBypassCache can re-POST and re-Set-Cookie.
-                    const u = webView.url
-                    if (u && u.toString())
-                        webView.url = u
+                    if (expected && expected.toString())
+                        webView.url = expected
                 }
             }
         )
@@ -210,6 +252,11 @@ AbstractWebView {
         onLoadingChanged: function(loadRequest) {
             if (loadRequest.status === WebEngineView.LoadStartedStatus) {
                 webView.htmlPageLoaded = false
+                // Expected GET after clear: unblock once navigation starts.
+                if (root._clearState === root._clearAwaitingReload
+                        && root._sameOrigin(loadRequest.url, root._clearingUrl)) {
+                    root._endClear()
+                }
             }
             if (loadRequest.status === WebEngineView.LoadSucceededStatus) {
                 webView.htmlPageLoaded = true
@@ -220,10 +267,18 @@ AbstractWebView {
                 webView.htmlPageLoaded = true
         }
         onNavigationRequested: function(request) {
-            if (root.clearing) {
-                // Block navigation while browsing data is being cleared.
+            if (root._clearState === root._clearSite
+                    || root._clearState === root._clearProfile) {
+                // Block user/site navigation while native clear is in flight.
                 request.reject()
                 return
+            }
+            if (root._clearState === root._clearAwaitingReload) {
+                // Allow only the expected same-origin GET reload after wipe.
+                if (!root._sameOrigin(request.url, root._clearingUrl)) {
+                    request.reject()
+                    return
+                }
             }
             if (request.url.toString().startsWith("file:/")) {
                 console.log("Local file browsing is disabled")
@@ -267,27 +322,29 @@ AbstractWebView {
                 return
             root.downloadRequested(download)
         }
-        function onClearHttpCacheCompleted() { root._finishClearBrowsingData() }
+        function onClearHttpCacheCompleted() { root._onNativeBrowsingClearDone() }
     }
 
     Connections {
         target: BrowserProfileUtils
-        function onClearSiteDataCompleted() { root._finishClearSiteData() }
+        function onClearSiteDataCompleted(requester) { root._onNativeSiteClearDone(requester) }
     }
 
-    // Fallback in case clearHttpCacheCompleted doesn't fire (e.g. empty cache).
+    // Safety net: unblock if native completion or expected reload never arrives.
     Timer {
-        id: _clearBrowsingDataFallbackTimer
-        interval: 1000
+        id: _clearFallbackTimer
+        interval: 2000
         repeat: false
-        onTriggered: root._finishClearBrowsingData()
-    }
-
-    Timer {
-        id: _clearSiteDataFallbackTimer
-        interval: 1000
-        repeat: false
-        onTriggered: root._finishClearSiteData()
+        onTriggered: {
+            if (root._clearState === root._clearSite
+                    || root._clearState === root._clearProfile) {
+                // Native phase stuck — still try DOM wipe if origin matches.
+                root._beginAwaitingReloadWipe()
+                return
+            }
+            if (root._clearState === root._clearAwaitingReload)
+                root._endClear()
+        }
     }
 
     WebEngineView {

--- a/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
@@ -39,15 +39,6 @@ AbstractWebView {
     // Cookies (incl. HttpOnly) via BrowserProfileUtils; DOM storage via site_utils.js.
     clearSiteDataSupported: true
 
-    // Unified clear lifecycle (see CONTEXT: Clearing). Mutual exclusion + nav guard.
-    readonly property int _clearIdle: 0
-    readonly property int _clearSite: 1
-    readonly property int _clearProfile: 2
-    readonly property int _clearAwaitingReload: 3
-    property int _clearState: _clearIdle
-    property url _clearingUrl
-    clearing: _clearState !== _clearIdle
-
     // Override functions
     function loadUrl(newUrl) { webView.url = newUrl }
     function goBack() { webView.goBack() }
@@ -57,59 +48,33 @@ AbstractWebView {
     function stop() { webView.stop() }
     function forceReload() { webView.triggerWebAction(WebEngineView.ReloadAndBypassCache) }
 
-    function _sameOrigin(a, b) {
-        if (!a || !b || !a.toString() || !b.toString())
-            return false
-        return a.scheme === b.scheme && a.host === b.host && a.port === b.port
-    }
-
-    function _endClear() {
-        root._clearState = root._clearIdle
-        root._clearingUrl = ""
-        _clearFallbackTimer.stop()
-    }
-
-    function _beginAwaitingReloadWipe() {
-        // Do not wipe DOM / reload a different origin than the one we cleared.
-        if (!root._sameOrigin(webView.url, root._clearingUrl)) {
-            root._endClear()
-            return
-        }
-        root._clearState = root._clearAwaitingReload
-        _clearFallbackTimer.restart()
-        root._wipeCurrentOriginDomAndReload()
-    }
-
     // Native per-site cookies, then site_utils.js for current-origin DOM + reload.
     function clearSiteData() {
-        if (root._clearState !== root._clearIdle || !root.profile)
+        if (root.clearing || !root.profile)
             return
-        const siteUrl = webView.url
-        if (!siteUrl.toString())
+        const site = webView.url
+        if (!site.toString())
             return
-        root._clearState = root._clearSite
-        root._clearingUrl = siteUrl
-        _clearFallbackTimer.restart()
-        // Pass `root` so only this adapter reacts to clearSiteDataCompleted.
-        BrowserProfileUtils.clearSiteData(root.profile, siteUrl, root)
-    }
-
-    function _onNativeSiteClearDone(requester) {
-        if (requester !== root)
-            return
-        if (root._clearState !== root._clearSite)
-            return
-        root._beginAwaitingReloadWipe()
+        root.clearing = true
+        BrowserProfileUtils.clearSiteData(root.profile, site, function() {
+            root.clearing = false
+            // Skip wipe/reload if the user navigated away during clear.
+            if (String(webView.url) === String(site))
+                root._wipeDomAndReload(site)
+        })
     }
 
     // Profile-wide cookies + HTTP cache, then current-origin DOM via site_utils.js.
     function clearBrowsingData() {
-        if (root._clearState !== root._clearIdle || !root.profile)
+        if (root.clearing || !root.profile)
             return
-        root._clearState = root._clearProfile
-        root._clearingUrl = webView.url
-        _clearFallbackTimer.restart()
-        BrowserProfileUtils.clearBrowsingData(root.profile)
+        const site = webView.url
+        root.clearing = true
+        BrowserProfileUtils.clearBrowsingData(root.profile, function() {
+            root.clearing = false
+            if (String(webView.url) === String(site))
+                root._wipeDomAndReload(site)
+        })
     }
 
     function runJavaScript(script, callback) {
@@ -119,28 +84,16 @@ AbstractWebView {
             webView.runJavaScript(script, callback)
     }
 
-    function _onNativeBrowsingClearDone() {
-        // Profile signal fans out to every tab; only the initiator finishes.
-        if (root._clearState !== root._clearProfile)
-            return
-        root._beginAwaitingReloadWipe()
-    }
-
-    function _wipeCurrentOriginDomAndReload() {
-        const expected = root._clearingUrl
+    function _wipeDomAndReload(site) {
         webView.runJavaScript(
             "(function(){ if (window.StatusSiteUtils) { window.StatusSiteUtils.clearSiteDataAndReload(); return true; } return false; })()",
             function(ok) {
-                if (root._clearState !== root._clearAwaitingReload)
+                if (String(webView.url) !== String(site))
                     return
-                if (!root._sameOrigin(webView.url, expected)) {
-                    root._endClear()
-                    return
-                }
                 if (!ok) {
                     // GET navigate — ReloadAndBypassCache can re-POST and re-Set-Cookie.
-                    if (expected && expected.toString())
-                        webView.url = expected
+                    if (site && site.toString())
+                        webView.url = site
                 }
             }
         )
@@ -252,11 +205,6 @@ AbstractWebView {
         onLoadingChanged: function(loadRequest) {
             if (loadRequest.status === WebEngineView.LoadStartedStatus) {
                 webView.htmlPageLoaded = false
-                // Expected GET after clear: unblock once navigation starts.
-                if (root._clearState === root._clearAwaitingReload
-                        && root._sameOrigin(loadRequest.url, root._clearingUrl)) {
-                    root._endClear()
-                }
             }
             if (loadRequest.status === WebEngineView.LoadSucceededStatus) {
                 webView.htmlPageLoaded = true
@@ -267,19 +215,6 @@ AbstractWebView {
                 webView.htmlPageLoaded = true
         }
         onNavigationRequested: function(request) {
-            if (root._clearState === root._clearSite
-                    || root._clearState === root._clearProfile) {
-                // Block user/site navigation while native clear is in flight.
-                request.reject()
-                return
-            }
-            if (root._clearState === root._clearAwaitingReload) {
-                // Allow only the expected same-origin GET reload after wipe.
-                if (!root._sameOrigin(request.url, root._clearingUrl)) {
-                    request.reject()
-                    return
-                }
-            }
             if (request.url.toString().startsWith("file:/")) {
                 console.log("Local file browsing is disabled")
                 request.reject()
@@ -321,29 +256,6 @@ AbstractWebView {
             if (!download?.view && !root.visible)
                 return
             root.downloadRequested(download)
-        }
-        function onClearHttpCacheCompleted() { root._onNativeBrowsingClearDone() }
-    }
-
-    Connections {
-        target: BrowserProfileUtils
-        function onClearSiteDataCompleted(requester) { root._onNativeSiteClearDone(requester) }
-    }
-
-    // Safety net: unblock if native completion or expected reload never arrives.
-    Timer {
-        id: _clearFallbackTimer
-        interval: 2000
-        repeat: false
-        onTriggered: {
-            if (root._clearState === root._clearSite
-                    || root._clearState === root._clearProfile) {
-                // Native phase stuck — still try DOM wipe if origin matches.
-                root._beginAwaitingReloadWipe()
-                return
-            }
-            if (root._clearState === root._clearAwaitingReload)
-                root._endClear()
         }
     }
 

--- a/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
@@ -35,6 +35,8 @@ AbstractWebView {
     supportsIncognito: true
     supportsHistory: true
     hasNativeFindPanel: false
+    // WebEngine can clear the current origin's web storage via injected JS (site_utils.js).
+    clearSiteDataSupported: true
 
     // Override functions
     function loadUrl(newUrl) { webView.url = newUrl }
@@ -43,6 +45,29 @@ AbstractWebView {
     function goBackOrForward(offset) { webView.goBackOrForward(offset) }
     function reload() { webView.reload() }
     function stop() { webView.stop() }
+    function forceReload() { webView.triggerWebAction(WebEngineView.ReloadAndBypassCache) }
+    // Per-origin web storage clear via injected site_utils.js, which reloads on completion.
+    // WebEngine has no honest per-site cookie/cache primitive (see mobilewebview ADR 0004).
+    function clearSiteData() {
+        webView.runJavaScript("window.StatusSiteUtils && window.StatusSiteUtils.clearSiteDataAndReload()")
+    }
+    // Profile-wide "clear browsing data": HTTP cache, cookies and visited links.
+    function clearCache() {
+        if (root.clearing || !root.profile)
+            return
+        root.clearing = true
+        root.profile.cookieStore.deleteAllCookies()
+        root.profile.clearAllVisitedLinks()
+        root.profile.clearHttpCache() // async; completion drives _finishClearCache()
+        _clearCacheFallbackTimer.restart()
+    }
+    function _finishClearCache() {
+        if (!root.clearing)
+            return
+        _clearCacheFallbackTimer.stop()
+        root.clearing = false
+        webView.reload()
+    }
     function findText(text, flags) { webView.findText(text, flags) }
     function changeZoomFactor(factor) { webView.zoomFactor = factor }
     function acceptAsNewWindow(request) { request.openIn(webView) }
@@ -160,6 +185,11 @@ AbstractWebView {
                 webView.htmlPageLoaded = true
         }
         onNavigationRequested: function(request) {
+            if (root.clearing) {
+                // Block navigation while browsing data is being cleared.
+                request.reject()
+                return
+            }
             if (request.url.toString().startsWith("file:/")) {
                 console.log("Local file browsing is disabled")
                 request.reject()
@@ -202,6 +232,15 @@ AbstractWebView {
                 return
             root.downloadRequested(download)
         }
+        function onClearHttpCacheCompleted() { root._finishClearCache() }
+    }
+
+    // Fallback in case clearHttpCacheCompleted doesn't fire (e.g. empty cache).
+    Timer {
+        id: _clearCacheFallbackTimer
+        interval: 1000
+        repeat: false
+        onTriggered: root._finishClearCache()
     }
 
     WebEngineView {

--- a/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
@@ -54,10 +54,9 @@ AbstractWebView {
     }
     // Profile-wide "clear browsing data": HTTP cache + cookies, via the native
     // BrowserProfileUtils (the QML WebEngineProfile exposes no cookie API).
-    // Global DOM storage isn't clearable via Qt's public API, so it's left as-is
-    // (unlike mobile's clearProfileData). The profile's clearHttpCacheCompleted
-    // drives _finishClearBrowsingData(); start the fallback timer first so `clearing`
-    // can never stick if the call fails.
+    // Global DOM storage isn't clearable via Qt's public API, so after the
+    // profile clear completes we also wipe the *current origin* via
+    // StatusSiteUtils (see CONTEXT: Clear browsing data) and reload once.
     function clearBrowsingData() {
         if (root.clearing || !root.profile)
             return
@@ -70,7 +69,15 @@ AbstractWebView {
             return
         _clearBrowsingDataFallbackTimer.stop()
         root.clearing = false
-        webView.reload()
+        // One reload: StatusSiteUtils.clearSiteDataAndReload wipes current-origin
+        // DOM storage then reloads. Fall back to a plain reload if missing.
+        webView.runJavaScript(
+            "(function(){ if (window.StatusSiteUtils) { window.StatusSiteUtils.clearSiteDataAndReload(); return true; } return false; })()",
+            function(ok) {
+                if (!ok)
+                    webView.reload()
+            }
+        )
     }
     function findText(text, flags) { webView.findText(text, flags) }
     function changeZoomFactor(factor) { webView.zoomFactor = factor }

--- a/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
@@ -293,12 +293,13 @@ AbstractWebView {
     }
 
     Binding {
-        // Always apply, including "". Empty must clear a previous override;
-        // gating on truthy userAgent leaves the last Chrome UA stuck on the profile.
-        when: !!(root.profile && root.profileParams)
+        // Always apply a non-empty UA. Setting httpUserAgent to "" after a
+        // custom override does not restore the Chromium default — use the
+        // snapshot captured at profile creation instead.
+        when: !!(root.profile && root.profileParams && root.profileManager)
         target: root.profile
         property: "httpUserAgent"
-        value: root.profileParams.userAgent
+        value: root.profileParams.userAgent || root.profileManager.defaultHttpUserAgent
     }
 
     function applyProfileScripts() {

--- a/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
@@ -76,6 +76,13 @@ AbstractWebView {
         _clearBrowsingDataFallbackTimer.restart()
         BrowserProfileUtils.clearBrowsingData(root.profile)
     }
+
+    function runJavaScript(script, callback) {
+        if (callback === undefined)
+            webView.runJavaScript(script)
+        else
+            webView.runJavaScript(script, callback)
+    }
     function _finishClearBrowsingData() {
         if (!root.clearing)
             return
@@ -87,8 +94,12 @@ AbstractWebView {
         webView.runJavaScript(
             "(function(){ if (window.StatusSiteUtils) { window.StatusSiteUtils.clearSiteDataAndReload(); return true; } return false; })()",
             function(ok) {
-                if (!ok)
-                    webView.triggerWebAction(WebEngineView.ReloadAndBypassCache)
+                if (!ok) {
+                    // GET navigate — ReloadAndBypassCache can re-POST and re-Set-Cookie.
+                    const u = webView.url
+                    if (u && u.toString())
+                        webView.url = u
+                }
             }
         )
     }

--- a/ui/app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml
@@ -27,9 +27,9 @@ StatusMenu {
     signal launchBrowserSettings()
     signal forceReload()
     signal clearSiteData()
-    signal clearCache()
+    signal clearBrowsingData()
 
-    property bool clearingCache: false
+    property bool clearingBrowsingData: false
     property bool clearSiteDataSupported: true
 
     background: Rectangle {
@@ -158,16 +158,16 @@ StatusMenu {
     }
 
     StatusMenuItem {
-        text: root.clearingCache ? qsTr("Clearing cache...") : qsTr("Clear cache")
+        text: root.clearingBrowsingData ? qsTr("Clearing browsing data...") : qsTr("Clear browsing data")
         icon.name: "broom"
         icon.color: Theme.palette.primaryColor1
-        enabled: !root.clearingCache
+        enabled: !root.clearingBrowsingData
         visibleOnDisabled: true
-        onTriggered: clearCache()
+        onTriggered: clearBrowsingData()
 
         StatusToolTip {
             visible: parent.hovered
-            text: qsTr("Clears cached files, cookies, and history for the entire browser. Browsing is paused until it is done.")
+            text: qsTr("Clears the cache and cookies for the entire browser. Browsing is paused until it is done.")
         }
     }
 

--- a/ui/app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml
@@ -121,7 +121,7 @@ StatusMenu {
     StatusAction {
         text: qsTr("Compatibility mode")
         checkable: true
-        checked: true
+        checked: root.browserSettings.compatibilityMode
         onToggled: toggleCompatibilityMode(checked)
     }
 

--- a/ui/app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml
@@ -25,10 +25,12 @@ StatusMenu {
     signal launchFindBar()
     signal toggleCompatibilityMode(bool checked)
     signal launchBrowserSettings()
+    signal forceReload()
     signal clearSiteData()
     signal clearCache()
 
     property bool clearingCache: false
+    property bool clearSiteDataSupported: true
 
     background: Rectangle {
         color: root.incognitoMode ?
@@ -134,10 +136,19 @@ StatusMenu {
         }
     }
 
+    StatusAction {
+        text: qsTr("Force reload")
+        icon.name: "refresh"
+        shortcut: "Ctrl+Shift+R"
+        onTriggered: forceReload()
+    }
+
     StatusMenuItem {
         text: qsTr("Clear site data")
         icon.name: "delete"
         icon.color: Theme.palette.primaryColor1
+        enabled: root.clearSiteDataSupported
+        visible: root.clearSiteDataSupported
         onTriggered: clearSiteData()
 
         StatusToolTip {

--- a/ui/app/AppLayouts/Browser/popups/MobileSettingsMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/MobileSettingsMenu.qml
@@ -47,7 +47,10 @@ StatusDialog {
                 StatusSwitch {
                     id: incognitoSwitch
                     checked: root.incognitoMode
-                    onToggled: root.goIncognito(checked)
+                    onToggled: {
+                        root.goIncognito(checked)
+                        root.close()
+                    }
                 }
             ]
             onClicked: {

--- a/ui/app/AppLayouts/Browser/popups/MobileSettingsMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/MobileSettingsMenu.qml
@@ -18,11 +18,19 @@ StatusDialog {
 
     required property bool supportsFind
 
+    // Whether "Clear site data" is available on the current backend (see ADR 0004).
+    property bool clearSiteDataSupported: false
+    // True while a data-clearing operation is in flight.
+    property bool clearing: false
+
     signal goIncognito(bool checked)
     signal launchFindBar
     signal zoomIn
     signal zoomOut
     signal resetZoomFactor
+    signal forceReload
+    signal clearSiteData
+    signal clearCache
     signal settingsRequested
 
     title: qsTr("Browser")
@@ -94,6 +102,32 @@ StatusDialog {
             ]
             onClicked: {
                 root.resetZoomFactor()
+                root.close()
+            }
+        }
+        SettingsListItem {
+            title: qsTr("Force reload")
+            asset.name: "refresh"
+            onClicked: {
+                root.forceReload()
+                root.close()
+            }
+        }
+        SettingsListItem {
+            visible: root.clearSiteDataSupported
+            title: qsTr("Clear site data")
+            asset.name: "delete"
+            onClicked: {
+                root.clearSiteData()
+                root.close()
+            }
+        }
+        SettingsListItem {
+            title: root.clearing ? qsTr("Clearing cache...") : qsTr("Clear cache")
+            asset.name: "broom"
+            enabled: !root.clearing
+            onClicked: {
+                root.clearCache()
                 root.close()
             }
         }

--- a/ui/app/AppLayouts/Browser/popups/MobileSettingsMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/MobileSettingsMenu.qml
@@ -30,7 +30,7 @@ StatusDialog {
     signal resetZoomFactor
     signal forceReload
     signal clearSiteData
-    signal clearCache
+    signal clearBrowsingData
     signal settingsRequested
 
     title: qsTr("Browser")
@@ -123,11 +123,11 @@ StatusDialog {
             }
         }
         SettingsListItem {
-            title: root.clearing ? qsTr("Clearing cache...") : qsTr("Clear cache")
+            title: root.clearing ? qsTr("Clearing browsing data...") : qsTr("Clear browsing data")
             asset.name: "broom"
             enabled: !root.clearing
             onClicked: {
-                root.clearCache()
+                root.clearBrowsingData()
                 root.close()
             }
         }

--- a/ui/app/AppLayouts/Browser/popups/MobileSettingsMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/MobileSettingsMenu.qml
@@ -22,6 +22,7 @@ StatusDialog {
     property bool clearSiteDataSupported: false
     // True while a data-clearing operation is in flight.
     property bool clearing: false
+    property bool compatibilityMode: true
 
     signal goIncognito(bool checked)
     signal launchFindBar
@@ -31,6 +32,7 @@ StatusDialog {
     signal forceReload
     signal clearSiteData
     signal clearBrowsingData
+    signal toggleCompatibilityMode(bool checked)
     signal settingsRequested
 
     title: qsTr("Browser")
@@ -106,6 +108,23 @@ StatusDialog {
             onClicked: {
                 root.resetZoomFactor()
                 root.close()
+            }
+        }
+        SettingsListItem {
+            title: qsTr("Compatibility mode")
+            asset.name: "browser"
+            components: [
+                StatusSwitch {
+                    id: compatibilitySwitch
+                    checked: root.compatibilityMode
+                    onToggled: {
+                        root.toggleCompatibilityMode(checked)
+                        root.close()
+                    }
+                }
+            ]
+            onClicked: {
+                compatibilitySwitch.click()
             }
         }
         SettingsListItem {

--- a/ui/app/AppLayouts/Browser/provider/js/site_utils.js
+++ b/ui/app/AppLayouts/Browser/provider/js/site_utils.js
@@ -1,0 +1,58 @@
+"use strict";
+
+// Site utilities for Status Browser - clears origin-scoped storage.
+// Injected as a user script so WebViewAdapter can trigger a per-origin clear
+// via runJavaScript("window.StatusSiteUtils.clearSiteDataAndReload()").
+// Desktop only: WebEngine has no honest per-site primitive (see mobilewebview
+// ADR 0004); mobile uses the native clearSiteData() instead.
+(function() {
+    async function clearSiteData() {
+        // Clear localStorage
+        try { localStorage.clear(); } catch(e) {}
+
+        // Clear sessionStorage
+        try { sessionStorage.clear(); } catch(e) {}
+
+        // Clear all IndexedDB databases
+        if (indexedDB?.databases) {
+            try {
+                const dbs = await indexedDB.databases();
+                await Promise.all(dbs.map(db => new Promise(resolve => {
+                    const req = indexedDB.deleteDatabase(db.name);
+                    req.onsuccess = req.onerror = req.onblocked = resolve;
+                })));
+            } catch(e) {}
+        }
+
+        // Clear Cache Storage (Service Worker caches)
+        if (window.caches) {
+            try {
+                const cacheNames = await caches.keys();
+                await Promise.all(cacheNames.map(name => caches.delete(name)));
+            } catch(e) {}
+        }
+
+        // Unregister all Service Workers
+        if (navigator.serviceWorker) {
+            try {
+                const registrations = await navigator.serviceWorker.getRegistrations();
+                await Promise.all(registrations.map(reg => reg.unregister()));
+            } catch(e) {}
+        }
+
+        // Clear cookies for current domain
+        try {
+            document.cookie.split(";").forEach(cookie => {
+                const name = cookie.split("=")[0].trim();
+                document.cookie = name + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/";
+            });
+        } catch(e) {}
+    }
+
+    async function clearSiteDataAndReload() {
+        await clearSiteData();
+        location.reload();
+    }
+
+    window.StatusSiteUtils = { clearSiteData, clearSiteDataAndReload };
+})();

--- a/ui/app/AppLayouts/Browser/provider/js/site_utils.js
+++ b/ui/app/AppLayouts/Browser/provider/js/site_utils.js
@@ -3,8 +3,8 @@
 // Site utilities for Status Browser - clears origin-scoped storage.
 // Injected as a user script so WebViewAdapter can trigger a per-origin clear
 // via runJavaScript("window.StatusSiteUtils.clearSiteDataAndReload()").
-// Desktop only: WebEngine has no honest per-site primitive (see mobilewebview
-// ADR 0004); mobile uses the native clearSiteData() instead.
+// Complements BrowserProfileUtils.clearSiteData (native cookies, incl. HttpOnly):
+// this JS path covers DOM storage that WebEngine does not expose in C++.
 (function() {
     async function clearSiteData() {
         // Clear localStorage
@@ -40,7 +40,7 @@
             } catch(e) {}
         }
 
-        // Clear cookies for current domain
+        // Clear cookies for current domain (non-HttpOnly only; HttpOnly via C++)
         try {
             document.cookie.split(";").forEach(cookie => {
                 const name = cookie.split("=")[0].trim();

--- a/ui/app/AppLayouts/Browser/provider/js/site_utils.js
+++ b/ui/app/AppLayouts/Browser/provider/js/site_utils.js
@@ -51,7 +51,10 @@
 
     async function clearSiteDataAndReload() {
         await clearSiteData();
-        location.reload();
+        // Use assign/replace (GET) instead of reload(): after a POST (e.g.
+        // setcookie.net form), reload() re-submits and can re-apply Set-Cookie.
+        const url = location.pathname + location.search + location.hash;
+        location.replace(url);
     }
 
     window.StatusSiteUtils = { clearSiteData, clearSiteDataAndReload };

--- a/ui/app/AppLayouts/Browser/provider/qml/BrowserConfig.qml
+++ b/ui/app/AppLayouts/Browser/provider/qml/BrowserConfig.qml
@@ -19,9 +19,8 @@ QtObject {
 
     readonly property var scriptPaths: {
         const scripts = []
-        // Injected regardless of the dApp connector feature so "Clear site data"
-        // works standalone. Desktop only: mobile uses the native clearSiteData()
-        // (mobilewebview ADR 0004), never this JS snippet.
+        // Desktop only: per-origin DOM wipe for clear site / browsing data.
+        // Cookies (incl. HttpOnly) are cleared via BrowserProfileUtils in C++.
         if (!SQUtils.Utils.isMobile)
             scripts.push({ path: Qt.resolvedUrl("../js/site_utils.js"), runOnSubFrames: true })
 

--- a/ui/app/AppLayouts/Browser/provider/qml/BrowserConfig.qml
+++ b/ui/app/AppLayouts/Browser/provider/qml/BrowserConfig.qml
@@ -1,5 +1,7 @@
 import QtQuick
 
+import StatusQ.Core.Utils as SQUtils
+
 import AppLayouts.Browser.adapters
 
 /**
@@ -15,13 +17,23 @@ QtObject {
     property bool featureEnabled: true
     property string httpUserAgent: ""
 
-    readonly property var scriptPaths: root.featureEnabled ? [
-        { path: Qt.resolvedUrl("../js/webengine_runtime_guard.js"), runOnSubFrames: true },
-        { path: Qt.resolvedUrl("../js/qwebchannel.js"), runOnSubFrames: true },
-        { path: Qt.resolvedUrl("../js/ethereum_wrapper.js"), runOnSubFrames: true },
-        { path: Qt.resolvedUrl("../js/eip6963_announcer.js"), runOnSubFrames: false },
-        { path: Qt.resolvedUrl("../js/ethereum_injector.js"), runOnSubFrames: true }
-    ] : []
+    readonly property var scriptPaths: {
+        const scripts = []
+        // Injected regardless of the dApp connector feature so "Clear site data"
+        // works standalone. Desktop only: mobile uses the native clearSiteData()
+        // (mobilewebview ADR 0004), never this JS snippet.
+        if (!SQUtils.Utils.isMobile)
+            scripts.push({ path: Qt.resolvedUrl("../js/site_utils.js"), runOnSubFrames: true })
+
+        if (root.featureEnabled) {
+            scripts.push({ path: Qt.resolvedUrl("../js/webengine_runtime_guard.js"), runOnSubFrames: true })
+            scripts.push({ path: Qt.resolvedUrl("../js/qwebchannel.js"), runOnSubFrames: true })
+            scripts.push({ path: Qt.resolvedUrl("../js/ethereum_wrapper.js"), runOnSubFrames: true })
+            scripts.push({ path: Qt.resolvedUrl("../js/eip6963_announcer.js"), runOnSubFrames: false })
+            scripts.push({ path: Qt.resolvedUrl("../js/ethereum_injector.js"), runOnSubFrames: true })
+        }
+        return scripts
+    }
 
     readonly property ProfileParams defaultProfileParams: ProfileParams {
         userId: root.userUID

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -232,6 +232,20 @@ QtObject {
             currentWebView.profileParams = target
     }
 
+    // Stop → update setting → deferred reload so profile.httpUserAgent Binding
+    // settles before navigation.
+    function setCompatibilityMode(checked) {
+        for (let i = 0; i < tabsModel.count; ++i)
+            getWebView(i)?.stop()
+
+        browserSettings.compatibilityMode = checked
+
+        Qt.callLater(() => {
+            for (let i = 0; i < tabsModel.count; ++i)
+                getWebView(i)?.reload()
+        })
+    }
+
     function changeZoomCurrent(delta) {
         if (!currentWebView)
             return

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -192,6 +192,26 @@ QtObject {
         currentWebView.stop()
     }
 
+    function forceReloadCurrent() {
+        if (!currentWebView)
+            return
+        if (typeof currentWebView.ensureLoaded === "function")
+            currentWebView.ensureLoaded()
+        currentWebView.forceReload()
+    }
+
+    function clearSiteDataCurrent() {
+        if (!currentWebView)
+            return
+        currentWebView.clearSiteData()
+    }
+
+    function clearCacheCurrent() {
+        if (!currentWebView)
+            return
+        currentWebView.clearCache()
+    }
+
     function findTextCurrent(text, backward = false) {
         if (!currentWebView)
             return

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -206,10 +206,10 @@ QtObject {
         currentWebView.clearSiteData()
     }
 
-    function clearCacheCurrent() {
+    function clearBrowsingDataCurrent() {
         if (!currentWebView)
             return
-        currentWebView.clearCache()
+        currentWebView.clearBrowsingData()
     }
 
     function findTextCurrent(text, backward = false) {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2583,6 +2583,10 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Force reload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Clear site data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2591,15 +2595,15 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clearing cache...</source>
+        <source>Clearing browsing data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clear cache</source>
+        <source>Clear browsing data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clears cached files, cookies, and history for the entire browser. Browsing is paused until it is done.</source>
+        <source>Clears the cache and cookies for the entire browser. Browsing is paused until it is done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11313,6 +11317,22 @@ to load</source>
     </message>
     <message>
         <source>Zoom Fit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force reload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear site data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clearing browsing data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear browsing data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -11320,6 +11320,10 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Compatibility mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Force reload</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2592,6 +2592,10 @@ Přejete si obejít bezpečnostní kontrolu a pokračovat?</translation>
         <translation>Vývojářské nástroje</translation>
     </message>
     <message>
+        <source>Force reload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Clear site data</source>
         <translation>Vyčistit data stránky</translation>
     </message>
@@ -2600,16 +2604,16 @@ Přejete si obejít bezpečnostní kontrolu a pokračovat?</translation>
         <translation>Použijte k obnovení aktuální stránky, pokud se nenačítá nebo nefunfuje správně.</translation>
     </message>
     <message>
-        <source>Clearing cache...</source>
-        <translation>Čistí se cache...</translation>
+        <source>Clearing browsing data...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clear cache</source>
-        <translation>Vyčistit cache</translation>
+        <source>Clear browsing data</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clears cached files, cookies, and history for the entire browser. Browsing is paused until it is done.</source>
-        <translation>Vyčistí soubory, cookies a historii celého prohlížeče. Prohlížení je pozastaveno, dokud není hotovo.</translation>
+        <source>Clears the cache and cookies for the entire browser. Browsing is paused until it is done.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings</source>
@@ -11381,6 +11385,22 @@ selhalo</translation>
     <message>
         <source>Zoom Fit</source>
         <translation type="unfinished">Přizpůsobit velikost</translation>
+    </message>
+    <message>
+        <source>Force reload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear site data</source>
+        <translation type="unfinished">Vyčistit data stránky</translation>
+    </message>
+    <message>
+        <source>Clearing browsing data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear browsing data</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -11387,6 +11387,10 @@ selhalo</translation>
         <translation type="unfinished">Přizpůsobit velikost</translation>
     </message>
     <message>
+        <source>Compatibility mode</source>
+        <translation type="unfinished">Režim kompatibility</translation>
+    </message>
+    <message>
         <source>Force reload</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -11333,6 +11333,10 @@ al cargar</translation>
         <translation type="unfinished">Ajustar zoom</translation>
     </message>
     <message>
+        <source>Compatibility mode</source>
+        <translation type="unfinished">Modo de compatibilidad</translation>
+    </message>
+    <message>
         <source>Force reload</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2589,6 +2589,10 @@ Do you wish to override the security check and continue?</source>
         <translation>Herramientas de desarrollo</translation>
     </message>
     <message>
+        <source>Force reload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Clear site data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2597,15 +2601,15 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clearing cache...</source>
+        <source>Clearing browsing data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clear cache</source>
+        <source>Clear browsing data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clears cached files, cookies, and history for the entire browser. Browsing is paused until it is done.</source>
+        <source>Clears the cache and cookies for the entire browser. Browsing is paused until it is done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11327,6 +11331,22 @@ al cargar</translation>
     <message>
         <source>Zoom Fit</source>
         <translation type="unfinished">Ajustar zoom</translation>
+    </message>
+    <message>
+        <source>Force reload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear site data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clearing browsing data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear browsing data</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -11280,6 +11280,10 @@ to load</source>
         <translation type="unfinished">맞춤 확대</translation>
     </message>
     <message>
+        <source>Compatibility mode</source>
+        <translation type="unfinished">호환 모드</translation>
+    </message>
+    <message>
         <source>Force reload</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2573,6 +2573,10 @@ Do you wish to override the security check and continue?</source>
         <translation>개발자 도구</translation>
     </message>
     <message>
+        <source>Force reload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Clear site data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2581,15 +2585,15 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clearing cache...</source>
+        <source>Clearing browsing data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clear cache</source>
+        <source>Clear browsing data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Clears cached files, cookies, and history for the entire browser. Browsing is paused until it is done.</source>
+        <source>Clears the cache and cookies for the entire browser. Browsing is paused until it is done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11274,6 +11278,22 @@ to load</source>
     <message>
         <source>Zoom Fit</source>
         <translation type="unfinished">맞춤 확대</translation>
+    </message>
+    <message>
+        <source>Force reload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear site data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clearing browsing data...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear browsing data</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings</source>


### PR DESCRIPTION
* Restores the Desktop's "clear site data" and "clear browsing data" actions lost after 2.36 merge. 
* Integrate mobilewebview clearSiteData, clear browsing data (https://github.com/status-im/mobilewebview/pull/16)
  *  Bumps mobilewebview to 5ba81a3
* Adds force reload (without http cache). unified on the AbstractWebView interface (desktop WebEngine + mobile native)
* Desktop clears cache and cookies via a new BrowserProfileUtils C++ helper +  site_utils.js
* Implement useragent on mobile.  Fixes compatibility-mode User-Agent on desktop 

fixes #21339
fixes #21416
fixes #21338 

Test scenario:
1. Open https://setcookie.net/, set the name and value, and submit. Refresh to make sure the HTTP cookie is visible.
2. Open https://html-utils.a.frfry.com/clear-browser-test/index.html and seed all. Or enter cookie (js, http), localStorage, and IndexedDB in any other 2 websites.
3. In the context menu, press "Clear Site Data" and make sure that the current site's cookies disappeared, but the second tab is not affected.
4. Then, use "Clear Browsing Data"; the second site should be wiped as well.
5. Toggle Incognito ON, set cookies again, then switch Incognito OFF to make sure no cookies left that were set in Incognito remain. And when entering Incognito mode again, there should be no cookies either. 
6. Toggle compatibility mode. Make sure `navigator.userAgent` (in javascript) is changed.

<table>
  <tr>
    <th align="center">Desktop</th>
    <th align="center">iOS</th>
    <th align="center">Android</th>
  </tr>
  <tr>
    <td align="center">
      <video src="https://github.com/user-attachments/assets/f318acf8-8269-4730-b155-9d15594d4225" width="320" controls></video>
    </td>
    <td align="center">
      <video src="https://github.com/user-attachments/assets/3c0c42fe-46d9-4608-b172-697bdae0ecf9" width="320" controls></video>
    </td>
    <td align="center">
      <video src="https://github.com/user-attachments/assets/1abc82af-b47d-468d-9a7f-d7d099cba8b7" width="320" controls></video>
    </td>
  </tr>
</table>
