### PR TITLE
fix(Chat): make 1-1 chats use mutual contacts model for the @ suggestions

### DIFF
--- a/ui/app/AppLayouts/Chat/adaptors/SuggestionsFilterAdaptor.qml
+++ b/ui/app/AppLayouts/Chat/adaptors/SuggestionsFilterAdaptor.qml
@@ -12,6 +12,7 @@ QObject {
 
     // input model
     required property var sourceModel
+    property bool usersModelIncludeAtEveryone: true
 
     // name used for filtering
     property string filter: ""
@@ -34,6 +35,20 @@ QObject {
         }
     }
 
+    SourceModel {
+        id: everyoneSourceModel
+        model: ListModel {
+            ListElement {
+                pubKey: "0x00001"
+                preferredDisplayName: "everyone"
+                icon: ""
+                colorId: 0
+                usesDefaultName: false
+            }
+        }
+        markerRoleValue: "everyone_model"
+    }
+
     ConcatModel {
         id: concatModel
 
@@ -41,21 +56,14 @@ QObject {
             SourceModel {
                 model: root.sourceModel
                 markerRoleValue: "filtered_model"
-            },
-            SourceModel {
-                model: ListModel {
-                    ListElement {
-                        pubKey: "0x00001"
-                        preferredDisplayName: "everyone"
-                        icon: ""
-                        colorId: 0
-                        usesDefaultName: false
-                    }
-                }
-                markerRoleValue: "everyone_model"
             }
         ]
         markerRoleName: "which_model"
         expectedRoles: ["pubKey", "preferredDisplayName"]
+        Component.onCompleted: {
+            if (root.usersModelIncludeAtEveryone) {
+                sources.push(everyoneSourceModel)
+            }
+        }
     }
 }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -65,6 +65,7 @@ QtObject {
     }
 
     readonly property var activeChatContentModule: root.currentChatContentModule()
+    readonly property int activeChatType: d.activeChatType
 
     property AppLayoutStores.ContactsStore contactsStore
     property CommunityTokensStore communityTokensStore

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -47,9 +47,9 @@ Item {
     property var stickersPopup
     property bool areTestNetworksEnabled
 
-    property string activeChatId: parentModule && parentModule.activeItem.id
-    property int chatsCount: parentModule && parentModule.model ? parentModule.model.count : 0
-    property int activeChatType: parentModule && parentModule.activeItem.type
+    readonly property string activeChatId: parentModule && parentModule.activeItem.id
+    readonly property int chatsCount: parentModule && parentModule.model ? parentModule.model.count : 0
+    readonly property int activeChatType: rootStore.activeChatType
     property bool stickersLoaded: false
     property bool canPost: true
     property var viewAndPostHoldingsModel
@@ -420,6 +420,7 @@ Item {
                     textInput.readOnly: d.sendingInProgress
 
                     usersModel: root.usersModel
+                    usersModelIncludeAtEveryone: root.activeChatType !== Constants.chatType.oneToOne
                     linkPreviewModel: !!d.activeChatContentModule ? d.activeChatContentModule.inputAreaModule.linkPreviewModel : null
                     paymentRequestModel: !!d.activeChatContentModule ? d.activeChatContentModule.inputAreaModule.paymentRequestModel : null
                     formatBalance: d.formatBalance

--- a/ui/app/mainui/sectionLoaders/ChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ChatLoader.qml
@@ -126,7 +126,8 @@ Loader {
             mutualContactsModel:            Qt.binding(() => root.contactsAdaptor.mutualContacts),
             gifUnfurlingEnabled:            Qt.binding(() => root.sharedRootStore.gifUnfurlingEnabled),
             neverAskAboutUnfurlingAgain:    Qt.binding(() => root.sharedRootStore.neverAskAboutUnfurlingAgain),
-            usersModel:                     Qt.binding(() => d.chatRootStore.usersStore.usersModel),
+            usersModel:                     Qt.binding(() => d.chatRootStore.activeChatType === Constants.chatType.oneToOne ? root.contactsAdaptor.mutualContacts
+                                                                                                                            : d.chatRootStore.usersStore.usersModel),
             myPublicKey:                    Qt.binding(() => root.contactsStore.myPublicKey),
             navToMsgDetails:                Qt.binding(() => root.rootStore.navToMsgDetails),
             navToMsgList:                   Qt.binding(() => root.rootStore.navToMsgList),

--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -39,6 +39,7 @@ Control {
     signal linkClicked(string link)
 
     property var usersModel
+    property bool usersModelIncludeAtEveryone: true
 
     property var emojiPopup: null
     property var stickersPopup: null
@@ -736,6 +737,7 @@ Control {
 
                         urlsList: root.urlsList
                         usersModel: root.usersModel
+                        usersModelIncludeAtEveryone: root.usersModelIncludeAtEveryone
                         urlToBeHighlighted: linkPreviewArea.hoveredUrl
 
                         suggestedMentionPubKey: {

--- a/ui/imports/shared/status/StatusChatInputTextArea.qml
+++ b/ui/imports/shared/status/StatusChatInputTextArea.qml
@@ -35,6 +35,7 @@ StatusQ.StatusTextArea {
     // Model of users used for creating mention suggestions list. Expected
     // roles: "pubKey", "preferredDisplayName".
     required property var usersModel
+    property bool usersModelIncludeAtEveryone: true
 
     // Read-only model of mentions suggestions. It's subset of usersModel
     // filtered according to the provided partial name.
@@ -782,6 +783,7 @@ StatusQ.StatusTextArea {
         id: suggestionsFilterAdaptor
 
         sourceModel: root.usersModel
+        usersModelIncludeAtEveryone: root.usersModelIncludeAtEveryone
 
         filter: {
             const effectiveCursor = root.cursorPosition + root.preeditText.length


### PR DESCRIPTION
### What does the PR do

- do not include the @everyone meta entry in such 1-1 chats

Fixes #20839

### Affected areas

Chat (1-1)

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2894" height="2184" alt="Snímek obrazovky z 2026-07-13 18-10-55" src="https://github.com/user-attachments/assets/e3c48d3a-58a2-40f1-9776-2f55bfca4a1f" />


### Impact on end user

Better (1-1) chat UX

### How to test

- type the at sign (@) in a chat
- observe the list of suggestions containing either the contacts model (for 1-1 chats), or the group/community members otherwise

### Risk 

low
