### PR TITLE
feat(link): implement link to message PoC

### DIFF
--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -22,6 +22,7 @@ const DEFAULT_FLAG_MARKET_ENABLED = true
 const DEFAULT_FLAG_HOMEPAGE_ENABLED = true
 const DEFAULT_FLAG_LOCAL_BACKUP_ENABLED = true
 const DEFAULT_FLAG_PRIVACY_MODE_FEATURE_ENABLED = true
+const DEFAULT_FLAG_MESSAGE_LINK_SHARING_ENABLED = false
 
 # Compile time feature flags
 const DEFAULT_FLAG_DAPPS_ENABLED  = true
@@ -40,6 +41,7 @@ featureFlag("MARKET_ENABLED",                 DEFAULT_FLAG_MARKET_ENABLED)
 featureFlag("HOMEPAGE_ENABLED",               DEFAULT_FLAG_HOMEPAGE_ENABLED)
 featureFlag("LOCAL_BACKUP_ENABLED",           DEFAULT_FLAG_LOCAL_BACKUP_ENABLED)
 featureFlag("PRIVACY_MODE_FEATURE_ENABLED",   DEFAULT_FLAG_PRIVACY_MODE_FEATURE_ENABLED)
+featureFlag("MESSAGE_LINK_SHARING_ENABLED",   DEFAULT_FLAG_MESSAGE_LINK_SHARING_ENABLED)
 
 featureFlag("DAPPS_ENABLED",                  DEFAULT_FLAG_DAPPS_ENABLED, true)
 featureFlag("BROWSER_ENABLED",                DEFAULT_FLAG_BROWSER_ENABLED, true)
@@ -93,6 +95,7 @@ QtObject:
     homePageEnabled: bool
     localBackupEnabled: bool
     privacyModeFeatureEnabled: bool
+    messageLinkSharingEnabled: bool
     buyEnabled: bool
 
   proc setup(self: FeatureFlags) =
@@ -108,6 +111,7 @@ QtObject:
     self.homePageEnabled = HOMEPAGE_ENABLED
     self.localBackupEnabled = LOCAL_BACKUP_ENABLED
     self.privacyModeFeatureEnabled = PRIVACY_MODE_FEATURE_ENABLED
+    self.messageLinkSharingEnabled = MESSAGE_LINK_SHARING_ENABLED
     self.buyEnabled = BUY_ENABLED
 
   proc newFeatureFlags*(): FeatureFlags =
@@ -182,6 +186,12 @@ QtObject:
 
   proc getPrivacyModeFeatureEnabled*(self: FeatureFlags): bool {.slot.} =
     return self.privacyModeFeatureEnabled
+
+  proc getMessageLinkSharingEnabled*(self: FeatureFlags): bool {.slot.} =
+    return self.messageLinkSharingEnabled
+
+  QtProperty[bool] messageLinkSharingEnabled:
+    read = getMessageLinkSharingEnabled
 
   QtProperty[bool] buyEnabled:
     read = getBuyEnabled

--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -1,4 +1,5 @@
 import io_interface, tables, sets
+import std/strutils
 
 
 import ../../../../../../app_service/service/settings/service as settings_service
@@ -175,6 +176,11 @@ proc setText*(self: Controller, text: string, unfurlNewUrls: bool) =
   self.unfurlingPlanActiveRequest = self.messageService.asyncGetTextURLsToUnfurl(text)
 
 proc handleUnfurlingPlan*(self: Controller, unfurlNewUrls: bool) =
+  proc isStatusMessageUrl(url: string): bool =
+      return startsWith(url, "https://status.app/m/") or
+        startsWith(url, "http://status.app/m/") or
+        startsWith(url, "status-app://m/")
+
   var allUrls = newSeq[string]() # Used for URLs syntax highlighting only
   var allAllowedUrls = newSeq[string]() # Used for LinkPreviewsModel to keep the urls order
   var statusAllowedUrls = newSeq[string]()
@@ -183,6 +189,11 @@ proc handleUnfurlingPlan*(self: Controller, unfurlNewUrls: bool) =
 
   for metadata in self.unfurlingPlan.urls:
     allUrls.add(metadata.url)
+
+    # Message deep links are navigational links for now and intentionally have no
+    # preview payload, so keep them clickable/highlighted but don't unfurl.
+    if isStatusMessageUrl(metadata.url):
+      continue
 
     if metadata.permission == UrlUnfurlingForbiddenBySettings or
        metadata.permission == UrlUnfurlingNotSupported:

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -412,7 +412,7 @@ method onCommunityMemberMessagesDeleted*(self: AccessInterface, messages: seq[st
 method communityContainsChat*(self: AccessInterface, chatId: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method openCommunityChatAndScrollToMessage*(self: AccessInterface, chatId: string, messageId: string) {.base.} =
+method openCommunityChatAndScrollToMessage*(self: AccessInterface, chatId: string, messageId: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method updateRequestToJoinState*(self: AccessInterface, state: RequestToJoinState) {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1606,10 +1606,13 @@ method onCommunityMemberMessagesDeleted*(self: Module, deletedMessages: seq[stri
 method communityContainsChat*(self: Module, chatId: string): bool =
   return self.chatContentModules.hasKey(chatId)
 
-method openCommunityChatAndScrollToMessage*(self: Module, chatId: string, messageId: string) =
-  if chatId in self.chatContentModules:
-    self.setActiveItem(chatId)
-    self.chatContentModules[chatId].scrollToMessage(messageId)
+method openCommunityChatAndScrollToMessage*(self: Module, chatId: string, messageId: string): bool =
+  if chatId notin self.chatContentModules:
+    return false
+
+  self.setActiveItem(chatId)
+  self.chatContentModules[chatId].scrollToMessage(messageId)
+  return true
 
 method updateRequestToJoinState*(self: Module, state: RequestToJoinState) =
   self.view.setRequestToJoinState(state)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -476,8 +476,8 @@ QtObject:
   proc deleteCommunityMemberMessages*(self: View, memberPubKey: string, messageId: string, chatId: string) {.slot.} =
     self.delegate.deleteCommunityMemberMessages(memberPubKey, messageId, chatId)
 
-  proc openCommunityChatAndScrollToMessage*(self: View, chatId: string, messageId: string) {.slot.} =
-    self.delegate.openCommunityChatAndScrollToMessage(chatId, messageId)
+  proc openCommunityChatAndScrollToMessage*(self: View, chatId: string, messageId: string): bool {.slot.} =
+    return self.delegate.openCommunityChatAndScrollToMessage(chatId, messageId)
 
   proc requestToJoinStateChanged*(self: View) {.signal.}
 

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -286,7 +286,7 @@ proc init*(self: Controller) =
     self.delegate.activeSectionSet(self.activeSectionId)
 
     if args.chatId != "":
-      self.delegate.openSectionChatAndMessage(args.sectionId, args.chatId, args.messageId)
+      discard self.delegate.openSectionChatAndMessage(args.sectionId, args.chatId, args.messageId)
 
   self.events.on(SIGNAL_STATUS_URL_ACTIVATED) do(e: Args):
     var args = StatusUrlArgs(e)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -421,7 +421,7 @@ method onCommunityTokensDetailsLoaded*(self: AccessInterface, communityId: strin
 method addressWasShown*(self: AccessInterface, address: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method openSectionChatAndMessage*(self: AccessInterface, sectionId: string, chatId: string, messageId: string) {.base.} =
+method openSectionChatAndMessage*(self: AccessInterface, sectionId: string, chatId: string, messageId: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method updateRequestToJoinState*(self: AccessInterface, sectionId: string, requestToJoinState: RequestToJoinState) {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1904,6 +1904,21 @@ proc activateChatDeepLink[T](self: Module[T], statusDeepLink: string): bool =
 
   return true
 
+proc activateMessageDeepLink[T](self: Module[T], statusDeepLink: string): bool =
+  let data = self.sharedUrlsModule.parseMessageUrl(statusDeepLink)
+  if data.chatId.len == 0 or data.messageId.len == 0:
+    return false
+
+  var sectionId = singletonInstance.userProfile.getPubKey()
+  if data.communityId.len > 0:
+    sectionId = data.communityId
+
+  if self.getActiveSectionId() != sectionId:
+    self.setActiveSectionById(sectionId)
+
+  self.view.emitNavigateToMessageDetailsSignal()
+  return self.openSectionChatAndMessage(sectionId, data.chatId, data.messageId)
+
 method onStatusUrlRequested*[T](self: Module[T], action: StatusUrlAction, communityId: string, channelId: string,
     url: string, userId: string) =
 
@@ -2048,6 +2063,8 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
   if statusDeepLink.contains("/wc?"):
     self.view.wcLinkActivated(statusDeepLink)
     return
+  if self.activateMessageDeepLink(statusDeepLink):
+    return
   # Generic, id-less navigation deep links (e.g. bundled in remote push notifications).
   # Matched before the chat/community/contact routes so the reserved keywords never
   # collide with a public-chat link of the form `status-app://<id>`.
@@ -2130,9 +2147,11 @@ method addressWasShown*[T](self: Module[T], address: string) =
     return
   self.walletAccountService.addressWasShown(address)
 
-method openSectionChatAndMessage*[T](self: Module[T], sectionId: string, chatId: string, messageId: string) =
-  if sectionId in self.chatSectionModules:
-    self.chatSectionModules[sectionId].openCommunityChatAndScrollToMessage(chatId, messageId)
+method openSectionChatAndMessage*[T](self: Module[T], sectionId: string, chatId: string, messageId: string): bool =
+  if sectionId notin self.chatSectionModules:
+    return false
+
+  return self.chatSectionModules[sectionId].openCommunityChatAndScrollToMessage(chatId, messageId)
 
 method updateRequestToJoinState*[T](self: Module[T], sectionId: string, requestToJoinState: RequestToJoinState) =
   if sectionId in self.chatSectionModules:

--- a/src/app/modules/main/shared_urls/controller.nim
+++ b/src/app/modules/main/shared_urls/controller.nim
@@ -35,5 +35,11 @@ proc parseContactSharedUrl*(self: Controller, url: string): ContactUrlDataDto =
   let data = self.sharedUrlsService.parseSharedUrl(url)
   return data.contact
 
+proc createMessageUrl*(self: Controller, chatId: string, messageId: string): string =
+  return self.sharedUrlsService.createMessageUrl(chatId, messageId)
+
+proc parseMessageUrl*(self: Controller, url: string): MessageUrlDataDto =
+  return self.sharedUrlsService.parseMessageUrl(url)
+
 proc parseSharedUrl*(self: Controller, url: string): UrlDataDto =
   return self.sharedUrlsService.parseSharedUrl(url)

--- a/src/app/modules/main/shared_urls/io_interface.nim
+++ b/src/app/modules/main/shared_urls/io_interface.nim
@@ -24,6 +24,12 @@ method parseCommunityChannelSharedUrl*(self: AccessInterface, url: string): stri
 method parseContactSharedUrl*(self: AccessInterface, url: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method createMessageUrl*(self: AccessInterface, chatId: string, messageId: string): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method parseMessageUrl*(self: AccessInterface, url: string): MessageUrlDataDto {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method parseSharedUrl*(self: AccessInterface, url: string): UrlDataDto {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/shared_urls/module.nim
+++ b/src/app/modules/main/shared_urls/module.nim
@@ -63,3 +63,9 @@ method parseCommunityChannelSharedUrl*(self: Module, url: string): string =
 method parseContactSharedUrl*(self: Module, url: string): string =
   let contactData = self.controller.parseContactSharedUrl(url)
   return $contactData
+
+method createMessageUrl*(self: Module, chatId: string, messageId: string): string =
+  return self.controller.createMessageUrl(chatId, messageId)
+
+method parseMessageUrl*(self: Module, url: string): MessageUrlDataDto =
+  return self.controller.parseMessageUrl(url)

--- a/src/app/modules/main/shared_urls/view.nim
+++ b/src/app/modules/main/shared_urls/view.nim
@@ -25,6 +25,9 @@ QtObject:
   proc parseContactSharedUrl*(self: View, url: string): string {.slot.} =
     return self.delegate.parseContactSharedUrl(url)
 
+  proc createMessageUrl*(self: View, chatId: string, messageId: string): string {.slot.} =
+    return self.delegate.createMessageUrl(chatId, messageId)
+
   proc delete*(self: View) =
     self.QObject.delete
 

--- a/src/app_service/service/shared_urls/dto/url_data.nim
+++ b/src/app_service/service/shared_urls/dto/url_data.nim
@@ -24,6 +24,11 @@ type ContactUrlDataDto* = object
   description*: string
   publicKey*: string
 
+type MessageUrlDataDto* = object
+  chatId*: string
+  messageId*: string
+  communityId*: string
+
 type UrlDataDto* = object
   community*: CommunityUrlDataDto
   channel*: CommunityChannelUrlDataDto
@@ -56,6 +61,12 @@ proc toContactUrlDataDto*(jsonObj: JsonNode): ContactUrlDataDto =
   discard jsonObj.getProp("displayName", result.displayName)
   discard jsonObj.getProp("description", result.description)
   discard jsonObj.getProp("publicKey", result.publicKey)
+
+proc toMessageUrlDataDto*(jsonObj: JsonNode): MessageUrlDataDto =
+  result = MessageUrlDataDto()
+  discard jsonObj.getProp("chatId", result.chatId)
+  discard jsonObj.getProp("messageId", result.messageId)
+  discard jsonObj.getProp("communityId", result.communityId)
 
 proc toUrlDataDto*(jsonObj: JsonNode): UrlDataDto =
   result = UrlDataDto()
@@ -98,4 +109,11 @@ proc `$`*(contactUrlDataDto: ContactUrlDataDto): string =
   jsonObj["displayName"] = %* contactUrlDataDto.displayName
   jsonObj["description"] = %* contactUrlDataDto.description
   jsonObj["publicKey"] = %* contactUrlDataDto.publicKey
+  return $jsonObj
+
+proc `$`*(messageUrlDataDto: MessageUrlDataDto): string =
+  var jsonObj = newJObject()
+  jsonObj["chatId"] = %* messageUrlDataDto.chatId
+  jsonObj["messageId"] = %* messageUrlDataDto.messageId
+  jsonObj["communityId"] = %* messageUrlDataDto.communityId
   return $jsonObj

--- a/src/app_service/service/shared_urls/service.nim
+++ b/src/app_service/service/shared_urls/service.nim
@@ -15,6 +15,11 @@ QtObject:
   type Service* = ref object of QObject
     events: EventEmitter
     threadpool: ThreadPool
+
+  proc extractResultError(payload: JsonNode): string =
+    if payload.kind == JObject and payload.contains("error"):
+      return payload["error"].getStr()
+    return ""
   
   proc newService*(events: EventEmitter, threadpool: ThreadPool): Service =
     result = Service()
@@ -24,8 +29,8 @@ QtObject:
   proc parseSharedUrl*(self: Service, url: string): UrlDataDto =
     try:
       let response = shared_urls.parseSharedUrl(url)
-      if  response.result.contains("error"):
-        let errMsg = response.result["error"].getStr()
+      let errMsg = extractResultError(response.result)
+      if errMsg != "":
         raise newException(Exception, errMsg)
       # not a status shared url
       return response.result.toUrlDataDto()
@@ -33,3 +38,25 @@ QtObject:
       if not e.msg.contains("not a status shared url"):
         error "failed to parse shared url: ", url, errDesription = e.msg
       result.notASupportedStatusLink = true
+
+  proc createMessageUrl*(self: Service, chatId: string, messageId: string): string =
+    try:
+      let response = shared_urls.shareMessageUrl(chatId, messageId)
+      let errMsg = extractResultError(response.result)
+      if errMsg != "":
+        raise newException(Exception, errMsg)
+      return response.result.getStr()
+    except Exception as e:
+      error "failed to create message url", chatId, messageId, errDescription = e.msg
+      return ""
+
+  proc parseMessageUrl*(self: Service, url: string): MessageUrlDataDto =
+    try:
+      let response = shared_urls.parseMessageUrl(url)
+      let errMsg = extractResultError(response.result)
+      if errMsg != "":
+        raise newException(Exception, errMsg)
+      return response.result.toMessageUrlDataDto()
+    except Exception as e:
+      if not e.msg.contains("not a status message url"):
+        error "failed to parse message url", url, errDescription = e.msg

--- a/src/backend/shared_urls.nim
+++ b/src/backend/shared_urls.nim
@@ -25,5 +25,11 @@ proc shareUserUrlWithChatKey*(pubkey: string): RpcResponse[JsonNode] =
 proc shareUserUrlWithENS*(pubkey: string): RpcResponse[JsonNode] =
   result = callPrivateRPC("shareUserURLWithENS".prefix, %*[pubkey])
 
+proc shareMessageUrl*(chatId: string, messageId: string): RpcResponse[JsonNode] =
+  result = callPrivateRPC("shareMessageURL".prefix, %*[chatId, messageId])
+
 proc parseSharedUrl*(url: string): RpcResponse[JsonNode] =
   result = callPrivateRPC("parseSharedURL".prefix, %*[url])
+
+proc parseMessageUrl*(url: string): RpcResponse[JsonNode] =
+  result = callPrivateRPC("parseMessageURL".prefix, %*[url])

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -182,7 +182,10 @@ QtObject {
 
         if (linkAddressAndEnsName) {
             // Wallet address
-            var replacePatternWalletAddress = /(^|[^\/])(0x[a-fA-F0-9]{40})/gim;
+            // Require a boundary before 0x so values inside URLs (e.g. query
+            // params) are not rewritten; include '>' to match addresses right
+            // after rich-text tags like <p> or <blockquote>.
+            var replacePatternWalletAddress = /(^|[\s\(\[,;:>])(0x[a-fA-F0-9]{40})/gim;
             replacedText = replacedText.replace(replacePatternWalletAddress, "$1<a class='eth-link' href='//send-via-personal-chat//$2'>$2</a>");
 
             // Ens Name

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -69,6 +69,7 @@ StackLayout {
     property bool showUsersList
 
     property bool sendViaPersonalChatEnabled
+    property bool messageLinkSharingEnabled
     property string disabledTooltipText
 
     property int extraLeftPadding: 0
@@ -285,6 +286,7 @@ StackLayout {
                              root.sectionItemModel.memberRole === Constants.memberRole.tokenMaster
             hasViewOnlyPermissions: root.communityPermissionsStore.viewOnlyPermissionsModel.count > 0
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
+            messageLinkSharingEnabled: root.messageLinkSharingEnabled
             disabledTooltipText: root.disabledTooltipText
             paymentRequestFeatureEnabled: root.paymentRequestFeatureEnabled
             extraLeftPadding: root.extraLeftPadding

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -235,4 +235,12 @@ QtObject {
             return ""
         return messageModule.firstUnseenMentionMessageId()
     }
+
+    function createMessageLink(chatId, messageId) {
+        if (!chatId || !messageId || !sharedUrlsModule) {
+            return ""
+        }
+
+        return sharedUrlsModule.createMessageUrl(chatId, messageId)
+    }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -56,6 +56,7 @@ Item {
     property bool amISectionAdmin: false
     property bool amIBanned: false
     property bool sendViaPersonalChatEnabled
+    property bool messageLinkSharingEnabled
     property string disabledTooltipText
     property bool paymentRequestFeatureEnabled
     property bool joined
@@ -330,6 +331,7 @@ Item {
                         stickersLoaded: root.stickersLoaded
                         isBlocked: model.blocked
                         sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
+                        messageLinkSharingEnabled: root.messageLinkSharingEnabled
                         disabledTooltipText: root.disabledTooltipText
                         areTestNetworksEnabled: root.areTestNetworksEnabled
                         extraLeftPadding: root.extraLeftPadding

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -61,6 +61,7 @@ ColumnLayout {
     }
 
     property bool sendViaPersonalChatEnabled
+    property bool messageLinkSharingEnabled
     property string disabledTooltipText
 
     property int extraLeftPadding: 0
@@ -121,6 +122,7 @@ ColumnLayout {
             isContactBlocked: root.isBlocked
             channelEmoji: !chatContentModule ? "" : (chatContentModule.chatDetails.emoji || "")
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
+            messageLinkSharingEnabled: root.messageLinkSharingEnabled
             disabledTooltipText: root.disabledTooltipText
             areTestNetworksEnabled: root.areTestNetworksEnabled
             extraLeftPadding: root.extraLeftPadding

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -55,6 +55,7 @@ Item {
     property bool joined
 
     property bool sendViaPersonalChatEnabled
+    property bool messageLinkSharingEnabled
     property string disabledTooltipText
 
     property int extraLeftPadding: 0
@@ -366,6 +367,8 @@ Item {
             joined: root.joined
 
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
+            messageLinkSharingEnabled: root.messageLinkSharingEnabled
+            createMessageLink: (chatId, messageId) => root.messageStore.createMessageLink(chatId, messageId)
             disabledTooltipText: root.disabledTooltipText
             areTestNetworksEnabled: root.areTestNetworksEnabled
             extraLeftPadding: root.extraLeftPadding

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -81,6 +81,7 @@ StatusSectionLayout {
     property var collectiblesModel
 
     property bool sendViaPersonalChatEnabled
+    property bool messageLinkSharingEnabled
     property string disabledTooltipText
     property bool paymentRequestFeatureEnabled
 
@@ -368,6 +369,7 @@ StatusSectionLayout {
             amISectionAdmin: root.amISectionAdmin
             amIBanned: root.sectionItemModel ? root.sectionItemModel.amIBanned : false
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
+            messageLinkSharingEnabled: root.messageLinkSharingEnabled
             disabledTooltipText: root.disabledTooltipText
             paymentRequestFeatureEnabled: root.paymentRequestFeatureEnabled
             extraLeftPadding: root.extraLeftPadding

--- a/ui/app/AppLayouts/stores/FeatureFlagsStore.qml
+++ b/ui/app/AppLayouts/stores/FeatureFlagsStore.qml
@@ -12,5 +12,6 @@ QtObject {
     property bool homePageEnabled
     property bool localBackupEnabled
     property bool privacyModeFeatureEnabled
+    property bool messageLinkSharingEnabled
     property bool buyEnabled
 }

--- a/ui/app/mainui/sectionLoaders/ChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ChatLoader.qml
@@ -121,6 +121,7 @@ Loader {
             sendViaPersonalChatEnabled:     Qt.binding(() => root.featureFlagsStore.sendViaPersonalChatEnabled),
             disabledTooltipText:            Qt.binding(() => !root.networkConnectionStore.sendBuyBridgeEnabled
                                                    ? root.networkConnectionStore.sendBuyBridgeToolTipText : ""),
+            messageLinkSharingEnabled:      Qt.binding(() => root.featureFlagsStore.messageLinkSharingEnabled),
             paymentRequestFeatureEnabled:   Qt.binding(() => root.featureFlagsStore.paymentRequestEnabled),
             extraLeftPadding:               Qt.binding(() => root.isPortraitMode ? SQUtils.Utils.swipeIndicatorWidth : 0),
             mutualContactsModel:            Qt.binding(() => root.contactsAdaptor.mutualContacts),

--- a/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
@@ -165,6 +165,7 @@ Loader {
             currencyStore:                  Qt.binding(() => root.currencyStore),
             networksStore:                  Qt.binding(() => root.networksStore),
             advancedStore:                  Qt.binding(() => root.advancedStore),
+            messageLinkSharingEnabled:      Qt.binding(() => root.featureFlagsStore.messageLinkSharingEnabled),
             paymentRequestFeatureEnabled:   Qt.binding(() => root.featureFlagsStore.paymentRequestEnabled),
             extraLeftPadding:               Qt.binding(() => root.isPortraitMode ? SQUtils.Utils.swipeIndicatorWidth : 0),
             mutualContactsModel:            Qt.binding(() => root.contactsAdaptor.mutualContacts),

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -10894,6 +10894,10 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Copy link to message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unpin</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -10959,6 +10959,10 @@ selhalo</translation>
         <translation>Kopírovat ID zprávy</translation>
     </message>
     <message>
+        <source>Copy link to message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unpin</source>
         <translation>Odepnout</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -10907,6 +10907,10 @@ al cargar</translation>
         <translation>Copiar ID del mensaje</translation>
     </message>
     <message>
+        <source>Copy link to message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unpin</source>
         <translation>Desfijar</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -10856,6 +10856,10 @@ to load</source>
         <translation>메시지 ID 복사</translation>
     </message>
     <message>
+        <source>Copy link to message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unpin</source>
         <translation>고정 해제</translation>
     </message>

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -33,6 +33,7 @@ StatusMenu {
     property bool pinnedMessage: false
     property bool canPin: false
     property bool emojiReactionLimitReached: false
+    property bool messageLinkSharingEnabled: false
 
     readonly property bool isMyMessage: {
         return root.messageSenderId !== "" && root.messageSenderId === root.myPublicKey;
@@ -47,6 +48,7 @@ StatusMenu {
     signal editClicked()
     signal markMessageAsUnread()
     signal copyToClipboard(string text)
+    signal copyMessageLink()
     signal openEmojiPopup(var parent, var mouse)
 
     MessageReactionsRow {
@@ -114,8 +116,7 @@ StatusMenu {
         enabled: (root.messageContentType === Constants.messageContentType.messageType ||
                   root.messageContentType === Constants.messageContentType.contactRequestType ||
                   root.messageContentType === Constants.messageContentType.bridgeMessageType ||
-                (root.messageContentType === Constants.messageContentType.imageType && root.unparsedText != "")) &&
-                replyToMenuItem.enabled
+                (root.messageContentType === Constants.messageContentType.imageType && root.unparsedText != ""))
     }
 
     StatusAction {
@@ -123,8 +124,17 @@ StatusMenu {
         objectName: "messageContextMenu_copyId"
         text: qsTr("Copy Message Id")
         icon.name: "copy"
-        enabled: root.isDebugEnabled && replyToMenuItem.enabled
+        enabled: root.isDebugEnabled
         onTriggered: root.copyToClipboard(root.messageId)
+    }
+
+    StatusAction {
+        id: copyMessageLinkAction
+        objectName: "messageContextMenu_copyLink"
+        text: qsTr("Copy link to message")
+        icon.name: "copy"
+        enabled: root.messageLinkSharingEnabled
+        onTriggered: root.copyMessageLink()
     }
 
     StatusAction {
@@ -170,6 +180,7 @@ StatusMenu {
                  (replyToMenuItem.enabled ||
                   copyMessageMenuItem.enabled ||
                   copyMessageIdAction.enabled ||
+                  copyMessageLinkAction.enabled ||
                   editMessageAction.enabled ||
                   pinAction.enabled ||
                   markMessageAsUnreadAction.enabled)

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -149,6 +149,7 @@ Loader {
     property bool hasMention: false
 
     property bool sendViaPersonalChatEnabled
+    property bool messageLinkSharingEnabled
     property string disabledTooltipText
 
     property int extraLeftPadding: 0
@@ -174,6 +175,8 @@ Loader {
 
     // Contacts related data:
     property string myPublicKey
+
+    property var createMessageLink // function(chatId, messageId) → string
 
     // Contacts related requests:
     signal changeContactNicknameRequest(string pubKey, string nickname, string displayName, bool isEdit)
@@ -278,6 +281,18 @@ Loader {
         d.preventVirtualKeyboardOpening()
         d.contextMenu = messageContextMenuComponent.createObject(root, params)
         d.contextMenu.popup(point)
+    }
+
+    function getMessageLinkUrl() {
+        if (!root.messageLinkSharingEnabled || !root.messageId) {
+            return ""
+        }
+
+        if (!root.createMessageLink) {
+            return ""
+        }
+
+        return root.createMessageLink(root.chatId, root.messageId) || ""
     }
 
     function setMessageActive(messageId, active) {
@@ -1371,6 +1386,7 @@ Loader {
             disabledForChat: !root.rootStore.isUserAllowedToSendMessage
             forceEnableEmojiReactions: !root.rootStore.isUserAllowedToSendMessage && d.addReactionAllowed
             isDebugEnabled: root.rootStore && root.rootStore.isDebugEnabled
+            messageLinkSharingEnabled: root.messageLinkSharingEnabled
             onPinMessage: root.messageStore.pinMessage(messageContextMenuView.messageId)
             onUnpinMessage: root.messageStore.unpinMessage(messageContextMenuView.messageId)
             onPinnedMessagesLimitReached: () => {
@@ -1393,6 +1409,11 @@ Loader {
             }
             onCopyToClipboard: (text) => {
                 ClipboardUtils.setText(text)
+            }
+            onCopyMessageLink: () => {
+                const url = root.getMessageLinkUrl()
+                if (url)
+                    ClipboardUtils.setText(url)
             }
             onOpenEmojiPopup: (parent, mouse) => d.addReactionClicked(parent, mouse)
             onOpened: {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -50,6 +50,7 @@ Window {
         homePageEnabled: featureFlags ? featureFlags.homePageEnabled : false
         localBackupEnabled: featureFlags ? featureFlags.localBackupEnabled : false
         privacyModeFeatureEnabled: featureFlags ? featureFlags.privacyModeFeatureEnabled : false
+        messageLinkSharingEnabled: featureFlags ? featureFlags.messageLinkSharingEnabled : false
         buyEnabled: featureFlags ? featureFlags.buyEnabled : false
     }
 


### PR DESCRIPTION
### What does the PR do

Fixes #21457

status-go PR: https://github.com/status-im/status-go/pull/7623

Implemented message link sharing in status-app behind a feature flag, including a new message context-menu action to copy a deep link that targets a specific chat and message. The feature flag was wired from Nim feature configuration through QML stores/loaders into the chat message components so the capability can be safely toggled at runtime. On the app side, deep-link activation now routes message links through shared URL module APIs instead of local parsing, so clicking a message link opens the correct chat and scrolls directly to the referenced message.

### Affected areas

- Feature flag plumbing for message-link sharing:
  - feature_flags.nim
  - FeatureFlagsStore.qml
  - main.qml

- Chat UI wiring for the flag and copy-link action:
  - ChatLoader.qml
  - CommunityChatLoader.qml
  - MessageContextMenuView.qml
  - MessageView.qml

- App store + module integration for message link create/parse:
  - MessageStore.qml
  - module.nim
  - io_interface.nim
  - controller.nim
  - module.nim
  - view.nim

- App service/backend bridge and DTOs:
  - shared_urls.nim
  - url_data.nim
  - service.nim

- Status-go shared URL API and parsing logic:
  - types.go
  - api.go
  - utils.go
  - service_test.go

- Status-go preview routing update for message links:
  - link_preview.go

- Desktop-side safeguards for remaining runtime issues:
  - controller.nim
  - Utils.qml

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[link-to-message.webm](https://github.com/user-attachments/assets/8c3f1d69-8dff-48dc-b37c-756b335e7f22)

### Impact on end user

Enables to link to a message. It does have limitations (see below)

### How to test

Use the feature flag `FLAG_MESSAGE_LINK_SHARING_ENABLED=1`

Right click a message

### Risk 

Low since put behind a feature flag

### Limitations and known issues

- If a chat or community is not know, it doesn't do anything (no error or anything)
- The link shows in full instead of being nice like on Discord
- No unfurl
- No UX for if the message is not fetched yet