### PR TITLE
feat(StatusQ): Add tap feedback to buttons and options

### DIFF
--- a/storybook/pages/StatusButtonPage.qml
+++ b/storybook/pages/StatusButtonPage.qml
@@ -9,13 +9,21 @@ import Storybook
 SplitView {
     Logs { id: logs }
 
+    ButtonGroup {
+        id: rippleOriginButtonGroup
+    }
+
     QtObject {
         id: d
         readonly property var sizesModel: [StatusBaseButton.Size.XSmall, StatusBaseButton.Size.Tiny, StatusBaseButton.Size.Small, StatusBaseButton.Size.Large]
+        readonly property real disabledControlOpacity: 0.5
 
         readonly property string effectiveEmoji: ctrlEmojiEnabled.checked ? ctrlEmoji.text : ""
         readonly property int effectiveTextPosition: ctrlTextPosLeft.checked ? StatusBaseButton.TextPosition.Left
                                                                              : StatusBaseButton.TextPosition.Right
+        readonly property int effectiveRippleOrigin: ctrlRippleFollowPointer.checked
+                                                     ? StatusRipple.RippleOrigin.Pointer
+                                                     : StatusRipple.RippleOrigin.Center
     }
 
     SplitView {
@@ -59,6 +67,9 @@ SplitView {
                         loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
+                        rippleEnabled: ctrlRipple.checked
+                        rippleOrigin: d.effectiveRippleOrigin
+                        scaleOnPressEnabled: ctrlScaleOnPress.checked
                         textFillWidth: ctrlFillWidth.checked
                         isOutline: ctrlIsOutline.checked
                     }
@@ -79,6 +90,9 @@ SplitView {
                         loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
+                        rippleEnabled: ctrlRipple.checked
+                        rippleOrigin: d.effectiveRippleOrigin
+                        scaleOnPressEnabled: ctrlScaleOnPress.checked
                         textFillWidth: ctrlFillWidth.checked
                         isOutline: ctrlIsOutline.checked
                     }
@@ -100,6 +114,9 @@ SplitView {
                         loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
+                        rippleEnabled: ctrlRipple.checked
+                        rippleOrigin: d.effectiveRippleOrigin
+                        scaleOnPressEnabled: ctrlScaleOnPress.checked
                         textFillWidth: ctrlFillWidth.checked
                         isOutline: ctrlIsOutline.checked
                     }
@@ -121,6 +138,9 @@ SplitView {
                         loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
+                        rippleEnabled: ctrlRipple.checked
+                        rippleOrigin: d.effectiveRippleOrigin
+                        scaleOnPressEnabled: ctrlScaleOnPress.checked
                         isRoundIcon: true
                         textFillWidth: ctrlFillWidth.checked
                         isOutline: ctrlIsOutline.checked
@@ -148,6 +168,9 @@ SplitView {
                         loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
+                        rippleEnabled: ctrlRipple.checked
+                        rippleOrigin: d.effectiveRippleOrigin
+                        scaleOnPressEnabled: ctrlScaleOnPress.checked
                         textFillWidth: ctrlFillWidth.checked
                     }
                 }
@@ -167,6 +190,9 @@ SplitView {
                         loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
+                        rippleEnabled: ctrlRipple.checked
+                        rippleOrigin: d.effectiveRippleOrigin
+                        scaleOnPressEnabled: ctrlScaleOnPress.checked
                         textFillWidth: ctrlFillWidth.checked
                     }
                 }
@@ -187,6 +213,9 @@ SplitView {
                         loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
+                        rippleEnabled: ctrlRipple.checked
+                        rippleOrigin: d.effectiveRippleOrigin
+                        scaleOnPressEnabled: ctrlScaleOnPress.checked
                         textFillWidth: ctrlFillWidth.checked
                     }
                 }
@@ -207,6 +236,9 @@ SplitView {
                         loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
+                        rippleEnabled: ctrlRipple.checked
+                        rippleOrigin: d.effectiveRippleOrigin
+                        scaleOnPressEnabled: ctrlScaleOnPress.checked
                         isRoundIcon: true
                         textFillWidth: ctrlFillWidth.checked
                     }
@@ -311,6 +343,39 @@ SplitView {
                 Switch {
                     id: ctrlEnabled
                     text: "Enabled"
+                    checked: true
+                }
+                Label {
+                    Layout.topMargin: Theme.defaultPadding
+                    text: "Animation on tap"
+                    font.weight: Font.Bold
+                }
+                CheckBox {
+                    id: ctrlRipple
+                    Layout.leftMargin: Theme.defaultPadding
+                    text: "Ripple"
+                    checked: true
+                }
+                RowLayout {
+                    Layout.leftMargin: Theme.defaultBigPadding
+                    enabled: ctrlRipple.checked
+                    opacity: enabled ? 1 : d.disabledControlOpacity
+                    RadioButton {
+                        id: ctrlRippleFollowPointer
+                        ButtonGroup.group: rippleOriginButtonGroup
+                        text: "Follow pointer"
+                    }
+                    RadioButton {
+                        id: ctrlRippleCentered
+                        ButtonGroup.group: rippleOriginButtonGroup
+                        text: "Centered"
+                        checked: true
+                    }
+                }
+                CheckBox {
+                    id: ctrlScaleOnPress
+                    Layout.leftMargin: Theme.defaultPadding
+                    text: "Scale down"
                     checked: true
                 }
             }

--- a/storybook/pages/StatusRipplePage.qml
+++ b/storybook/pages/StatusRipplePage.qml
@@ -1,0 +1,232 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Components
+import StatusQ.Controls
+import StatusQ.Popups
+
+import Storybook
+
+SplitView {
+    Logs { id: logs }
+
+    ButtonGroup {
+        id: rippleOriginButtonGroup
+    }
+
+    QtObject {
+        id: d
+
+        readonly property int effectiveRippleOrigin: ctrlFollowPointer.checked
+                                                     ? StatusRipple.RippleOrigin.Pointer
+                                                     : StatusRipple.RippleOrigin.Center
+    }
+
+    ScrollView {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+        contentWidth: availableWidth
+
+        ColumnLayout {
+            width: parent.width
+            spacing: Theme.defaultBigPadding
+
+            Pane {
+                Layout.fillWidth: true
+
+                ColumnLayout {
+                    width: parent.width
+                    spacing: Theme.padding
+
+                    Label {
+                        text: "Regular buttons and icons"
+                        font.bold: true
+                    }
+
+                    RowLayout {
+                        spacing: Theme.padding
+
+                        StatusButton {
+                            text: "StatusButton"
+                            rippleEnabled: ctrlRipple.checked
+                            rippleOrigin: d.effectiveRippleOrigin
+                            scaleOnPressEnabled: false
+                            onClicked: logs.logEvent("StatusButton clicked")
+                        }
+
+                        StatusButton {
+                            icon.name: "info"
+                            rippleEnabled: ctrlRipple.checked
+                            rippleOrigin: d.effectiveRippleOrigin
+                            scaleOnPressEnabled: false
+                            onClicked: logs.logEvent("Icon StatusButton clicked")
+                        }
+
+                        StatusFlatButton {
+                            text: "StatusFlatButton"
+                            rippleEnabled: ctrlRipple.checked
+                            rippleOrigin: d.effectiveRippleOrigin
+                            scaleOnPressEnabled: false
+                            onClicked: logs.logEvent("StatusFlatButton clicked")
+                        }
+                    }
+                }
+            }
+
+            Pane {
+                Layout.fillWidth: true
+
+                ColumnLayout {
+                    width: parent.width
+                    spacing: Theme.padding
+
+                    Label {
+                        text: "Dropdown button"
+                        font.bold: true
+                    }
+
+                    StatusComboBox {
+                        Layout.preferredWidth: 280
+                        label: "StatusComboBox"
+                        model: ["One", "Two", "Three"]
+                    }
+                }
+            }
+
+            Pane {
+                Layout.fillWidth: true
+
+                ColumnLayout {
+                    width: parent.width
+                    spacing: Theme.padding
+
+                    Label {
+                        text: "Dropdown options"
+                        font.bold: true
+                    }
+
+                    StatusItemDelegate {
+                        Layout.preferredWidth: 280
+                        text: "StatusItemDelegate"
+                        icon.name: "info"
+                        icon.color: Theme.palette.primaryColor1
+                        highlighted: ctrlHighlighted.checked
+                        onClicked: logs.logEvent("StatusItemDelegate clicked")
+                    }
+
+                    StatusButton {
+                        text: "Open StatusMenu"
+                        scaleOnPressEnabled: false
+                        onClicked: menu.popup()
+                    }
+
+                    StatusMenu {
+                        id: menu
+
+                        StatusAction {
+                            text: "Menu option"
+                            assetSettings.name: "info"
+                            onTriggered: logs.logEvent("Menu option triggered")
+                        }
+
+                        StatusAction {
+                            text: "Danger option"
+                            type: StatusAction.Type.Danger
+                            onTriggered: logs.logEvent("Danger option triggered")
+                        }
+                    }
+                }
+            }
+
+            Pane {
+                Layout.fillWidth: true
+
+                ColumnLayout {
+                    width: parent.width
+                    spacing: Theme.padding
+
+                    Label {
+                        text: "List options"
+                        font.bold: true
+                    }
+
+                    StatusListItem {
+                        Layout.preferredWidth: 360
+                        title: "StatusListItem"
+                        subTitle: "Primary list option"
+                        asset.name: "info"
+                        highlighted: ctrlHighlighted.checked
+                        onClicked: logs.logEvent("StatusListItem clicked")
+                    }
+
+                    StatusListItem {
+                        Layout.preferredWidth: 360
+                        title: "Danger StatusListItem"
+                        subTitle: "Danger list option"
+                        type: StatusListItem.Type.Danger
+                        asset.name: "warning"
+                        highlighted: ctrlHighlighted.checked
+                        onClicked: logs.logEvent("Danger StatusListItem clicked")
+                    }
+                }
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.preferredWidth: 300
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            spacing: Theme.padding
+
+            Label {
+                text: "Button feedback"
+                font.bold: true
+            }
+
+            CheckBox {
+                id: ctrlRipple
+                text: "Ripple"
+                checked: true
+            }
+
+            RowLayout {
+                Layout.leftMargin: Theme.defaultPadding
+                enabled: ctrlRipple.checked
+                opacity: enabled ? 1 : 0.5
+
+                RadioButton {
+                    id: ctrlCentered
+                    text: "Centered"
+                    checked: true
+                    ButtonGroup.group: rippleOriginButtonGroup
+                }
+
+                RadioButton {
+                    id: ctrlFollowPointer
+                    text: "Follow pointer"
+                    ButtonGroup.group: rippleOriginButtonGroup
+                }
+            }
+
+            Label {
+                Layout.topMargin: Theme.defaultBigPadding
+                text: "Options state"
+                font.bold: true
+            }
+
+            CheckBox {
+                id: ctrlHighlighted
+                text: "Highlighted"
+            }
+        }
+    }
+}
+
+// category: Controls
+// status: good

--- a/storybook/qmlTests/tests/tst_StatusButton.qml
+++ b/storybook/qmlTests/tests/tst_StatusButton.qml
@@ -25,6 +25,8 @@ Item {
     }
 
     property StatusButton controlUnderTest: null
+    readonly property real coordinateTolerance: 1
+    readonly property real radiusTolerance: 0.5
 
     TestCase {
         name: "StatusButton"
@@ -46,6 +48,9 @@ Item {
             verify(!controlUnderTest.loading)
             verify(!controlUnderTest.loadingWithText)
             verify(!controlUnderTest.isRoundIcon)
+            verify(controlUnderTest.rippleEnabled)
+            verify(controlUnderTest.scaleOnPressEnabled)
+            compare(controlUnderTest.rippleOrigin, StatusRipple.RippleOrigin.Center)
         }
 
         function test_text() {
@@ -255,6 +260,63 @@ Item {
             compare(buttonIcon.visible, false)
             compare(buttonText.visible, true)
             compare(buttonEmoji.visible, false)
+        }
+
+        function test_pressFeedback() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, { text: "Hello" })
+            verify(!!controlUnderTest)
+
+            const buttonRipple = findChild(controlUnderTest, "buttonRipple")
+            verify(!!buttonRipple)
+            verify(buttonRipple.enabled)
+            verify(!buttonRipple.visible)
+            const buttonBackground = findChild(controlUnderTest, "buttonBackground")
+            verify(!!buttonBackground)
+            compare(buttonBackground.scale, 1)
+            compare(controlUnderTest.contentItem.scale, 1)
+
+            mousePress(controlUnderTest, controlUnderTest.width / 2, controlUnderTest.height / 2)
+            tryVerify(() => buttonRipple.visible)
+            tryCompare(buttonBackground, "scale", controlUnderTest.pressedScale)
+            compare(controlUnderTest.contentItem.scale, 1)
+            verify(buttonRipple.rippleRadius >= 0)
+
+            mouseRelease(controlUnderTest, controlUnderTest.width / 2, controlUnderTest.height / 2)
+            tryCompare(buttonRipple, "visible", false)
+            tryCompare(buttonBackground, "scale", 1)
+            compare(buttonRipple.rippleRadius, 0)
+
+            const pressX = controlUnderTest.width / 4
+            const pressY = controlUnderTest.height * 3 / 4
+            controlUnderTest.rippleOrigin = StatusRipple.RippleOrigin.Pointer
+            compare(buttonRipple.origin, StatusRipple.RippleOrigin.Pointer)
+            mousePress(controlUnderTest, pressX, pressY)
+            tryVerify(() => buttonRipple.visible)
+            verify(Math.abs(buttonRipple.pressX - pressX) <= coordinateTolerance)
+            verify(Math.abs(buttonRipple.pressY - pressY) <= coordinateTolerance)
+            mouseRelease(controlUnderTest, pressX, pressY)
+            tryCompare(buttonRipple, "visible", false)
+
+            controlUnderTest.rippleOrigin = StatusRipple.RippleOrigin.Center
+            compare(buttonRipple.origin, StatusRipple.RippleOrigin.Center)
+            mousePress(controlUnderTest, pressX, pressY)
+            tryVerify(() => buttonRipple.visible)
+            verify(Math.abs(buttonRipple.pressX - controlUnderTest.width / 2) <= coordinateTolerance)
+            verify(Math.abs(buttonRipple.pressY - controlUnderTest.height / 2) <= coordinateTolerance)
+            mouseRelease(controlUnderTest, pressX, pressY)
+            tryCompare(buttonRipple, "visible", false)
+
+            mousePress(controlUnderTest, controlUnderTest.width / 2, controlUnderTest.height / 2)
+            tryVerify(() => buttonRipple.visible)
+            wait(buttonRipple.expandDuration + buttonRipple.collapseDuration)
+            verify(buttonRipple.visible)
+            verify(buttonRipple.rippleRadius >= buttonRipple.endRadius - radiusTolerance)
+            mouseRelease(controlUnderTest, controlUnderTest.width / 2, controlUnderTest.height / 2)
+            tryCompare(buttonRipple, "visible", false)
+            compare(buttonRipple.rippleRadius, 0)
+
+            controlUnderTest.rippleEnabled = false
+            verify(!buttonRipple.enabled)
         }
 
         function test_outlineButton_data() {

--- a/storybook/qmlTests/tests/tst_StatusButton.qml
+++ b/storybook/qmlTests/tests/tst_StatusButton.qml
@@ -213,6 +213,55 @@ Item {
             compare(signalSpy.count, data.spyCount)
         }
 
+        function test_nonEnabledAndNonInteractiveStates_data() {
+            return [
+                { tag: "disabled", enabled: false, interactive: true },
+                { tag: "non interactive", enabled: true, interactive: false },
+                { tag: "disabled and non interactive", enabled: false, interactive: false },
+            ]
+        }
+
+        function test_nonEnabledAndNonInteractiveStates(data) {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, {
+                                                        text: "Hello",
+                                                        "icon.name": "gif",
+                                                        "asset.emoji": "😀"
+                                                    })
+            verify(!!controlUnderTest)
+            controlUnderTest.enabled = data.enabled
+            controlUnderTest.interactive = data.interactive
+
+            const buttonBackground = findChild(controlUnderTest, "buttonBackground")
+            verify(!!buttonBackground)
+            verify(Qt.colorEqual(buttonBackground.color, controlUnderTest.disabledColor))
+
+            const buttonText = findChild(controlUnderTest, "buttonText")
+            verify(!!buttonText)
+            verify(Qt.colorEqual(buttonText.color, controlUnderTest.disabledTextColor))
+
+            const buttonEmoji = findChild(controlUnderTest, "buttonEmoji")
+            verify(!!buttonEmoji)
+            compare(buttonEmoji.opacity, 0.4)
+
+            const buttonRipple = findChild(controlUnderTest, "buttonRipple")
+            verify(!!buttonRipple)
+            verify(!buttonRipple.enabled)
+
+            mousePress(controlUnderTest, controlUnderTest.width / 2, controlUnderTest.height / 2)
+            compare(buttonBackground.scale, 1)
+            verify(!buttonRipple.visible)
+            mouseRelease(controlUnderTest, controlUnderTest.width / 2, controlUnderTest.height / 2)
+            compare(signalSpy.count, 0)
+
+            touchEvent(controlUnderTest)
+                    .press(0, controlUnderTest, controlUnderTest.width / 2, controlUnderTest.height / 2)
+                    .release(0, controlUnderTest, controlUnderTest.width / 2, controlUnderTest.height / 2)
+                    .commit()
+            compare(buttonBackground.scale, 1)
+            verify(!buttonRipple.visible)
+            compare(signalSpy.count, 0)
+        }
+
         function test_loadingIndicators() {
             controlUnderTest =
                     createTemporaryObject(componentUnderTest, root,

--- a/storybook/qmlTests/tests/tst_StatusRippleFeedback.qml
+++ b/storybook/qmlTests/tests/tst_StatusRippleFeedback.qml
@@ -1,0 +1,126 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Components
+import StatusQ.Controls
+import StatusQ.Popups
+
+Item {
+    id: root
+    width: 600
+    height: 400
+
+    Component {
+        id: comboBoxComponent
+
+        StatusComboBox {
+            width: 240
+            model: ["One", "Two"]
+        }
+    }
+
+    Component {
+        id: itemDelegateComponent
+
+        StatusItemDelegate {
+            property int clickCount: 0
+
+            width: 240
+            height: 40
+            text: "One"
+            onClicked: clickCount++
+        }
+    }
+
+    Component {
+        id: listItemComponent
+
+        StatusListItem {
+            property int clickCount: 0
+
+            width: 240
+            title: "One"
+            onClicked: clickCount++
+        }
+    }
+
+    Component {
+        id: menuItemComponent
+
+        StatusMenuItem {
+            property int clickCount: 0
+
+            width: 240
+            height: 40
+            text: "One"
+            onClicked: clickCount++
+        }
+    }
+
+    property Item controlUnderTest: null
+
+    TestCase {
+        name: "StatusRippleFeedback"
+        when: windowShown
+
+        function cleanup() {
+            if (!!controlUnderTest)
+                controlUnderTest.destroy()
+        }
+
+        function verifyRippleFeedback(item, rippleObjectName, followsPointer, expectClick) {
+            const ripple = findChild(item, rippleObjectName)
+            verify(!!ripple)
+            verify(ripple.enabled)
+            verify(!ripple.visible)
+
+            const pressX = item.width / 4
+            const pressY = item.height / 2
+            const clickCount = expectClick ? item.clickCount : 0
+
+            mousePress(item, pressX, pressY)
+            tryVerify(() => ripple.visible)
+            verify(ripple.pressed)
+            compare(ripple.pressX, followsPointer ? pressX : item.width / 2)
+            compare(ripple.pressY, pressY)
+
+            mouseRelease(item, pressX, pressY)
+            tryCompare(ripple, "visible", false)
+            verify(!ripple.pressed)
+            if (expectClick)
+                compare(item.clickCount, clickCount + 1)
+        }
+
+        function test_comboBoxRipple() {
+            controlUnderTest = createTemporaryObject(comboBoxComponent, root)
+            verify(!!controlUnderTest)
+
+            verifyRippleFeedback(controlUnderTest.control, "statusComboBoxRipple", false, false)
+            compare(controlUnderTest.control.scale, 1)
+        }
+
+        function test_itemDelegateRipple() {
+            controlUnderTest = createTemporaryObject(itemDelegateComponent, root)
+            verify(!!controlUnderTest)
+
+            verifyRippleFeedback(controlUnderTest, "statusItemDelegateRipple", true, true)
+            compare(controlUnderTest.scale, 1)
+        }
+
+        function test_listItemRipple() {
+            controlUnderTest = createTemporaryObject(listItemComponent, root)
+            verify(!!controlUnderTest)
+
+            verifyRippleFeedback(controlUnderTest, "statusListItemRipple", true, true)
+            compare(controlUnderTest.scale, 1)
+        }
+
+        function test_menuItemRipple() {
+            controlUnderTest = createTemporaryObject(menuItemComponent, root)
+            verify(!!controlUnderTest)
+
+            verifyRippleFeedback(controlUnderTest, "statusMenuItemRipple", true, true)
+            compare(controlUnderTest.scale, 1)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_StatusRippleFeedback.qml
+++ b/storybook/qmlTests/tests/tst_StatusRippleFeedback.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtTest
 
+import StatusQ.Core.Theme
 import StatusQ.Components
 import StatusQ.Controls
 import StatusQ.Popups
@@ -105,6 +106,33 @@ Item {
 
             verifyRippleFeedback(controlUnderTest, "statusItemDelegateRipple", true, true)
             compare(controlUnderTest.scale, 1)
+        }
+
+        function test_highlightedItemDelegateDefaultColors() {
+            controlUnderTest = createTemporaryObject(itemDelegateComponent, root, { highlighted: true })
+            verify(!!controlUnderTest)
+
+            const textItem = controlUnderTest.contentItem.children[1]
+            const ripple = findChild(controlUnderTest, "statusItemDelegateRipple")
+            verify(!!textItem)
+            verify(!!ripple)
+            compare(textItem.color, Theme.palette.directColor1)
+            compare(ripple.color, Theme.palette.directColor1)
+        }
+
+        function test_highlightedItemDelegatePrimaryColors() {
+            controlUnderTest = createTemporaryObject(itemDelegateComponent, root, {
+                highlighted: true,
+                highlightColor: Theme.palette.primaryColor1
+            })
+            verify(!!controlUnderTest)
+
+            const textItem = controlUnderTest.contentItem.children[1]
+            const ripple = findChild(controlUnderTest, "statusItemDelegateRipple")
+            verify(!!textItem)
+            verify(!!ripple)
+            compare(textItem.color, StatusColors.white)
+            compare(ripple.color, StatusColors.white)
         }
 
         function test_listItemRipple() {

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -132,9 +132,41 @@ Rectangle {
     }
     radius: Theme.radius
 
+    StatusRipple {
+        id: listItemRipple
+        objectName: "statusListItemRipple"
+        anchors.fill: parent
+        enabled: root.enabled && sensor.enabled
+        color: root.type === StatusListItem.Type.Danger ? Theme.palette.dangerColor1
+                                                        : Theme.palette.directColor1
+        radius: root.radius
+        origin: StatusRipple.RippleOrigin.Pointer
+    }
+
+    QtObject {
+        id: rippleFeedback
+
+        function pressRipple(mouse, sourceItem) {
+            if (!listItemRipple.enabled || mouse.button !== Qt.LeftButton)
+                return
+
+            const ripplePoint = sourceItem.mapToItem(root, mouse.x, mouse.y)
+            listItemRipple.press(ripplePoint.x, ripplePoint.y)
+        }
+
+        function releaseRipple() {
+            listItemRipple.release()
+        }
+    }
+
     StatusMouseArea {
+        id: clickSensor
+
         anchors.fill: parent
         acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onPressed: (mouse) => rippleFeedback.pressRipple(mouse, clickSensor)
+        onReleased: () => rippleFeedback.releaseRipple()
+        onCanceled: () => rippleFeedback.releaseRipple()
         onClicked: (mouse) => {
             root.clicked(root.itemId, mouse)
         }
@@ -243,6 +275,9 @@ Rectangle {
                     hoverEnabled: true
                     acceptedButtons: Qt.LeftButton | Qt.RightButton
                     propagateComposedEvents: root.propagateTitleClicks
+                    onPressed: (mouse) => rippleFeedback.pressRipple(mouse, statusListItemTitleMouseArea)
+                    onReleased: () => rippleFeedback.releaseRipple()
+                    onCanceled: () => rippleFeedback.releaseRipple()
                     onClicked: (mouse) => {
                         root.titleClicked(root.titleId, mouse)
                         mouse.accepted = false

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
@@ -47,6 +47,35 @@ AbstractButton {
     property bool loadingWithText // loading indicator instead of icon, mutually exclusive with `loading`
     property bool interactive: true
 
+    /*!
+       Enables the press ripple animation. The ripple expands on press, stays open
+       while the button is held, and collapses on release.
+    */
+    property bool rippleEnabled: true
+
+    /*!
+       Controls where the ripple starts from. Use \c StatusRipple.RippleOrigin.Center
+       for a centered ripple or \c StatusRipple.RippleOrigin.Pointer to start from
+       the press position.
+    */
+    property int rippleOrigin: StatusRipple.RippleOrigin.Center
+
+    /*!
+       Color used by the ripple animation.
+    */
+    property color rippleColor: d.textColor
+
+    /*!
+       Enables the background scale-down animation while the button is pressed.
+       The content item is not scaled.
+    */
+    property bool scaleOnPressEnabled: true
+
+    /*!
+       Scale applied to the button background while pressed.
+    */
+    property real pressedScale: d.defaultPressedScale
+
     property color normalColor
     property color hoverColor
     property color disabledColor
@@ -71,6 +100,8 @@ AbstractButton {
     QtObject {
         id: d
 
+        readonly property real defaultPressedScale: 0.92
+
         readonly property color textColor: {
             if (!root.interactive || !root.enabled)
                 return root.disabledTextColor
@@ -80,6 +111,9 @@ AbstractButton {
         }
 
         readonly property bool iconOnly: root.display === AbstractButton.IconOnly || root.text === ""
+        readonly property bool pressFeedbackActive: root.pressed && root.enabled && root.interactive
+                                                 && !root.loading && !root.loadingWithText
+                                                 && root.scaleOnPressEnabled
         readonly property int iconSize: {
             switch(root.size) {
             case StatusBaseButton.Size.XSmall:
@@ -151,14 +185,55 @@ AbstractButton {
     }
 
     background: Rectangle {
+        objectName: "buttonBackground"
         radius: root.radius
         border.color: root.borderColor
         border.width: root.borderWidth
+        scale: d.pressFeedbackActive ? root.pressedScale : 1
         color: {
             if ((!root.enabled || !root.interactive) && !root.checked)
                 return disabledColor
             return !root.loading && !root.loadingWithText && (pointerHoverHandler.hovered || root.highlighted || root.checked) ? hoverColor : normalColor
         }
+
+        Behavior on scale {
+            NumberAnimation {
+                duration: ThemeUtils.AnimationDuration.Default
+                easing.type: Easing.OutQuad
+            }
+        }
+
+        StatusRipple {
+            id: ripple
+            objectName: "buttonRipple"
+            anchors.fill: parent
+            enabled: root.rippleEnabled && root.enabled && root.interactive && !root.loading && !root.loadingWithText
+            color: root.rippleColor
+            radius: root.radius
+            origin: root.rippleOrigin
+        }
+    }
+
+    TapHandler {
+        id: pressFeedbackHandler
+        enabled: ripple.enabled
+        acceptedButtons: Qt.LeftButton
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchScreen | PointerDevice.TouchPad | PointerDevice.Stylus
+        gesturePolicy: TapHandler.DragThreshold
+
+        onPressedChanged: {
+            if (pressed) {
+                const ripplePoint = root.mapToItem(ripple, point.position.x, point.position.y)
+                ripple.press(ripplePoint.x, ripplePoint.y)
+            } else {
+                ripple.release()
+            }
+        }
+    }
+
+    onPressedChanged: {
+        if (!pressed)
+            ripple.release()
     }
 
     contentItem: Item {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
@@ -60,6 +60,24 @@ Item {
             return "transparent"
         }
 
+        StatusRipple {
+            id: comboBoxRipple
+            objectName: "statusComboBoxRipple"
+            anchors.fill: parent
+            enabled: comboBox.enabled
+            color: root.type === StatusComboBox.Type.Secondary ? Theme.palette.baseColor1
+                                                               : Theme.palette.directColor1
+            radius: parent.radius
+        }
+
+        function pressRipple(x, y) {
+            comboBoxRipple.press(x, y)
+        }
+
+        function releaseRipple() {
+            comboBoxRipple.release()
+        }
+
         HoverHandler {
             cursorShape: root.enabled ? Qt.PointingHandCursor : undefined
         }
@@ -111,7 +129,23 @@ Item {
             spacing: 16
 
             background: Loader {
+                id: comboBoxBackground
                 sourceComponent: root.defaultBackgroundComponent
+            }
+
+            TapHandler {
+                enabled: comboBox.enabled && !!comboBoxBackground.item
+                acceptedButtons: Qt.LeftButton
+                acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchScreen | PointerDevice.TouchPad | PointerDevice.Stylus
+
+                onPressedChanged: {
+                    if (pressed) {
+                        const ripplePoint = comboBox.mapToItem(comboBoxBackground.item, point.position.x, point.position.y)
+                        comboBoxBackground.item.pressRipple(ripplePoint.x, ripplePoint.y)
+                    } else {
+                        comboBoxBackground.item.releaseRipple()
+                    }
+                }
             }
 
             contentItem: StatusBaseText {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
@@ -22,6 +22,16 @@ ItemDelegate {
     font.family: Fonts.baseFont.family
     font.pixelSize: Theme.primaryTextFontSize
 
+    QtObject {
+        id: d
+
+        readonly property bool highlightedWithPrimaryColor: root.highlighted &&
+                                                           Qt.colorEqual(root.highlightColor, Theme.palette.primaryColor1)
+        readonly property color contentColor: !root.enabled ? Theme.palette.baseColor1 :
+                                                d.highlightedWithPrimaryColor ? StatusColors.white :
+                                                                                Theme.palette.directColor1
+    }
+
     contentItem: RowLayout {
         spacing: root.spacing
 
@@ -41,7 +51,7 @@ ItemDelegate {
             text: root.text
             verticalAlignment: Text.AlignVCenter
             elide: Text.ElideRight
-            color: root.highlighted ? StatusColors.white : root.enabled ? Theme.palette.directColor1 : Theme.palette.baseColor1
+            color: d.contentColor
 
             Binding on horizontalAlignment {
                 when: root.centerTextHorizontally
@@ -59,7 +69,7 @@ ItemDelegate {
             objectName: "statusItemDelegateRipple"
             anchors.fill: parent
             enabled: root.enabled
-            color: root.highlighted ? StatusColors.white : Theme.palette.directColor1
+            color: d.contentColor
             radius: parent.radius
             origin: StatusRipple.RippleOrigin.Pointer
         }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
@@ -53,6 +53,31 @@ ItemDelegate {
     background: Rectangle {
         color: root.highlighted ? root.highlightColor : "transparent"
         radius: root.radius
+
+        StatusRipple {
+            id: itemDelegateRipple
+            objectName: "statusItemDelegateRipple"
+            anchors.fill: parent
+            enabled: root.enabled
+            color: root.highlighted ? StatusColors.white : Theme.palette.directColor1
+            radius: parent.radius
+            origin: StatusRipple.RippleOrigin.Pointer
+        }
+    }
+
+    TapHandler {
+        enabled: itemDelegateRipple.enabled
+        acceptedButtons: Qt.LeftButton
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchScreen | PointerDevice.TouchPad | PointerDevice.Stylus
+
+        onPressedChanged: {
+            if (pressed) {
+                const ripplePoint = root.mapToItem(itemDelegateRipple, point.position.x, point.position.y)
+                itemDelegateRipple.press(ripplePoint.x, ripplePoint.y)
+            } else {
+                itemDelegateRipple.release()
+            }
+        }
     }
 
     HoverHandler {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusRipple.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusRipple.qml
@@ -20,7 +20,7 @@ Item {
     /*!
        Color used by the ripple circle.
     */
-    property color color: "transparent"
+    property color color: StatusColors.transparent
 
     /*!
        Radius used by the clipping mask.

--- a/ui/StatusQ/src/StatusQ/Controls/StatusRipple.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusRipple.qml
@@ -1,0 +1,158 @@
+import QtQuick
+import Qt5Compat.GraphicalEffects
+
+import StatusQ.Core.Theme
+
+/*!
+   \qmltype StatusRipple
+   \inqmlmodule StatusQ.Controls
+   \since StatusQ.Controls 0.1
+   \brief Press ripple animation clipped to the component bounds.
+*/
+Item {
+    id: root
+
+    enum RippleOrigin {
+        Pointer,
+        Center
+    }
+
+    /*!
+       Color used by the ripple circle.
+    */
+    property color color: "transparent"
+
+    /*!
+       Radius used by the clipping mask.
+    */
+    property int radius: 0
+
+    /*!
+       Controls where the ripple starts from. Use \c RippleOrigin.Center for a
+       centered ripple or \c RippleOrigin.Pointer to start from the coordinates
+       passed to \c press.
+    */
+    property int origin: StatusRipple.RippleOrigin.Center
+
+    /*!
+       Duration of the expansion animation.
+    */
+    property int expandDuration: ThemeUtils.AnimationDuration.Fast
+
+    /*!
+       Duration of the collapse animation.
+    */
+    property int collapseDuration: ThemeUtils.AnimationDuration.Default
+
+    /*!
+       Maximum opacity of the ripple circle.
+    */
+    property real maxOpacity: d.defaultMaxOpacity
+
+    /*!
+       Horizontal coordinate where the current ripple started.
+    */
+    readonly property real pressX: d.pressX
+
+    /*!
+       Vertical coordinate where the current ripple started.
+    */
+    readonly property real pressY: d.pressY
+
+    /*!
+       Current radius of the ripple circle.
+    */
+    readonly property real rippleRadius: d.rippleRadius
+
+    /*!
+       True while the ripple is being held after a press.
+    */
+    readonly property bool pressed: d.pressed
+
+    readonly property real endRadius: Math.max(
+        Math.sqrt(pressX * pressX + pressY * pressY),
+        Math.sqrt(Math.pow(width - pressX, 2) + pressY * pressY),
+        Math.sqrt(pressX * pressX + Math.pow(height - pressY, 2)),
+        Math.sqrt(Math.pow(width - pressX, 2) + Math.pow(height - pressY, 2))
+    )
+
+    function press(x, y) {
+        if (origin === StatusRipple.RippleOrigin.Center) {
+            d.pressX = width / 2
+            d.pressY = height / 2
+        } else {
+            d.pressX = Math.max(0, Math.min(width, x))
+            d.pressY = Math.max(0, Math.min(height, y))
+        }
+        d.pressed = true
+        d.rippleRadius = 0
+        ripple.opacity = maxOpacity
+        collapseAnimation.stop()
+        expandAnimation.restart()
+    }
+
+    function release() {
+        d.pressed = false
+        if (!expandAnimation.running)
+            collapseAnimation.restart()
+    }
+
+    QtObject {
+        id: d
+
+        readonly property real defaultMaxOpacity: 0.18
+        property real pressX: root.width / 2
+        property real pressY: root.height / 2
+        property real rippleRadius: 0
+        property bool pressed: false
+    }
+
+    visible: ripple.opacity > 0
+    layer.enabled: visible
+    layer.effect: OpacityMask {
+        maskSource: Rectangle {
+            width: root.width
+            height: root.height
+            radius: root.radius
+        }
+    }
+
+    Rectangle {
+        id: ripple
+        x: root.pressX - root.rippleRadius
+        y: root.pressY - root.rippleRadius
+        width: root.rippleRadius * 2
+        height: width
+        radius: width / 2
+        color: root.color
+        opacity: 0
+    }
+
+    NumberAnimation {
+        id: expandAnimation
+        target: d
+        property: "rippleRadius"
+        to: root.endRadius
+        duration: root.expandDuration
+        easing.type: Easing.OutCubic
+
+        onStopped: {
+            if (!root.pressed)
+                collapseAnimation.restart()
+        }
+    }
+
+    NumberAnimation {
+        id: collapseAnimation
+        target: d
+        property: "rippleRadius"
+        to: 0
+        duration: root.collapseDuration
+        easing.type: Easing.InOutQuad
+
+        onStopped: {
+            if (!root.pressed && root.rippleRadius === 0)
+                ripple.opacity = 0
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Controls/qmldir
+++ b/ui/StatusQ/src/StatusQ/Controls/qmldir
@@ -44,6 +44,7 @@ StatusPickerButton 0.1 StatusPickerButton.qml
 StatusPinInput 0.1 StatusPinInput.qml
 StatusProgressBar 0.1 StatusProgressBar.qml
 StatusRadioButton 0.1 StatusRadioButton.qml
+StatusRipple 0.1 StatusRipple.qml
 StatusRoundButton 0.1 StatusRoundButton.qml
 StatusScrollBar 0.1 StatusScrollBar.qml
 StatusSecondaryActionHandler 0.1 StatusSecondaryActionHandler.qml

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts
 import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Components
+import StatusQ.Controls
 import StatusQ.Core.Utils
 
 MenuItem {
@@ -175,6 +176,33 @@ MenuItem {
             if (d.isStatusSuccessAction)
                 return Theme.palette.successColor3;
             return Theme.palette.statusMenu.hoverBackgroundColor;
+        }
+
+        StatusRipple {
+            id: menuItemRipple
+            objectName: "statusMenuItemRipple"
+            anchors.fill: parent
+            enabled: root.enabled
+            color: d.isStatusDangerAction ? Theme.palette.dangerColor1
+                  : d.isStatusSuccessAction ? Theme.palette.successColor1
+                                            : Theme.palette.directColor1
+            radius: parent.radius
+            origin: StatusRipple.RippleOrigin.Pointer
+        }
+    }
+
+    TapHandler {
+        enabled: menuItemRipple.enabled
+        acceptedButtons: Qt.LeftButton
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchScreen | PointerDevice.TouchPad | PointerDevice.Stylus
+
+        onPressedChanged: {
+            if (pressed) {
+                const ripplePoint = root.mapToItem(menuItemRipple, point.position.x, point.position.y)
+                menuItemRipple.press(ripplePoint.x, ripplePoint.y)
+            } else {
+                menuItemRipple.release()
+            }
         }
     }
 

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -134,6 +134,7 @@
         <file>StatusQ/Controls/StatusPinInput.qml</file>
         <file>StatusQ/Controls/StatusProgressBar.qml</file>
         <file>StatusQ/Controls/StatusRadioButton.qml</file>
+        <file>StatusQ/Controls/StatusRipple.qml</file>
         <file>StatusQ/Controls/StatusRoundButton.qml</file>
         <file>StatusQ/Controls/StatusScrollBar.qml</file>
         <file>StatusQ/Controls/StatusSeedPhraseField.qml</file>


### PR DESCRIPTION
Closes #21094.

### What does the PR do

Adds tap/click feedback across the StatusQ interactive controls.

- Adds ripple + scale-down feedback to regular buttons and icon buttons.
- Adds ripple-only feedback to dropdown buttons.
- Adds ripple-only feedback to dropdown/list options.
- Adds `StatusRipple` as the shared ripple primitive.
- Adds Storybook controls/pages to visually test button feedback and ripple behavior.
- Adds focused QML coverage for press feedback and verifies existing click behavior is preserved.

### Affected areas

- StatusQ controls
- StatusQ components
- StatusQ popups
- Storybook

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/2a041f09-8eaa-44bd-b609-6ef8ecd3fedc

https://github.com/user-attachments/assets/d4755173-f5f0-4b39-9270-e20fc073aac4

### Impact on end user

Buttons, icon buttons, dropdown buttons, dropdown options, menu options, and list options now provide clearer visual feedback on tap/click.

Regular buttons scale down and show ripple feedback. Dropdowns and list/menu options show ripple feedback only.

### How to test

Open Storybook:

- `StatusButtonPage`: check regular buttons and icon buttons with ripple, centered/follow-pointer origin, and scale-down controls.
- `StatusRipplePage`: check ripple feedback on dropdown buttons, dropdown options, menu options, and list options.

Automated checks run:

- `storybook/build/Qt_6_11_0_for_macOS-Release/bin/QmlTests -platform offscreen -input storybook/qmlTests/tests/tst_StatusButton.qml`
- `storybook/build/Qt_6_11_0_for_macOS-Release/bin/QmlTests -platform offscreen -input storybook/qmlTests/tests/tst_StatusRippleFeedback.qml`

### Risk

Medium.

The change touches shared StatusQ controls used across the app. Main risks are visual regressions, unexpected interaction conflicts with existing click/press handling, or feedback appearing in states where controls should be disabled/loading. Focused QML tests cover the new feedback behavior and verify existing click behavior for the touched option components.