### PR TITLE
perf: model-sync library, typed threadpool handoff, CowSeq, signal-type scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1061,6 +1061,14 @@ nim-test-run/test/nim/signal_handler_test.nim: | statusq
 nim-test-run/test/nim/url_scheme_event_test.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
 nim-test-run/test/nim/url_scheme_event_test.nim: | statusq
 
+# Model-spy tests call inspection accessors gated behind
+# `when defined(testing) or defined(QT_MODEL_SPY)` or assert on the granular
+# signals model_sync records only under QT_MODEL_SPY. The define is applied
+# per-file, NOT globally, so the timing benches keep measuring uninstrumented
+# models.
+nim-test-run/test/nim/model_sync_move_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
+nim-test-run/test/nim/model_sync_unified_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
+
 ifneq ($(mkspecs),win32)
 nim-test-run/%: NIM_PARAMS += --passL:"$(QT_SEAQT_EXTRA_LIBS)"
 endif

--- a/Makefile
+++ b/Makefile
@@ -1061,6 +1061,11 @@ nim-test-run/test/nim/signal_handler_test.nim: | statusq
 nim-test-run/test/nim/url_scheme_event_test.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
 nim-test-run/test/nim/url_scheme_event_test.nim: | statusq
 
+# typed_completion_test drives finishTyped -> signal_handler -> statusq_invoke_method_queued,
+# so it needs the StatusQ library linked (like signal_handler_test above).
+nim-test-run/test/nim/typed_completion_test.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
+nim-test-run/test/nim/typed_completion_test.nim: | statusq
+
 # Model-spy tests call inspection accessors gated behind
 # `when defined(testing) or defined(QT_MODEL_SPY)` or assert on the granular
 # signals model_sync records only under QT_MODEL_SPY. The define is applied

--- a/docs/adr/0004-typed-task-completion-handoff.md
+++ b/docs/adr/0004-typed-task-completion-handoff.md
@@ -1,0 +1,111 @@
+# ADR 0004: Typed task-completion handoff for worker→GUI data transfer
+
+## Status
+
+Accepted
+
+- **Date**: 2026-07-13
+- **Owners**: Status Desktop (wallet / core task infrastructure)
+
+## Context
+
+Threadpool workers hand their results back to the GUI thread through a queued
+invoke: the worker calls `finish`, which serializes the result to a string and
+passes it across the bridge; the GUI-thread completion slot re-parses that
+string and builds its models. For small payloads this is invisible. For the
+wallet token results it is not — the payload is a multi-megabyte JSON document,
+and **the parse happens on the GUI thread inside the completion slot**.
+
+On a device wake (issue #21395) several of these completions land at once. The
+GUI thread spends its time parsing JSON instead of drawing, and the app shows a
+**black screen for ~13s** (measured on device). The work the worker did in
+parallel is thrown away and redone, single-threaded, on the one thread that must
+stay responsive.
+
+The worker already holds the fully-built object graph. Serializing it only to
+re-parse an identical graph on the GUI thread is pure overhead. We want the
+worker to hand the *graph itself* to the GUI thread.
+
+## Decision
+
+Add an opt-in **typed completion path** alongside the existing string `finish`:
+
+- The worker builds its result as a Nim `ref object` graph and calls
+  `finishTyped(arg, graph)`. This **parks** the graph in an in-process registry
+  and sends only a small integer handle across the queued-invoke bridge.
+- The GUI-thread completion slot calls `takeTyped[T](response)`, which **claims**
+  the graph back out of the registry by handle. No string is ever serialized or
+  parsed; no copy of the graph is made.
+
+Ownership is **exclusive and moved, never shared**. The worker must hold the
+only reference at the call site and must not touch the graph after parking. The
+registry is the sole owner while parked. The slot becomes the sole owner after
+claiming, and the graph is destroyed on the GUI thread when that reference goes
+out of scope. Because only one place ever references the graph at a time, its
+(non-atomic) refcount is never mutated concurrently; a lock around the registry
+table gives the park a happens-before edge to the claim so the graph's bytes are
+visible to the GUI thread.
+
+The following constraints are load-bearing and are enforced or documented in
+the code:
+
+1. **ORC (or ARC) only — enforced at compile time.** Under refc each thread has
+   its own GC heap; claiming a worker-allocated graph on the GUI thread reads
+   foreign-heap memory and SIGSEGVs. A `{.error.}` guard keyed on `-d:useMalloc`
+   (which both the desktop and mobile app builds set, and the unit-test suite
+   does not) turns this into a build failure for any production build that
+   selects a non-ORC/ARC memory manager. The single-threaded unit tests keep
+   compiling under the suite's refc.
+
+2. **Move, not copy.** The whole point is to avoid duplicating the graph — a
+   deep copy of the token graph was measured at ~1.1s (O(graph)), the same class
+   of cost as the JSON round trip it replaces. The payload is `sink`-taken into
+   the registry and `pop`-ed out, so the refcount stays 1 throughout and the
+   graph is destroyed exactly once.
+
+3. **Transferred ref types must be `{.acyclic.}`.** ORC's cycle collector,
+   running over these graphs as they are destroyed on the GUI thread, is a
+   known SIGSEGV class on arm64. The transferred DTOs are tree-shaped (value
+   fields plus seqs of child refs, no back-edges), so marking them `{.acyclic.}`
+   tells ORC to skip cycle tracking entirely — both a correctness fix and a
+   cost saving.
+
+4. **The finish path must be deadlock-safe.** Completion slots run inside
+   coalescing gates and in-flight latches; if the claim ever *raised* out of the
+   completion path, those gates would never clear and the caller would wedge.
+   `takeTyped` therefore returns `nil` (never raises) for an unknown, already
+   claimed, drained, or malformed handle, and the worker task body runs under
+   `except Exception`. On shutdown the registry is swept by `drainHandoffs` at
+   task-infra teardown, and `finishTyped` destroys its own payload (still
+   exclusively owned, safe) rather than parking into a loop that has stopped.
+
+The typed path is opt-in per producer. Callers with small payloads keep using
+string `finish`; only the hot, large-payload completions migrate.
+
+## Consequences
+
+### Positive
+
+- The wallet token completions no longer parse multi-MB JSON on the GUI thread;
+  the graph the worker built is handed over directly. The GUI-thread cost of a
+  completion drops from "re-parse the whole payload" to "take a pointer".
+- The two completion paths coexist behind one task-arg type, so migration is
+  incremental and low-risk.
+
+### Negative / trade-offs
+
+- Producers on the typed path carry an ownership obligation the compiler cannot
+  fully check: the parked graph must be isolated at the call site. This is
+  documented at both `finishTyped` and the registry, but it is a discipline, not
+  a guarantee.
+- New transferred DTO types must remember `{.acyclic.}`, and the whole path is
+  bound to ORC/ARC — a constraint the build guard makes loud but which still
+  narrows the memory-manager choice for the app.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|-------------|--------------|
+| Keep JSON, but parse off the GUI thread | Still serializes on the worker and re-parses into a second identical graph — two full O(graph) passes to move data the worker already had. Moves the cost, doesn't remove it. |
+| Shared-memory result buffer with locks | Keeps the graph reachable from two threads, reintroducing concurrent refcount mutation (the exact hazard the move design avoids) and adding lock contention on the hot completion path. |
+| Always-on typed path (retire string `finish`) | Unjustified churn: most completions are small and the string path is simpler and allocation-free of a registry entry. Opt-in keeps the risk on the few hot producers. |

--- a/src/app/core/cow_seq.nim
+++ b/src/app/core/cow_seq.nim
@@ -1,0 +1,327 @@
+## Copy-on-Write Sequence Container (single-threaded)
+##
+## A seq-like container with transparent Copy-on-Write semantics: memory is
+## shared between copies until a mutation occurs, at which point the mutating
+## copy forks its own buffer.
+##
+## Key features:
+## - Transparent CoW via =copy / =sink hooks
+## - seq-compatible API
+## - O(1) copy operations (refcount bump)
+## - O(n) mutation only when the buffer is shared
+## - Value type semantics (the wrapper itself can be copied freely)
+##
+## Refcount type: a PLAIN `int`, not an atomic. The intended flow keeps every
+## CowSeq on the GUI thread — the service owns the authoritative CowSeq and the
+## GUI-thread model diffs prev vs next against it; worker state reaches the GUI
+## thread via a typed move (typed_handoff), so a CowSeq value never crosses a
+## thread boundary. Under single-thread use there is no contention, so an atomic
+## refcount would only add cost. Do NOT copy/destroy a CowSeq from another thread.
+##
+## Example:
+## ```nim
+## var original = @[1, 2, 3].toCowSeq()
+## var copy = original  # O(1) - shares memory
+## copy.add(4)          # CoW triggered: copy gets its own buffer
+## # original: [1, 2, 3]
+## # copy: [1, 2, 3, 4]
+## ```
+
+import std/hashes
+
+type
+  CowSeqData[T] = ref object
+    ## Internal data container with reference counting.
+    ## Not exported - callers should never reach in here.
+    data: seq[T]
+    refCount: int
+    owningThread: int  ## thread that created the buffer; mutations must stay on it
+
+  CowSeq*[T] = object
+    ## Copy-on-Write sequence container.
+    ## Behaves like seq[T] but shares the backing buffer until mutation.
+    dataRef: CowSeqData[T]
+
+#
+# Thread-ownership guard (debug-only)
+#
+
+proc cowOwningThreadId(): int {.inline.} =
+  ## Current thread id under a threaded build, else 0 (single-thread build).
+  when compileOption("threads"):
+    getThreadId()
+  else:
+    0
+
+proc assertOwningThread[T](self: CowSeq[T]) {.inline.} =
+  ## Enforce the documented single-thread (GUI-thread) mutation constraint.
+  when compileOption("assertions"):
+    if not self.dataRef.isNil:
+      assert self.dataRef.owningThread == cowOwningThreadId(),
+        "CowSeq mutated from a thread other than the one that created it"
+
+#
+# Constructors
+#
+
+proc newCowSeq*[T](initialData: seq[T] = @[]): CowSeq[T] =
+  ## Create a new CowSeq from a regular seq.
+  ## Takes the input by value so the caller's variable remains usable.
+  result.dataRef = CowSeqData[T](data: initialData, refCount: 1,
+    owningThread: cowOwningThreadId())
+
+proc newCowSeq*[T](size: int): CowSeq[T] =
+  ## Create a new CowSeq with pre-allocated size.
+  result.dataRef = CowSeqData[T](data: newSeq[T](size), refCount: 1,
+    owningThread: cowOwningThreadId())
+
+proc toCowSeq*[T](s: seq[T]): CowSeq[T] {.inline.} =
+  ## Convert a regular seq to CowSeq (copy semantics - see newCowSeq).
+  newCowSeq(s)
+
+#
+# Lifecycle hooks (transparent CoW)
+#
+
+proc `=destroy`*[T](x: var CowSeq[T]) =
+  ## Destructor: decrements the refcount and drops the ref.
+  if not x.dataRef.isNil:
+    dec x.dataRef.refCount
+    x.dataRef = nil
+
+proc `=copy`*[T](dest: var CowSeq[T], src: CowSeq[T]) =
+  ## Copy hook: O(1) - shares the buffer and bumps the refcount.
+  if dest.dataRef == src.dataRef:
+    return  # Self-assignment
+
+  `=destroy`(dest)
+  wasMoved(dest)
+
+  if not src.dataRef.isNil:
+    dest.dataRef = src.dataRef
+    inc dest.dataRef.refCount
+
+proc `=sink`*[T](dest: var CowSeq[T], src: CowSeq[T]) =
+  ## Sink hook: transfers ownership without touching the refcount.
+  ## Clears the source so its eventual destructor does not decrement the
+  ## refcount we just transferred.
+  # Self-move (`a = move(a)`): leave dest intact, never clear it.
+  if cast[pointer](unsafeAddr dest) == cast[pointer](unsafeAddr src):
+    return
+
+  if dest.dataRef == src.dataRef:
+    # dest and src alias the same buffer: release src's reference so dest keeps
+    # exactly one and the refcount stays balanced (else it leaks one).
+    if not src.dataRef.isNil:
+      dec src.dataRef.refCount
+    cast[ptr CowSeq[T]](unsafeAddr src).dataRef = nil
+    return
+
+  `=destroy`(dest)
+  wasMoved(dest)
+  dest.dataRef = src.dataRef
+  cast[ptr CowSeq[T]](unsafeAddr src).dataRef = nil
+
+#
+# Internal: CoW trigger
+#
+
+proc ensureUnique[T](self: var CowSeq[T]) =
+  ## Ensure this CowSeq has exclusive ownership of its data.
+  ## Triggers Copy-on-Write if the buffer is shared.
+  self.assertOwningThread()
+  if self.dataRef.isNil:
+    self.dataRef = CowSeqData[T](data: @[], refCount: 1,
+      owningThread: cowOwningThreadId())
+    return
+
+  if self.dataRef.refCount > 1:
+    let newData = self.dataRef.data  # Nim seq value semantics: deep copy
+    dec self.dataRef.refCount
+    self.dataRef = CowSeqData[T](data: newData, refCount: 1,
+      owningThread: cowOwningThreadId())
+
+#
+# Read-only operations (O(1), no CoW)
+#
+
+proc len*[T](self: CowSeq[T]): int {.inline.} =
+  if self.dataRef.isNil: 0
+  else: self.dataRef.data.len
+
+proc high*[T](self: CowSeq[T]): int {.inline.} =
+  self.len - 1
+
+proc low*[T](self: CowSeq[T]): int {.inline.} =
+  0
+
+proc `[]`*[T](self: CowSeq[T], idx: int): lent T {.inline.} =
+  ## Access element at index (read-only).
+  ## Raises IndexDefect on a default-constructed (nil) CowSeq, mirroring
+  ## seq[T]'s out-of-bounds behaviour.
+  if self.dataRef.isNil:
+    raise newException(IndexDefect, "CowSeq is empty (nil dataRef)")
+  self.dataRef.data[idx]
+
+proc `[]`*[T](self: CowSeq[T], slice: HSlice[int, int]): seq[T] =
+  if self.dataRef.isNil:
+    return @[]
+  self.dataRef.data[slice]
+
+proc borrow*[T](self: var CowSeq[T]): lent seq[T] {.inline.} =
+  ## Zero-copy read access to the underlying seq.
+  ## The returned reference is valid until `self` is mutated.
+  ## Use this in hot paths instead of asSeq() to avoid the O(n) copy.
+  if self.dataRef.isNil:
+    self.dataRef = CowSeqData[T](data: @[], refCount: 1,
+      owningThread: cowOwningThreadId())
+  result = self.dataRef.data
+
+#
+# Mutable operations (trigger CoW if shared)
+#
+
+proc `[]=`*[T](self: var CowSeq[T], idx: int, val: T) =
+  self.ensureUnique()
+  self.dataRef.data[idx] = val
+
+proc add*[T](self: var CowSeq[T], val: sink T) =
+  self.ensureUnique()
+  self.dataRef.data.add(val)
+
+proc add*[T](self: var CowSeq[T], other: CowSeq[T]) =
+  if other.len == 0:
+    return
+  self.ensureUnique()
+  if not other.dataRef.isNil:
+    self.dataRef.data.add(other.dataRef.data)
+
+proc add*[T](self: var CowSeq[T], other: openArray[T]) =
+  if other.len == 0:
+    return
+  self.ensureUnique()
+  for item in other:
+    self.dataRef.data.add(item)
+
+proc delete*[T](self: var CowSeq[T], idx: int) =
+  self.ensureUnique()
+  self.dataRef.data.delete(idx)
+
+proc delete*[T](self: var CowSeq[T], first: int, last: int) =
+  self.ensureUnique()
+  for i in countdown(last, first):
+    self.dataRef.data.delete(i)
+
+proc insert*[T](self: var CowSeq[T], val: sink T, idx: int = 0) =
+  self.ensureUnique()
+  self.dataRef.data.insert(val, idx)
+
+proc setLen*[T](self: var CowSeq[T], newLen: int) =
+  self.ensureUnique()
+  self.dataRef.data.setLen(newLen)
+
+proc clear*[T](self: var CowSeq[T]) =
+  ## Empty the sequence (O(1) when shared - drops the buffer; O(n) when unique).
+  self.assertOwningThread()
+  if self.dataRef.isNil:
+    return
+  if self.dataRef.refCount > 1:
+    dec self.dataRef.refCount
+    self.dataRef = CowSeqData[T](data: @[], refCount: 1,
+      owningThread: cowOwningThreadId())
+  else:
+    self.dataRef.data.setLen(0)
+
+#
+# Iteration
+#
+
+iterator items*[T](self: CowSeq[T]): lent T =
+  if not self.dataRef.isNil:
+    for item in self.dataRef.data:
+      yield item
+
+iterator mitems*[T](self: var CowSeq[T]): var T =
+  ## Mutable iteration. Always triggers CoW if shared - even if the caller
+  ## doesn't end up writing. Prefer `items` for read-only loops.
+  self.ensureUnique()
+  for item in self.dataRef.data.mitems:
+    yield item
+
+iterator pairs*[T](self: CowSeq[T]): tuple[key: int, val: lent T] =
+  if not self.dataRef.isNil:
+    for i, item in self.dataRef.data.pairs:
+      yield (i, item)
+
+#
+# Conversion
+#
+
+proc asSeq*[T](self: CowSeq[T]): seq[T] =
+  ## Returns a *copy* of the underlying seq. Always O(n).
+  ## For zero-copy reads, use `borrow()` instead.
+  if self.dataRef.isNil: @[]
+  else: self.dataRef.data
+
+#
+# Comparison
+#
+
+proc `==`*[T](a, b: CowSeq[T]): bool =
+  if a.dataRef == b.dataRef:
+    return true  # Same backing buffer
+  if a.len != b.len:
+    return false
+  for i in 0..<a.len:
+    if a[i] != b[i]:
+      return false
+  return true
+
+proc hash*[T](self: CowSeq[T]): Hash =
+  var h: Hash = 0
+  for item in self:
+    h = h !& hash(item)
+  result = !$h
+
+#
+# Utility
+#
+
+proc contains*[T](self: CowSeq[T], val: T): bool =
+  if self.dataRef.isNil:
+    return false
+  for item in self.dataRef.data:
+    if item == val:
+      return true
+  return false
+
+proc find*[T](self: CowSeq[T], val: T): int =
+  if self.dataRef.isNil:
+    return -1
+  for i, item in self.dataRef.data:
+    if item == val:
+      return i
+  return -1
+
+proc `$`*[T](self: CowSeq[T]): string =
+  if self.dataRef.isNil:
+    return "@[]"
+  result = "@["
+  for i, item in self:
+    if i > 0:
+      result.add(", ")
+    result.add($item)
+  result.add("]")
+
+#
+# Debug helpers (test-only - guarded so production callers cannot branch on them)
+#
+
+when defined(testing) or defined(QT_MODEL_SPY):
+  proc getRefCount*[T](self: CowSeq[T]): int =
+    if self.dataRef.isNil: 0
+    else: self.dataRef.refCount
+
+  proc isShared*[T](self: CowSeq[T]): bool =
+    if self.dataRef.isNil: false
+    else: self.dataRef.refCount > 1

--- a/src/app/core/signals/signal_type_scan.nim
+++ b/src/app/core/signals/signal_type_scan.nim
@@ -12,7 +12,7 @@
 import std/strutils
 import ./remote_signals/signal_type
 
-const kTypeToken = "\"type\":\""
+const TYPE_TOKEN = "\"type\":\""
 
 # Signal processing runs single-threaded on the Qt main thread, so a plain
 # module-level counter is sufficient (no threadvar / lock needed).
@@ -24,10 +24,10 @@ proc extractSignalType*(rawSignal: string): string =
   ## signal.Envelope), so the first occurrence is the envelope's, never a nested
   ## one. Signal type strings are plain identifiers (no JSON escapes). Returns
   ## "" when no type member is present.
-  let key = rawSignal.find(kTypeToken)
+  let key = rawSignal.find(TYPE_TOKEN)
   if key < 0:
     return ""
-  let start = key + kTypeToken.len
+  let start = key + TYPE_TOKEN.len
   let stop = rawSignal.find('"', start)
   if stop < 0:
     return ""

--- a/src/app/core/signals/signal_type_scan.nim
+++ b/src/app/core/signals/signal_type_scan.nim
@@ -1,0 +1,54 @@
+## Cheap signal-type triage for the signals manager.
+##
+## status-go delivers every backend event as an envelope string
+## `{"type":"<t>","event":{...}}`. A large payload of an unhandled type (e.g. a
+## ~222KB local-notifications event) would otherwise be fully JSON-decoded on the
+## Qt main thread only to be thrown away once nobody is found to handle the type.
+##
+## This module extracts the envelope type with a substring scan (no JSON parse)
+## and checks it against the known `SignalType` set. Only known types are worth a
+## full decode; unknown/unhandled ones are counted and dropped untouched.
+
+import std/strutils
+import ./remote_signals/signal_type
+
+const kTypeToken = "\"type\":\""
+
+# Signal processing runs single-threaded on the Qt main thread, so a plain
+# module-level counter is sufficient (no threadvar / lock needed).
+var gUnhandledSignalCount = 0
+
+proc extractSignalType*(rawSignal: string): string =
+  ## Extract the envelope's top-level `"type"` value by substring scan, without
+  ## building a JsonNode. status-go marshals `Type` before `Event` (see
+  ## signal.Envelope), so the first occurrence is the envelope's, never a nested
+  ## one. Signal type strings are plain identifiers (no JSON escapes). Returns
+  ## "" when no type member is present.
+  let key = rawSignal.find(kTypeToken)
+  if key < 0:
+    return ""
+  let start = key + kTypeToken.len
+  let stop = rawSignal.find('"', start)
+  if stop < 0:
+    return ""
+  rawSignal[start ..< stop]
+
+proc isKnownSignalType*(signalType: string): bool =
+  ## True when the type string maps to a `SignalType` enum member, i.e. a type
+  ## the desktop knows how to decode/dispatch.
+  if signalType.len == 0:
+    return false
+  try:
+    discard parseEnum[SignalType](signalType)
+    true
+  except CatchableError:
+    false
+
+proc noteUnhandledSignal*() =
+  ## Record that one signal was dropped without decoding (observability +
+  ## test seam).
+  inc gUnhandledSignalCount
+
+proc unhandledSignalCount*(): int = gUnhandledSignalCount
+
+proc resetUnhandledSignalCount*() = gUnhandledSignalCount = 0

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -1,5 +1,6 @@
 import nimqml, json, strutils, chronicles
 import ../eventemitter
+import ./signal_type_scan
 
 include types
 
@@ -26,7 +27,16 @@ QtObject:
     result.setup()
     result.events = events
 
-  proc processSignal(self: SignalsManager, statusSignal: string) =
+  proc processSignal*(self: SignalsManager, statusSignal: string) =
+    # Cheap triage before any JSON parsing: extract the envelope type
+    # by substring scan and drop payloads of types the desktop does not handle,
+    # so a large unhandled event is never fully decoded on the Qt main thread.
+    let signalType = extractSignalType(statusSignal)
+    if not isKnownSignalType(signalType):
+      noteUnhandledSignal()
+      debug "Skipping unhandled signal type", signalType, bytes = statusSignal.len
+      return
+
     var jsonSignal: JsonNode
     try:
       jsonSignal = statusSignal.parseJson

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -31,8 +31,11 @@ QtObject:
     # Cheap triage before any JSON parsing: extract the envelope type
     # by substring scan and drop payloads of types the desktop does not handle,
     # so a large unhandled event is never fully decoded on the Qt main thread.
+    # Only a positively-identified unhandled type is dropped; a scan miss
+    # (empty result, e.g. the marshaling format changed) falls through to the
+    # full-parse path below so handled signals are never silently lost.
     let signalType = extractSignalType(statusSignal)
-    if not isKnownSignalType(signalType):
+    if signalType.len > 0 and not isKnownSignalType(signalType):
       noteUnhandledSignal()
       debug "Skipping unhandled signal type", signalType, bytes = statusSignal.len
       return

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -29,7 +29,7 @@ QtObject:
 
   proc processSignal*(self: SignalsManager, statusSignal: string) =
     # Cheap triage before any JSON parsing: extract the envelope type
-    # by substring scan and drop payloads of types the desktop does not handle,
+    # by substring scan and drop payloads of types the app does not handle,
     # so a large unhandled event is never fully decoded on the Qt main thread.
     # Only a positively-identified unhandled type is dropped; a scan miss
     # (empty result, e.g. the marshaling format changed) falls through to the

--- a/src/app/core/tasks/qt.nim
+++ b/src/app/core/tasks/qt.nim
@@ -1,11 +1,16 @@
 import # vendor libs
   nimqml, json_serialization
 
+import std/strutils
+
 import app/core/signal_handler
 
 import # status-desktop libs
   ./common,
+  ./typed_handoff,
   app/global/app_lifecycle
+
+export typed_handoff.TaskHandle, typed_handoff.drainHandoffs
 
 type
   QObjectTaskArg* = ref object of TaskArg
@@ -19,3 +24,27 @@ proc finish*[T](arg: QObjectTaskArg, payload: T) =
 proc finish*(arg: QObjectTaskArg, payload: string) =
   if isShuttingDown(): return
   signal_handler(cast[pointer](arg.vptr), cstring(payload), cstring(arg.slot))
+
+proc finishTyped*[T](arg: QObjectTaskArg, payload: sink T) =
+  ## Opt-in typed completion path — the companion to `finish`.
+  ## The worker hands the GUI thread a fully-built, EXCLUSIVELY-OWNED object graph
+  ## (`T` must be a `ref object of RootObj`) with no JSON serialize/re-parse round
+  ## trip. Only a small integer handle crosses the queued-invoke bridge; the heavy
+  ## graph is parked in the `typed_handoff` registry.
+  ##
+  ## Ownership: `payload` must be isolated — the sole reference at the call site.
+  ## After this call the worker MUST NOT touch it. The receiving slot claims it via
+  ## `takeTyped[T](response)`; the object is then destroyed on the GUI thread. On
+  ## shutdown the object is destroyed here on the worker thread (still exclusively
+  ## owned — safe) and no slot is invoked; a handoff already parked when shutdown
+  ## races in is swept by `drainHandoffs` at task-infra teardown.
+  if isShuttingDown(): return
+  let handle = parkHandoff(payload)
+  signal_handler(cast[pointer](arg.vptr), cstring($handle), cstring(arg.slot))
+
+proc takeTyped*[T](response: string): T =
+  ## Claim the object delivered by `finishTyped`. Call from the completion slot,
+  ## passing the slot's string argument. Transfers exclusive ownership to the GUI
+  ## thread. Returns nil if the handoff was drained (shutdown) before the slot ran.
+  let handle = parseBiggestUInt(response).TaskHandle
+  claimHandoff[T](handle)

--- a/src/app/core/tasks/qt.nim
+++ b/src/app/core/tasks/qt.nim
@@ -45,6 +45,11 @@ proc finishTyped*[T](arg: QObjectTaskArg, payload: sink T) =
 proc takeTyped*[T](response: string): T =
   ## Claim the object delivered by `finishTyped`. Call from the completion slot,
   ## passing the slot's string argument. Transfers exclusive ownership to the GUI
-  ## thread. Returns nil if the handoff was drained (shutdown) before the slot ran.
-  let handle = parseBiggestUInt(response).TaskHandle
+  ## thread. Returns nil if the handoff was drained (shutdown) before the slot
+  ## ran, or if `response` is not a valid handle — never raises.
+  var handle: TaskHandle
+  try:
+    handle = parseBiggestUInt(response).TaskHandle
+  except ValueError:
+    return nil
   claimHandoff[T](handle)

--- a/src/app/core/tasks/threadpool.nim
+++ b/src/app/core/tasks/threadpool.nim
@@ -1,5 +1,5 @@
 import # status-desktop libs
-  ./common, app/global/feature_flags
+  ./common, ./typed_handoff, app/global/feature_flags
 
 featureGuard THREADPOOL_ENABLED:
   import # std libs
@@ -37,6 +37,10 @@ proc teardown*(self: ThreadPool) =
   featureGuard THREADPOOL_ENABLED:
     self.pool.syncAll()
     self.pool.shutdown()
+  # Sweep any typed completions parked by workers whose GUI slot never ran (loop
+  # stopped mid-flight). All workers are quiesced by this point, so no producer
+  # can race the drain. Destroys them on the shutdown thread — see typed_handoff.
+  drainHandoffs()
 
 proc newThreadPool*(): ThreadPool =
   new(result)

--- a/src/app/core/tasks/typed_handoff.nim
+++ b/src/app/core/tasks/typed_handoff.nim
@@ -74,14 +74,15 @@ proc parkHandoff*[T](obj: sink T): TaskHandle {.gcsafe.} =
 proc claimHandoff*[T](handle: TaskHandle): T {.gcsafe.} =
   ## Retrieve and remove the object for `handle`, transferring exclusive
   ## ownership to the caller. Returns nil if the handle is unknown (already
-  ## claimed, or drained at shutdown before the slot ran).
+  ## claimed, or drained at shutdown before the slot ran) or if the parked
+  ## object is not a `T` — never raises; a mismatched claim destroys the object.
   var base: RootRef
   {.cast(gcsafe).}:
     withLock gLock:
       discard gTable.pop(handle, base)   # move out; entry removed
-  if base.isNil:
+  if base.isNil or not (base of T):
     return nil
-  result = T(base)                     # checked ref down-conversion
+  result = T(base)                     # down-conversion, guarded above
 
 proc drainHandoffs*() {.gcsafe.} =
   ## Destroy every still-parked object. Call on shutdown (from the thread that

--- a/src/app/core/tasks/typed_handoff.nim
+++ b/src/app/core/tasks/typed_handoff.nim
@@ -13,7 +13,7 @@
 ##   exclusive ownership to the calling (receiving) thread; the object is
 ##   destroyed on the receiving thread when the returned ref goes out of scope.
 ##
-## Why this is safe under ORC (and refc):
+## Why this is safe under ORC/ARC (shared heap):
 ##   The object is only ever reachable from one place at a time — the producer's
 ##   local before `parkHandoff`, the registry table in between, the consumer's
 ##   local after `claimHandoff`. No two threads ever hold a reference at once, so

--- a/src/app/core/tasks/typed_handoff.nim
+++ b/src/app/core/tasks/typed_handoff.nim
@@ -1,0 +1,97 @@
+## Typed task-completion handoff registry.
+##
+## Companion to the string-based `finish` path (see `qt.nim`): instead of
+## serializing a worker-built result to JSON and re-parsing it on the GUI thread,
+## the worker parks the *finished object graph* here and delivers only a tiny
+## integer handle through the existing queued-invoke bridge. The GUI slot claims
+## the graph back by handle — no multi-MB string ever crosses the boundary.
+##
+## OWNERSHIP RULE (read before use):
+##   `parkHandoff` takes EXCLUSIVE ownership of `obj`. The object must be isolated
+##   at the call site — the producing thread must hold the *only* reference and
+##   MUST NOT touch it again after parking. `claimHandoff` transfers that
+##   exclusive ownership to the calling (receiving) thread; the object is
+##   destroyed on the receiving thread when the returned ref goes out of scope.
+##
+## Why this is safe under ORC (and refc):
+##   The object is only ever reachable from one place at a time — the producer's
+##   local before `parkHandoff`, the registry table in between, the consumer's
+##   local after `claimHandoff`. No two threads ever hold a reference at once, so
+##   its (non-atomic) refcount is never mutated concurrently. The lock around the
+##   table gives the producer's `park` a happens-before edge to the consumer's
+##   `claim`, so the stored bytes and the object's fields are visible to the
+##   consumer thread. Payloads are moved in and out (`sink` / `pop`), so the
+##   refcount stays 1 throughout and the graph is destroyed exactly once.
+##
+## Shutdown: any handoff whose slot never runs (GUI loop stopped mid-flight)
+## stays parked. `drainHandoffs` destroys all such stragglers; call it from the
+## task-infra teardown so nothing leaks at shutdown.
+
+import std/[locks, tables]
+
+# This registry transfers a ref graph BETWEEN threads (a worker parks; the GUI
+# thread claims). That is sound only on a shared heap — ORC/ARC. Under refc each
+# thread has its own GC heap, so claiming a worker-allocated graph on another
+# thread reads foreign-heap memory and SIGSEGVs (observed in claimHandoff ->
+# tables.pop). Turn that runtime footgun into a BUILD error for the real app build.
+#
+# The guard keys on `-d:useMalloc`, which BOTH app builds set (desktop Makefile and
+# mobile buildNimStatusClient.sh) and the nim-test suite does not. That is
+# deliberate: the danger is the cross-thread transfer, which only the threaded app
+# exercises; the unit tests use the registry single-threaded (safe on any mm) and
+# must keep compiling under the suite's refc. So: error only when a production
+# (useMalloc) build picks a non-orc/arc mm — e.g. someone flips `--mm:orc` to refc.
+when defined(useMalloc) and not (defined(gcOrc) or defined(gcArc)):
+  {.error: "app/core/tasks/typed_handoff requires --mm:orc (or --mm:arc): it moves a ref graph across threads, unsound on refc's thread-local GC heaps. (Guarded on -d:useMalloc so it fires on the app build, not the refc unit-test suite.)".}
+
+type TaskHandle* = uint64
+
+var
+  gLock: Lock
+  gNextHandle: uint64
+  gTable {.guard: gLock.}: Table[TaskHandle, RootRef]
+
+gLock.initLock()
+
+# gcsafe is asserted on the registry procs: `gTable` is a GC'd global, which the
+# compiler flags as unsafe to touch from a threaded (gcsafe) context — but the
+# producer (a threadpool worker calling finishTyped -> parkHandoff) needs exactly
+# that. It is genuinely safe here: `gLock` serializes ALL access so no two threads
+# ever touch the table or an entry's refcount concurrently, and under --mm:orc the
+# shared-heap allocator the table grows into is itself thread-safe. The compiler
+# cannot see the lock, so we assert what the lock guarantees.
+
+proc parkHandoff*[T](obj: sink T): TaskHandle {.gcsafe.} =
+  ## Park an isolated object graph, returning a handle to deliver out-of-band.
+  ## Transfers exclusive ownership into the registry. `T` must be a
+  ## `ref object of RootObj` so it can be reclaimed via `claimHandoff[T]`.
+  {.cast(gcsafe).}:                 # gTable access is lock-serialized (see note above)
+    withLock gLock:
+      inc gNextHandle
+      result = gNextHandle
+      gTable[result] = obj          # move: table becomes the sole owner
+
+proc claimHandoff*[T](handle: TaskHandle): T {.gcsafe.} =
+  ## Retrieve and remove the object for `handle`, transferring exclusive
+  ## ownership to the caller. Returns nil if the handle is unknown (already
+  ## claimed, or drained at shutdown before the slot ran).
+  var base: RootRef
+  {.cast(gcsafe).}:
+    withLock gLock:
+      discard gTable.pop(handle, base)   # move out; entry removed
+  if base.isNil:
+    return nil
+  result = T(base)                     # checked ref down-conversion
+
+proc drainHandoffs*() {.gcsafe.} =
+  ## Destroy every still-parked object. Call on shutdown (from the thread that
+  ## owns the receiving event loop) so in-flight handoffs don't leak.
+  {.cast(gcsafe).}:
+    withLock gLock:
+      gTable.clear()
+
+proc pendingHandoffs*(): int {.gcsafe.} =
+  ## Number of parked-but-unclaimed handoffs. Diagnostics / tests only.
+  {.cast(gcsafe).}:
+    withLock gLock:
+      result = gTable.len

--- a/src/app/modules/shared/model_sync.nim
+++ b/src/app/modules/shared/model_sync.nim
@@ -1,0 +1,649 @@
+# Model Synchronization Utilities
+#
+# Efficient utilities for synchronizing Qt models with new data without a
+# full model reset. Calculates a minimal diff and applies granular updates
+# (insertRows / removeRows / dataChanged).
+#
+# ----------------------------------------------------------------------------
+# Quick start (Pattern 1 - simple model owning its own data)
+# ----------------------------------------------------------------------------
+#
+#   proc setItems*(self: MyModel, newItems: seq[MyItem]) =
+#     setItemsWithSync(
+#       self,
+#       self.items,
+#       newItems,
+#       getId = proc(it: MyItem): string = it.id,
+#       getRoles = proc(o, n: MyItem): seq[int] =
+#         var roles: seq[int]
+#         if o.name != n.name: roles.add(ModelRole.Name.int)
+#         return roles,
+#       countChanged = proc() = self.countChanged(),
+#     )
+#
+# `self.items` is a plain `seq[T]` field on the model. applySync mutates it in
+# lockstep with the begin*/end* signals it emits, so `rowCount()` and `data()`
+# (which read from `self.items`) always see consistent state.
+#
+# ----------------------------------------------------------------------------
+# Pattern 4 (nested model with side effects on insert/update/remove)
+# ----------------------------------------------------------------------------
+#
+#   setItemsWithSync(
+#     self, self.items, snapshot,
+#     getId    = ...,
+#     getRoles = ...,
+#     onInsert = proc(idx: int, item: T) =
+#       self.children.insert(newChildModel(...), idx),
+#     onUpdate = proc(idx: int, oldItem, newItem: T) =
+#       self.children[idx].update(oldItem.subItems, newItem.subItems),
+#     onRemove = proc(idx: int) =
+#       self.children.delete(idx),
+#   )
+#
+# All three side-effect callbacks default to `nil`.
+#
+# ----------------------------------------------------------------------------
+# Operation order and index semantics
+# ----------------------------------------------------------------------------
+#
+# applySync walks operations in this order:
+#   1. removes  (descending index order, so earlier removes don't shift the
+#                indices of later ones)
+#   2. updates  (with indices adjusted for the removes that just happened)
+#   3. inserts  (in ascending newIdx order)
+#
+# Callback indices are the row's position at the moment the callback fires:
+# post-removes-pre-inserts for onUpdate, and the final position for onInsert.
+#
+# Reorder handling: items whose id exists in both lists but at non-stable
+# positions (per LIS) are emitted as remove+insert pairs. There is no Qt
+# moveRows emission - reorders degrade to remove+insert.
+
+import nimqml, tables, algorithm, sequtils, sets
+
+# Spy support for testing (only active when QT_MODEL_SPY is defined)
+when defined(QT_MODEL_SPY):
+  import qt_model_spy
+
+type
+  ItemIdentifier*[T] = proc(item: T): string {.closure.}
+  ItemComparator*[T] = proc(a, b: T): bool {.closure.}
+  RoleDetector*[T] = proc(oldItem, newItem: T): seq[int] {.closure.}
+  UpdateItemCallback*[T] = proc(existing: T, updated: T) {.closure.}
+
+  # Discriminated side-effect callbacks. Each fires at the moment the
+  # corresponding sync operation completes against the model's `items` seq.
+  OnInsertCallback*[T] = proc(idx: int, item: T) {.closure.}
+  OnUpdateCallback*[T] = proc(idx: int, oldItem, newItem: T) {.closure.}
+  OnRemoveCallback* = proc(idx: int) {.closure.}
+
+  UpdateOp*[T] = object
+    index*: int
+    item*: T
+    roles*: seq[int]
+
+  InsertOp*[T] = object
+    index*: int
+    item*: T
+
+  RemoveOp* = object
+    index*: int
+
+  MoveOp* = object
+    fromIndex*: int
+    toIndex*: int
+
+  SyncResult*[T] = object
+    toInsert*: seq[InsertOp[T]]
+    toRemove*: seq[RemoveOp]
+    toUpdate*: seq[UpdateOp[T]]
+    toMove*: seq[MoveOp]
+    hasChanges*: bool
+
+proc longestIncreasingSubseqIndices(values: openArray[int]): HashSet[int] =
+  ## Returns the SET of indices into `values` that participate in the longest
+  ## strictly-increasing subsequence. Standard O(n log n) patience sort with
+  ## parent pointers.
+  result = initHashSet[int]()
+  if values.len == 0:
+    return
+
+  var tails: seq[int] = @[]   # tails[i] = index into values for the smallest tail of an LIS of length i+1
+  var prev = newSeq[int](values.len)
+  for i in 0..<values.len:
+    prev[i] = -1
+
+  for i, x in values:
+    var lo = 0
+    var hi = tails.len
+    while lo < hi:
+      let mid = (lo + hi) div 2
+      if values[tails[mid]] < x: lo = mid + 1
+      else: hi = mid
+    if lo > 0:
+      prev[i] = tails[lo - 1]
+    if lo == tails.len:
+      tails.add(i)
+    else:
+      tails[lo] = i
+
+  if tails.len == 0:
+    return
+  var k = tails[tails.high]
+  while k != -1:
+    result.incl(k)
+    k = prev[k]
+
+proc syncModel*[T](
+  oldItems: openArray[T],
+  newItems: openArray[T],
+  getId: ItemIdentifier[T],
+  getRoles: RoleDetector[T] = nil
+): SyncResult[T] =
+  ## Computes the minimal set of operations needed to transform `oldItems`
+  ## into `newItems`.
+  ##
+  ## Reorderings are detected via LIS over the items present in both lists:
+  ## items participating in the LIS keep their position (emitted as updates
+  ## only); items outside the LIS are emitted as remove+insert pairs. This
+  ## handles pure inserts, pure removes, and arbitrary mixed orderings without
+  ## false positives.
+  ##
+  ## Complexity: O((n + m) log m) where n = oldItems.len, m = items present in
+  ## both lists. In the steady state (no reorders) the LIS covers everything
+  ## and it degrades to O(n).
+
+  result.hasChanges = false
+
+  if oldItems.len == 0 and newItems.len == 0:
+    return
+
+  if oldItems.len == 0:
+    for i, item in newItems:
+      result.toInsert.add(InsertOp[T](index: i, item: item))
+    result.hasChanges = true
+    return
+
+  if newItems.len == 0:
+    for i in countdown(oldItems.high, 0):
+      result.toRemove.add(RemoveOp(index: i))
+    result.hasChanges = true
+    return
+
+  # O(1) id lookup for old items.
+  var oldMap = initTable[string, int]()
+  for i, item in oldItems:
+    oldMap[getId(item)] = i
+
+  # Build the "common" sequence: pairs (oldIdx, newIdx) for ids present in both
+  # lists, walked in newItems order. It is sorted ascending by newIdx by
+  # construction; LIS over the oldIdx values finds which pairs can stay put.
+  type Common = tuple[oldIdx: int, newIdx: int]
+  var common: seq[Common] = @[]
+  for newIdx, newItem in newItems:
+    let id = getId(newItem)
+    if oldMap.hasKey(id):
+      common.add((oldMap[id], newIdx))
+
+  let stable = longestIncreasingSubseqIndices(common.mapIt(it.oldIdx))
+
+  var keepOld = newSeq[bool](oldItems.len)
+
+  # Phase 1: walk new items, emit updates for stable rows and inserts for the rest.
+  var commonPtr = 0
+  for newIdx, newItem in newItems:
+    let id = getId(newItem)
+    if oldMap.hasKey(id):
+      while commonPtr < common.len and common[commonPtr].newIdx < newIdx:
+        inc commonPtr
+      let isStable = commonPtr < common.len and
+                     common[commonPtr].newIdx == newIdx and
+                     commonPtr in stable
+      if isStable:
+        let oldIdx = common[commonPtr].oldIdx
+        keepOld[oldIdx] = true
+        if getRoles != nil:
+          let changedRoles = getRoles(oldItems[oldIdx], newItem)
+          if changedRoles.len > 0:
+            result.toUpdate.add(UpdateOp[T](
+              index: oldIdx,
+              item: newItem,
+              roles: changedRoles
+            ))
+            result.hasChanges = true
+      else:
+        # Reorder: insert now, the corresponding old position is removed in
+        # Phase 2 because keepOld stays false.
+        result.toInsert.add(InsertOp[T](index: newIdx, item: newItem))
+        result.hasChanges = true
+    else:
+      result.toInsert.add(InsertOp[T](index: newIdx, item: newItem))
+      result.hasChanges = true
+
+  # Phase 2: removes - everything in old that wasn't kept by the LIS.
+  # Descending order so successive removals don't invalidate earlier indices.
+  for i in countdown(oldItems.high, 0):
+    if not keepOld[i]:
+      result.toRemove.add(RemoveOp(index: i))
+      result.hasChanges = true
+
+proc groupConsecutiveRanges*(indices: seq[int]): seq[tuple[first: int, last: int]] =
+  ## Groups consecutive integers into ranges for bulk operations.
+  ## Example: [0,1,2,5,6,9] -> [(0,2), (5,6), (9,9)]
+  if indices.len == 0:
+    return @[]
+
+  var sorted = indices
+  sorted.sort()
+
+  var currentFirst = sorted[0]
+  var currentLast = sorted[0]
+
+  for i in 1..sorted.high:
+    if sorted[i] == currentLast + 1:
+      currentLast = sorted[i]
+    else:
+      result.add((currentFirst, currentLast))
+      currentFirst = sorted[i]
+      currentLast = sorted[i]
+
+  result.add((currentFirst, currentLast))
+
+proc adjustForRemoves(updates: seq[UpdateOp], removes: seq[RemoveOp]): seq[tuple[adjustedIdx: int, originalIdx: int]] =
+  ## For each update, compute its index after the (descending) removes have
+  ## been applied. O(R + U): sort updates by index ascending, walk a single
+  ## pointer through the ascending remove indices, accumulate the offset.
+  ## Precondition: `removes` is in descending order (as syncModel emits).
+  result = newSeq[tuple[adjustedIdx: int, originalIdx: int]](updates.len)
+  if updates.len == 0:
+    return
+
+  var removeIdxAsc = newSeq[int](removes.len)
+  for i, r in removes:
+    removeIdxAsc[i] = r.index
+  removeIdxAsc.sort()
+
+  type Slot = tuple[origIdx: int, slot: int]
+  var sortedSlots = newSeq[Slot](updates.len)
+  for i, u in updates:
+    sortedSlots[i] = (u.index, i)
+  sortedSlots.sort(proc(a, b: Slot): int = cmp(a.origIdx, b.origIdx))
+
+  var removePtr = 0
+  var offset = 0
+  for entry in sortedSlots:
+    while removePtr < removeIdxAsc.len and removeIdxAsc[removePtr] < entry.origIdx:
+      inc offset
+      inc removePtr
+    result[entry.slot] = (entry.origIdx - offset, entry.origIdx)
+
+proc applySync*[T](
+  model: QAbstractListModel,
+  items: var seq[T],
+  syncResult: SyncResult[T],
+  updateItem: UpdateItemCallback[T] = nil,
+  onInsert: OnInsertCallback[T] = nil,
+  onUpdate: OnUpdateCallback[T] = nil,
+  onRemove: OnRemoveCallback = nil,
+) =
+  ## Applies a SyncResult to a Qt model with proper notifications.
+  ## Order of operations: removes (descending) -> updates -> inserts.
+  ## Side-effect callbacks fire AFTER the corresponding `items` mutation and
+  ## AFTER the matching Qt signal pair, so they observe the post-op state.
+
+  if not syncResult.hasChanges:
+    return
+
+  let parentIndex = newQModelIndex()
+  defer: parentIndex.delete
+
+  # Step 1: removes (already in descending order from syncModel).
+  for removeOp in syncResult.toRemove:
+    let removedIdx = removeOp.index
+    when defined(QT_MODEL_SPY):
+      recordBeginRemoveRows(removedIdx, removedIdx)
+    model.beginRemoveRows(parentIndex, removedIdx, removedIdx)
+    items.delete(removedIdx)
+    model.endRemoveRows()
+    when defined(QT_MODEL_SPY):
+      recordEndRemoveRows()
+    if not onRemove.isNil:
+      onRemove(removedIdx)
+
+  # Step 2: updates. Adjust indices for the removes that already happened.
+  let adjusted = adjustForRemoves(syncResult.toUpdate, syncResult.toRemove)
+  for i, info in adjusted:
+    let adjustedIdx = info.adjustedIdx
+    if adjustedIdx < 0 or adjustedIdx >= items.len:
+      continue
+    let updateOp = syncResult.toUpdate[i]
+    let oldItem = items[adjustedIdx]
+
+    if updateItem != nil:
+      # Pattern 5: call setters on existing item (QObject-exposing models).
+      updateItem(items[adjustedIdx], updateOp.item)
+    else:
+      items[adjustedIdx] = updateOp.item
+      when defined(QT_MODEL_SPY):
+        recordDataChanged(adjustedIdx, adjustedIdx, updateOp.roles)
+      let modelIndex = model.createIndex(adjustedIdx, 0, nil)
+      model.dataChanged(modelIndex, modelIndex, updateOp.roles)
+      modelIndex.delete  # release immediately - defer would leak per iteration
+
+    if not onUpdate.isNil:
+      onUpdate(adjustedIdx, oldItem, items[adjustedIdx])
+
+  # Step 3: inserts (in ascending newIdx order from syncModel).
+  for insertOp in syncResult.toInsert:
+    var insertIdx = insertOp.index
+    if insertIdx < 0:
+      insertIdx = 0
+    elif insertIdx > items.len:
+      insertIdx = items.len
+
+    when defined(QT_MODEL_SPY):
+      recordBeginInsertRows(insertIdx, insertIdx)
+    model.beginInsertRows(parentIndex, insertIdx, insertIdx)
+    items.insert(insertOp.item, insertIdx)
+    model.endInsertRows()
+    when defined(QT_MODEL_SPY):
+      recordEndInsertRows()
+
+    if not onInsert.isNil:
+      onInsert(insertIdx, items[insertIdx])
+
+proc applySyncWithBulkOps*[T](
+  model: QAbstractListModel,
+  items: var seq[T],
+  syncResult: SyncResult[T],
+  updateItem: UpdateItemCallback[T] = nil,
+  onInsert: OnInsertCallback[T] = nil,
+  onUpdate: OnUpdateCallback[T] = nil,
+  onRemove: OnRemoveCallback = nil,
+) =
+  ## Optimized applySync that groups consecutive operations into bulk Qt
+  ## notifications where possible.
+
+  if not syncResult.hasChanges:
+    return
+
+  let parentIndex = newQModelIndex()
+  defer: parentIndex.delete
+
+  # Step 1: bulk removes. Remove indices come descending; group them ascending
+  # then iterate the groups in reverse so each group's removal does not
+  # invalidate earlier-indexed groups.
+  if syncResult.toRemove.len > 0:
+    let indices = syncResult.toRemove.mapIt(it.index)
+    let ranges = groupConsecutiveRanges(indices)
+
+    for i in countdown(ranges.high, 0):
+      let (first, last) = ranges[i]
+      when defined(QT_MODEL_SPY):
+        recordBeginRemoveRows(first, last)
+      model.beginRemoveRows(parentIndex, first, last)
+      for j in countdown(last, first):
+        items.delete(j)
+      model.endRemoveRows()
+      when defined(QT_MODEL_SPY):
+        recordEndRemoveRows()
+      if not onRemove.isNil:
+        for j in countdown(last, first):
+          onRemove(j)
+
+  # Step 2: bulk updates. Group consecutive updates with identical role sets
+  # into a single ranged dataChanged.
+  if syncResult.toUpdate.len > 0:
+    let adjusted = adjustForRemoves(syncResult.toUpdate, syncResult.toRemove)
+
+    type AdjustedUpdate = tuple[adjustedIdx: int, item: T, roles: seq[int]]
+    var adjustedUpdates: seq[AdjustedUpdate] = @[]
+    for i, info in adjusted:
+      if info.adjustedIdx >= 0 and info.adjustedIdx < items.len:
+        let u = syncResult.toUpdate[i]
+        adjustedUpdates.add((info.adjustedIdx, u.item, u.roles))
+
+    adjustedUpdates.sort(proc(a, b: AdjustedUpdate): int = cmp(a.adjustedIdx, b.adjustedIdx))
+
+    if updateItem != nil:
+      for u in adjustedUpdates:
+        let oldItem = items[u.adjustedIdx]
+        updateItem(items[u.adjustedIdx], u.item)
+        if not onUpdate.isNil:
+          onUpdate(u.adjustedIdx, oldItem, items[u.adjustedIdx])
+    else:
+      var i = 0
+      while i < adjustedUpdates.len:
+        let startIdx = adjustedUpdates[i].adjustedIdx
+        let roles = adjustedUpdates[i].roles
+        var endIdx = startIdx
+
+        var oldItems: seq[T] = @[items[startIdx]]
+        items[startIdx] = adjustedUpdates[i].item
+
+        var j = i + 1
+        while j < adjustedUpdates.len:
+          if adjustedUpdates[j].adjustedIdx == endIdx + 1 and
+             adjustedUpdates[j].roles == roles:
+            endIdx = adjustedUpdates[j].adjustedIdx
+            oldItems.add(items[endIdx])
+            items[endIdx] = adjustedUpdates[j].item
+            j.inc
+          else:
+            break
+
+        when defined(QT_MODEL_SPY):
+          recordDataChanged(startIdx, endIdx, roles)
+        let startModelIdx = model.createIndex(startIdx, 0, nil)
+        let endModelIdx = model.createIndex(endIdx, 0, nil)
+        model.dataChanged(startModelIdx, endModelIdx, roles)
+        startModelIdx.delete()
+        endModelIdx.delete()
+
+        if not onUpdate.isNil:
+          for k in 0 .. (endIdx - startIdx):
+            onUpdate(startIdx + k, oldItems[k], items[startIdx + k])
+
+        i = j
+
+  # Step 3: bulk inserts. Sort by index, group consecutive runs into a single
+  # beginInsertRows/endInsertRows call.
+  if syncResult.toInsert.len > 0:
+    var sortedInserts = syncResult.toInsert
+    sortedInserts.sort(proc(a, b: InsertOp[T]): int = cmp(a.index, b.index))
+
+    var i = 0
+    while i < sortedInserts.len:
+      let startIdx = sortedInserts[i].index
+      var endIdx = startIdx
+      var insertItems: seq[T] = @[sortedInserts[i].item]
+
+      var j = i + 1
+      while j < sortedInserts.len and sortedInserts[j].index == endIdx + 1:
+        endIdx = sortedInserts[j].index
+        insertItems.add(sortedInserts[j].item)
+        j.inc
+
+      var actualStartIdx = startIdx
+      if actualStartIdx < 0: actualStartIdx = 0
+      elif actualStartIdx > items.len: actualStartIdx = items.len
+
+      when defined(QT_MODEL_SPY):
+        recordBeginInsertRows(actualStartIdx, actualStartIdx + insertItems.len - 1)
+      model.beginInsertRows(parentIndex, actualStartIdx, actualStartIdx + insertItems.len - 1)
+      for k, item in insertItems:
+        items.insert(item, actualStartIdx + k)
+      model.endInsertRows()
+      when defined(QT_MODEL_SPY):
+        recordEndInsertRows()
+
+      if not onInsert.isNil:
+        for k in 0..<insertItems.len:
+          onInsert(actualStartIdx + k, items[actualStartIdx + k])
+
+      i = j
+
+proc setItemsWithSync*[T](
+  model: QAbstractListModel,
+  items: var seq[T],
+  newItems: openArray[T],
+  getId: ItemIdentifier[T],
+  getRoles: RoleDetector[T] = nil,
+  updateItem: UpdateItemCallback[T] = nil,
+  countChanged: proc() {.closure.} = nil,
+  useBulkOps: bool = false,
+  onInsert: OnInsertCallback[T] = nil,
+  onUpdate: OnUpdateCallback[T] = nil,
+  onRemove: OnRemoveCallback = nil,
+) =
+  ## Drop-in replacement for the begin/endResetModel pattern. See the file
+  ## header for usage.
+  ##
+  ## Pattern 5 (QObject-exposing models): pass `updateItem` to call setters on
+  ## the existing item; no dataChanged is emitted.
+  ##
+  ## Pattern 1-4 (multiple roles or value types): pass `getRoles` for ranged
+  ## dataChanged emissions.
+  ##
+  ## Pattern 4 (nested models): pass `onInsert` / `onUpdate` / `onRemove` to
+  ## keep a sibling `seq[NestedModel]` in sync with `items`.
+
+  # Debug/test contract: input keys must be unique (repo `key` convention). A
+  # duplicate would make the diff's id->index map last-wins and emit a spurious
+  # insert/remove for the shadowed row. Runs in debug app builds and in the
+  # spy-instrumented test/bench builds (which are -d:release); compiled out of
+  # shipping release builds.
+  when defined(QT_MODEL_SPY) or not defined(release):
+    if getId != nil:
+      var seenKeys = initHashSet[string]()
+      for it in newItems:
+        let k = getId(it)
+        doAssert not seenKeys.containsOrIncl(k),
+          "setItemsWithSync: duplicate key in newItems: " & k
+
+  # Fast path: first load (empty -> N). The diff pipeline deep-copies every T
+  # several times as it walks; bulk-load via beginResetModel instead.
+  if items.len == 0 and newItems.len > 0:
+    let parentIndex = newQModelIndex()
+    defer: parentIndex.delete
+    when defined(QT_MODEL_SPY):
+      recordBeginResetModel()
+    model.beginResetModel()
+    items = @newItems
+    model.endResetModel()
+    when defined(QT_MODEL_SPY):
+      recordEndResetModel()
+    if not onInsert.isNil:
+      for i in 0 ..< items.len:
+        onInsert(i, items[i])
+    if countChanged != nil:
+      countChanged()
+    return
+
+  # Fast path: full clear (N -> empty).
+  if items.len > 0 and newItems.len == 0:
+    let parentIndex = newQModelIndex()
+    defer: parentIndex.delete
+    when defined(QT_MODEL_SPY):
+      recordBeginResetModel()
+    model.beginResetModel()
+    let oldLen = items.len
+    items.setLen(0)
+    model.endResetModel()
+    when defined(QT_MODEL_SPY):
+      recordEndResetModel()
+    if not onRemove.isNil:
+      for i in countdown(oldLen - 1, 0):
+        onRemove(i)
+    if countChanged != nil:
+      countChanged()
+    return
+
+  let syncResult = syncModel(items, newItems, getId, getRoles)
+
+  if syncResult.hasChanges:
+    if useBulkOps:
+      model.applySyncWithBulkOps(items, syncResult, updateItem, onInsert, onUpdate, onRemove)
+    else:
+      model.applySync(items, syncResult, updateItem, onInsert, onUpdate, onRemove)
+
+    if countChanged != nil and (syncResult.toInsert.len > 0 or syncResult.toRemove.len > 0):
+      countChanged()
+
+# ----------------------------------------------------------------------------
+# v3 unified API
+# ----------------------------------------------------------------------------
+#
+# `modelSync` collapses the four-closure `setItemsWithSync` call into a one-liner.
+# Consumers define two overloads near their item type; `modelSync` resolves them
+# at instantiation via `mixin`, the same way `hash`/`==`/`$` are picked up:
+#
+#   proc syncKey(it: MyItem): string = it.key              # row identity
+#   proc syncRoles(o, n: MyItem): seq[int] = ...           # changed role ints
+#
+# then the whole sync at the call site is:
+#
+#   self.modelSync(self.items, newItems)
+#
+# The model's `countChanged()` signal is emitted automatically when the model
+# type declares one. The bulk-ops path (grouped inserts/removes, ranged
+# dataChanged) and the QT_MODEL_SPY instrumentation are always used.
+
+proc modelSync*[M: QAbstractListModel, T](
+    model: M, container: var seq[T], newItems: sink seq[T]) =
+  ## Unified granular sync. `container` becomes the new state in lockstep with the
+  ## begin/end signals `modelSync` emits; `newItems` is moved in, not copied.
+  ## Requires `syncKey(T): string` in scope; `syncRoles(T, T): seq[int]` optional
+  ## (omit for identity-only rows). Emits `model.countChanged()` if it exists.
+  mixin syncKey, syncRoles, countChanged
+  # DX guard: surface the missing-overload requirement at the CALLER's instantiation
+  # instead of failing deep inside the getId closure with a bare "undeclared
+  # identifier: 'syncKey'". Fires per-instantiation on the offending T.
+  when not compiles(syncKey(newItems[0])):
+    {.error: "modelSync requires `proc syncKey(it: T): string` declared before this call " &
+      "(and optional `proc syncRoles(o, n: T): seq[int]`) near the item type T — see the " &
+      "model_sync.nim v3 header.".}
+  let getId = proc(it: T): string = syncKey(it)
+  var getRoles: RoleDetector[T] = nil
+  when compiles(syncRoles(newItems[0], newItems[0])):
+    getRoles = proc(o, n: T): seq[int] = syncRoles(o, n)
+  var cc: proc() {.closure.} = nil
+  when compiles(model.countChanged()):
+    cc = proc() = model.countChanged()
+  setItemsWithSync(
+    model.QAbstractListModel, container, newItems,
+    getId = getId,
+    getRoles = getRoles,
+    countChanged = cc,
+    useBulkOps = true)
+
+proc reconcileByKey*[T, C](
+    table: var Table[string, C],
+    items: openArray[T],
+    create: proc(it: T): C {.closure.},
+    update: proc(existing: C, it: T) {.closure.} = nil) =
+  ## Rebuilds `table` to exactly the keys of `items` (via `syncKey`), preserving
+  ## the existing `C` for a surviving key (calling `update` if given) and building
+  ## a fresh one otherwise. Dropped keys fall away with the old table. Run this
+  ## BEFORE `modelSync` so a newly inserted row's `data()` already sees its child.
+  mixin syncKey
+  var updated = initTable[string, C]()
+  for it in items:
+    let k = syncKey(it)
+    if table.hasKey(k):
+      let existing = table[k]
+      if update != nil:
+        update(existing, it)
+      updated[k] = existing
+    else:
+      updated[k] = create(it)
+  table = updated
+
+# Export main types and procs
+export ItemIdentifier, ItemComparator, RoleDetector
+export OnInsertCallback, OnUpdateCallback, OnRemoveCallback
+export UpdateOp, InsertOp, RemoveOp, MoveOp, SyncResult
+export syncModel, applySync, applySyncWithBulkOps, setItemsWithSync
+export groupConsecutiveRanges
+export modelSync, reconcileByKey

--- a/src/app/modules/shared/model_sync.nim
+++ b/src/app/modules/shared/model_sync.nim
@@ -24,8 +24,10 @@
 #
 # `self.items` is the model's own `seq[MyItem]` backing field; `modelSync` mutates
 # it in lockstep with the begin*/end* signals it emits, so `rowCount()` / `data()`
-# always read consistent state. `newItems` is moved in, not copied. The model's
-# `countChanged()` fires automatically when the type declares one. Omitting
+# always read consistent state. `newItems` is consumed (sink) — the caller must
+# not reuse it after the call; its rows are copied into `container` as the diff
+# inserts them. The model's `countChanged()` fires automatically when the type
+# declares one. Omitting
 # `syncRoles` syncs the row SET only (insert/remove, no dataChanged).
 #
 # Nested / keyed child models (a per-row sub-model or QObject):
@@ -578,7 +580,8 @@ proc setItemsWithSync*[T](
 proc modelSync*[M: QAbstractListModel, T](
     model: M, container: var seq[T], newItems: sink seq[T]) =
   ## Unified granular sync. `container` becomes the new state in lockstep with the
-  ## begin/end signals `modelSync` emits; `newItems` is moved in, not copied.
+  ## begin/end signals `modelSync` emits; `newItems` is consumed (sink) — the caller
+  ## must not reuse it after the call; rows are copied into `container` as needed.
   ## Requires `syncKey(T): string` in scope; `syncRoles(T, T): seq[int]` optional
   ## (omit for identity-only rows). Emits `model.countChanged()` if it exists.
   mixin syncKey, syncRoles, countChanged

--- a/src/app/modules/shared/model_sync.nim
+++ b/src/app/modules/shared/model_sync.nim
@@ -68,7 +68,6 @@ when defined(QT_MODEL_SPY):
 
 type
   ItemIdentifier*[T] = proc(item: T): string {.closure.}
-  ItemComparator*[T] = proc(a, b: T): bool {.closure.}
   RoleDetector*[T] = proc(oldItem, newItem: T): seq[int] {.closure.}
   UpdateItemCallback*[T] = proc(existing: T, updated: T) {.closure.}
 
@@ -90,15 +89,10 @@ type
   RemoveOp* = object
     index*: int
 
-  MoveOp* = object
-    fromIndex*: int
-    toIndex*: int
-
   SyncResult*[T] = object
     toInsert*: seq[InsertOp[T]]
     toRemove*: seq[RemoveOp]
     toUpdate*: seq[UpdateOp[T]]
-    toMove*: seq[MoveOp]
     hasChanges*: bool
 
 proc longestIncreasingSubseqIndices(values: openArray[int]): HashSet[int] =
@@ -641,9 +635,9 @@ proc reconcileByKey*[T, C](
   table = updated
 
 # Export main types and procs
-export ItemIdentifier, ItemComparator, RoleDetector
+export ItemIdentifier, RoleDetector
 export OnInsertCallback, OnUpdateCallback, OnRemoveCallback
-export UpdateOp, InsertOp, RemoveOp, MoveOp, SyncResult
+export UpdateOp, InsertOp, RemoveOp, SyncResult
 export syncModel, applySync, applySyncWithBulkOps, setItemsWithSync
 export groupConsecutiveRanges
 export modelSync, reconcileByKey

--- a/src/app/modules/shared/model_sync.nim
+++ b/src/app/modules/shared/model_sync.nim
@@ -5,60 +5,67 @@
 # (insertRows / removeRows / dataChanged).
 #
 # ----------------------------------------------------------------------------
-# Quick start (Pattern 1 - simple model owning its own data)
+# Public API — this is all a consumer needs
 # ----------------------------------------------------------------------------
 #
-#   proc setItems*(self: MyModel, newItems: seq[MyItem]) =
-#     setItemsWithSync(
-#       self,
-#       self.items,
-#       newItems,
-#       getId = proc(it: MyItem): string = it.id,
-#       getRoles = proc(o, n: MyItem): seq[int] =
-#         var roles: seq[int]
-#         if o.name != n.name: roles.add(ModelRole.Name.int)
-#         return roles,
-#       countChanged = proc() = self.countChanged(),
-#     )
+#   modelSync(model, container, newItems)          -- granular sync, one-liner
+#   reconcileByKey(table, items, create, update)   -- keyed nested child models
 #
-# `self.items` is a plain `seq[T]` field on the model. applySync mutates it in
-# lockstep with the begin*/end* signals it emits, so `rowCount()` and `data()`
-# (which read from `self.items`) always see consistent state.
+# `modelSync` collapses the whole sync into a single call. Declare two overloads
+# next to your item type; `modelSync` picks them up at instantiation via `mixin`,
+# the same way `hash` / `==` / `$` are resolved:
 #
-# ----------------------------------------------------------------------------
-# Pattern 4 (nested model with side effects on insert/update/remove)
-# ----------------------------------------------------------------------------
+#   proc syncKey(it: MyItem): string = it.key        # row identity (required)
+#   proc syncRoles(o, n: MyItem): seq[int] = ...      # changed role ints (optional)
 #
-#   setItemsWithSync(
-#     self, self.items, snapshot,
-#     getId    = ...,
-#     getRoles = ...,
-#     onInsert = proc(idx: int, item: T) =
-#       self.children.insert(newChildModel(...), idx),
-#     onUpdate = proc(idx: int, oldItem, newItem: T) =
-#       self.children[idx].update(oldItem.subItems, newItem.subItems),
-#     onRemove = proc(idx: int) =
-#       self.children.delete(idx),
-#   )
+# then, wherever the model receives fresh data:
 #
-# All three side-effect callbacks default to `nil`.
+#   self.modelSync(self.items, newItems)
+#
+# `self.items` is the model's own `seq[MyItem]` backing field; `modelSync` mutates
+# it in lockstep with the begin*/end* signals it emits, so `rowCount()` / `data()`
+# always read consistent state. `newItems` is moved in, not copied. The model's
+# `countChanged()` fires automatically when the type declares one. Omitting
+# `syncRoles` syncs the row SET only (insert/remove, no dataChanged).
+#
+# Nested / keyed child models (a per-row sub-model or QObject):
+#
+#   reconcileByKey(self.childrenByKey, newItems,
+#     create = proc(it: MyItem): ChildModel = newChildModel(it),
+#     update = proc(c: ChildModel, it: MyItem) = c.update(it))
+#   self.modelSync(self.items, newItems)
+#
+# Run `reconcileByKey` BEFORE `modelSync` so a freshly inserted row's `data()`
+# already sees its child. It keeps the `C` for a surviving key and drops removed
+# keys — this replaces the older per-row onInsert/onUpdate/onRemove callbacks.
 #
 # ----------------------------------------------------------------------------
 # Operation order and index semantics
 # ----------------------------------------------------------------------------
 #
-# applySync walks operations in this order:
+# The apply pass walks operations in this order:
 #   1. removes  (descending index order, so earlier removes don't shift the
 #                indices of later ones)
 #   2. updates  (with indices adjusted for the removes that just happened)
 #   3. inserts  (in ascending newIdx order)
 #
-# Callback indices are the row's position at the moment the callback fires:
-# post-removes-pre-inserts for onUpdate, and the final position for onInsert.
-#
 # Reorder handling: items whose id exists in both lists but at non-stable
 # positions (per LIS) are emitted as remove+insert pairs. There is no Qt
-# moveRows emission - reorders degrade to remove+insert.
+# moveRows emission.
+#
+# Whole-list fast paths: first load (empty -> N) and full clear (N -> empty) use
+# beginResetModel/endResetModel instead of walking the diff. (An append onto a
+# non-empty model runs the normal diff — there is no dedicated append fast path.)
+#
+# ----------------------------------------------------------------------------
+# Internals (exported for unit tests, NOT part of the consumer surface)
+# ----------------------------------------------------------------------------
+#
+# `setItemsWithSync` (the explicit-closure form `modelSync` delegates to),
+# `syncModel` (pure diff -> SyncResult), `applySync` / `applySyncWithBulkOps`
+# (the apply passes) and `groupConsecutiveRanges` are lower-level building blocks.
+# They carry the granular test coverage; new consumers should reach for
+# `modelSync` / `reconcileByKey` above, never these directly.
 
 import nimqml, tables, algorithm, sequtils, sets
 
@@ -491,17 +498,15 @@ proc setItemsWithSync*[T](
   onUpdate: OnUpdateCallback[T] = nil,
   onRemove: OnRemoveCallback = nil,
 ) =
-  ## Drop-in replacement for the begin/endResetModel pattern. See the file
-  ## header for usage.
-  ##
-  ## Pattern 5 (QObject-exposing models): pass `updateItem` to call setters on
-  ## the existing item; no dataChanged is emitted.
-  ##
-  ## Pattern 1-4 (multiple roles or value types): pass `getRoles` for ranged
-  ## dataChanged emissions.
-  ##
-  ## Pattern 4 (nested models): pass `onInsert` / `onUpdate` / `onRemove` to
-  ## keep a sibling `seq[NestedModel]` in sync with `items`.
+  ## Lower-level, explicit-closure form of the sync (a drop-in replacement for
+  ## the begin/endResetModel pattern). Prefer `modelSync` — see the file header;
+  ## this is the proc `modelSync` delegates to, kept exported for the unit tests
+  ## and for the rare model that needs a closure `modelSync` doesn't expose:
+  ##   - `updateItem`: for QObject-exposing rows, call setters on the existing
+  ##     item instead of emitting dataChanged.
+  ##   - `getRoles`: emit ranged dataChanged for the changed roles.
+  ##   - `onInsert` / `onUpdate` / `onRemove`: keep a sibling `seq[NestedModel]`
+  ##     in sync with `items` (the v3 API uses `reconcileByKey` for this instead).
 
   # Debug/test contract: input keys must be unique (repo `key` convention). A
   # duplicate would make the diff's id->index map last-wins and emit a spurious
@@ -565,24 +570,10 @@ proc setItemsWithSync*[T](
     if countChanged != nil and (syncResult.toInsert.len > 0 or syncResult.toRemove.len > 0):
       countChanged()
 
-# ----------------------------------------------------------------------------
-# v3 unified API
-# ----------------------------------------------------------------------------
-#
-# `modelSync` collapses the four-closure `setItemsWithSync` call into a one-liner.
-# Consumers define two overloads near their item type; `modelSync` resolves them
-# at instantiation via `mixin`, the same way `hash`/`==`/`$` are picked up:
-#
-#   proc syncKey(it: MyItem): string = it.key              # row identity
-#   proc syncRoles(o, n: MyItem): seq[int] = ...           # changed role ints
-#
-# then the whole sync at the call site is:
-#
-#   self.modelSync(self.items, newItems)
-#
-# The model's `countChanged()` signal is emitted automatically when the model
-# type declares one. The bulk-ops path (grouped inserts/removes, ranged
-# dataChanged) and the QT_MODEL_SPY instrumentation are always used.
+# `modelSync` is the primary consumer API — see the file header for the
+# `syncKey` / `syncRoles` protocol and usage. It collapses the four-closure
+# `setItemsWithSync` call into a one-liner and always uses the bulk-ops path
+# (grouped inserts/removes, ranged dataChanged) plus QT_MODEL_SPY instrumentation.
 
 proc modelSync*[M: QAbstractListModel, T](
     model: M, container: var seq[T], newItems: sink seq[T]) =

--- a/src/app/modules/shared/qt_model_spy.nim
+++ b/src/app/modules/shared/qt_model_spy.nim
@@ -1,0 +1,166 @@
+## Qt Model Spy - Tracks all Qt model signal emissions for testing
+## 
+## This module provides a spy layer that intercepts Qt model signals
+## to verify bulk operations are working correctly.
+
+import sequtils
+
+type
+  SignalType* = enum
+    BeginInsertRows
+    EndInsertRows
+    BeginRemoveRows
+    EndRemoveRows
+    DataChanged
+    BeginResetModel
+    EndResetModel
+    BeginMoveRows
+    EndMoveRows
+  
+  SignalCall* = object
+    case kind*: SignalType
+    of BeginInsertRows, BeginRemoveRows:
+      first*: int
+      last*: int
+    of DataChanged:
+      topLeft*: int
+      bottomRight*: int
+      roles*: seq[int]
+    of BeginMoveRows:
+      sourceFirst*: int
+      sourceLast*: int
+      destChild*: int
+    else:
+      discard
+  
+  QtModelSpy* = ref object
+    calls*: seq[SignalCall]
+    enabled*: bool
+
+var globalSpy*: QtModelSpy = nil
+
+proc newQtModelSpy*(): QtModelSpy =
+  ## Creates a new Qt model spy
+  result = QtModelSpy(calls: @[], enabled: true)
+
+proc enable*(self: QtModelSpy) =
+  self.enabled = true
+  globalSpy = self
+
+proc disable*(self: QtModelSpy) =
+  self.enabled = false
+  if globalSpy == self:
+    globalSpy = nil
+
+proc clear*(self: QtModelSpy) =
+  self.calls = @[]
+
+proc recordBeginInsertRows*(first, last: int) =
+  if globalSpy != nil and globalSpy.enabled:
+    globalSpy.calls.add(SignalCall(
+      kind: BeginInsertRows,
+      first: first,
+      last: last
+    ))
+
+proc recordEndInsertRows*() =
+  if globalSpy != nil and globalSpy.enabled:
+    globalSpy.calls.add(SignalCall(kind: EndInsertRows))
+
+proc recordBeginRemoveRows*(first, last: int) =
+  if globalSpy != nil and globalSpy.enabled:
+    globalSpy.calls.add(SignalCall(
+      kind: BeginRemoveRows,
+      first: first,
+      last: last
+    ))
+
+proc recordEndRemoveRows*() =
+  if globalSpy != nil and globalSpy.enabled:
+    globalSpy.calls.add(SignalCall(kind: EndRemoveRows))
+
+proc recordDataChanged*(topLeft, bottomRight: int, roles: seq[int]) =
+  if globalSpy != nil and globalSpy.enabled:
+    globalSpy.calls.add(SignalCall(
+      kind: DataChanged,
+      topLeft: topLeft,
+      bottomRight: bottomRight,
+      roles: roles
+    ))
+
+proc recordBeginResetModel*() =
+  if globalSpy != nil and globalSpy.enabled:
+    globalSpy.calls.add(SignalCall(kind: BeginResetModel))
+
+proc recordEndResetModel*() =
+  if globalSpy != nil and globalSpy.enabled:
+    globalSpy.calls.add(SignalCall(kind: EndResetModel))
+
+proc recordBeginMoveRows*(sourceFirst, sourceLast, destChild: int) =
+  if globalSpy != nil and globalSpy.enabled:
+    globalSpy.calls.add(SignalCall(
+      kind: BeginMoveRows,
+      sourceFirst: sourceFirst,
+      sourceLast: sourceLast,
+      destChild: destChild
+    ))
+
+proc recordEndMoveRows*() =
+  if globalSpy != nil and globalSpy.enabled:
+    globalSpy.calls.add(SignalCall(kind: EndMoveRows))
+
+# Query helpers
+proc countInserts*(self: QtModelSpy): int =
+  ## Count number of beginInsertRows calls
+  self.calls.filterIt(it.kind == BeginInsertRows).len
+
+proc countRemoves*(self: QtModelSpy): int =
+  ## Count number of beginRemoveRows calls
+  self.calls.filterIt(it.kind == BeginRemoveRows).len
+
+proc countDataChanged*(self: QtModelSpy): int =
+  ## Count number of dataChanged calls
+  self.calls.filterIt(it.kind == DataChanged).len
+
+proc countResets*(self: QtModelSpy): int =
+  ## Count number of beginResetModel calls
+  self.calls.filterIt(it.kind == BeginResetModel).len
+
+proc getInserts*(self: QtModelSpy): seq[SignalCall] =
+  ## Get all beginInsertRows calls
+  self.calls.filterIt(it.kind == BeginInsertRows)
+
+proc getRemoves*(self: QtModelSpy): seq[SignalCall] =
+  ## Get all beginRemoveRows calls
+  self.calls.filterIt(it.kind == BeginRemoveRows)
+
+proc getDataChanged*(self: QtModelSpy): seq[SignalCall] =
+  ## Get all dataChanged calls
+  self.calls.filterIt(it.kind == DataChanged)
+
+proc `$`*(self: SignalCall): string =
+  case self.kind
+  of BeginInsertRows:
+    result = "beginInsertRows(" & $self.first & ", " & $self.last & ")"
+  of EndInsertRows:
+    result = "endInsertRows()"
+  of BeginRemoveRows:
+    result = "beginRemoveRows(" & $self.first & ", " & $self.last & ")"
+  of EndRemoveRows:
+    result = "endRemoveRows()"
+  of DataChanged:
+    result = "dataChanged(" & $self.topLeft & ", " & $self.bottomRight & ", " & $self.roles & ")"
+  of BeginResetModel:
+    result = "beginResetModel()"
+  of EndResetModel:
+    result = "endResetModel()"
+  of BeginMoveRows:
+    result = "beginMoveRows(" & $self.sourceFirst & ", " & $self.sourceLast & ", " & $self.destChild & ")"
+  of EndMoveRows:
+    result = "endMoveRows()"
+
+proc `$`*(self: QtModelSpy): string =
+  result = "QtModelSpy(" & $self.calls.len & " calls):\n"
+  for call in self.calls:
+    result &= "  " & $call & "\n"
+

--- a/src/app/modules/shared/qt_model_spy.nim
+++ b/src/app/modules/shared/qt_model_spy.nim
@@ -6,7 +6,7 @@
 import sequtils
 
 type
-  SignalType* = enum
+  SpySignalKind* = enum
     BeginInsertRows
     EndInsertRows
     BeginRemoveRows
@@ -18,7 +18,7 @@ type
     EndMoveRows
   
   SignalCall* = object
-    case kind*: SignalType
+    case kind*: SpySignalKind
     of BeginInsertRows, BeginRemoveRows:
       first*: int
       last*: int
@@ -96,18 +96,9 @@ proc recordEndResetModel*() =
   if globalSpy != nil and globalSpy.enabled:
     globalSpy.calls.add(SignalCall(kind: EndResetModel))
 
-proc recordBeginMoveRows*(sourceFirst, sourceLast, destChild: int) =
-  if globalSpy != nil and globalSpy.enabled:
-    globalSpy.calls.add(SignalCall(
-      kind: BeginMoveRows,
-      sourceFirst: sourceFirst,
-      sourceLast: sourceLast,
-      destChild: destChild
-    ))
-
-proc recordEndMoveRows*() =
-  if globalSpy != nil and globalSpy.enabled:
-    globalSpy.calls.add(SignalCall(kind: EndMoveRows))
+# The BeginMoveRows/EndMoveRows kinds are kept (without recorders): model_sync
+# never emits moves — reorders degrade to remove+insert — and model tests filter
+# on these kinds to assert exactly that.
 
 # Query helpers
 proc countInserts*(self: QtModelSpy): int =

--- a/test/nim/model_sync_move_test.nim
+++ b/test/nim/model_sync_move_test.nim
@@ -1,0 +1,117 @@
+## Functional verification of syncModel's reorder handling under the real Qt
+## model path. Compile with -d:QT_MODEL_SPY so model_sync records the granular
+## signals it emits. Reorders degrade to remove+insert (no beginMoveRows): after
+## a reorder the model reads back in the target order via data(), the recorded
+## signals are inserts/removes (never a reset), and the concurrent insert+reorder
+## / remove+reorder cases walk the reconciled indices.
+
+import unittest, tables, sequtils
+import nimqml
+
+import app/modules/shared/model_sync
+import app/modules/shared/qt_model_spy
+
+type
+  TItem = object
+    id: string
+    v: int
+
+QtObject:
+  type TModel = ref object of QAbstractListModel
+    items: seq[TItem]
+
+  proc setup(self: TModel) = self.QAbstractListModel.setup
+  proc delete(self: TModel) = self.QAbstractListModel.delete
+  proc newTModel(): TModel =
+    new(result, delete)
+    result.setup
+
+  method rowCount(self: TModel, index: QModelIndex = nil): int =
+    self.items.len
+
+  method roleNames(self: TModel): Table[int, string] =
+    {0: "id", 1: "v"}.toTable
+
+  method data(self: TModel, index: QModelIndex, role: int): QVariant =
+    if not index.isValid: return
+    if index.row < 0 or index.row >= self.items.len: return
+    case role
+    of 0: return newQVariant(self.items[index.row].id)
+    of 1: return newQVariant(self.items[index.row].v)
+    else: return
+
+  proc sync(self: TModel, newItems: seq[TItem]) =
+    setItemsWithSync(
+      self, self.items, newItems,
+      getId = proc(x: TItem): string = x.id,
+      getRoles = proc(a, b: TItem): seq[int] = (if a.v != b.v: @[1] else: @[]))
+
+proc ids(items: seq[TItem]): seq[string] = items.mapIt(it.id)
+
+# Read the order back through data() (what a QML view would see), not the backing seq.
+proc orderViaData(m: TModel): seq[string] =
+  result = @[]
+  for i in 0 ..< m.rowCount():
+    let idx = m.createIndex(i, 0, nil)
+    result.add(m.data(idx, 0).stringVal)
+
+proc mk(idsSeq: seq[string]): seq[TItem] =
+  idsSeq.mapIt(TItem(id: it, v: 0))
+
+suite "model_sync reorder - functional (remove+insert, no moves)":
+
+  setup:
+    let spy = newQtModelSpy()
+    spy.enable()
+
+  teardown:
+    spy.disable()
+
+  test "reversal: model reads back in target order via data(), remove+insert, no move, no reset":
+    let m = newTModel()
+    m.sync(mk(@["a", "b", "c", "d"]))
+    spy.clear()
+
+    m.sync(mk(@["d", "c", "b", "a"]))
+
+    check m.orderViaData() == @["d", "c", "b", "a"]
+    check spy.calls.filterIt(it.kind == BeginMoveRows).len == 0
+    check spy.countInserts() > 0
+    check spy.countRemoves() > 0
+    check spy.countResets() == 0
+
+  test "stable set + data change: dataChanged only, no move, no reset":
+    let m = newTModel()
+    m.sync(@[TItem(id: "a", v: 1), TItem(id: "b", v: 2)])
+    spy.clear()
+
+    m.sync(@[TItem(id: "a", v: 9), TItem(id: "b", v: 2)])
+
+    check m.orderViaData() == @["a", "b"]
+    check spy.countDataChanged() > 0
+    check spy.calls.filterIt(it.kind == BeginMoveRows).len == 0
+    check spy.countInserts() == 0
+    check spy.countRemoves() == 0
+    check spy.countResets() == 0
+
+  test "reorder + concurrent insert (walks reconciled indices)":
+    let m = newTModel()
+    m.sync(mk(@["a", "b", "c"]))
+    spy.clear()
+
+    m.sync(mk(@["c", "x", "a", "b"]))  # insert x, reorder survivors
+
+    check m.orderViaData() == @["c", "x", "a", "b"]
+    check spy.countResets() == 0
+    check spy.calls.filterIt(it.kind == BeginMoveRows).len == 0
+
+  test "reorder + concurrent remove (walks reconciled indices)":
+    let m = newTModel()
+    m.sync(mk(@["a", "b", "c", "d"]))
+    spy.clear()
+
+    m.sync(mk(@["d", "a", "c"]))  # remove b, reorder survivors
+
+    check m.orderViaData() == @["d", "a", "c"]
+    check spy.countResets() == 0
+    check spy.calls.filterIt(it.kind == BeginMoveRows).len == 0

--- a/test/nim/model_sync_reorder_test.nim
+++ b/test/nim/model_sync_reorder_test.nim
@@ -1,0 +1,76 @@
+## Reorder-matrix coverage for syncModel's inline LIS reorder detection.
+##
+## syncModel emits reorders as remove+insert pairs (no Qt moveRows). These tests
+## exercise the diff (no Qt model): for each (current, target) pair, apply the
+## computed removes (descending) then inserts (ascending) to a working seq and
+## check it reproduces the target order, with the LIS keeping a maximal stable
+## subsequence (so a pure reorder never touches more rows than necessary).
+
+import unittest, sequtils, algorithm
+import app/modules/shared/model_sync
+
+type Item = object
+  id: string
+
+let itemId: ItemIdentifier[Item] = proc(it: Item): string = it.id
+
+proc applyDiff(current, target: seq[string]): seq[string] =
+  ## Mirror of applySync's ordering on a plain seq.
+  let old = current.mapIt(Item(id: it))
+  let nu = target.mapIt(Item(id: it))
+  var work = old
+  let r = syncModel(old, nu, itemId)
+  for rem in r.toRemove:            # descending from syncModel
+    work.delete(rem.index)
+  var ins = r.toInsert
+  ins.sort(proc(a, b: InsertOp[Item]): int = cmp(a.index, b.index))
+  for op in ins:
+    work.insert(op.item, op.index)
+  result = work.mapIt(it.id)
+
+proc movedRows(current, target: seq[string]): int =
+  ## Number of rows the reorder touches (insert count == remove count here).
+  let old = current.mapIt(Item(id: it))
+  let nu = target.mapIt(Item(id: it))
+  syncModel(old, nu, itemId).toInsert.len
+
+suite "syncModel reorder matrix (LIS remove+insert)":
+
+  test "already in order -> no changes":
+    let s = @["a", "b", "c", "d"]
+    let r = syncModel(s.mapIt(Item(id: it)), s.mapIt(Item(id: it)), itemId)
+    check not r.hasChanges
+
+  test "empty -> no changes":
+    let r = syncModel[Item](@[], @[], itemId)
+    check not r.hasChanges
+
+  test "adjacent swap":
+    check applyDiff(@["a", "b", "c"], @["b", "a", "c"]) == @["b", "a", "c"]
+
+  test "full reversal keeps a length-1 stable subsequence":
+    check applyDiff(@["a", "b", "c", "d", "e"], @["e", "d", "c", "b", "a"]) ==
+      @["e", "d", "c", "b", "a"]
+
+  test "rotate left by one":
+    check applyDiff(@["a", "b", "c", "d"], @["b", "c", "d", "a"]) ==
+      @["b", "c", "d", "a"]
+
+  test "rotate right by one":
+    check applyDiff(@["a", "b", "c", "d"], @["d", "a", "b", "c"]) ==
+      @["d", "a", "b", "c"]
+
+  test "arbitrary shuffle":
+    check applyDiff(@["a", "b", "c", "d", "e", "f"], @["c", "f", "a", "e", "b", "d"]) ==
+      @["c", "f", "a", "e", "b", "d"]
+
+  test "two elements swapped":
+    check applyDiff(@["x", "y"], @["y", "x"]) == @["y", "x"]
+
+  test "hash-order-change proxy (survivors reordered, same set)":
+    check applyDiff(@["eth", "dai", "usdc", "snt"], @["snt", "eth", "usdc", "dai"]) ==
+      @["snt", "eth", "usdc", "dai"]
+
+  test "rotate-right touches only one row (LIS is minimal)":
+    # [a,b,c,d] -> [d,a,b,c]: a,b,c stay stable, only d moves.
+    check movedRows(@["a", "b", "c", "d"], @["d", "a", "b", "c"]) == 1

--- a/test/nim/model_sync_unified_test.nim
+++ b/test/nim/model_sync_unified_test.nim
@@ -1,0 +1,240 @@
+## v3 unified API: `modelSync` one-liner + `reconcileByKey` child reconciliation.
+## Compile with -d:QT_MODEL_SPY so the granular signals are recorded and asserted:
+## a stable-set value change is a single dataChanged (no reset/insert/remove); a
+## nested-submodel change recurses into the child (child emits, parent silent); a
+## QObject-per-key row keeps its instance across a diff.
+
+import unittest, tables, sequtils
+import nimqml
+
+import app/modules/shared/model_sync
+import app/modules/shared/qt_model_spy
+
+# ---------------------------------------------------------------------------
+# Leaf value model driven purely by the modelSync one-liner.
+# ---------------------------------------------------------------------------
+type
+  Leaf = object
+    id: string
+    name: string
+    v: int
+
+proc syncKey(it: Leaf): string = it.id
+proc syncRoles(o, n: Leaf): seq[int] =
+  result = @[]
+  if o.name != n.name: result.add(1)
+  if o.v != n.v: result.add(2)
+
+QtObject:
+  type LeafModel = ref object of QAbstractListModel
+    items: seq[Leaf]
+
+  proc setup(self: LeafModel) = self.QAbstractListModel.setup
+  proc delete(self: LeafModel) = self.QAbstractListModel.delete
+  proc newLeafModel(): LeafModel =
+    new(result, delete)
+    result.setup
+
+  proc countChanged(self: LeafModel) {.signal.}
+  method rowCount(self: LeafModel, index: QModelIndex = nil): int = self.items.len
+  method roleNames(self: LeafModel): Table[int, string] =
+    {0: "id", 1: "name", 2: "v"}.toTable
+  method data(self: LeafModel, index: QModelIndex, role: int): QVariant =
+    if not index.isValid or index.row < 0 or index.row >= self.items.len: return
+    case role
+    of 0: return newQVariant(self.items[index.row].id)
+    of 1: return newQVariant(self.items[index.row].name)
+    of 2: return newQVariant(self.items[index.row].v)
+    else: return
+
+  proc sync(self: LeafModel, newItems: seq[Leaf]) =
+    self.modelSync(self.items, newItems)
+
+  proc idsInOrder(self: LeafModel): seq[string] = self.items.mapIt(it.id)
+
+# ---------------------------------------------------------------------------
+# Nested-submodel parent: each group carries a child model of subitems. A change
+# confined to a subitem must recurse into the child (child signals), leaving the
+# parent silent for that role.
+# ---------------------------------------------------------------------------
+type
+  Sub = object
+    id: string
+    bal: int
+  Group = object
+    id: string
+    title: string
+    subs: seq[Sub]
+
+proc syncKey(it: Sub): string = it.id
+proc syncRoles(o, n: Sub): seq[int] =
+  result = @[]
+  if o.bal != n.bal: result.add(1)
+
+proc syncKey(it: Group): string = it.id
+proc syncRoles(o, n: Group): seq[int] =
+  result = @[]
+  if o.title != n.title: result.add(1)
+  # subs travel through the child model's own signals — not a parent role.
+
+QtObject:
+  type SubModel = ref object of QAbstractListModel
+    items: seq[Sub]
+  proc setup(self: SubModel) = self.QAbstractListModel.setup
+  proc delete(self: SubModel) = self.QAbstractListModel.delete
+  proc newSubModel(subs: seq[Sub]): SubModel =
+    new(result, delete)
+    result.setup
+    result.items = subs
+  proc countChanged(self: SubModel) {.signal.}
+  method rowCount(self: SubModel, index: QModelIndex = nil): int = self.items.len
+  method roleNames(self: SubModel): Table[int, string] = {0: "id", 1: "bal"}.toTable
+  method data(self: SubModel, index: QModelIndex, role: int): QVariant =
+    if not index.isValid or index.row < 0 or index.row >= self.items.len: return
+    case role
+    of 0: return newQVariant(self.items[index.row].id)
+    of 1: return newQVariant(self.items[index.row].bal)
+    else: return
+  proc setSubs(self: SubModel, subs: seq[Sub]) =
+    self.modelSync(self.items, subs)
+
+QtObject:
+  type GroupModel = ref object of QAbstractListModel
+    items: seq[Group]
+    childByKey: Table[string, SubModel]
+  proc setup(self: GroupModel) = self.QAbstractListModel.setup
+  proc delete(self: GroupModel) = self.QAbstractListModel.delete
+  proc newGroupModel(): GroupModel =
+    new(result, delete)
+    result.setup
+    result.childByKey = initTable[string, SubModel]()
+  proc countChanged(self: GroupModel) {.signal.}
+  method rowCount(self: GroupModel, index: QModelIndex = nil): int = self.items.len
+  method roleNames(self: GroupModel): Table[int, string] =
+    {0: "id", 1: "title", 2: "subs"}.toTable
+  method data(self: GroupModel, index: QModelIndex, role: int): QVariant =
+    if not index.isValid or index.row < 0 or index.row >= self.items.len: return
+    let g = self.items[index.row]
+    case role
+    of 0: return newQVariant(g.id)
+    of 1: return newQVariant(g.title)
+    of 2:
+      if self.childByKey.hasKey(g.id): return newQVariant(self.childByKey[g.id])
+      return
+    else: return
+
+  proc sync(self: GroupModel, newGroups: seq[Group]) =
+    reconcileByKey(self.childByKey, newGroups,
+      create = proc(g: Group): SubModel = newSubModel(g.subs),
+      update = proc(sm: SubModel, g: Group) = sm.setSubs(g.subs))
+    self.modelSync(self.items, newGroups)
+
+  proc childForKey(self: GroupModel, key: string): SubModel =
+    if self.childByKey.hasKey(key): return self.childByKey[key]
+    return nil
+  proc idsInOrder(self: GroupModel): seq[string] = self.items.mapIt(it.id)
+
+# ---------------------------------------------------------------------------
+# QObject-per-key reconciliation (market-details shape): the instance must be
+# preserved across a diff for a surviving key.
+# ---------------------------------------------------------------------------
+QtObject:
+  type Detail = ref object of QObject
+    key: string
+  proc delete(self: Detail) = self.QObject.delete
+  proc setup(self: Detail) = self.QObject.setup
+  proc newDetail(key: string): Detail =
+    new(result, delete)
+    result.setup
+    result.key = key
+
+suite "model_sync v3 unified API":
+  setup:
+    let spy = newQtModelSpy()
+    spy.enable()
+  teardown:
+    spy.disable()
+
+  test "leaf one-liner: first load, then stable-set value change is a single dataChanged":
+    let m = newLeafModel()
+    m.sync(@[Leaf(id: "a", name: "A", v: 1), Leaf(id: "b", name: "B", v: 2)])
+    check m.idsInOrder() == @["a", "b"]
+    spy.clear()
+
+    m.sync(@[Leaf(id: "a", name: "A", v: 9), Leaf(id: "b", name: "B", v: 2)])
+    check m.idsInOrder() == @["a", "b"]
+    check spy.countDataChanged() == 1
+    check spy.getDataChanged()[0].roles == @[2]
+    check spy.countInserts() == 0
+    check spy.countRemoves() == 0
+    check spy.countResets() == 0
+
+  test "leaf one-liner: insert + remove, no reset":
+    let m = newLeafModel()
+    m.sync(@[Leaf(id: "a"), Leaf(id: "b"), Leaf(id: "c")])
+    spy.clear()
+
+    m.sync(@[Leaf(id: "a"), Leaf(id: "x"), Leaf(id: "c")])  # remove b, insert x
+    check m.idsInOrder() == @["a", "x", "c"]
+    check spy.countResets() == 0
+    check spy.countInserts() > 0
+    check spy.countRemoves() > 0
+
+  test "recursion: subitem change recurses into child, parent stays silent":
+    let m = newGroupModel()
+    m.sync(@[
+      Group(id: "g1", title: "G1", subs: @[Sub(id: "s1", bal: 1), Sub(id: "s2", bal: 2)]),
+      Group(id: "g2", title: "G2", subs: @[Sub(id: "s3", bal: 3)]),
+    ])
+    let child1 = m.childForKey("g1")
+    check child1 != nil
+    spy.clear()
+
+    # Only s1's balance changes; group set + titles unchanged.
+    m.sync(@[
+      Group(id: "g1", title: "G1", subs: @[Sub(id: "s1", bal: 99), Sub(id: "s2", bal: 2)]),
+      Group(id: "g2", title: "G2", subs: @[Sub(id: "s3", bal: 3)]),
+    ])
+
+    # Same child instance preserved.
+    check m.childForKey("g1") == child1
+    # Exactly one dataChanged, on the child (bal role = 1), nothing else.
+    check spy.countResets() == 0
+    check spy.countInserts() == 0
+    check spy.countRemoves() == 0
+    check spy.countDataChanged() == 1
+    check spy.getDataChanged()[0].roles == @[1]
+
+  test "recursion: parent title change is a parent dataChanged, child untouched":
+    let m = newGroupModel()
+    m.sync(@[Group(id: "g1", title: "G1", subs: @[Sub(id: "s1", bal: 1)])])
+    spy.clear()
+
+    m.sync(@[Group(id: "g1", title: "RENAMED", subs: @[Sub(id: "s1", bal: 1)])])
+    check spy.countDataChanged() == 1
+    check spy.getDataChanged()[0].roles == @[1]
+    check spy.countResets() == 0
+
+  test "duplicate keys in input trip the debug/test uniqueness guard":
+    let m = newLeafModel()
+    m.sync(@[Leaf(id: "a", name: "A", v: 1)])
+    # Two rows share id "a": the diff's id->index map would be last-wins and emit a
+    # spurious op for the shadowed row. The debug/testing guard rejects it up front.
+    expect AssertionDefect:
+      m.sync(@[Leaf(id: "a", name: "A", v: 1), Leaf(id: "a", name: "B", v: 2)])
+
+  test "reconcileByKey preserves QObject instance across a diff, drops removed keys":
+    var table = initTable[string, Detail]()
+    reconcileByKey(table, @[Leaf(id: "a"), Leaf(id: "b")],
+      create = proc(it: Leaf): Detail = newDetail(it.id))
+    let a0 = table["a"]
+    check table.len == 2
+
+    # "a" survives, "b" removed, "c" added.
+    reconcileByKey(table, @[Leaf(id: "a"), Leaf(id: "c")],
+      create = proc(it: Leaf): Detail = newDetail(it.id))
+    check table.len == 2
+    check table.hasKey("a")
+    check table.hasKey("c")
+    check not table.hasKey("b")
+    check table["a"] == a0   # same instance preserved

--- a/test/nim/signal_type_scan_test.nim
+++ b/test/nim/signal_type_scan_test.nim
@@ -1,0 +1,53 @@
+import unittest
+
+import app/core/signals/signal_type_scan
+
+suite "signal_type_scan - cheap type extraction":
+
+  test "extracts the envelope type ahead of a nested event type":
+    let raw = """{"type":"messages.new","event":{"type":"nested-should-be-ignored"}}"""
+    check extractSignalType(raw) == "messages.new"
+
+  test "extracts a dotted/dashed type value verbatim":
+    check extractSignalType("""{"type":"wallet.token-lists.updated","event":{}}""") ==
+      "wallet.token-lists.updated"
+
+  test "handles a leading injected member before type (wtSeq instrumentation)":
+    check extractSignalType("""{"wtSeq":42,"type":"wallet","event":{}}""") == "wallet"
+
+  test "missing type member yields empty string":
+    check extractSignalType("""{"event":{"foo":1}}""") == ""
+
+  test "unterminated type value yields empty string":
+    check extractSignalType("""{"type":"broken""") == ""
+
+suite "signal_type_scan - known-type recognition":
+
+  test "recognises handled signal types":
+    check isKnownSignalType("messages.new")
+    check isKnownSignalType("wallet.token-lists.updated")
+    check isKnownSignalType("node.login")
+
+  test "rejects unknown / unhandled types":
+    check not isKnownSignalType("local-notifications")
+    check not isKnownSignalType("some.type.nobody.handles")
+
+  test "rejects empty type":
+    check not isKnownSignalType("")
+
+  test "an unknown type with a malformed body is rejected without parsing":
+    # The manager relies on this: the decision is made from the type alone, so a
+    # malformed body of an unhandled type never reaches parseJson.
+    let raw = """{"type":"local-notifications","event":{ this is not : valid json ,,, }}"""
+    check not isKnownSignalType(extractSignalType(raw))
+
+suite "signal_type_scan - unhandled counter":
+
+  test "counter accumulates and resets":
+    resetUnhandledSignalCount()
+    check unhandledSignalCount() == 0
+    noteUnhandledSignal()
+    noteUnhandledSignal()
+    check unhandledSignalCount() == 2
+    resetUnhandledSignalCount()
+    check unhandledSignalCount() == 0

--- a/test/nim/signals_manager_test.nim
+++ b/test/nim/signals_manager_test.nim
@@ -55,3 +55,18 @@ suite "SignalsManager - unhandled signal-type skipping":
 
     check dispatchedCount == 1
     check unhandledSignalCount() == 1
+
+  test "a handled type in a whitespaced envelope still dispatches (scan-miss fallback)":
+    # The fast substring scan assumes status-go's compact `"type":"` byte token.
+    # If the marshaling format ever changes (e.g. a space after the colon), the
+    # scan misses — that must degrade to the full-parse path, not drop the signal.
+    let emitter = createEventEmitter()
+    var dispatched = false
+    emitter.on(SignalType.DiscoveryStarted.event) do(a: Args):
+      dispatched = true
+
+    let manager = newSignalsManager(emitter)
+    manager.processSignal("""{"type": "discovery.started", "event": {}}""")
+
+    check dispatched
+    check unhandledSignalCount() == 0

--- a/test/nim/signals_manager_test.nim
+++ b/test/nim/signals_manager_test.nim
@@ -1,0 +1,57 @@
+import unittest
+
+import app/core/eventemitter
+import app/core/signals/signals_manager
+import app/core/signals/signal_type_scan
+import app/core/signals/remote_signals/signal_type
+
+# Exercises the real ManageSignals dispatch path (`processSignal`) to prove that
+# the cheap-triage guard skips unhandled types before parsing
+# while leaving known-type decode/dispatch intact.
+
+suite "SignalsManager - unhandled signal-type skipping":
+
+  setup:
+    resetUnhandledSignalCount()
+
+  test "a known signal type is decoded and dispatched":
+    let emitter = createEventEmitter()
+    var dispatched = false
+    # discovery.started is a known SignalType handled via the generic branch, so
+    # it dispatches without needing any specific event fields.
+    emitter.on(SignalType.DiscoveryStarted.event) do(a: Args):
+      dispatched = true
+
+    let manager = newSignalsManager(emitter)
+    manager.processSignal("""{"type":"discovery.started","event":{}}""")
+
+    check dispatched
+    check unhandledSignalCount() == 0
+
+  test "an unknown type with a malformed body is skipped without raising and counted":
+    let emitter = createEventEmitter()
+    var dispatched = false
+    emitter.on(SignalType.DiscoveryStarted.event) do(a: Args):
+      dispatched = true
+
+    let manager = newSignalsManager(emitter)
+    # Deliberately malformed event body: the guard must drop it on the type
+    # alone, before any parse (a full parse would raise).
+    let raw = """{"type":"local-notifications","event":{ not valid json ,,, }}"""
+    manager.processSignal(raw)
+
+    check unhandledSignalCount() == 1
+    check not dispatched
+
+  test "a known type keeps dispatching after an unknown one was skipped":
+    let emitter = createEventEmitter()
+    var dispatchedCount = 0
+    emitter.on(SignalType.DiscoveryStarted.event) do(a: Args):
+      inc dispatchedCount
+
+    let manager = newSignalsManager(emitter)
+    manager.processSignal("""{"type":"local-notifications","event":{}}""")
+    manager.processSignal("""{"type":"discovery.started","event":{}}""")
+
+    check dispatchedCount == 1
+    check unhandledSignalCount() == 1

--- a/test/nim/test_cow_seq.nim
+++ b/test/nim/test_cow_seq.nim
@@ -1,0 +1,166 @@
+## Tests for src/app/core/cow_seq.nim (single-threaded, GUI-thread only).
+##
+## Coverage focus:
+##   - seq-compatible API (read, write, iterate)
+##   - CoW semantics: copies share until mutation, then fork
+##   - =sink transfers ownership without a double-decrement
+##   - indexed access on a default-constructed CowSeq raises IndexDefect
+##   - borrow() returns a lent view (no copy)
+##
+## Build with `-d:testing` so the debug helpers (getRefCount/isShared) are
+## visible.
+
+{.define: testing.}
+
+import unittest
+import app/core/cow_seq
+
+suite "CowSeq - basics":
+  test "empty default-constructed CowSeq":
+    var s: CowSeq[int]
+    check s.len == 0
+    check s.high == -1
+
+  test "construct from seq":
+    let s = toCowSeq(@[1, 2, 3])
+    check s.len == 3
+    check s[0] == 1
+    check s[2] == 3
+
+  test "iterate items":
+    let s = toCowSeq(@[10, 20, 30])
+    var collected: seq[int] = @[]
+    for x in s:
+      collected.add(x)
+    check collected == @[10, 20, 30]
+
+  test "iterate pairs":
+    let s = toCowSeq(@["a", "b", "c"])
+    var keys: seq[int] = @[]
+    var vals: seq[string] = @[]
+    for k, v in s:
+      keys.add(k)
+      vals.add(v)
+    check keys == @[0, 1, 2]
+    check vals == @["a", "b", "c"]
+
+  test "add / delete / insert / setLen":
+    var s = toCowSeq(@[1, 2, 3])
+    s.add(4)
+    check s.asSeq == @[1, 2, 3, 4]
+    s.insert(0, 0)
+    check s.asSeq == @[0, 1, 2, 3, 4]
+    s.delete(2)
+    check s.asSeq == @[0, 1, 3, 4]
+    s.setLen(2)
+    check s.asSeq == @[0, 1]
+
+  test "equality":
+    let a = toCowSeq(@[1, 2, 3])
+    let b = toCowSeq(@[1, 2, 3])
+    let c = toCowSeq(@[1, 2, 4])
+    check a == b
+    check a != c
+
+suite "CowSeq - copy on write":
+  test "copy is O(1) - shares backing buffer":
+    var a = toCowSeq(@[1, 2, 3])
+    var b = a
+    check a.getRefCount == 2
+    check b.getRefCount == 2
+    check a.isShared
+    check b.isShared
+
+  test "mutation forks the buffer":
+    var a = toCowSeq(@[1, 2, 3])
+    var b = a
+    check a.isShared
+
+    b.add(4)
+    # b should now be unique; a should be unique too (refCount drops to 1)
+    check not b.isShared
+    check not a.isShared
+    check a.asSeq == @[1, 2, 3]
+    check b.asSeq == @[1, 2, 3, 4]
+
+  test "destructor releases the buffer":
+    var a = toCowSeq(@[1, 2, 3])
+    block:
+      let b = a
+      check a.getRefCount == 2
+    # b is destroyed here
+    check a.getRefCount == 1
+
+  test "self-assignment is a no-op":
+    var a = toCowSeq(@[1, 2, 3])
+    a = a
+    check a.getRefCount == 1
+    check a.asSeq == @[1, 2, 3]
+
+  test "=sink does not double-decrement":
+    # If =sink left src.dataRef intact, the moved-from variable's destructor
+    # would decrement again -> the surviving copy's refcount would be wrong.
+    proc returnsCow(): CowSeq[int] =
+      var local = toCowSeq(@[1, 2, 3])
+      result = local  # sink
+    var s = returnsCow()
+    check s.getRefCount == 1
+    check s.asSeq == @[1, 2, 3]
+
+  test "=sink self-move keeps the value intact":
+    var a = toCowSeq(@[1, 2, 3])
+    a = move(a)
+    check a.getRefCount == 1
+    check a.asSeq == @[1, 2, 3]
+
+  test "=sink from a shared distinct copy keeps the refcount balanced":
+    # a and b share one buffer (refCount 2). Sinking b (which aliases a's
+    # buffer) into a must leave a owning it alone, not double-count.
+    var a = toCowSeq(@[1, 2, 3])
+    var b = a
+    check a.getRefCount == 2
+    a = move(b)
+    check a.getRefCount == 1
+    check a.asSeq == @[1, 2, 3]
+
+suite "CowSeq - safety":
+  test "indexed access on default-constructed CowSeq raises":
+    var s: CowSeq[int]
+    expect IndexDefect:
+      discard s[0]
+
+  test "slice access on default-constructed CowSeq returns empty":
+    var s: CowSeq[int]
+    check s[0..10] == newSeq[int]()
+
+  test "borrow returns lent view, mutation lazily inits the buffer":
+    var s: CowSeq[int]
+    let view = s.borrow()
+    check view.len == 0
+    check s.getRefCount == 1
+
+    var t = toCowSeq(@[1, 2, 3])
+    let tview = t.borrow()
+    check tview.len == 3
+    check tview[0] == 1
+
+  test "clear releases shared buffer in O(1)":
+    var a = toCowSeq(@[1, 2, 3])
+    var b = a
+    check a.isShared
+    a.clear()
+    check a.len == 0
+    check not a.isShared
+    check b.asSeq == @[1, 2, 3]   # b is unaffected
+
+suite "CowSeq - bulk add":
+  test "add seq concatenation":
+    var a = toCowSeq(@[1, 2])
+    a.add(@[3, 4, 5])
+    check a.asSeq == @[1, 2, 3, 4, 5]
+
+  test "add CowSeq concatenation":
+    var a = toCowSeq(@[1, 2])
+    let b = toCowSeq(@[3, 4])
+    a.add(b)
+    check a.asSeq == @[1, 2, 3, 4]

--- a/test/nim/test_model_sync.nim
+++ b/test/nim/test_model_sync.nim
@@ -1,0 +1,1087 @@
+import unittest, sequtils, tables, algorithm
+import app/modules/shared/model_sync
+
+# Test item type
+type
+  TestItem = object
+    id: string
+    name: string
+    value: int
+    flag: bool
+
+proc `==`(a, b: TestItem): bool =
+  a.id == b.id and a.name == b.name and a.value == b.value and a.flag == b.flag
+
+suite "Model Sync Tests":
+  
+  test "Empty to empty - no changes":
+    let oldItems: seq[TestItem] = @[]
+    let newItems: seq[TestItem] = @[]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id
+    )
+    
+    check result.hasChanges == false
+    check result.toInsert.len == 0
+    check result.toRemove.len == 0
+    check result.toUpdate.len == 0
+  
+  test "Empty to non-empty - all inserts":
+    let oldItems: seq[TestItem] = @[]
+    let newItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id
+    )
+    
+    check result.hasChanges == true
+    check result.toInsert.len == 3
+    check result.toRemove.len == 0
+    check result.toUpdate.len == 0
+    check result.toInsert[0].index == 0
+    check result.toInsert[1].index == 1
+    check result.toInsert[2].index == 2
+  
+  test "Non-empty to empty - all removes":
+    let oldItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    let newItems: seq[TestItem] = @[]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id
+    )
+    
+    check result.hasChanges == true
+    check result.toInsert.len == 0
+    check result.toRemove.len == 3
+    check result.toUpdate.len == 0
+    # Removes should be in reverse order
+    check result.toRemove[0].index == 2
+    check result.toRemove[1].index == 1
+    check result.toRemove[2].index == 0
+  
+  test "No changes - identical items":
+    let oldItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+    ]
+    let newItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id,
+      getRoles = proc(old, new: TestItem): seq[int] =
+        var roles: seq[int]
+        if old.name != new.name: roles.add(1)
+        if old.value != new.value: roles.add(2)
+        return roles
+    )
+    
+    check result.hasChanges == false
+    check result.toInsert.len == 0
+    check result.toRemove.len == 0
+    check result.toUpdate.len == 0
+  
+  test "Update single field":
+    let oldItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+    ]
+    let newItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2-Updated", value: 200),
+    ]
+    
+    const NameRole = 1
+    const ValueRole = 2
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id,
+      getRoles = proc(old, new: TestItem): seq[int] =
+        var roles: seq[int]
+        if old.name != new.name: roles.add(NameRole)
+        if old.value != new.value: roles.add(ValueRole)
+        return roles
+    )
+    
+    check result.hasChanges == true
+    check result.toInsert.len == 0
+    check result.toRemove.len == 0
+    check result.toUpdate.len == 1
+    check result.toUpdate[0].index == 1
+    check result.toUpdate[0].roles == @[NameRole]
+    check result.toUpdate[0].item.name == "Item2-Updated"
+  
+  test "Update multiple fields":
+    let oldItems = @[
+      TestItem(id: "1", name: "Item1", value: 100, flag: false),
+    ]
+    let newItems = @[
+      TestItem(id: "1", name: "Item1-New", value: 999, flag: true),
+    ]
+    
+    const NameRole = 1
+    const ValueRole = 2
+    const FlagRole = 3
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id,
+      getRoles = proc(old, new: TestItem): seq[int] =
+        var roles: seq[int]
+        if old.name != new.name: roles.add(NameRole)
+        if old.value != new.value: roles.add(ValueRole)
+        if old.flag != new.flag: roles.add(FlagRole)
+        return roles
+    )
+    
+    check result.hasChanges == true
+    check result.toUpdate.len == 1
+    check result.toUpdate[0].roles.len == 3
+    check NameRole in result.toUpdate[0].roles
+    check ValueRole in result.toUpdate[0].roles
+    check FlagRole in result.toUpdate[0].roles
+  
+  test "Mix of operations - insert, update, remove":
+    let oldItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    let newItems = @[
+      TestItem(id: "1", name: "Item1-Updated", value: 100),  # Update
+      TestItem(id: "4", name: "Item4", value: 400),          # Insert
+      TestItem(id: "3", name: "Item3", value: 300),          # No change
+      # Item2 removed
+    ]
+    
+    const NameRole = 1
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id,
+      getRoles = proc(old, new: TestItem): seq[int] =
+        var roles: seq[int]
+        if old.name != new.name: roles.add(NameRole)
+        return roles
+    )
+    
+    check result.hasChanges == true
+    check result.toInsert.len == 1  # Item4
+    check result.toRemove.len == 1  # Item2
+    check result.toUpdate.len == 1  # Item1
+    
+    check result.toInsert[0].item.id == "4"
+    check result.toRemove[0].index == 1  # Item2 was at index 1
+    check result.toUpdate[0].index == 0  # Item1 at index 0
+    check result.toUpdate[0].item.name == "Item1-Updated"
+  
+  test "Insert at beginning":
+    let oldItems = @[
+      TestItem(id: "2", name: "Item2", value: 200),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    let newItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id
+    )
+    
+    check result.hasChanges == true
+    check result.toInsert.len == 1
+    check result.toInsert[0].index == 0
+    check result.toInsert[0].item.id == "1"
+  
+  test "Insert at end":
+    let oldItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+    ]
+    let newItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id
+    )
+    
+    check result.hasChanges == true
+    check result.toInsert.len == 1
+    check result.toInsert[0].index == 2
+    check result.toInsert[0].item.id == "3"
+  
+  test "Insert in middle":
+    let oldItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    let newItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id
+    )
+    
+    check result.hasChanges == true
+    check result.toInsert.len == 1
+    check result.toInsert[0].index == 1
+    check result.toInsert[0].item.id == "2"
+  
+  test "Remove from beginning":
+    let oldItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    let newItems = @[
+      TestItem(id: "2", name: "Item2", value: 200),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id
+    )
+    
+    check result.hasChanges == true
+    check result.toRemove.len == 1
+    check result.toRemove[0].index == 0
+  
+  test "Remove from end":
+    let oldItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    let newItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id
+    )
+    
+    check result.hasChanges == true
+    check result.toRemove.len == 1
+    check result.toRemove[0].index == 2
+  
+  test "Remove from middle":
+    let oldItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    let newItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "3", name: "Item3", value: 300),
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id
+    )
+    
+    check result.hasChanges == true
+    check result.toRemove.len == 1
+    check result.toRemove[0].index == 1
+  
+  test "Remove multiple consecutive items":
+    let oldItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "2", name: "Item2", value: 200),
+      TestItem(id: "3", name: "Item3", value: 300),
+      TestItem(id: "4", name: "Item4", value: 400),
+      TestItem(id: "5", name: "Item5", value: 500),
+    ]
+    let newItems = @[
+      TestItem(id: "1", name: "Item1", value: 100),
+      TestItem(id: "5", name: "Item5", value: 500),
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id
+    )
+    
+    check result.hasChanges == true
+    check result.toRemove.len == 3
+    # Should be in reverse order: 3, 2, 1
+    check result.toRemove[0].index == 3
+    check result.toRemove[1].index == 2
+    check result.toRemove[2].index == 1
+  
+  test "Group consecutive ranges":
+    let indices = @[0, 1, 2, 5, 6, 9, 15, 16, 17, 18]
+    let ranges = groupConsecutiveRanges(indices)
+    
+    check ranges.len == 4
+    check ranges[0] == (0, 2)
+    check ranges[1] == (5, 6)
+    check ranges[2] == (9, 9)
+    check ranges[3] == (15, 18)
+  
+  test "Group consecutive ranges - single items":
+    let indices = @[1, 3, 5, 7]
+    let ranges = groupConsecutiveRanges(indices)
+    
+    check ranges.len == 4
+    check ranges[0] == (1, 1)
+    check ranges[1] == (3, 3)
+    check ranges[2] == (5, 5)
+    check ranges[3] == (7, 7)
+  
+  test "Group consecutive ranges - empty":
+    let indices: seq[int] = @[]
+    let ranges = groupConsecutiveRanges(indices)
+    
+    check ranges.len == 0
+  
+  test "Group consecutive ranges - single range":
+    let indices = @[5, 6, 7, 8, 9]
+    let ranges = groupConsecutiveRanges(indices)
+    
+    check ranges.len == 1
+    check ranges[0] == (5, 9)
+  
+  test "Large dataset performance":
+    # Create a large dataset
+    var oldItems: seq[TestItem] = @[]
+    for i in 0..999:
+      oldItems.add(TestItem(id: $i, name: "Item" & $i, value: i * 100))
+    
+    # Modify some items, remove some, add some
+    var newItems: seq[TestItem] = @[]
+    for i in 0..899:  # Remove last 100
+      if i mod 10 == 0:  # Update every 10th item
+        newItems.add(TestItem(id: $i, name: "Updated-" & $i, value: i * 100))
+      else:
+        newItems.add(TestItem(id: $i, name: "Item" & $i, value: i * 100))
+    
+    # Add new items
+    for i in 1000..1099:
+      newItems.add(TestItem(id: $i, name: "NewItem" & $i, value: i * 100))
+    
+    const NameRole = 1
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id,
+      getRoles = proc(old, new: TestItem): seq[int] =
+        var roles: seq[int]
+        if old.name != new.name: roles.add(NameRole)
+        return roles
+    )
+    
+    check result.hasChanges == true
+    check result.toRemove.len == 100  # Removed 900-999
+    check result.toInsert.len == 100  # Added 1000-1099
+    check result.toUpdate.len == 90   # Updated every 10th from 0-899
+
+suite "Nested Model Sync (update detection for nested models)":
+  test "afterItemSync callback is called for updated items":
+    var callbackCalled = 0
+    var lastOldId = ""
+    var lastNewId = ""
+    var lastIdx = -1
+    
+    var items: seq[TestItem] = @[
+      TestItem(id: "1", name: "Alice", value: 100),
+      TestItem(id: "2", name: "Bob", value: 200),
+      TestItem(id: "3", name: "Charlie", value: 300)
+    ]
+    
+    let newItems: seq[TestItem] = @[
+      TestItem(id: "1", name: "Alice Updated", value: 150),  # Changed
+      TestItem(id: "2", name: "Bob", value: 200),            # Unchanged
+      TestItem(id: "3", name: "Charlie", value: 350)         # Changed
+    ]
+    
+    # Manually apply sync with callback (without Qt model)
+    let syncResult = syncModel(
+      items, newItems,
+      getId = proc(item: TestItem): string = item.id,
+      getRoles = proc(old, new: TestItem): seq[int] =
+        var roles: seq[int]
+        if old.name != new.name: roles.add(1)
+        if old.value != new.value: roles.add(2)
+        return roles
+    )
+    
+    # Manually apply updates with callback
+    for updateOp in syncResult.toUpdate:
+      let oldItem = items[updateOp.index]
+      items[updateOp.index] = updateOp.item
+      # Simulate nested-sync side effect on update
+      callbackCalled.inc
+      lastOldId = oldItem.id
+      lastNewId = updateOp.item.id
+      lastIdx = updateOp.index
+    
+    check callbackCalled == 2  # Called for items 1 and 3
+    check lastIdx >= 0
+    check items[0].name == "Alice Updated"
+    check items[2].value == 350
+
+  test "afterItemSync can detect nested changes":
+    type
+      NestedItem = object
+        id: string
+        count: int
+      
+      ParentItem = object
+        id: string
+        name: string
+        nested: seq[NestedItem]
+    
+    var items: seq[ParentItem] = @[
+      ParentItem(
+        id: "p1",
+        name: "Parent1",
+        nested: @[
+          NestedItem(id: "n1", count: 1),
+          NestedItem(id: "n2", count: 2)
+        ]
+      )
+    ]
+    
+    let newItems: seq[ParentItem] = @[
+      ParentItem(
+        id: "p1",
+        name: "Parent1 Updated",
+        nested: @[
+          NestedItem(id: "n1", count: 10),  # Updated
+          NestedItem(id: "n2", count: 20)   # Updated
+        ]
+      )
+    ]
+    
+    var nestedSyncCalled = false
+    
+    let syncResult = syncModel(
+      items, newItems,
+      getId = proc(item: ParentItem): string = item.id,
+      getRoles = proc(old, new: ParentItem): seq[int] =
+        var roles: seq[int]
+        if old.name != new.name: roles.add(1)
+        return roles
+    )
+    
+    # Manually apply with nested sync simulation
+    for updateOp in syncResult.toUpdate:
+      let oldItem = items[updateOp.index]
+      items[updateOp.index] = updateOp.item
+      # Simulate nested-sync side effect on update
+      for i in 0..<updateOp.item.nested.len:
+        if i < oldItem.nested.len:
+          if oldItem.nested[i].count != updateOp.item.nested[i].count:
+            nestedSyncCalled = true
+    
+    check nestedSyncCalled
+    check items[0].name == "Parent1 Updated"
+    check items[0].nested[0].count == 10
+
+  test "afterItemSync called for all updated items":
+    var callbackCount = 0
+    
+    var items: seq[TestItem] = @[
+      TestItem(id: "1", name: "A", value: 1),
+      TestItem(id: "2", name: "B", value: 2),
+      TestItem(id: "3", name: "C", value: 3)
+    ]
+    
+    let newItems: seq[TestItem] = @[
+      TestItem(id: "1", name: "A-new", value: 1),
+      TestItem(id: "2", name: "B-new", value: 2),
+      TestItem(id: "3", name: "C-new", value: 3)
+    ]
+    
+    let syncResult = syncModel(
+      items, newItems,
+      getId = proc(item: TestItem): string = item.id,
+      getRoles = proc(old, new: TestItem): seq[int] =
+        if old.name != new.name: @[1] else: @[]
+    )
+    
+    # Simulate a nested-sync side effect for each update
+    for updateOp in syncResult.toUpdate:
+      items[updateOp.index] = updateOp.item
+      callbackCount.inc
+    
+    check callbackCount == 3  # Called for all updated items
+    check items[0].name == "A-new"
+    check items[1].name == "B-new"
+    check items[2].name == "C-new"
+
+  test "afterItemSync not called for insertions or deletions":
+    var callbackCount = 0
+    
+    let oldItems: seq[TestItem] = @[
+      TestItem(id: "1", name: "A", value: 1),
+      TestItem(id: "2", name: "B", value: 2)
+    ]
+    
+    let newItems: seq[TestItem] = @[
+      TestItem(id: "2", name: "B", value: 2),  # Item 1 removed
+      TestItem(id: "3", name: "C", value: 3)   # Item 3 added
+    ]
+    
+    let syncResult = syncModel(
+      oldItems, newItems,
+      getId = proc(item: TestItem): string = item.id,
+      getRoles = proc(old, new: TestItem): seq[int] = @[]
+    )
+    
+    # Count updates only (not inserts/removes)
+    for updateOp in syncResult.toUpdate:
+      callbackCount.inc
+    
+    # Callback should not be called - no updates, only insert + remove
+    check callbackCount == 0
+    check syncResult.toInsert.len == 1
+    check syncResult.toRemove.len == 1
+
+suite "Reorder detection (LIS)":
+  # syncModel must detect surviving-row reorders and emit them as minimal
+  # remove+insert pairs (it does NOT emit Qt moves). A pure reorder of the same
+  # set therefore has changes.
+  test "swap last two -> minimal remove+insert":
+    # old = [a, b, c], new = [a, c, b].
+    # LIS over the common oldIdx sequence keeps {a, b} stable; c is moved.
+    let old = @[TestItem(id: "a"), TestItem(id: "b"), TestItem(id: "c")]
+    let nu = @[TestItem(id: "a"), TestItem(id: "c"), TestItem(id: "b")]
+    let r = syncModel(old, nu, getId = proc(it: TestItem): string = it.id)
+    check r.hasChanges
+    check r.toInsert.len == 1
+    check r.toInsert[0].index == 1
+    check r.toRemove.len == 1
+    check r.toRemove[0].index == 2
+
+  test "full reverse -> LIS keeps one stable element":
+    let old = @[TestItem(id: "a"), TestItem(id: "b"), TestItem(id: "c")]
+    let nu = @[TestItem(id: "c"), TestItem(id: "b"), TestItem(id: "a")]
+    let r = syncModel(old, nu, getId = proc(it: TestItem): string = it.id)
+    check r.hasChanges
+    check r.toInsert.len == 2
+    check r.toRemove.len == 2
+
+  test "pure mid-list insert does NOT flag survivors as reordered":
+    # Regression guard: a cheap oldIdx==newIdx heuristic would spuriously mark
+    # every shifted survivor as moved. The LIS keeps them stable.
+    let old = @[TestItem(id: "a"), TestItem(id: "b"), TestItem(id: "c")]
+    let nu = @[TestItem(id: "x"), TestItem(id: "a"), TestItem(id: "b"), TestItem(id: "c")]
+    let r = syncModel(old, nu, getId = proc(it: TestItem): string = it.id)
+    check r.toInsert.len == 1
+    check r.toInsert[0].index == 0
+    check r.toRemove.len == 0
+
+  test "reorder deltas applied to a plain seq reproduce target order":
+    # Simulate applySync ordering (removes descending, then inserts ascending)
+    # on a plain seq and check it reproduces the target.
+    proc simulate(current, target: seq[string]): seq[string] =
+      let old = current.mapIt(TestItem(id: it))
+      let nu = target.mapIt(TestItem(id: it))
+      var work = old
+      let r = syncModel(old, nu, getId = proc(it: TestItem): string = it.id)
+      for rem in r.toRemove:            # descending from syncModel
+        work.delete(rem.index)
+      var ins = r.toInsert
+      ins.sort(proc(a, b: InsertOp[TestItem]): int = cmp(a.index, b.index))
+      for op in ins:
+        work.insert(op.item, op.index)
+      return work.mapIt(it.id)
+
+    check simulate(@["a", "b", "c"], @["b", "a", "c"]) == @["b", "a", "c"]
+    check simulate(@["a", "b", "c", "d", "e"], @["e", "d", "c", "b", "a"]) ==
+      @["e", "d", "c", "b", "a"]
+    check simulate(@["a", "b", "c", "d"], @["d", "a", "b", "c"]) ==
+      @["d", "a", "b", "c"]
+    check simulate(@["a", "b", "c", "d", "e", "f"], @["c", "f", "a", "e", "b", "d"]) ==
+      @["c", "f", "a", "e", "b", "d"]
+
+suite "Bulk Operations Tests":
+  test "Bulk remove - consecutive ranges are grouped":
+    # Test that consecutive removes are grouped into ranges
+    let items = @[
+      TestItem(id: "1", value: 1),
+      TestItem(id: "2", value: 2),
+      TestItem(id: "3", value: 3),
+      TestItem(id: "4", value: 4),
+      TestItem(id: "5", value: 5),
+      TestItem(id: "6", value: 6),
+      TestItem(id: "7", value: 7),
+    ]
+    
+    # Remove items 1, 2, 3 (consecutive) and 5, 6 (consecutive)
+    let newItems = @[
+      TestItem(id: "4", value: 4),
+      TestItem(id: "7", value: 7),
+    ]
+    
+    let result = syncModel(
+      items, newItems,
+      getId = proc(item: TestItem): string = item.id
+    )
+    
+    # Should have 5 remove operations (items 1,2,3,5,6 removed)
+    check result.toRemove.len == 5
+    
+    # Test groupConsecutiveRanges helper
+    let indices = result.toRemove.mapIt(it.index)
+    let ranges = groupConsecutiveRanges(indices)
+    
+    # Should group into 2 ranges
+    check ranges.len == 2
+    # First range: items at indices 0,1,2 (items with ids "1","2","3")
+    # Second range: items at indices 4,5 (items with ids "5","6")
+    check ranges[0].first == 0
+    check ranges[0].last == 2
+    check ranges[1].first == 4
+    check ranges[1].last == 5
+  
+  test "Bulk insert - consecutive inserts are grouped":
+    # Test that consecutive inserts are grouped
+    let items = @[
+      TestItem(id: "1", value: 1),
+      TestItem(id: "7", value: 7),
+    ]
+    
+    # Insert items 2,3,4,5,6 between 1 and 7
+    let newItems = @[
+      TestItem(id: "1", value: 1),
+      TestItem(id: "2", value: 2),
+      TestItem(id: "3", value: 3),
+      TestItem(id: "4", value: 4),
+      TestItem(id: "5", value: 5),
+      TestItem(id: "6", value: 6),
+      TestItem(id: "7", value: 7),
+    ]
+    
+    let result = syncModel(
+      items, newItems,
+      getId = proc(item: TestItem): string = item.id
+    )
+    
+    # Should have 5 insert operations
+    check result.toInsert.len == 5
+    
+    # All inserts should be consecutive indices (1,2,3,4,5)
+    var sortedInserts = result.toInsert
+    sortedInserts.sort(proc(a, b: InsertOp[TestItem]): int = cmp(a.index, b.index))
+    
+    check sortedInserts[0].index == 1
+    check sortedInserts[1].index == 2
+    check sortedInserts[2].index == 3
+    check sortedInserts[3].index == 4
+    check sortedInserts[4].index == 5
+  
+  test "Bulk dataChanged - consecutive updates with same roles are grouped":
+    # Test that consecutive updates with same roles are grouped
+    let items = @[
+      TestItem(id: "1", value: 1, name: "A"),
+      TestItem(id: "2", value: 2, name: "B"),
+      TestItem(id: "3", value: 3, name: "C"),
+      TestItem(id: "4", value: 4, name: "D"),
+      TestItem(id: "5", value: 5, name: "E"),
+    ]
+    
+    # Update all items - only value changed (same role for all)
+    let newItems = @[
+      TestItem(id: "1", value: 10, name: "A"),
+      TestItem(id: "2", value: 20, name: "B"),
+      TestItem(id: "3", value: 30, name: "C"),
+      TestItem(id: "4", value: 40, name: "D"),
+      TestItem(id: "5", value: 50, name: "E"),
+    ]
+    
+    let result = syncModel(
+      items, newItems,
+      getId = proc(item: TestItem): string = item.id,
+      getRoles = proc(old, new: TestItem): seq[int] =
+        var roles: seq[int]
+        if old.value != new.value:
+          roles.add(1)  # Value role
+        if old.name != new.name:
+          roles.add(2)  # Name role
+        return roles
+    )
+    
+    # All 5 items should be marked for update
+    check result.toUpdate.len == 5
+    
+    # All should have same roles (only value changed)
+    for updateOp in result.toUpdate:
+      check updateOp.roles == @[1]
+    
+    # With bulk ops, these should be emitted as single dataChanged(0, 4, [1])
+  
+  test "Bulk dataChanged - different roles prevent grouping":
+    # Test that updates with different roles are NOT grouped
+    let items = @[
+      TestItem(id: "1", value: 1, name: "A"),
+      TestItem(id: "2", value: 2, name: "B"),
+      TestItem(id: "3", value: 3, name: "C"),
+    ]
+    
+    # Update items with different role combinations
+    let newItems = @[
+      TestItem(id: "1", value: 10, name: "A"),      # Only value
+      TestItem(id: "2", value: 2, name: "Updated"),  # Only name
+      TestItem(id: "3", value: 30, name: "C"),      # Only value
+    ]
+    
+    let result = syncModel(
+      items, newItems,
+      getId = proc(item: TestItem): string = item.id,
+      getRoles = proc(old, new: TestItem): seq[int] =
+        var roles: seq[int]
+        if old.value != new.value:
+          roles.add(1)  # Value role
+        if old.name != new.name:
+          roles.add(2)  # Name role
+        return roles
+    )
+    
+    check result.toUpdate.len == 3
+    
+    # Different roles for each
+    check result.toUpdate[0].roles == @[1]     # Item 1: value only
+    check result.toUpdate[1].roles == @[2]     # Item 2: name only
+    check result.toUpdate[2].roles == @[1]     # Item 3: value only
+    
+    # Items 0 and 2 have same roles but are NOT consecutive,
+    # so should result in 3 separate dataChanged calls
+  
+  test "Bulk dataChanged - mixed consecutive groups":
+    # Test grouping with multiple consecutive groups
+    let items = @[
+      TestItem(id: "1", value: 1, name: "A"),
+      TestItem(id: "2", value: 2, name: "B"),
+      TestItem(id: "3", value: 3, name: "C"),
+      TestItem(id: "4", value: 4, name: "D"),
+      TestItem(id: "5", value: 5, name: "E"),
+      TestItem(id: "6", value: 6, name: "F"),
+    ]
+    
+    # Update with pattern: [value,value,name,name,value,value]
+    let newItems = @[
+      TestItem(id: "1", value: 10, name: "A"),     # Value
+      TestItem(id: "2", value: 20, name: "B"),     # Value
+      TestItem(id: "3", value: 3, name: "C2"),     # Name
+      TestItem(id: "4", value: 4, name: "D2"),     # Name
+      TestItem(id: "5", value: 50, name: "E"),     # Value
+      TestItem(id: "6", value: 60, name: "F"),     # Value
+    ]
+    
+    let result = syncModel(
+      items, newItems,
+      getId = proc(item: TestItem): string = item.id,
+      getRoles = proc(old, new: TestItem): seq[int] =
+        var roles: seq[int]
+        if old.value != new.value:
+          roles.add(1)  # Value role
+        if old.name != new.name:
+          roles.add(2)  # Name role
+        return roles
+    )
+    
+    check result.toUpdate.len == 6
+    
+    # Verify role patterns
+    check result.toUpdate[0].roles == @[1]  # Items 0-1: value
+    check result.toUpdate[1].roles == @[1]
+    check result.toUpdate[2].roles == @[2]  # Items 2-3: name
+    check result.toUpdate[3].roles == @[2]
+    check result.toUpdate[4].roles == @[1]  # Items 4-5: value
+    check result.toUpdate[5].roles == @[1]
+    
+    # With bulk ops, should emit 3 dataChanged calls:
+    # - dataChanged(0, 1, [1])  // Items 0-1
+    # - dataChanged(2, 3, [2])  // Items 2-3
+    # - dataChanged(4, 5, [1])  // Items 4-5
+  
+  test "Bulk operations - large dataset performance":
+    # Test bulk operations with large dataset
+    var items: seq[TestItem] = @[]
+    for i in 0..<1000:
+      items.add(TestItem(id: $i, value: i, name: "Item" & $i))
+    
+    # Update all items - only value changed (add 100 to ensure all change)
+    var newItems: seq[TestItem] = @[]
+    for i in 0..<1000:
+      newItems.add(TestItem(id: $i, value: i + 100, name: "Item" & $i))
+    
+    let result = syncModel(
+      items, newItems,
+      getId = proc(item: TestItem): string = item.id,
+      getRoles = proc(old, new: TestItem): seq[int] =
+        var roles: seq[int]
+        if old.value != new.value:
+          roles.add(1)
+        return roles
+    )
+    
+    # All 1000 items should be marked for update
+    check result.toUpdate.len == 1000
+    
+    # All should have same roles
+    for updateOp in result.toUpdate:
+      check updateOp.roles == @[1]
+    
+    # With bulk ops, this should result in just 1 dataChanged call!
+    # dataChanged(0, 999, [1])
+
+suite "Pattern 5: QObject-Exposing Models - updateItem Callback Tests":
+  
+  # For Pattern 5 tests, we need a QObject-like item with setters
+  type
+    QObjectLikeItem = ref object
+      id: string
+      name: string
+      value: int
+      nameSetterCalled: int
+      valueSetterCalled: int
+  
+  proc setName(self: QObjectLikeItem, newName: string) =
+    self.name = newName
+    self.nameSetterCalled.inc
+  
+  proc setValue(self: QObjectLikeItem, newValue: int) =
+    self.value = newValue
+    self.valueSetterCalled.inc
+  
+  test "updateItem callback is called for updates":
+    let oldItems = @[
+      QObjectLikeItem(id: "1", name: "Old1", value: 100),
+      QObjectLikeItem(id: "2", name: "Old2", value: 200),
+    ]
+    let newItems = @[
+      QObjectLikeItem(id: "1", name: "New1", value: 150),  # Updated
+      QObjectLikeItem(id: "2", name: "Old2", value: 200),  # Unchanged
+    ]
+    
+    var updateItemCalls = 0
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: QObjectLikeItem): string = item.id,
+      getRoles = proc(old, new: QObjectLikeItem): seq[int] =
+        var roles: seq[int]
+        if old.name != new.name: roles.add(1)
+        if old.value != new.value: roles.add(2)
+        return roles
+    )
+    
+    check result.toUpdate.len == 1
+    check result.toUpdate[0].index == 0
+    
+    # Simulate what applySyncWithBulkOps would do with updateItem callback
+    let updateItem = proc(existing: QObjectLikeItem, updated: QObjectLikeItem) =
+      updateItemCalls.inc
+      if existing.name != updated.name:
+        existing.setName(updated.name)
+      if existing.value != updated.value:
+        existing.setValue(updated.value)
+    
+    # Call updateItem for each update
+    for updateOp in result.toUpdate:
+      updateItem(oldItems[updateOp.index], updateOp.item)
+    
+    # Verify setters were called
+    check updateItemCalls == 1
+    check oldItems[0].nameSetterCalled == 1
+    check oldItems[0].valueSetterCalled == 1
+    check oldItems[0].name == "New1"
+    check oldItems[0].value == 150
+  
+  test "updateItem calls only changed property setters":
+    let oldItems = @[
+      QObjectLikeItem(id: "1", name: "Name1", value: 100),
+    ]
+    let newItems = @[
+      QObjectLikeItem(id: "1", name: "Name1", value: 999),  # Only value changed!
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: QObjectLikeItem): string = item.id,
+      getRoles = proc(old, new: QObjectLikeItem): seq[int] =
+        var roles: seq[int]
+        if old.name != new.name: roles.add(1)
+        if old.value != new.value: roles.add(2)
+        return roles
+    )
+    
+    check result.toUpdate.len == 1
+    
+    # updateItem callback
+    let updateItem = proc(existing: QObjectLikeItem, updated: QObjectLikeItem) =
+      if existing.name != updated.name:
+        existing.setName(updated.name)
+      if existing.value != updated.value:
+        existing.setValue(updated.value)
+    
+    updateItem(oldItems[0], result.toUpdate[0].item)
+    
+    # Only value setter should be called!
+    check oldItems[0].nameSetterCalled == 0  # NOT called
+    check oldItems[0].valueSetterCalled == 1  # Called once
+    check oldItems[0].value == 999
+  
+  test "updateItem with multiple items - fine-grained updates":
+    let oldItems = @[
+      QObjectLikeItem(id: "1", name: "A", value: 1),
+      QObjectLikeItem(id: "2", name: "B", value: 2),
+      QObjectLikeItem(id: "3", name: "C", value: 3),
+    ]
+    let newItems = @[
+      QObjectLikeItem(id: "1", name: "A_changed", value: 1),  # Name only
+      QObjectLikeItem(id: "2", name: "B", value: 222),         # Value only
+      QObjectLikeItem(id: "3", name: "C_changed", value: 333), # Both changed
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: QObjectLikeItem): string = item.id,
+      getRoles = proc(old, new: QObjectLikeItem): seq[int] =
+        var roles: seq[int]
+        if old.name != new.name: roles.add(1)
+        if old.value != new.value: roles.add(2)
+        return roles
+    )
+    
+    check result.toUpdate.len == 3
+    
+    # updateItem callback
+    let updateItem = proc(existing: QObjectLikeItem, updated: QObjectLikeItem) =
+      if existing.name != updated.name:
+        existing.setName(updated.name)
+      if existing.value != updated.value:
+        existing.setValue(updated.value)
+    
+    for updateOp in result.toUpdate:
+      updateItem(oldItems[updateOp.index], updateOp.item)
+    
+    # Item 1: Name setter called, value setter NOT called
+    check oldItems[0].nameSetterCalled == 1
+    check oldItems[0].valueSetterCalled == 0
+    check oldItems[0].name == "A_changed"
+    
+    # Item 2: Value setter called, name setter NOT called
+    check oldItems[1].nameSetterCalled == 0
+    check oldItems[1].valueSetterCalled == 1
+    check oldItems[1].value == 222
+    
+    # Item 3: BOTH setters called
+    check oldItems[2].nameSetterCalled == 1
+    check oldItems[2].valueSetterCalled == 1
+    check oldItems[2].name == "C_changed"
+    check oldItems[2].value == 333
+  
+  test "updateItem does not call setters when item unchanged":
+    let oldItems = @[
+      QObjectLikeItem(id: "1", name: "Same", value: 42),
+    ]
+    let newItems = @[
+      QObjectLikeItem(id: "1", name: "Same", value: 42),  # Identical!
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: QObjectLikeItem): string = item.id,
+      getRoles = proc(old, new: QObjectLikeItem): seq[int] =
+        var roles: seq[int]
+        if old.name != new.name: roles.add(1)
+        if old.value != new.value: roles.add(2)
+        return roles
+    )
+    
+    # No updates detected!
+    check result.toUpdate.len == 0
+    
+    # No setters should be called
+    check oldItems[0].nameSetterCalled == 0
+    check oldItems[0].valueSetterCalled == 0
+  
+  test "Pattern 5 proof: setters handle signals, no dataChanged needed":
+    # This test documents the key Pattern 5 optimization:
+    # Instead of calling dataChanged(entire item) which triggers ALL bindings,
+    # we call individual setters which emit fine-grained signals (nameChanged, valueChanged)
+    # that only trigger SPECIFIC bindings.
+    
+    let oldItems = @[
+      QObjectLikeItem(id: "1", name: "Old", value: 1),
+      QObjectLikeItem(id: "2", name: "Old", value: 2),
+      QObjectLikeItem(id: "3", name: "Old", value: 3),
+    ]
+    let newItems = @[
+      QObjectLikeItem(id: "1", name: "New", value: 1),  # Name changed
+      QObjectLikeItem(id: "2", name: "New", value: 2),  # Name changed
+      QObjectLikeItem(id: "3", name: "New", value: 3),  # Name changed
+    ]
+    
+    let result = syncModel(
+      oldItems, newItems,
+      getId = proc(item: QObjectLikeItem): string = item.id,
+      getRoles = proc(old, new: QObjectLikeItem): seq[int] =
+        var roles: seq[int]
+        if old.name != new.name: roles.add(1)
+        if old.value != new.value: roles.add(2)
+        return roles
+    )
+    
+    check result.toUpdate.len == 3
+    
+    let updateItem = proc(existing: QObjectLikeItem, updated: QObjectLikeItem) =
+      if existing.name != updated.name:
+        existing.setName(updated.name)  # Emits nameChanged() only!
+      # No need to check value - it didn't change
+    
+    for updateOp in result.toUpdate:
+      updateItem(oldItems[updateOp.index], updateOp.item)
+    
+    # PROOF: Only name setters called (3 times)
+    # In QML: Only bindings to `item.name` would re-evaluate
+    # Bindings to `item.value` would NOT be triggered!
+    check oldItems[0].nameSetterCalled == 1
+    check oldItems[0].valueSetterCalled == 0  # Not called!
+    check oldItems[1].nameSetterCalled == 1
+    check oldItems[1].valueSetterCalled == 0
+    check oldItems[2].nameSetterCalled == 1
+    check oldItems[2].valueSetterCalled == 0
+    
+    # In contrast, with dataChanged(role=KeyPair):
+    # - All 3 items would emit "entire item changed"
+    # - QML would re-evaluate ALL bindings (name AND value)
+    # - Result: 2x more QML work than necessary!
+
+when isMainModule:
+  echo "Running model sync tests..."
+

--- a/test/nim/typed_completion_test.nim
+++ b/test/nim/typed_completion_test.nim
@@ -1,0 +1,111 @@
+## End-to-end test for the typed task-completion primitive (finishTyped/takeTyped,
+## see app/core/tasks/qt) over the *real* StatusQ queued-invoke bridge.
+##
+## Proves the wiring the pure typed_handoff_test can't: a worker-built object graph
+## is delivered to a QObject slot on the GUI thread by handle (no JSON round-trip),
+## in emission order under rapid fire, that a handoff drained mid-flight makes the
+## slot's claim return nil without crashing, and that finishTyped is a no-op once
+## the app is shutting down. Mirrors signal_handler_test's QCoreApplication +
+## processEvents harness.
+
+import unittest, os
+import nimqml
+import app/core/tasks/qt
+import app/global/app_lifecycle
+# Selective import: pulling all of gen_qcoreapplication would re-export the seaqt
+# QObject and make the nimqml QtObject macro below ambiguous.
+from seaqt/qcoreapplication import QCoreApplication, create, processEvents
+
+# Pilot payload: a ref graph the worker builds and hands over intact. A dedicated
+# task-arg subtype is declared for the pilot per project convention (every new
+# threadpool task gets its own AsyncXxxTaskArg, even if empty).
+type
+  AsyncEchoPilotTaskArg* = ref object of QObjectTaskArg
+    seqNo: int
+
+  PilotResultObj = object of RootObj
+    seqNo: int
+    label: string
+    items: seq[int]
+  PilotResult = ref PilotResultObj
+
+QtObject:
+  type Receiver = ref object of QObject
+    lastLabel: string
+    lastItemsLen: int
+    order: seq[int]
+    nilCount: int
+
+  proc delete(self: Receiver) =
+    self.QObject.delete
+
+  proc onTypedDone*(self: Receiver, response: string) {.slot.} =
+    let r = takeTyped[PilotResult](response)
+    if r.isNil:
+      inc self.nilCount
+      return
+    self.lastLabel = r.label
+    self.lastItemsLen = r.items.len
+    self.order.add r.seqNo
+
+  proc newReceiver(): Receiver =
+    new(result, delete)
+    result.QObject.setup
+
+discard QCoreApplication.create()   # one app for the whole suite
+
+# Simulate a worker completion: build the finished graph, hand it off. In the real
+# system this body runs on a threadpool thread; here we invoke it directly since
+# the primitive under test is the completion handoff, not the scheduling.
+proc completeEcho(r: Receiver, seqNo: int, label: string, n: int) =
+  let arg = AsyncEchoPilotTaskArg(vptr: cast[uint](r.vptr), slot: "onTypedDone", seqNo: seqNo)
+  var items = newSeq[int](n)
+  for i in 0 ..< n:
+    items[i] = i
+  arg.finishTyped(PilotResult(seqNo: seqNo, label: label, items: items))
+
+proc pump(until: proc(): bool) =
+  var spins = 0
+  while not until() and spins < 300:
+    QCoreApplication.processEvents()
+    sleep(2)
+    inc spins
+
+suite "typed task completion (end-to-end bridge)":
+
+  test "typed object delivered to the slot by handle, not serialized":
+    let r = newReceiver()
+    r.completeEcho(1, "hello", 3)
+    check r.order.len == 0                     # QueuedConnection: not synchronous
+    pump(proc(): bool = r.order.len == 1)
+    check r.order == @[1]
+    check r.lastLabel == "hello"
+    check r.lastItemsLen == 3
+
+  test "rapid fire preserves emission order":
+    let r = newReceiver()
+    for i in 1 .. 50:
+      r.completeEcho(i, "n", 0)
+    pump(proc(): bool = r.order.len == 50)
+    var expected: seq[int]
+    for i in 1 .. 50:
+      expected.add i
+    check r.order == expected
+
+  test "handoff drained in flight: slot claim returns nil, no crash":
+    let r = newReceiver()
+    r.completeEcho(99, "late", 1)              # parked + slot invoke queued
+    drainHandoffs()                            # shutdown sweep before slot runs
+    pump(proc(): bool = r.nilCount >= 1)
+    check r.order.len == 0                      # drained object never applied
+    check r.nilCount == 1                       # slot ran, claim nil-safe
+
+  test "finishTyped is a no-op once shutting down":
+    # Kept last: markShuttingDown flips a process-global that later completions
+    # would also observe.
+    let r = newReceiver()
+    markShuttingDown()
+    r.completeEcho(7, "ignored", 1)            # early-returns; nothing parked/queued
+    pump(proc(): bool = r.order.len > 0 or r.nilCount > 0)
+    check r.order.len == 0
+    check r.nilCount == 0

--- a/test/nim/typed_completion_test.nim
+++ b/test/nim/typed_completion_test.nim
@@ -100,6 +100,13 @@ suite "typed task completion (end-to-end bridge)":
     check r.order.len == 0                      # drained object never applied
     check r.nilCount == 1                       # slot ran, claim nil-safe
 
+  test "takeTyped returns nil on a malformed handle string (never raises)":
+    # ADR 0004 contract: takeTyped is nil-safe for unknown/claimed/drained AND
+    # malformed handles — the GUI-thread completion slot must never raise.
+    for garbage in ["", "not-a-number", "12abc", "-1", "18446744073709551616999"]:
+      let claimed = takeTyped[PilotResult](garbage)
+      check claimed.isNil
+
   test "finishTyped is a no-op once shutting down":
     # Kept last: markShuttingDown flips a process-global that later completions
     # would also observe.

--- a/test/nim/typed_handoff_test.nim
+++ b/test/nim/typed_handoff_test.nim
@@ -1,0 +1,98 @@
+## Unit tests for the typed task-completion handoff registry
+## (app/core/tasks/typed_handoff). Pure — no Qt.
+##
+## Proves the ownership contract of the registry seam: a producer parks an
+## object graph and a consumer claims it exactly once, with no leak or
+## double-free under ORC/refc, and a shutdown drain destroys anything still in
+## flight. Delivery *ordering* (a Qt queued-connection property) is proven
+## separately in the end-to-end bridge test.
+
+import unittest
+import std/atomics
+
+import app/core/tasks/typed_handoff
+
+# Destructor-instrumented pilot payload. `liveCount` is the independent source of
+# truth for leak / double-free detection: every construction bumps it, every
+# destruction drops it; a clean run ends at exactly zero.
+var liveCount: Atomic[int]
+
+type
+  PilotPayloadObj = object of RootObj
+    value: int
+  PilotPayload = ref PilotPayloadObj
+
+proc `=destroy`(o: var PilotPayloadObj) =
+  liveCount.atomicDec
+
+proc newPilot(value: int): PilotPayload =
+  result = PilotPayload(value: value)
+  liveCount.atomicInc
+
+# Leak / double-free is proven by the destructor count reaching zero — but only
+# under ORC, the app's actual mm, where destruction is deterministic at scope
+# exit. Under refc (the test-runner default) destruction is deferred to GC cycles
+# and not deterministic, so the count assertions are ORC-gated. The soak loops
+# still *run* under both modes: a double-free would crash the process regardless,
+# so refc still exercises the claim/drain paths for corruption.
+template checkNoLeak(body: untyped) =
+  when compileOption("mm", "orc"):
+    body
+
+suite "typed_handoff registry":
+
+  setup:
+    drainHandoffs()          # isolate tests from any prior parked entries
+    liveCount.store(0)
+
+  test "park then claim returns the same object graph":
+    let h = parkHandoff(newPilot(42))
+    check pendingHandoffs() == 1
+    let got = claimHandoff[PilotPayload](h)
+    check got != nil
+    check got.value == 42
+    check pendingHandoffs() == 0
+
+  test "claim removes the entry; a second claim yields nil":
+    let h = parkHandoff(newPilot(7))
+    discard claimHandoff[PilotPayload](h)
+    check claimHandoff[PilotPayload](h) == nil
+
+  test "claim of an unknown handle yields nil":
+    check claimHandoff[PilotPayload](999999.TaskHandle) == nil
+
+  test "many outstanding handoffs never cross-talk (claimed in reverse)":
+    var handles: seq[TaskHandle]
+    for i in 0 ..< 1000:
+      handles.add parkHandoff(newPilot(i))
+    check pendingHandoffs() == 1000
+    for i in countdown(999, 0):
+      let got = claimHandoff[PilotPayload](handles[i])
+      check got.value == i
+    check pendingHandoffs() == 0
+
+  test "drain destroys every in-flight handoff (shutdown-in-flight)":
+    for i in 0 ..< 50:
+      discard parkHandoff(newPilot(i))
+    check pendingHandoffs() == 50
+    check liveCount.load == 50
+    drainHandoffs()
+    check pendingHandoffs() == 0
+    checkNoLeak: check liveCount.load == 0    # all destroyed, none leaked
+
+  test "soak: no leak or double-free across many park/claim cycles":
+    for i in 0 ..< 20000:
+      let h = parkHandoff(newPilot(i))
+      let got = claimHandoff[PilotPayload](h)
+      doAssert got.value == i
+    check pendingHandoffs() == 0
+    checkNoLeak: check liveCount.load == 0    # every object destroyed exactly once
+
+  test "soak mixed: claimed and drained paths both balance":
+    for round in 0 ..< 1000:
+      let a = parkHandoff(newPilot(1))
+      discard parkHandoff(newPilot(2))     # left in flight
+      discard claimHandoff[PilotPayload](a)
+      drainHandoffs()                       # sweeps the un-claimed one
+    check pendingHandoffs() == 0
+    checkNoLeak: check liveCount.load == 0

--- a/test/nim/typed_handoff_test.nim
+++ b/test/nim/typed_handoff_test.nim
@@ -61,6 +61,16 @@ suite "typed_handoff registry":
   test "claim of an unknown handle yields nil":
     check claimHandoff[PilotPayload](999999.TaskHandle) == nil
 
+  test "claim as the wrong type yields nil (never raises)":
+    # Same never-raises contract as an unknown handle: a mismatched claim on the
+    # GUI thread must degrade to nil, not an ObjectConversionDefect. The parked
+    # object is popped and destroyed either way.
+    type UnrelatedPayload = ref object of RootObj
+    let h = parkHandoff(newPilot(3))
+    let got = claimHandoff[UnrelatedPayload](h)
+    check got.isNil
+    check pendingHandoffs() == 0
+
   test "many outstanding handoffs never cross-talk (claimed in reverse)":
     var handles: seq[TaskHandle]
     for i in 0 ..< 1000:

--- a/test/nim/typed_handoff_thread_soak_test.nim
+++ b/test/nim/typed_handoff_thread_soak_test.nim
@@ -1,0 +1,130 @@
+## Cross-thread ORC soak for the typed-completion handoff.
+##
+## The device gate SIGSEGV'd on the GUI thread inside eqcopy(token_group) ->
+## rememberCycle while applying a worker-built token graph. This reproduces the
+## SHAPE minimally, under the app's memory model (--mm:orc -d:useMalloc
+## --threads:on): a real worker thread builds a big ref-of-seq-of-ref graph with
+## items ALIASED across two containers (like tokensOfInterestByKey +
+## groupsOfInterestByKey sharing TokenItems), hands it over via the registry, and
+## the main thread "applies" it. Copy-apply is what crashed on device; move-apply
+## is the candidate fix. `liveItems` is the independent leak/double-free witness.
+##
+## Build with: nim c -r --mm:orc -d:useMalloc --threads:on
+
+import std/[tables, strutils, atomics, sequtils, times]
+import unittest
+
+import app/core/tasks/typed_handoff
+
+var liveItems: Atomic[int]
+
+type
+  ItemObj {.acyclic.} = object of RootObj
+    key: string
+    payload: string
+  Item = ref ItemObj
+  GroupObj {.acyclic.} = object of RootObj
+    key: string
+    items: seq[Item]
+  Group = ref GroupObj
+  BuiltResult = ref object of RootObj
+    byKey: Table[string, Item]
+    groupsByKey: Table[string, Group]
+    groupSeq: seq[Group]
+
+proc `=destroy`(o: var ItemObj) =
+  liveItems.atomicDec
+  `=destroy`(o.key)
+  `=destroy`(o.payload)
+
+proc newItem(key: string): Item =
+  result = Item(key: key, payload: "x".repeat(64))
+  liveItems.atomicInc
+
+proc buildGraph(n, groups: int): BuiltResult =
+  result = BuiltResult(byKey: initTable[string, Item](), groupsByKey: initTable[string, Group]())
+  for i in 0 ..< n:
+    let it = newItem($i)
+    result.byKey[it.key] = it                       # container 1
+    let gk = "g" & $(i mod groups)
+    if not result.groupsByKey.hasKey(gk):
+      result.groupsByKey[gk] = Group(key: gk, items: @[])
+    result.groupsByKey[gk].items.add(it)            # container 2 (aliased ref)
+  result.groupSeq = toSeq(result.groupsByKey.values)
+
+# --- worker thread: build + park ---------------------------------------------
+type BuildSpec = tuple[n, groups: int, outHandle: ptr TaskHandle]
+proc workerBuild(spec: BuildSpec) {.thread.} =
+  let h = parkHandoff(buildGraph(spec.n, spec.groups))
+  spec.outHandle[] = h
+
+proc handoffFromWorker(n, groups: int): BuiltResult =
+  var handle: TaskHandle
+  var t: Thread[BuildSpec]
+  createThread(t, workerBuild, (n, groups, addr handle))
+  joinThread(t)
+  claimHandoff[BuiltResult](handle)
+
+# Copy the built containers into service state (the crashing path under refc).
+proc applyByCopy(r: BuiltResult): tuple[a: Table[string, Item], b: Table[string, Group], c: seq[Group]] =
+  result.a = r.byKey
+  result.b = r.groupsByKey
+  result.c = r.groupSeq
+
+# Move the containers instead of copying.
+proc applyByMove(r: BuiltResult): tuple[a: Table[string, Item], b: Table[string, Group], c: seq[Group]] =
+  result.a = move r.byKey
+  result.b = move r.groupsByKey
+  result.c = move r.groupSeq
+
+# The whole suite is ORC-only. The handoff transfers a ref graph BETWEEN threads,
+# which is sound only on ORC's shared heap (the app builds --mm:orc -d:useMalloc).
+# Under refc each thread has its own GC heap, so claiming a worker-allocated graph on
+# the main thread reads freed/foreign memory and crashes — so these tests are skipped
+# under refc (the mm the make suite uses); run them with `nim c -r --mm:orc`.
+suite "typed handoff — cross-thread ORC graph apply":
+
+  test "move-apply of a large worker-built aliased graph: no crash, no leak":
+    when compileOption("mm", "orc"):
+      liveItems.store(0)
+      for iter in 0 ..< 20:
+        let r = handoffFromWorker(2000, 50)
+        var applied = applyByMove(r)
+        check applied.a.len == 2000
+        check applied.b.len == 50
+        check applied.c.len == 50
+      check liveItems.load == 0
+    else:
+      skip()
+
+  test "copy-apply of a large worker-built aliased graph (device-crash repro)":
+    when compileOption("mm", "orc"):
+      liveItems.store(0)
+      for iter in 0 ..< 20:
+        let r = handoffFromWorker(2000, 50)
+        var applied = applyByCopy(r)
+        check applied.a.len == 2000
+      check liveItems.load == 0
+    else:
+      skip()
+
+  test "perf: copy-apply is the O(graph) cost; move-apply is O(1) per container":
+    # The slot's copy is the O(graph) cost; move eliminates it. Timing only (no
+    # hard threshold — just evidence that copy >> move on the same graph).
+    when compileOption("mm", "orc"):
+      const N = 20000
+      var rCopy = handoffFromWorker(N, 200)
+      let t0 = epochTime()
+      var appliedCopy = applyByCopy(rCopy)
+      let copyMs = (epochTime() - t0) * 1000
+      var rMove = handoffFromWorker(N, 200)
+      let t1 = epochTime()
+      var appliedMove = applyByMove(rMove)
+      let moveMs = (epochTime() - t1) * 1000
+      echo "  [perf] copy-apply=", copyMs.formatFloat(ffDecimal, 3), "ms  move-apply=",
+        moveMs.formatFloat(ffDecimal, 3), "ms  (N=", N, ")"
+      check appliedCopy.a.len == N
+      check appliedMove.a.len == N
+      check moveMs < copyMs   # move must be cheaper than the per-element copy
+    else:
+      skip()


### PR DESCRIPTION
Core infrastructure used by the wallet perf rework (first of a 5-PR stack). `model_sync`, the typed handoff and `CowSeq` are dormant until the follow-up PRs wire them in; the signal-type scan is the one live change (see its bullet).

Addressing a few issues:
1- Efficient qt model update signals. Adding a single-line utility to efficiently update models
2- Moving data efficiently between services and modules, controllers, views and models. Introducing a COW seq.
3- Efficient data parsing. Most of the times we need to parse twice expensive json data coming from statusgo. Once in the threadpool and then in the main thread. Now that we're using ORC everywhere we're free to use typed asynchronous task results. Parsing happens only in the threadpool.
4- Avoid parsing unknown status-go events.

- **model_sync** — granular model-update library: diffs an incoming snapshot against a live `QAbstractListModel` and emits minimal insert/remove/dataChanged instead of `beginResetModel` (reorders emit as remove+insert — there is no Qt moveRows emission). Inline LIS-based reorder detection, indexed callbacks, fast paths for no-change and whole-list load/clear (empty↔N via reset). Caller surface: the `modelSync(model, container, newItems)` one-liner — identity/roles supplied by compile-time `syncKey`/`syncRoles` overloads next to the item type — plus `reconcileByKey` for identity-preserving keyed child models/QObjects, with debug/test guards (duplicate-key assert, missing-`syncKey` diagnostic at the call site).

Usage
```
  # specify the key
  proc syncKey(it: BalanceItem): string = it.tokenKey

  # answers the question What changed
  proc syncRoles(o, n: BalanceItem): seq[int] =
    result = @[]
    if o.balance != n.balance: result.add(ModelRole.Balance.int)
    if o.loading != n.loading: result.add(ModelRole.Loading.int)

  # single line update for both self.items and qt model signals
  proc updateBalances*(self: BalancesModel, newBalances: seq[BalanceItem]) =
     self.modelSync(self.items, newBalances)
```

- **Typed task-completion handoff** (threadpool) — workers pass fully-built Nim objects to GUI-thread completion slots by handle (`finishTyped`/`takeTyped`), MOVE semantics, exactly-once. Replaces re-serializing results to JSON and re-parsing them on the GUI thread. See the ADR added in this PR.

```
  # define the result
  type
    RefreshResult* = ref object of RootObj
      tokens*: seq[TokenItem]
      error*: string
    
    AsyncRefreshTaskArg = ref object of QObjectTaskArg
      requestId: int

  proc asyncRefreshTask(argEncoded: string) =
    let arg = decode(argEncoded, AsyncRefreshTaskArg)

    var res: RefreshResult
    try:
      let raw = backend.fetchTokens()
      res = RefreshResult(tokens: buildTokens(raw))
    finally:
      if res.isNil:
        res = RefreshResult(error: "assembly produced no result")
      arg.finishTyped(res)

  proc onAsyncRefreshDone(self: Service, response: string) {.slot.} =
    # !!! IMPORTANT!!!
    # Somebody has to claim the threadpool result, otherwise it will leak
    let res = takeTyped[RefreshResult](response)
    self.applyTokens(res.tokens)
```

- **CowSeq** — copy-on-write seq with O(1) snapshot, for handing model snapshots across threads without copying.
- **Signal-type scan** — the signals manager scans the envelope for the signal type and skips full JSON decode for unhandled signal types (if the type token isn't found it falls back to a full parse, so a status-go marshaling change can't silently drop a handled signal). This is the one live behavior change here: unhandled types are now dropped at `debug` before parsing, where they previously reached the decoder and logged at `warn` — net signal dispatch is unchanged.

**Why**: device profiling (Android warm restart, modal opens) attributed multi-second GUI stalls to full-model resets propagating through QML proxy chains and giant JSON payloads decoded on the GUI thread in task completions. These are the primitives the follow-up PRs use to fix that.

**How to review**: each component is self-contained with unit tests in `test/nim/` (model_sync reorder + bulk, typed handoff incl. cross-thread thread soak, signal scan). The ADR explains the handoff design and its ORC/`{.acyclic.}` constraints.

Stack: this PR → token-service rework → terminal models → modal-open fixes → benches/tooling. Umbrella: #21505.

See it in action here https://github.com/status-im/status-app/pull/21501
