### PR TITLE
perf(wallet): token service — worker-side parsing, refresh-storm fixes, granular model updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1073,6 +1073,8 @@ nim-test-run/test/nim/typed_completion_test.nim: | statusq
 # models.
 nim-test-run/test/nim/model_sync_move_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
 nim-test-run/test/nim/model_sync_unified_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
+nim-test-run/test/nim/token_groups_model_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
+nim-test-run/test/nim/grouped_account_assets_model_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
 
 ifneq ($(mkspecs),win32)
 nim-test-run/%: NIM_PARAMS += --passL:"$(QT_SEAQT_EXTRA_LIBS)"

--- a/src/app/core/tasks/qt.nim
+++ b/src/app/core/tasks/qt.nim
@@ -45,8 +45,10 @@ proc finishTyped*[T](arg: QObjectTaskArg, payload: sink T) =
 proc takeTyped*[T](response: string): T =
   ## Claim the object delivered by `finishTyped`. Call from the completion slot,
   ## passing the slot's string argument. Transfers exclusive ownership to the GUI
-  ## thread. Returns nil if the handoff was drained (shutdown) before the slot
-  ## ran, or if `response` is not a valid handle — never raises.
+  ## thread. Returns nil if the handoff was drained (shutdown) before the slot ran,
+  ## or if `response` is not a valid handle — a non-numeric string must yield nil
+  ## (drained semantics), never raise, so a slot wired to the wrong producer can't
+  ## throw out of the completion path and wedge a caller's in-flight gate.
   var handle: TaskHandle
   try:
     handle = parseBiggestUInt(response).TaskHandle

--- a/src/app/modules/main/wallet_section/all_tokens/market_details_item.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/market_details_item.nim
@@ -122,6 +122,28 @@ QtObject:
     self.changePct24hourChanged()
     self.change24hourChanged()
 
+  proc updateRepresentativeToken*(self: MarketDetailsItem, tokenKey: string, tokenPrice: float64,
+      tokenMarketValues: TokenMarketValuesItem) =
+    ## The group's representative token (the first priced token in the group) changed
+    ## for a surviving group key: repoint tokenKey and refresh every derived figure so
+    ## the market-values signal path (which re-fetches by self.tokenKey) reads the new
+    ## token rather than the stale one. Currency format is untouched (its own updater).
+    self.tokenKey = tokenKey
+    self.tokenPrice = tokenPrice
+    self.tokenMarketValues = tokenMarketValues
+    self.currencyPriceItem = currencyAmountToItem(self.tokenPrice, self.currencyFormat)
+    self.marketCapItem = currencyAmountToItem(self.tokenMarketValues.marketCap, self.currencyFormat)
+    self.highDayItem = currencyAmountToItem(self.tokenMarketValues.highDay, self.currencyFormat)
+    self.lowDayItem = currencyAmountToItem(self.tokenMarketValues.lowDay, self.currencyFormat)
+    self.currencyPriceChanged()
+    self.marketCapChanged()
+    self.highDayChanged()
+    self.lowDayChanged()
+    self.changePctHourChanged()
+    self.changePctDayChanged()
+    self.changePct24hourChanged()
+    self.change24hourChanged()
+
   proc setup*(self: MarketDetailsItem) =
     self.QObject.setup
 

--- a/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
@@ -1,5 +1,6 @@
 import app/modules/shared_models/model_utils
-import nimqml, tables, strutils, algorithm
+import app/modules/shared/model_sync
+import nimqml, tables, strutils, algorithm, sequtils
 
 import io_interface, tokens_model, market_details_item
 
@@ -35,7 +36,13 @@ QtObject:
     delegate: io_interface.TokenGroupsModelDataSource
     tokensModel: TokensModel
     marketValuesDelegate: io_interface.TokenMarketValuesDataSource
-    tokenMarketDetails: seq[MarketDetailsItem]
+    # Market details keyed by group key (not row index): identity-independent of
+    # insert/remove/move so survivors keep the SAME MarketDetailsItem instance the
+    # QML view is bound to.
+    tokenMarketDetails: Table[string, MarketDetailsItem]
+    # Cached snapshot the main (non-lazy) model diffs against via modelSync,
+    # replacing the beginResetModel on every refresh. data()/rowCount read this.
+    cachedGroups: seq[TokenGroupItem]
     modelModes: seq[ModelMode]
     lazyLoadingBatchSize: int
     lazyLoadingInitialCount: int
@@ -58,7 +65,7 @@ QtObject:
     result.setup
     result.delegate = delegate
     result.marketValuesDelegate = marketValuesDelegate
-    result.tokenMarketDetails = @[]
+    result.tokenMarketDetails = initTable[string, MarketDetailsItem]()
     result.modelModes = modelModes
     result.lazyLoadingBatchSize = lazyLoadingBatchSize
     result.lazyLoadingInitialCount = lazyLoadingInitialCount
@@ -72,7 +79,9 @@ QtObject:
   proc getDisplayModel(self: TokenGroupsModel): var seq[TokenGroupItem] =
     if ModelMode.UseLazyLoading in self.modelModes or ModelMode.IsSearchResult in self.modelModes:
       return self.loadedItems
-    return self.getSourceModel()
+    # Main model: read the cached snapshot maintained by modelSync, not the
+    # live delegate seq — so the model's rows are what the granular diff produced.
+    return self.cachedGroups
 
   method rowCount(self: TokenGroupsModel, index: QModelIndex = nil): int =
     return self.getDisplayModel().len
@@ -131,10 +140,11 @@ QtObject:
     guardModelData(index, self.rowCount(), role, ModelRole)
 
     let noMarketDetails = ModelMode.NoMarketDetails in self.modelModes
-    if not noMarketDetails and index.row >= self.tokenMarketDetails.len:
-      return
 
     let item = self.getDisplayModel()[index.row]
+
+    if not noMarketDetails and not self.tokenMarketDetails.hasKey(item.key):
+      return
 
     let enumRole = role.ModelRole
     case enumRole:
@@ -175,7 +185,7 @@ QtObject:
       of ModelRole.MarketDetails:
         if noMarketDetails:
           return newQVariant("")
-        return newQVariant(self.tokenMarketDetails[index.row])
+        return newQVariant(self.tokenMarketDetails[item.key])
       of ModelRole.DetailsLoading:
         return newQVariant(self.delegate.getTokensDetailsLoading())
       of ModelRole.MarketDetailsLoading:
@@ -194,16 +204,86 @@ QtObject:
       return (tokens[0].key, self.marketValuesDelegate.getPriceForToken(tokens[0].key))
     return ("", 0.0)
 
-  proc addMarketDetailsItem*(self: TokenGroupsModel, index: int, tokensList: var seq[TokenGroupItem], currencyFormat: var CurrencyFormatDto) =
-    let group = tokensList[index]
-    if group.tokens.len == 0:
-      return
+  proc buildMarketDetailsItem(self: TokenGroupsModel, group: TokenGroupItem, currencyFormat: CurrencyFormatDto): MarketDetailsItem =
     let (tokenKey, tokenPrice) = self.priceForTokenGroup(group.tokens)
     let tokenMarketValues = self.marketValuesDelegate.getMarketValuesForToken(tokenKey)
-    let item = newMarketDetailsItem(tokenKey, tokenPrice, tokenMarketValues, currencyFormat)
-    self.tokenMarketDetails.add(item)
+    return newMarketDetailsItem(tokenKey, tokenPrice, tokenMarketValues, currencyFormat)
+
+  proc syncKey(it: TokenGroupItem): string = it.key
+
+  proc rebuildMarketDetails(self: TokenGroupsModel, groups: seq[TokenGroupItem]) =
+    ## Rebuild tokenMarketDetails (keyed by group key) for the given display list,
+    ## PRESERVING the existing MarketDetailsItem instance for a surviving group key
+    ## (QML is bound to it, and the market-values signal path updates it in place),
+    ## creating a new one only for a new key, and dropping removed keys. Keying by
+    ## group key makes this immune to insert/remove/move — no index realignment.
+    if ModelMode.NoMarketDetails in self.modelModes:
+      return
+    let currencyFormat = self.marketValuesDelegate.getCurrentCurrencyFormat()
+    # Groups with no tokens carry no market details; drop them before reconciling
+    # so a tokenless key never gets an instance (matches the pre-modelSync skip).
+    let withTokens = groups.filterIt(it.tokens.len > 0)
+    reconcileByKey(self.tokenMarketDetails, withTokens,
+      create = proc(group: TokenGroupItem): MarketDetailsItem =
+        self.buildMarketDetailsItem(group, currencyFormat))
+
+  proc syncRoles(oldItem, newItem: TokenGroupItem): seq[int] =
+    ## Item-derived roles only (Name/Symbol/Decimals/LogoUri/Type/Tokens/CommunityId).
+    ## Service-getter roles (WebsiteUrl/Description/Visible/Position/*Loading) are
+    ## driven by their own separate dataChanged signals and are NOT folded in here.
+    ## TokenItem holds only static metadata (no balances), so a plain refresh with an
+    ## unchanged group set yields no role changes — the common, zero-work case.
+    result = @[]
+    if oldItem.name != newItem.name: result.add(ModelRole.Name.int)
+    if oldItem.symbol != newItem.symbol: result.add(ModelRole.Symbol.int)
+    if oldItem.decimals != newItem.decimals: result.add(ModelRole.Decimals.int)
+    if oldItem.logoUri != newItem.logoUri: result.add(ModelRole.LogoUri.int)
+    if oldItem.`type` != newItem.`type`: result.add(ModelRole.Type.int)
+    # Tokens is a ref seq — compare by content signature, not reference identity.
+    # Includes customToken (tokens_model shows it) so a customToken flip on a
+    # surviving token key re-reads the Tokens sub-model.
+    let oldSig = oldItem.tokens.mapIt((it.key, it.name, it.symbol, it.decimals,
+      it.chainId, it.address, it.logoUri, it.communityData.id, it.customToken, it.`type`))
+    let newSig = newItem.tokens.mapIt((it.key, it.name, it.symbol, it.decimals,
+      it.chainId, it.address, it.logoUri, it.communityData.id, it.customToken, it.`type`))
+    if oldSig != newSig:
+      result.add(ModelRole.Tokens.int)
+      result.add(ModelRole.MarketDetails.int)
+      result.add(ModelRole.CommunityId.int)
+      # Description is community-branched (isCommunityTokenGroup); a community-status
+      # flip is captured by communityData.id in the signature above, so re-read it.
+      result.add(ModelRole.Description.int)
 
   proc modelsUpdated*(self: TokenGroupsModel, resetModelSize: bool = false, mandatoryKeys: seq[string] = @[]) =
+    let isMainModel = ModelMode.UseLazyLoading notin self.modelModes and
+                      ModelMode.IsSearchResult notin self.modelModes
+
+    # Incremental path: the main model on a plain refresh diffs the new
+    # groups against its cached snapshot and emits granular insert/remove/
+    # dataChanged instead of a full beginResetModel (which tears down every QML
+    # delegate and rebuilds every per-row sub-model). syncModel detects the
+    # hash-order reorder of the group set via LIS and degrades it to
+    # remove+insert. Market details are re-keyed by group key so surviving
+    # groups keep their MarketDetailsItem instance across the diff.
+    if isMainModel and not resetModelSize:
+      # CORRECTNESS DEPENDENCY: this old-vs-new diff only works because the token
+      # service swaps in FRESH TokenGroupItem instances each refresh
+      # (swap-not-clear) rather than mutating in place — cachedGroups holds
+      # the prior fresh instances as the snapshot. If a future change mutates the
+      # group items in place, cachedGroups would alias newGroups and every diff
+      # would see "no change". Keep the swap.
+      let newGroups = self.getSourceModel()
+      # Build market-details keys BEFORE modelSync announces beginInsertRows
+      # for any new group: data(MarketDetails) early-returns an empty QVariant when
+      # the row's key is missing from the table, and nothing emits dataChanged
+      # afterwards — so a newly-inserted row would render empty until an unrelated
+      # signal fired. rebuildMarketDetails is identity-preserving, so survivors keep
+      # their instances and the transient gating of a being-removed row is harmless.
+      self.rebuildMarketDetails(newGroups)
+      self.modelSync(self.cachedGroups, newGroups)
+      self.hasMoreItemsChanged()
+      return
+
     self.beginResetModel()
     defer:
       self.endResetModel()
@@ -241,15 +321,7 @@ QtObject:
           if self.loadedItems.len >= self.lazyLoadingInitialCount:
             break
 
-    if ModelMode.NoMarketDetails in self.modelModes:
-      return
-
-    self.tokenMarketDetails = @[]
-    var
-      tokensList = self.getDisplayModel()
-      currencyFormat = self.marketValuesDelegate.getCurrentCurrencyFormat()
-    for index in countup(0, self.rowCount()-1):
-      self.addMarketDetailsItem(index, tokensList, currencyFormat)
+    self.rebuildMarketDetails(self.getDisplayModel())
 
   proc fetchMore*(self: TokenGroupsModel) {.slot.} =
     if not self.getHasMoreItems() or self.isLoadingMore:
@@ -276,14 +348,7 @@ QtObject:
         self.loadedKeys[key] = true
         self.loadedItems.add(sourceModel[index])
 
-    if ModelMode.NoMarketDetails in self.modelModes:
-      return
-
-    var
-      tokensList = self.getDisplayModel()
-      currencyFormat = self.marketValuesDelegate.getCurrentCurrencyFormat()
-    for index in countup(first, last):
-      self.addMarketDetailsItem(index, tokensList, currencyFormat)
+    self.rebuildMarketDetails(self.getDisplayModel())
 
   proc getSearchRelevance(item: TokenGroupItem, keywordLower: string): int =
     if keywordLower.len == 0:
@@ -350,7 +415,7 @@ QtObject:
     if ModelMode.NoMarketDetails in self.modelModes:
       return
     if not self.delegate.getTokensMarketValuesLoading():
-      for marketDetails in self.tokenMarketDetails:
+      for marketDetails in self.tokenMarketDetails.values:
         marketDetails.updateTokenPrice(self.marketValuesDelegate.getPriceForToken(marketDetails.tokenKey))
         marketDetails.updateTokenMarketValues(self.marketValuesDelegate.getMarketValuesForToken(marketDetails.tokenKey))
 
@@ -376,7 +441,7 @@ QtObject:
     if ModelMode.NoMarketDetails in self.modelModes:
       return
     let currencyFormat = self.marketValuesDelegate.getCurrentCurrencyFormat()
-    for marketDetails in self.tokenMarketDetails:
+    for marketDetails in self.tokenMarketDetails.values:
         marketDetails.updateCurrencyFormat(currencyFormat)
 
   proc tokenPreferencesUpdated*(self: TokenGroupsModel) =
@@ -388,9 +453,18 @@ QtObject:
       defer: lastindex.delete
       self.dataChanged(index, lastindex, @[ModelRole.Visible.int, ModelRole.Position.int])
 
+  proc marketDetailsItemForKey*(self: TokenGroupsModel, groupKey: string): MarketDetailsItem =
+    ## Test/inspection accessor: the MarketDetailsItem instance held for a group
+    ## key, or nil if none. Used to assert identity preservation across a diff.
+    self.tokenMarketDetails.getOrDefault(groupKey, nil)
+
+  proc groupKeysInOrder*(self: TokenGroupsModel): seq[string] =
+    ## Test/inspection accessor: the group keys in display order (what QML sees).
+    self.getDisplayModel().mapIt(it.key)
+
   proc setup(self: TokenGroupsModel) =
     self.QAbstractListModel.setup
-    self.tokenMarketDetails = @[]
+    self.tokenMarketDetails = initTable[string, MarketDetailsItem]()
 
   proc delete(self: TokenGroupsModel) =
     self.QAbstractListModel.delete

--- a/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
@@ -225,7 +225,15 @@ QtObject:
     let withTokens = groups.filterIt(it.tokens.len > 0)
     reconcileByKey(self.tokenMarketDetails, withTokens,
       create = proc(group: TokenGroupItem): MarketDetailsItem =
-        self.buildMarketDetailsItem(group, currencyFormat))
+        self.buildMarketDetailsItem(group, currencyFormat),
+      update = proc(existing: MarketDetailsItem, group: TokenGroupItem) =
+        # A surviving group can change its representative token (e.g. a previously
+        # unpriced token in the group gains a price). Only repoint when it actually
+        # changed, so the common stable refresh stays a genuine no-op (no churn).
+        let (tokenKey, tokenPrice) = self.priceForTokenGroup(group.tokens)
+        if existing.tokenKey != tokenKey:
+          existing.updateRepresentativeToken(tokenKey, tokenPrice,
+            self.marketValuesDelegate.getMarketValuesForToken(tokenKey)))
 
   proc syncRoles(oldItem, newItem: TokenGroupItem): seq[int] =
     ## Item-derived roles only (Name/Symbol/Decimals/LogoUri/Type/Tokens/CommunityId).

--- a/src/app/modules/main/wallet_section/assets/balances_model.nim
+++ b/src/app/modules/main/wallet_section/assets/balances_model.nim
@@ -1,7 +1,9 @@
 import app/modules/shared_models/model_utils
-import nimqml, tables, strutils, sequtils, stint
+import nimqml, tables, strutils, stint
 
-import ./io_interface
+import app_service/service/wallet_account/dto/asset_group_item
+import app/modules/shared/model_sync
+
 type
   ModelRole {.pure.} = enum
     Account = UserRole + 1,
@@ -14,21 +16,23 @@ type
 
 QtObject:
   type BalancesModel* = ref object of QAbstractListModel
-    delegate: io_interface.GroupedAccountAssetsDataSource
-    index: int
+    # Self-updating snapshot of the per-(token, account) balances of a single token
+    # group. Held by key (the parent keeps a BalancesModel per group key), NOT by
+    # positional index, so it survives the parent's granular reorders. The parent
+    # pushes fresh balances via updateBalances(), which diffs against this snapshot
+    # and emits granular dataChanged/insert/remove — this is the only path that
+    # delivers balance changes to the view without the parent resetting.
+    items: seq[BalanceItem]
 
   proc setup(self: BalancesModel)
   proc delete(self: BalancesModel)
-  proc newBalancesModel*(delegate: io_interface.GroupedAccountAssetsDataSource, index: int): BalancesModel =
+  proc newBalancesModel*(balances: seq[BalanceItem] = @[]): BalancesModel =
     new(result, delete)
     result.setup
-    result.delegate = delegate
-    result.index = index
+    result.items = balances
 
   method rowCount(self: BalancesModel, index: QModelIndex = nil): int =
-    if self.index < 0 or self.index >= self.delegate.getGroupedAssetsList().len:
-      return 0
-    return self.delegate.getGroupedAssetsList()[self.index].balancesPerAccount.len
+    return self.items.len
 
   proc countChanged(self: BalancesModel) {.signal.}
   proc getCount(self: BalancesModel): int {.slot.} =
@@ -51,7 +55,7 @@ QtObject:
   method data(self: BalancesModel, index: QModelIndex, role: int): QVariant =
     guardModelData(index, self.rowCount(), role, ModelRole)
 
-    let item = self.delegate.getGroupedAssetsList()[self.index].balancesPerAccount[index.row]
+    let item = self.items[index.row]
 
     let enumRole = role.ModelRole
     case enumRole:
@@ -70,8 +74,33 @@ QtObject:
       of ModelRole.Loading:
         result = newQVariant(item.loading)
 
+  proc syncKey(it: BalanceItem): string =
+    # A balance row is uniquely a (token, account) pair (tokenKey already encodes
+    # the chain). Stable across refreshes -> lets the diff recognise survivors.
+    it.tokenKey & "|" & it.account
+
+  proc syncRoles(o, n: BalanceItem): seq[int] =
+    # Identity fields (account/tokenKey/chainId/tokenAddress/groupKey) are static for
+    # a given id; only the fetched value and its loading flag move.
+    result = @[]
+    if o.balance != n.balance: result.add(ModelRole.Balance.int)
+    if o.loading != n.loading: result.add(ModelRole.Loading.int)
+
+  proc updateBalances*(self: BalancesModel, newBalances: seq[BalanceItem]) =
+    # Granular in-place update: diff the new balances against the cached snapshot and
+    # emit only the minimal insert/remove/dataChanged. No beginResetModel -> the
+    # nested filteredBalances SFPM and the FunctionAggregators in AssetsViewAdaptor
+    # update in place instead of being rebuilt.
+    self.modelSync(self.items, newBalances)
+
   proc setup(self: BalancesModel) =
     self.QAbstractListModel.setup
 
   proc delete(self: BalancesModel) =
     self.QAbstractListModel.delete
+
+  # Test-only accessors (used by grouped_account_assets_model_test).
+  proc balanceCountForTest*(self: BalancesModel): int =
+    self.items.len
+  proc balanceAtForTest*(self: BalancesModel, i: int): string =
+    self.items[i].balance.toString(10)

--- a/src/app/modules/main/wallet_section/assets/balances_model.nim
+++ b/src/app/modules/main/wallet_section/assets/balances_model.nim
@@ -24,6 +24,12 @@ QtObject:
     # delivers balance changes to the view without the parent resetting.
     items: seq[BalanceItem]
 
+  when defined(QT_MODEL_SPY):
+    # Test-only destruction hook: lets grouped_account_assets_model_test observe WHEN
+    # a dropped BalancesModel is ORC-freed relative to the parent's remove signals,
+    # proving the child outlives modelSync's beginRemoveRows (no use-after-free).
+    var onBalancesModelDeleted*: proc(self: BalancesModel) = nil
+
   proc setup(self: BalancesModel)
   proc delete(self: BalancesModel)
   proc newBalancesModel*(balances: seq[BalanceItem] = @[]): BalancesModel =
@@ -97,6 +103,9 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: BalancesModel) =
+    when defined(QT_MODEL_SPY):
+      if onBalancesModelDeleted != nil:
+        onBalancesModelDeleted(self)
     self.QAbstractListModel.delete
 
   # Test-only accessors (used by grouped_account_assets_model_test).

--- a/src/app/modules/main/wallet_section/assets/grouped_account_assets_model.nim
+++ b/src/app/modules/main/wallet_section/assets/grouped_account_assets_model.nim
@@ -1,6 +1,8 @@
 import app/modules/shared_models/model_utils
-import nimqml, tables, sequtils
+import nimqml, tables, algorithm
 
+import app_service/service/wallet_account/dto/asset_group_item
+import app/modules/shared/model_sync
 import ./io_interface, ./balances_model
 
 type
@@ -12,7 +14,15 @@ QtObject:
   type
     Model* = ref object of QAbstractListModel
       delegate: io_interface.GroupedAccountAssetsDataSource
-      balancesPerChain: seq[BalancesModel]
+      # Cached display snapshot, diffed against the incoming group list on every
+      # refresh so we emit granular insert/remove/move/dataChanged instead of a full
+      # beginResetModel. A reset here tears down the entire AssetsView
+      # proxy chain (LeftJoinModel -> ObjectProxyModel -> SFPMs -> ListView delegates).
+      items: seq[AssetGroupItem]
+      # One BalancesModel per group KEY (not per positional index), preserved across
+      # refreshes so QML keeps its nested filteredBalances SFPM + aggregators alive.
+      # The BalancesModel delivers balance changes via its own granular signals.
+      balancesByKey: Table[string, BalancesModel]
 
   proc delete(self: Model)
   proc setup(self: Model)
@@ -20,16 +30,17 @@ QtObject:
     new(result, delete)
     result.setup
     result.delegate = delegate
+    result.balancesByKey = initTable[string, BalancesModel]()
 
   proc countChanged(self: Model) {.signal.}
   proc getCount*(self: Model): int {.slot.} =
-    return self.delegate.getGroupedAssetsList().len
+    return self.items.len
   QtProperty[int] count:
     read = getCount
     notify = countChanged
 
   method rowCount(self: Model, index: QModelIndex = nil): int =
-    return self.delegate.getGroupedAssetsList().len
+    return self.items.len
 
   method roleNames(self: Model): Table[int, string] =
     {
@@ -40,36 +51,59 @@ QtObject:
   method data(self: Model, index: QModelIndex, role: int): QVariant =
     guardModelData(index, self.rowCount(), role, ModelRole)
 
-    if index.row >= self.balancesPerChain.len:
-      return
-
+    let item = self.items[index.row]
     let enumRole = role.ModelRole
-    let item = self.delegate.getGroupedAssetsList()[index.row]
     case enumRole:
     of ModelRole.Key:
       result = newQVariant(item.key)
     of ModelRole.Balances:
-      result = newQVariant(self.balancesPerChain[index.row])
+      if self.balancesByKey.hasKey(item.key):
+        result = newQVariant(self.balancesByKey[item.key])
+
+  proc syncKey(it: AssetGroupItem): string = it.key
+  # No syncRoles(AssetGroupItem): the only exposed roles are Key (stable per id) and
+  # Balances (stable object identity per key). Balance value changes travel through the
+  # BalancesModel's own dataChanged, so surviving rows need no parent-level dataChanged;
+  # omitting syncRoles leaves modelSync's getRoles nil, syncing the group SET only.
+
+  proc reconcileBalances(self: Model, newGroups: seq[AssetGroupItem]) =
+    # Rebuild balancesByKey identity-preservingly: keep the existing BalancesModel for
+    # a surviving group key (QML is bound to it) and push its fresh balances in place,
+    # create one for a new key, drop removed keys. Done BEFORE modelSync announces
+    # inserts so data(Balances) is populated for a newly inserted row within this same
+    # call (mirrors token_groups_model's market-details F1 fix).
+    reconcileByKey(self.balancesByKey, newGroups,
+      create = proc(g: AssetGroupItem): BalancesModel =
+        newBalancesModel(g.balancesPerAccount),
+      update = proc(bm: BalancesModel, g: AssetGroupItem) =
+        bm.updateBalances(g.balancesPerAccount))
 
   proc modelsUpdated*(self: Model) =
-    self.beginResetModel()
-    let lengthOfGroupedAssets = self.delegate.getGroupedAssetsList().len
-    let balancesPerChainLen = self.balancesPerChain.len
-    let diff = abs(lengthOfGroupedAssets - balancesPerChainLen)
-    # Please note that in case more tokens are added either due to refresh or adding of new accounts
-    # new entries to fetch balances data are created.
-    # On the other hand we are not deleting in case the assets disappear either on refresh
-    # as there is no balance or accounts were deleted because it causes a crash on UI.
-    # Also this will automatically be removed on the next time app is restarted
-    if lengthOfGroupedAssets > balancesPerChainLen:
-      for i in countup(0, diff-1):
-        self.balancesPerChain.add(newBalancesModel(self.delegate, balancesPerChainLen+i))
-    self.endResetModel()
-    self.countChanged()
+    # The service builds groupedAssets via Table.values() (hash order), which can
+    # reshuffle between refreshes even for an unchanged key set. The display order is
+    # decided downstream by the AssetsView SortFilterProxyModel, so this model's row
+    # order is display-irrelevant; sort by key here to give modelSync a deterministic
+    # order and avoid spurious per-cycle moves. Key-sorted so survivors keep their
+    # relative order across refreshes: the diff of matched ids never reorders (only
+    # inserts/removes at sorted positions), so the remove+insert reorder path is never
+    # exercised here.
+    let newGroups = self.delegate.getGroupedAssetsList().sorted(
+      proc(a, b: AssetGroupItem): int = cmp(a.key, b.key))
+    self.reconcileBalances(newGroups)
+    self.modelSync(self.items, newGroups)
 
   proc delete(self: Model) =
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =
     self.QAbstractListModel.setup
-    self.balancesPerChain = @[]
+
+  # Test-only accessors (used by grouped_account_assets_model_test).
+  proc groupKeysInOrder*(self: Model): seq[string] =
+    result = @[]
+    for item in self.items:
+      result.add(item.key)
+  proc balancesModelForKey*(self: Model, key: string): BalancesModel =
+    if self.balancesByKey.hasKey(key):
+      return self.balancesByKey[key]
+    return nil

--- a/src/app/modules/main/wallet_section/assets/grouped_account_assets_model.nim
+++ b/src/app/modules/main/wallet_section/assets/grouped_account_assets_model.nim
@@ -1,5 +1,5 @@
 import app/modules/shared_models/model_utils
-import nimqml, tables, algorithm
+import nimqml, tables, algorithm, sequtils, sets
 
 import app_service/service/wallet_account/dto/asset_group_item
 import app/modules/shared/model_sync
@@ -89,6 +89,20 @@ QtObject:
     # exercised here.
     let newGroups = self.delegate.getGroupedAssetsList().sorted(
       proc(a, b: AssetGroupItem): int = cmp(a.key, b.key))
+    # Keep every BalancesModel this refresh removes alive on the stack until AFTER
+    # modelSync has emitted its remove signals. balancesByKey is a dropped child's
+    # SOLE ORC owner, and reconcileBalances (below) frees it synchronously the moment
+    # it drops the key — which is BEFORE modelSync announces the row removal. QML
+    # delegates still hold the raw BalancesModel* handed out via data(Balances) (a
+    # nimqml QVariant of a QObject does not keep the Nim ref alive), so freeing it
+    # first is a use-after-free during the delegate's own row teardown. This local
+    # seq outlives the whole proc, so ORC frees the dropped models only after the
+    # view has torn the rows down.
+    let survivingKeys = newGroups.mapIt(it.key).toHashSet
+    var retained {.used.}: seq[BalancesModel] = @[]
+    for key, bm in self.balancesByKey:
+      if key notin survivingKeys:
+        retained.add(bm)
     self.reconcileBalances(newGroups)
     self.modelSync(self.items, newGroups)
 

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -571,6 +571,12 @@ QtObject:
         token = tokenFound
         break
 
+    if token.isNil:
+      # Defensive: the native anchor above resolves synchronously (getTokenByChainAddress
+      # synthesizes native tokens), so this should not happen; guard the deref anyway in
+      # case neither the native nor a contract token is available (nil-first).
+      return ("", message.transactionParameters.value)
+
     let tokenStr = $(Json.encode(token))
     var weiStr = service_conversion.wei2Eth(message.transactionParameters.value, token.decimals)
     weiStr.trimZeros()

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -1,4 +1,4 @@
-import tables, json, options, tables, strutils, times, chronicles
+import tables, json, options, tables, strutils, chronicles
 
 import constants
 import app_service/service/stickers/dto/stickers
@@ -251,12 +251,9 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
 
   var lastTokensUpdate: string
   discard jsonObj.getProp(KEY_LAST_TOKENS_UPDATE, lastTokensUpdate)
-  if lastTokensUpdate == "":
-    try:
-      let dateTime = parse(lastTokensUpdate, DATE_TIME_FORMAT_2)
-      result.lastTokensUpdate = dateTime.toTime().toUnix()
-    except Exception as e:
-      warn "failed to parse lastTokensUpdate: ", data=lastTokensUpdate, errName = e.name, errDesription = e.msg
+  # timestampToUnix accepts the formats seen in the field and returns 0 without
+  # raising on empty/unparseable input, so this stays off the exception path at wake.
+  result.lastTokensUpdate = timestampToUnix(lastTokensUpdate)
 
   var urlUnfurlingMode: int
   discard jsonObj.getProp(KEY_URL_UNFURLING_MODE, urlUnfurlingMode)

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -2,6 +2,7 @@ import tables, json, options, tables, strutils, chronicles
 
 import constants
 import app_service/service/stickers/dto/stickers
+import app_service/common/utils # timestampToUnix (do not rely on the stickers dto's transitive include)
 
 include app_service/common/json_utils
 from app_service/common/types import StatusType
@@ -253,7 +254,9 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
   discard jsonObj.getProp(KEY_LAST_TOKENS_UPDATE, lastTokensUpdate)
   # timestampToUnix accepts the formats seen in the field and returns 0 without
   # raising on empty/unparseable input, so this stays off the exception path at wake.
-  result.lastTokensUpdate = timestampToUnix(lastTokensUpdate)
+  # Module-qualified: the stickers dto textually `include`s common/utils, so an
+  # unqualified call is ambiguous once we depend on utils explicitly (below).
+  result.lastTokensUpdate = utils.timestampToUnix(lastTokensUpdate)
 
   var urlUnfurlingMode: int
   discard jsonObj.getProp(KEY_URL_UNFURLING_MODE, urlUnfurlingMode)

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -1,10 +1,11 @@
-import nimqml, chronicles, json, strutils, sequtils, tables, times
+import nimqml, chronicles, json, strutils, sequtils, tables
 
 import app/core/eventemitter
 import app/core/signals/types
 when defined(android):
   import app/android/safutils
 import app_service/common/types as common_types
+import app_service/common/utils as common_utils
 import backend/newsfeed as status_newsfeed
 import backend/mailservers as status_mailservers
 import backend/settings as status_settings
@@ -1115,18 +1116,17 @@ QtObject:
     return self.settings.autoRefreshTokens
 
   proc getLastTokensUpdate*(self: Service): int64 =
-    var lastTokensUpdate: string
     try:
       let response = status_settings.lastTokensUpdate()
       if not response.error.isNil:
         error "fetching lastTokensUpdate: ", errDescription = response.error.message
         return
 
-      lastTokensUpdate = response.result.getStr
-      let dateTime = parse(lastTokensUpdate, DATE_TIME_FORMAT_2)
-      self.settings.lastTokensUpdate = dateTime.toTime().toUnix()
+      # timestampToUnix normalizes the formats seen in the field and never raises
+      # on the hot path (returns 0 on failure), so the wake path stays exception-free.
+      self.settings.lastTokensUpdate = common_utils.timestampToUnix(response.result.getStr)
     except Exception as e:
-      error "parse lastTokensUpdate: ", data=lastTokensUpdate, errName = e.name, errDesription = e.msg
+      error "fetching lastTokensUpdate: ", errName = e.name, errDesription = e.msg
     return self.settings.lastTokensUpdate
 
   ### News Feed Settings ###

--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -22,7 +22,13 @@ type
     error*: string
 
   FetchAllTokenListsResponse* = object
+    requestId*: int # generation stamp for coalescing
     allTokenLists*: seq[TokenListDto]
+    error*: string
+
+  FetchMissingTokensResponse* = object
+    requestedKeys*: seq[string] # echoed back so the slot knows which keys were asked for
+    tokens*: seq[TokenDtoSafe]  # the subset the backend actually resolved
     error*: string
 
   TokensMarketValuesSlotResponse* = object
@@ -89,11 +95,12 @@ proc asyncRefreshTokensTask*(argEncoded: string) {.gcsafe, nimcall.} =
 
 type
   AsyncFetchAllTokenListsTaskArg = ref object of QObjectTaskArg
-    discard
+    requestId: int
 
 proc asyncFetchAllTokenListsTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncFetchAllTokenListsTaskArg](argEncoded)
   var output = %*{
+    "requestId": arg.requestId,
     "allTokenLists": newJArray(),
     "error": ""
   }
@@ -146,6 +153,27 @@ proc asyncBuildGroupsForChainTask*(argEncoded: string) {.gcsafe, nimcall.} =
     output["tokens"] = if response.isNil: newJArray() else: response
   except Exception as e:
     output["error"] = %* fmt"Error building groups for chain {arg.chainId}: {e.msg}"
+  arg.finish(output)
+
+type
+  AsyncFetchMissingTokensTaskArg = ref object of QObjectTaskArg
+    keys: seq[string]
+
+proc asyncFetchMissingTokensTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncFetchMissingTokensTaskArg](argEncoded)
+  var output = %*{
+    "requestedKeys": arg.keys,
+    "tokens": newJArray(),
+    "error": ""
+  }
+  try:
+    var response: JsonNode
+    let err = status_go_tokens.getTokensByKeys(response, arg.keys)
+    if err.len > 0:
+      raise newException(CatchableError, "getTokensByKeys failed: " & err)
+    output["tokens"] = if response.isNil: newJArray() else: response
+  except Exception as e:
+    output["error"] = %* fmt"Error fetching missing tokens: {e.msg}"
   arg.finish(output)
 
 #################################################

--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -5,14 +5,6 @@ import times, std/strformat, json
 #################################################
 
 type
-  # The heavy tasks build their finished structures on the worker and hand them
-  # over typed via finishTyped (see token_apply_builder): asyncRefreshTokensTask,
-  # asyncFetchAllTokenListsTask, asyncFetchAllTokenGroupsTask and
-  # asyncBuildGroupsForChainTask, so none carries a string-envelope result type.
-
-  # FetchMissingTokensResponse (the missing-tokens batch envelope) lives in
-  # token_missing_fetch so its decode+release step is unit-testable.
-
   TokensMarketValuesSlotResponse* = object
     tokenMarketValues*: JsonNode
     error*: string

--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -10,10 +10,8 @@ type
   # asyncFetchAllTokenListsTask, asyncFetchAllTokenGroupsTask and
   # asyncBuildGroupsForChainTask, so none carries a string-envelope result type.
 
-  FetchMissingTokensResponse* = object
-    requestedKeys*: seq[string] # echoed back so the slot knows which keys were asked for
-    tokens*: seq[TokenDtoSafe]  # the subset the backend actually resolved
-    error*: string
+  # FetchMissingTokensResponse (the missing-tokens batch envelope) lives in
+  # token_missing_fetch so its decode+release step is unit-testable.
 
   TokensMarketValuesSlotResponse* = object
     tokenMarketValues*: JsonNode

--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -5,19 +5,10 @@ import times, std/strformat, json
 #################################################
 
 type
-  BuildGroupsForChainResponse* = object
-    chainId*: int
-    tokens*: seq[TokenDtoSafe]
-    error*: string
-
-  FetchAllTokenGroupsResponse* = object
-    tokens*: seq[TokenDtoSafe]
-    error*: string
-
-  # The two heavy tasks build their finished structures on the worker and hand
-  # them over typed via finishTyped (see token_apply_builder +
-  # asyncRefreshTokensTask / asyncFetchAllTokenListsTask), so they carry no
-  # string-envelope result type.
+  # The heavy tasks build their finished structures on the worker and hand them
+  # over typed via finishTyped (see token_apply_builder): asyncRefreshTokensTask,
+  # asyncFetchAllTokenListsTask, asyncFetchAllTokenGroupsTask and
+  # asyncBuildGroupsForChainTask, so none carries a string-envelope result type.
 
   FetchMissingTokensResponse* = object
     requestedKeys*: seq[string] # echoed back so the slot knows which keys were asked for
@@ -136,19 +127,27 @@ type
 
 proc asyncFetchAllTokenGroupsTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncFetchAllTokenGroupsTaskArg](argEncoded)
-  var output = %*{
-    "tokens": newJArray(),
-    "error": ""
-  }
+  # Decode + build the name-sorted groups off the GUI thread and hand them over via
+  # finishTyped (no multi-MB JSON crosses the boundary, no group build on the GUI
+  # slot). Always finishes with a non-nil result (structural finally) so the
+  # allTokenGroupsLoading bool the slot clears can never stay stuck true.
+  var tokensNode: JsonNode = newJArray()
+  var errorMsg = ""
   try:
     var response: JsonNode
     var err = status_go_tokens.getTokensForActiveNetworksMode(response)
     if err.len > 0:
       raise newException(CatchableError, "getTokensForActiveNetworksMode failed: " & err)
-    output["tokens"] = if response.isNil: newJArray() else: response
+    if not response.isNil: tokensNode = response
   except Exception as e:
-    output["error"] = %* fmt"Error fetching all token groups: {e.msg}"
-  arg.finish(output)
+    errorMsg = fmt"Error fetching all token groups: {e.msg}"
+  var res: TokenGroupsApplyResult
+  try:
+    res = assembleTokenGroupsResult(tokensNode, errorMsg)
+  finally:
+    if res.isNil:
+      res = TokenGroupsApplyResult(error: "internal: token groups result assembly produced no result")
+    arg.finishTyped(res)
 
 type
   AsyncBuildGroupsForChainTaskArg = ref object of QObjectTaskArg
@@ -156,20 +155,24 @@ type
 
 proc asyncBuildGroupsForChainTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncBuildGroupsForChainTaskArg](argEncoded)
-  var output = %*{
-    "chainId": arg.chainId,
-    "tokens": newJArray(),
-    "error": ""
-  }
+  # Same typed-handoff build as asyncFetchAllTokenGroupsTask, for one chain.
+  var tokensNode: JsonNode = newJArray()
+  var errorMsg = ""
   try:
     var response: JsonNode
     var err = status_go_tokens.getTokensByChain(response, arg.chainId)
     if err.len > 0:
       raise newException(CatchableError, "getTokensByChain failed: " & err)
-    output["tokens"] = if response.isNil: newJArray() else: response
+    if not response.isNil: tokensNode = response
   except Exception as e:
-    output["error"] = %* fmt"Error building groups for chain {arg.chainId}: {e.msg}"
-  arg.finish(output)
+    errorMsg = fmt"Error building groups for chain {arg.chainId}: {e.msg}"
+  var res: TokenGroupsApplyResult
+  try:
+    res = assembleTokenGroupsResult(tokensNode, errorMsg)
+  finally:
+    if res.isNil:
+      res = TokenGroupsApplyResult(error: "internal: groups-for-chain result assembly produced no result")
+    arg.finishTyped(res)
 
 type
   AsyncFetchMissingTokensTaskArg = ref object of QObjectTaskArg

--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -14,17 +14,10 @@ type
     tokens*: seq[TokenDtoSafe]
     error*: string
 
-  RefreshTokensResponse* = object
-    requestId*: int
-    tokensOfInterest*: seq[TokenDtoSafe]
-    tokenPreferences*: JsonNode
-    allTokens*: seq[TokenDtoSafe]
-    error*: string
-
-  FetchAllTokenListsResponse* = object
-    requestId*: int # generation stamp for coalescing
-    allTokenLists*: seq[TokenListDto]
-    error*: string
+  # The two heavy tasks build their finished structures on the worker and hand
+  # them over typed via finishTyped (see token_apply_builder +
+  # asyncRefreshTokensTask / asyncFetchAllTokenListsTask), so they carry no
+  # string-envelope result type.
 
   FetchMissingTokensResponse* = object
     requestedKeys*: seq[string] # echoed back so the slot knows which keys were asked for
@@ -57,41 +50,56 @@ type
 
 proc asyncRefreshTokensTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncRefreshTokensTaskArg](argEncoded)
-  var output = %*{
-    "requestId": arg.requestId,
-    "tokensOfInterest": newJArray(),
-    "tokenPreferences": newJArray(),
-    "allTokens": newJArray(),
-    "error": ""
-  }
+  # Decode the RPC responses AND build the finished token structures here on the
+  # threadpool, then hand the GUI slot a ready object via finishTyped — no multi-MB
+  # JSON crosses the boundary and no token-model build runs on the GUI thread.
+  # finishTyped is always called (assemble*Result never returns nil / never raises)
+  # so the generation gate never wedges.
+  var tokensOfInterestNode: JsonNode = newJArray()
+  var tokenPrefsNode: JsonNode = newJArray()
+  var allTokensNode: JsonNode = newJArray()
+  var errorMsg = ""
   try:
     var tokensOfInterestResponse: JsonNode
     var err = status_go_tokens.getTokensOfInterestForActiveNetworksMode(tokensOfInterestResponse)
     if err.len > 0:
       raise newException(CatchableError, "getTokensOfInterestForActiveNetworksMode failed: " & err)
-    output["tokensOfInterest"] = if tokensOfInterestResponse.isNil: newJArray() else: tokensOfInterestResponse
+    if not tokensOfInterestResponse.isNil: tokensOfInterestNode = tokensOfInterestResponse
 
     let prefsResponse = backend.getTokenPreferences()
     if not prefsResponse.error.isNil:
       raise newException(CatchableError, "getTokenPreferences failed: " & prefsResponse.error.message)
-    output["tokenPreferences"] = if prefsResponse.result.isNil: newJNull() else: prefsResponse.result
+    tokenPrefsNode = if prefsResponse.result.isNil: newJNull() else: prefsResponse.result
   except Exception as e:
-    output["error"] = %* fmt"Error refreshing tokens: {e.msg}"
+    errorMsg = fmt"Error refreshing tokens: {e.msg}"
 
-  # fetch all tokens for the group-key index only when the catalogue may have changed.
-  # Skipping this on routine refreshes avoids shipping+decoding ~3MB on the main thread.
+  # fetch all tokens for the group-key index only when the catalogue may have
+  # changed: routine refreshes skip the ~3MB getAllTokens fetch.
   if arg.fetchAllTokens:
     try:
       var allTokensResponse: JsonNode
       let allTokensErr = status_go_tokens.getAllTokens(allTokensResponse)
       if allTokensErr.len > 0:
         warn "asyncRefreshTokensTask: getAllTokens failed", err = allTokensErr
-      else:
-        output["allTokens"] = if allTokensResponse.isNil: newJArray() else: allTokensResponse
+      elif not allTokensResponse.isNil:
+        allTokensNode = allTokensResponse
     except Exception as e:
       warn "asyncRefreshTokensTask: getAllTokens exception", err = e.msg
 
-  arg.finish(output)
+  # Liveness invariant: finishTyped MUST run on every task invocation, with a
+  # non-nil result, or the generation in-flight gate wedges permanently (tokens
+  # never refresh again until app restart). assembleRefreshResult is written to
+  # never raise / never return nil; this finally makes that structural — the gate's
+  # liveness must not depend on a catch-clause choice in another file.
+  var res: RefreshTokensApplyResult
+  try:
+    res = assembleRefreshResult(tokensOfInterestNode, allTokensNode, tokenPrefsNode,
+                                arg.requestId, errorMsg)
+  finally:
+    if res.isNil:
+      res = RefreshTokensApplyResult(generation: arg.requestId,
+        error: "internal: refresh result assembly produced no result")
+    arg.finishTyped(res)
 
 type
   AsyncFetchAllTokenListsTaskArg = ref object of QObjectTaskArg
@@ -99,20 +107,28 @@ type
 
 proc asyncFetchAllTokenListsTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncFetchAllTokenListsTaskArg](argEncoded)
-  var output = %*{
-    "requestId": arg.requestId,
-    "allTokenLists": newJArray(),
-    "error": ""
-  }
+  # Decode + build the token-list items off the GUI thread and hand them over via
+  # finishTyped. Always finishes (deadlock-safe, see refresh).
+  var allTokenListsNode: JsonNode = newJArray()
+  var errorMsg = ""
   try:
     var allTokenListsResponse: JsonNode
     var err = status_go_tokens.getAllTokenLists(allTokenListsResponse)
     if err.len > 0:
       raise newException(CatchableError, "getAllTokenLists failed: " & err)
-    output["allTokenLists"] = if allTokenListsResponse.isNil: newJArray() else: allTokenListsResponse
+    if not allTokenListsResponse.isNil: allTokenListsNode = allTokenListsResponse
   except Exception as e:
-    output["error"] = %* fmt"Error fetching all token lists: {e.msg}"
-  arg.finish(output)
+    errorMsg = fmt"Error fetching all token lists: {e.msg}"
+  # Same liveness invariant as asyncRefreshTokensTask: finishTyped always fires with
+  # a non-nil result (structural finally), so the 0004 gate can never wedge.
+  var res: AllTokenListsApplyResult
+  try:
+    res = assembleAllTokenListsResult(allTokenListsNode, arg.requestId, errorMsg)
+  finally:
+    if res.isNil:
+      res = AllTokenListsApplyResult(generation: arg.requestId,
+        error: "internal: token lists result assembly produced no result")
+    arg.finishTyped(res)
 
 type
   AsyncFetchAllTokenGroupsTaskArg = ref object of QObjectTaskArg

--- a/src/app_service/service/token/items/preferences.nim
+++ b/src/app_service/service/token/items/preferences.nim
@@ -2,7 +2,9 @@ import std/strformat
 
 
 type
-  TokenPreferencesItem* = ref object of RootObj
+  # {.acyclic.}: only value fields, no refs — ORC must skip cycle tracking so a
+  # worker-built preferences row applied on the GUI thread never calls rememberCycle.
+  TokenPreferencesItem* {.acyclic.} = ref object of RootObj
     key*: string # key used here should be crossChainId if not empty, otherwise tokenKey
     position*: int
     groupPosition*: int

--- a/src/app_service/service/token/items/token.nim
+++ b/src/app_service/service/token/items/token.nim
@@ -13,7 +13,12 @@ type CommunityDataItem* = CommunityDataDto
 
 type TokenDetailsItem* = TokenDetailsDto
 
-type TokenItemObj = object of RootObj
+# {.acyclic.}: TokenItem is tree-shaped (only value fields + a value CommunityDataItem,
+# no ref back-edges), so ORC must never treat it as a cycle candidate. Without this,
+# copying/destroying a TokenItem calls system.rememberCycle — which crashed (SIGSEGV)
+# on Android arm64 when the graph was built on a worker thread and touched on the GUI
+# thread. Acyclic types skip the cycle collector entirely.
+type TokenItemObj {.acyclic.} = object of RootObj
   key: string
   groupKey: string
   crossChainId: string

--- a/src/app_service/service/token/items/token_group.nim
+++ b/src/app_service/service/token/items/token_group.nim
@@ -1,3 +1,4 @@
+import algorithm
 import sequtils
 import strutils
 
@@ -38,3 +39,12 @@ proc addToken*(self: TokenGroupItem, token: TokenItem) =
     return
 
   self.tokens.add(token)
+
+proc sortTokenGroupsByKey*(groups: var seq[TokenGroupItem]) =
+  ## Deterministic order by group key. The group source order is
+  ## otherwise Nim Table hash order, which rehashes on any set change and
+  ## reshuffles survivors for no semantic reason — making setItemsWithSync
+  ## reorder pass emit O(n^2) moves on a structural refresh. The visible order is
+  ## set downstream by ManageTokensController's saved sort, so this is invisible.
+  ## The key here is exactly the getId token_groups_model passes to setItemsWithSync.
+  groups.sort(proc(a, b: TokenGroupItem): int = cmp(a.key, b.key))

--- a/src/app_service/service/token/items/token_group.nim
+++ b/src/app_service/service/token/items/token_group.nim
@@ -7,7 +7,10 @@ import ./token
 
 export token
 
-type TokenGroupItem* = ref object of RootObj
+# {.acyclic.}: a group holds a seq of (acyclic) TokenItems and no back-edge, so it is
+# tree-shaped — ORC must skip cycle tracking (rememberCycle), which crashed on
+# Android arm64 for worker-built graphs applied on the GUI thread.
+type TokenGroupItem* {.acyclic.} = ref object of RootObj
   key*: string
   name*: string
   symbol*: string

--- a/src/app_service/service/token/items/token_list.nim
+++ b/src/app_service/service/token/items/token_list.nim
@@ -13,7 +13,9 @@ type VersionItem = VersionDto
 proc `$`*(self: VersionItem): string =
   return $self.major & "." & $self.minor & "." & $self.patch
 
-type TokenListItemObj = object of RootObj
+# {.acyclic.}: tree-shaped (value fields + a seq of acyclic TokenItems), so ORC skips
+# cycle tracking — see the token.nim / token_group.nim note.
+type TokenListItemObj {.acyclic.} = object of RootObj
   id: string
   name: string
   timestamp: int64

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -1,4 +1,4 @@
-import nimqml, tables, json, std/sequtils, chronicles, strutils, sugar, algorithm, std/sets
+import nimqml, tables, sets, json, std/sequtils, chronicles, strutils, sugar, algorithm
 
 import web3/eth_api_types
 import backend/backend as backend
@@ -20,6 +20,9 @@ import backend/tokens as status_go_tokens
 
 import dto/types as dto_types
 import items/types as items_types
+import token_lookup_cache
+import token_pending_fetch
+import token_refresh_generation
 
 export dto_types, items_types
 
@@ -45,6 +48,9 @@ QtObject:
     chainsSupportedForSwapViaLiFi: Table[int, bool] # [chainId, bool]
     # local storage
     tokensOfInterestByKey: Table[string, TokenItem] # [tokenKey, TokenItem]
+    knownMissingKeys: HashSet[string] # keys the backend confirmed as "not found"; skip re-fetching until a refresh applies
+    pendingTokenFetch: PendingTokenFetch # missing keys awaiting an async batch fetch (replaces the sync GUI-thread RPC)
+    missingTokenKeysFetchDebouncer: debouncer_service.Debouncer # coalesces a burst of misses into one batch
     groupsOfInterestByKey: Table[string, TokenGroupItem] # [tokenGroupKey, TokenGroupItem]
     groupsOfInterest: seq[TokenGroupItem] # refers to groups for tokens of interest
     allTokensByGroupKey: Table[string, seq[TokenItem]] # rebuilt in applyRefreshTokensData for getTokenByKeyOrGroupKeyFromAllTokens
@@ -68,15 +74,24 @@ QtObject:
     hasMarketDetailsCache: bool
     hasPriceValuesCache: bool
     tokenListUpdatedAt: int64
-    refreshTokensRequestId: int
-    # Negative cache: token keys that status-go could not resolve. Prevents re-hitting
-    # wallet_getTokensByKeys for the same unknown key on every lookup. Cleared on token refresh.
-    notFoundKeys: HashSet[string]
+    # Generation coalescing for the two heavy async tasks: N queued triggers ->
+    # one apply of the newest data, no piling-up in-flight tasks.
+    refreshTokensGen: RefreshGenerationState
+    fetchAllTokenListsGen: RefreshGenerationState
+    # Catalogue-fetch want for refresh tasks: ORed
+    # across coalesced triggers, consumed at task start, re-fetched when a flagged
+    # task's result is dropped as stale.
+    pendingFetchAllTokens: bool
+    inFlightFetchAllTokens: bool
 
   # Forward declaration
   proc getCurrency*(self: Service): string
   proc rebuildMarketData*(self: Service)
   proc fetchTokenPreferences(self: Service)
+  proc scheduleMissingTokenKeysFetch(self: Service)
+  proc fetchPendingMissingTokenKeys(self: Service)
+  proc startRefreshTokensTask(self: Service, generation: int, fetchAllTokens: bool = false)
+  proc startFetchAllTokenListsTask(self: Service, generation: int)
 
   # All slots defined in included files have to be forward declared
   proc tokensMarketValuesRetrieved(self: Service, response: string) {.slot.}
@@ -85,6 +100,7 @@ QtObject:
   proc tokenHistoricalDataResolved*(self: Service, response: string) {.slot.}
   proc onAsyncRefreshTokensDone(self: Service, response: string) {.slot.}
   proc onAsyncFetchAllTokenListsDone(self: Service, response: string) {.slot.}
+  proc onAsyncFetchMissingTokensDone(self: Service, response: string) {.slot.}
   proc onAsyncBuildGroupsForChainDone(self: Service, response: string) {.slot.}
   proc onAsyncBuildGroupsForChainToDone(self: Service, response: string) {.slot.}
   proc onAsyncFetchAllTokenGroupsDone(self: Service, response: string) {.slot.}
@@ -108,6 +124,10 @@ QtObject:
     result.settingsService = settingsService
 
     result.tokensOfInterestByKey = initTable[string, TokenItem]()
+    result.knownMissingKeys = initHashSet[string]()
+    result.pendingTokenFetch = initPendingTokenFetch()
+    result.refreshTokensGen = initRefreshGenerationState()
+    result.fetchAllTokenListsGen = initRefreshGenerationState()
     result.groupsOfInterestByKey = initTable[string, TokenGroupItem]()
     result.allTokensByGroupKey = initTable[string, seq[TokenItem]]()
     result.tokenDetailsTable = initTable[string, TokenDetailsItem]()
@@ -119,7 +139,6 @@ QtObject:
     result.tokensMarketDetailsLoading = true
     result.hasMarketDetailsCache = false
     result.hasPriceValuesCache = false
-    result.notFoundKeys = initHashSet[string]()
 
 
   include service_tokens

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -21,6 +21,7 @@ import backend/tokens as status_go_tokens
 import dto/types as dto_types
 import items/types as items_types
 import token_lookup_cache
+import token_missing_fetch
 import token_pending_fetch
 import token_refresh_generation
 import token_apply_builder

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -23,6 +23,7 @@ import items/types as items_types
 import token_lookup_cache
 import token_pending_fetch
 import token_refresh_generation
+import token_apply_builder
 
 export dto_types, items_types
 

--- a/src/app_service/service/token/service_main.nim
+++ b/src/app_service/service/token/service_main.nim
@@ -18,12 +18,6 @@ proc createTokenGroupsFromTokens(tokens: seq[TokenItem], groupsByKey: var Table[
       )
     groupsByKey[groupKey].addToken(token)
 
-proc sortTokenGroupsByName(groups: var seq[TokenGroupItem]) =
-  groups.sort(
-    proc(a: TokenGroupItem, b: TokenGroupItem): int =
-      return a.name.cmp(b.name)
-  )
-
 proc addNewTokensToGroupsOfInterest(self: Service, tokens: seq[TokenItem]) =
   createTokenGroupsFromTokens(tokens, self.groupsOfInterestByKey)
   self.groupsOfInterest = toSeq(self.groupsOfInterestByKey.values)
@@ -354,22 +348,20 @@ proc buildGroupsForChain*(self: Service, chainId: int) =
   self.threadpool.start(arg)
 
 proc onAsyncBuildGroupsForChainDone(self: Service, response: string) {.slot.} =
+  # The worker already decoded + built the name-sorted groups; MOVE them into state
+  # (never copy — see applyRefreshTokensResult) with no GUI-thread JSON parse or
+  # group build. `res` is nil only if the handoff was drained at shutdown.
   self.groupsForChainLoading = false
-  try:
-    let env = Json.decode(response, BuildGroupsForChainResponse, allowUnknownFields = true)
-    if env.error.len > 0:
-      error "async build groups for chain failed", errDescription = env.error
-      self.events.emit(SIGNAL_GROUPS_FOR_CHAIN_LOADED, Args())
-      return
-    let tokens = env.tokens.map(t => createTokenItem(t))
-    var groupsByKey = initTable[string, TokenGroupItem](tokens.len)
-    createTokenGroupsFromTokens(tokens, groupsByKey)
-    self.groupsForChain = toSeq(groupsByKey.values)
-    sortTokenGroupsByName(self.groupsForChain)
+  let res = takeTyped[TokenGroupsApplyResult](response)
+  if res.isNil:
     self.events.emit(SIGNAL_GROUPS_FOR_CHAIN_LOADED, Args())
-  except Exception as e:
-    error "error processing async build groups for chain", msg = e.msg
+    return
+  if res.error.len > 0:
+    error "async build groups for chain failed", errDescription = res.error
     self.events.emit(SIGNAL_GROUPS_FOR_CHAIN_LOADED, Args())
+    return
+  self.groupsForChain = move res.groups
+  self.events.emit(SIGNAL_GROUPS_FOR_CHAIN_LOADED, Args())
 
 proc getGroupsForChainLoading*(self: Service): bool =
   return self.groupsForChainLoading
@@ -388,22 +380,19 @@ proc buildGroupsForChainTo*(self: Service, chainId: int) =
   self.threadpool.start(arg)
 
 proc onAsyncBuildGroupsForChainToDone(self: Service, response: string) {.slot.} =
+  # Same typed handoff as the source-chain slot: the worker already built the
+  # name-sorted groups; MOVE them into state (never copy).
   self.groupsForChainToLoading = false
-  try:
-    let env = Json.decode(response, BuildGroupsForChainResponse, allowUnknownFields = true)
-    if env.error.len > 0:
-      error "async build groups for chain (to) failed", errDescription = env.error
-      self.events.emit(SIGNAL_GROUPS_FOR_CHAIN_TO_LOADED, Args())
-      return
-    let tokens = env.tokens.map(t => createTokenItem(t))
-    var groupsByKey = initTable[string, TokenGroupItem](tokens.len)
-    createTokenGroupsFromTokens(tokens, groupsByKey)
-    self.groupsForChainTo = toSeq(groupsByKey.values)
-    sortTokenGroupsByName(self.groupsForChainTo)
+  let res = takeTyped[TokenGroupsApplyResult](response)
+  if res.isNil:
     self.events.emit(SIGNAL_GROUPS_FOR_CHAIN_TO_LOADED, Args())
-  except Exception as e:
-    error "error processing async build groups for chain (to)", msg = e.msg
+    return
+  if res.error.len > 0:
+    error "async build groups for chain (to) failed", errDescription = res.error
     self.events.emit(SIGNAL_GROUPS_FOR_CHAIN_TO_LOADED, Args())
+    return
+  self.groupsForChainTo = move res.groups
+  self.events.emit(SIGNAL_GROUPS_FOR_CHAIN_TO_LOADED, Args())
 
 proc getGroupsForChainToLoading*(self: Service): bool =
   return self.groupsForChainToLoading
@@ -418,22 +407,18 @@ proc asyncFetchAllTokenGroups*(self: Service) =
   self.threadpool.start(arg)
 
 proc onAsyncFetchAllTokenGroupsDone(self: Service, response: string) {.slot.} =
+  # Worker-built, name-sorted groups moved into state (see onAsyncBuildGroupsForChainDone).
   self.allTokenGroupsLoading = false
-  try:
-    let env = Json.decode(response, FetchAllTokenGroupsResponse, allowUnknownFields = true)
-    if env.error.len > 0:
-      error "async fetch all token groups failed", errDescription = env.error
-      self.events.emit(SIGNAL_ALL_TOKEN_GROUPS_LOADED, Args())
-      return
-    let tokens = env.tokens.map(t => createTokenItem(t))
-    var groupsByKey = initTable[string, TokenGroupItem](tokens.len)
-    createTokenGroupsFromTokens(tokens, groupsByKey)
-    self.allTokenGroupsForActiveNetworks = toSeq(groupsByKey.values)
-    sortTokenGroupsByName(self.allTokenGroupsForActiveNetworks)
+  let res = takeTyped[TokenGroupsApplyResult](response)
+  if res.isNil:
     self.events.emit(SIGNAL_ALL_TOKEN_GROUPS_LOADED, Args())
-  except Exception as e:
-    error "error processing async fetch all token groups", msg = e.msg
+    return
+  if res.error.len > 0:
+    error "async fetch all token groups failed", errDescription = res.error
     self.events.emit(SIGNAL_ALL_TOKEN_GROUPS_LOADED, Args())
+    return
+  self.allTokenGroupsForActiveNetworks = move res.groups
+  self.events.emit(SIGNAL_ALL_TOKEN_GROUPS_LOADED, Args())
 
 proc getAllTokenGroupsForActiveNetworksMode*(self: Service): seq[TokenGroupItem] =
   return self.allTokenGroupsForActiveNetworks

--- a/src/app_service/service/token/service_main.nim
+++ b/src/app_service/service/token/service_main.nim
@@ -100,16 +100,17 @@ proc prefetchLiFiSupportRetrieved(self: Service, response: string) {.slot.} =
 proc applyRefreshTokensData(self: Service, tokenDtos: seq[TokenDtoSafe], allTokenDtos: seq[TokenDtoSafe], tokenPrefsNode: JsonNode) =
   let tokens = tokenDtos.map(t => createTokenItem(t))
 
-  # Token catalogue changed -> previously-unresolvable keys may now resolve.
-  if tokenDtos.len > 0 or allTokenDtos.len > 0:
-    self.notFoundKeys.clear()
-
-  if tokens.len > 0 or self.groupsOfInterestByKey.len == 0:
-    self.tokensOfInterestByKey.clear()
-    self.groupsOfInterestByKey.clear()
-    for token in tokens:
-      self.tokensOfInterestByKey[token.key] = token
-    self.addNewTokensToGroupsOfInterest(tokens)
+  if shouldReplaceTokensCache(tokens.len, self.groupsOfInterestByKey.len):
+    # Build the replacement state aside and swap it in, rather than clear-then-fill:
+    # a wiped-then-refilled table would leave a window where every key lookup misses.
+    var newGroupsByKey = initTable[string, TokenGroupItem]()
+    createTokenGroupsFromTokens(tokens, newGroupsByKey)
+    self.tokensOfInterestByKey = buildTokensByKey(tokens)
+    self.groupsOfInterestByKey = newGroupsByKey
+    self.groupsOfInterest = toSeq(self.groupsOfInterestByKey.values)
+    # Fresh token data invalidates prior "not found" markers: a key that was
+    # missing before may now resolve.
+    self.knownMissingKeys.clear()
   else:
     debug "ignoring empty tokens-of-interest refresh; keeping existing token groups cache"
 
@@ -126,11 +127,13 @@ proc applyRefreshTokensData(self: Service, tokenDtos: seq[TokenDtoSafe], allToke
         visible: dto.visible,
         communityId: dto.communityId)
 
-  if allTokenDtos.len > 0 or self.allTokensByGroupKey.len == 0:
-    self.allTokensByGroupKey.clear()
+  if shouldReplaceTokensCache(allTokenDtos.len, self.allTokensByGroupKey.len):
+    # Same swap-not-clear discipline as the tokens-of-interest cache above.
+    var newAllTokensByGroupKey = initTable[string, seq[TokenItem]]()
     for dto in allTokenDtos:
       let item = createTokenItem(dto)
-      self.allTokensByGroupKey.mgetOrPut(item.groupKey, @[]).add(item)
+      newAllTokensByGroupKey.mgetOrPut(item.groupKey, @[]).add(item)
+    self.allTokensByGroupKey = newAllTokensByGroupKey
   else:
     debug "ignoring empty all-tokens refresh; keeping existing all tokens cache"
   self.rebuildMarketData()
@@ -140,52 +143,155 @@ proc applyRefreshTokensData(self: Service, tokenDtos: seq[TokenDtoSafe], allToke
   self.events.emit(SIGNAL_TOKEN_PREFERENCES_UPDATED, Args())
 
 proc onAsyncRefreshTokensDone(self: Service, response: string) {.slot.} =
+  var env: RefreshTokensResponse
+  var decodeOk = false
   try:
-    let env = Json.decode(response, RefreshTokensResponse, allowUnknownFields = true)
-    if env.error.len > 0:
-      error "async refresh tokens failed", errDescription = env.error
-      return
-    if env.requestId != self.refreshTokensRequestId:
-      debug "ignoring stale async refresh tokens response",
-        requestId = env.requestId, latestRequestId = self.refreshTokensRequestId
-      return
-    self.applyRefreshTokensData(env.tokensOfInterest, env.allTokens, env.tokenPreferences)
+    env = Json.decode(response, RefreshTokensResponse, allowUnknownFields = true)
+    decodeOk = true
   except Exception as e:
     error "error processing async refresh tokens", msg = e.msg
+  # Always advance the coordinator so a failed/undecodable completion never wedges
+  # the in-flight gate. On decode failure use the in-flight generation (not a stale
+  # sentinel) so a persistently undecodable response cannot re-fire forever.
+  let completedGen = if decodeOk: env.requestId else: self.refreshTokensGen.currentGeneration
+  let c = self.refreshTokensGen.onCompletion(completedGen)
+  if c.action == rcaDropAndRefire:
+    debug "dropping stale async refresh tokens response; re-firing newest",
+      completedGen = completedGen
+    # A dropped flagged result discards the catalogue it fetched — the re-fire must
+    # re-fetch it, in addition to any want queued by the triggers that made us stale.
+    let refireFetchAllTokens = self.pendingFetchAllTokens or self.inFlightFetchAllTokens
+    self.pendingFetchAllTokens = false
+    self.inFlightFetchAllTokens = refireFetchAllTokens
+    self.startRefreshTokensTask(c.gen, refireFetchAllTokens)
+    return
+  # rcaApply: this is the newest generation.
+  if not decodeOk:
+    return
+  if env.error.len > 0:
+    error "async refresh tokens failed", errDescription = env.error
+    return
+  self.applyRefreshTokensData(env.tokensOfInterest, env.allTokens, env.tokenPreferences)
 
 proc onAsyncFetchAllTokenListsDone(self: Service, response: string) {.slot.} =
-  self.tokenListsLoading = false
+  var env: FetchAllTokenListsResponse
+  var decodeOk = false
   try:
-    let env = Json.decode(response, FetchAllTokenListsResponse, allowUnknownFields = true)
-    if env.error.len > 0:
-      error "async fetch all token lists failed", errDescription = env.error
-      return
-    self.applyAllTokenListsData(env.allTokenLists)
-    self.events.emit(SIGNAL_TOKEN_LISTS_LOADED, Args())
+    env = Json.decode(response, FetchAllTokenListsResponse, allowUnknownFields = true)
+    decodeOk = true
   except Exception as e:
     error "error processing async fetch all token lists", msg = e.msg
+  let completedGen = if decodeOk: env.requestId else: self.fetchAllTokenListsGen.currentGeneration
+  let c = self.fetchAllTokenListsGen.onCompletion(completedGen)
+  if c.action == rcaDropAndRefire:
+    debug "dropping stale async fetch all token lists response; re-firing newest",
+      completedGen = completedGen
+    self.startFetchAllTokenListsTask(c.gen) # keeps tokenListsLoading true
+    return
+  # rcaApply: newest generation, nothing more in flight.
+  self.tokenListsLoading = false
+  if not decodeOk:
+    return
+  if env.error.len > 0:
+    error "async fetch all token lists failed", errDescription = env.error
+    return
+  self.applyAllTokenListsData(env.allTokenLists)
+  self.events.emit(SIGNAL_TOKEN_LISTS_LOADED, Args())
 
-# fetchAllTokens must be true only when the full catalogue can change (init /
-# token-lists-updated); routine refreshes skip the ~3MB getAllTokens fetch+decode.
-proc asyncRefreshTokens(self: Service, fetchAllTokens: bool = false) =
-  inc self.refreshTokensRequestId
+proc fetchPendingMissingTokenKeys(self: Service) =
+  # Debounced: drain every key that missed since the last batch and fetch them in
+  # one async RPC on the threadpool.
+  let keys = self.pendingTokenFetch.takeBatch()
+  if keys.len == 0:
+    return
+  let arg = AsyncFetchMissingTokensTaskArg(
+    tptr: asyncFetchMissingTokensTask,
+    vptr: cast[uint](self.vptr),
+    slot: "onAsyncFetchMissingTokensDone",
+    keys: keys,
+  )
+  self.threadpool.start(arg)
+
+proc scheduleMissingTokenKeysFetch(self: Service) =
+  self.missingTokenKeysFetchDebouncer.call()
+
+proc onAsyncFetchMissingTokensDone(self: Service, response: string) {.slot.} =
+  try:
+    let env = Json.decode(response, FetchMissingTokensResponse, allowUnknownFields = true)
+    # Release the batch's keys from the in-flight set regardless of outcome.
+    self.pendingTokenFetch.completeBatch(env.requestedKeys)
+    if env.error.len > 0:
+      # Transient backend failure: leave the keys unmarked so a later lookup retries
+      # (async, off the GUI thread) rather than caching a false "missing".
+      error "async fetch missing tokens failed", errDescription = env.error
+      return
+    # Index the returned tokens by their (lower-cased) key so each requested key is
+    # cached under the exact string that was looked up. This preserves the old
+    # getTokenByKey semantics (store under the requested key) even when the request
+    # used a checksummed/mixed-case address, so the next lookup Hits instead of
+    # re-enqueuing forever.
+    var tokenByLowerKey = initTable[string, TokenItem]()
+    for token in env.tokens.map(t => createTokenItem(t)):
+      tokenByLowerKey[token.key.toLowerAscii] = token
+    var foundTokens: seq[TokenItem]
+    var foundKeys = initHashSet[string]()
+    for requestedKey in env.requestedKeys:
+      let matched = tokenByLowerKey.getOrDefault(requestedKey.toLowerAscii)
+      if not matched.isNil:
+        self.tokensOfInterestByKey[requestedKey] = matched
+        foundTokens.add(matched)
+        foundKeys.incl(requestedKey)
+    if foundTokens.len > 0:
+      self.addNewTokensToGroupsOfInterest(foundTokens)
+    # Keys the backend did not return are genuinely missing -> feed the 0001 markers.
+    for key in missingFromBatch(env.requestedKeys, foundKeys):
+      self.knownMissingKeys.incl(key)
+    if foundTokens.len > 0:
+      # Notify consumers so they re-read and the late tokens resolve.
+      self.events.emit(SIGNAL_TOKENS_LIST_UPDATED, Args())
+  except Exception as e:
+    error "error processing async fetch missing tokens", msg = e.msg
+
+proc startRefreshTokensTask(self: Service, generation: int, fetchAllTokens: bool = false) =
   let arg = AsyncRefreshTokensTaskArg(
     tptr: asyncRefreshTokensTask,
     vptr: cast[uint](self.vptr),
     slot: "onAsyncRefreshTokensDone",
-    requestId: self.refreshTokensRequestId,
+    requestId: generation,
     fetchAllTokens: fetchAllTokens,
   )
   self.threadpool.start(arg)
 
-proc asyncFetchAllTokenLists*(self: Service) =
+# fetchAllTokens must be true only when the full catalogue can change (init /
+# token-lists-updated); routine refreshes skip the ~3MB getAllTokens fetch+decode.
+# The want is ORed across coalesced triggers and consumed when
+# a task actually starts, so a flagged trigger arriving while a task is in flight
+# still gets its catalogue fetch on the eventual re-fire.
+proc asyncRefreshTokens(self: Service, fetchAllTokens: bool = false) =
+  # Coalesced: bump the generation and start a task only when none is
+  # in flight; an in-flight task re-fires once on completion if newer triggers came.
+  if fetchAllTokens:
+    self.pendingFetchAllTokens = true
+  let (shouldStart, gen) = self.refreshTokensGen.requestRefresh()
+  if shouldStart:
+    self.inFlightFetchAllTokens = self.pendingFetchAllTokens
+    self.pendingFetchAllTokens = false
+    self.startRefreshTokensTask(gen, self.inFlightFetchAllTokens)
+
+proc startFetchAllTokenListsTask(self: Service, generation: int) =
   self.tokenListsLoading = true
   let arg = AsyncFetchAllTokenListsTaskArg(
     tptr: asyncFetchAllTokenListsTask,
     vptr: cast[uint](self.vptr),
     slot: "onAsyncFetchAllTokenListsDone",
+    requestId: generation,
   )
   self.threadpool.start(arg)
+
+proc asyncFetchAllTokenLists*(self: Service) =
+  let (shouldStart, gen) = self.fetchAllTokenListsGen.requestRefresh()
+  if shouldStart:
+    self.startFetchAllTokenListsTask(gen)
 
 proc getTokenListsLoading*(self: Service): bool =
   return self.tokenListsLoading
@@ -199,6 +305,14 @@ proc init*(self: Service) =
     delayMs = 1000,
     checkIntervalMs = 500)
   self.rebuildMarketDataDebouncer.registerCall0(callback = proc() = self.rebuildMarketDataInternal())
+
+  # Coalesce a burst of by-key misses (e.g. a model rebuild) into one batch fetch.
+  # Short delay so late tokens resolve quickly while still collapsing the burst.
+  self.missingTokenKeysFetchDebouncer = debouncer_service.newDebouncer(
+    self.threadpool,
+    delayMs = 200,
+    checkIntervalMs = 100)
+  self.missingTokenKeysFetchDebouncer.registerCall0(callback = proc() = self.fetchPendingMissingTokenKeys())
 
   self.events.on(SignalType.Wallet.event) do(e:Args):
     var data = WalletSignal(e)
@@ -363,23 +477,30 @@ proc getTokenBySymbolOnChain*(self: Service, symbol: string, chainId: int): Toke
 proc getTokenByKey*(self: Service, key: string): TokenItem =
   if not common_utils.isTokenKey(key):
     return nil
-  if self.tokensOfInterestByKey.hasKey(key):
+  case classifyTokenLookup(self.tokensOfInterestByKey, self.knownMissingKeys, key)
+  of TokenLookupOutcome.Hit:
     return self.tokensOfInterestByKey[key]
-  if self.notFoundKeys.contains(key):
+  of TokenLookupOutcome.KnownMissing:
+    # The backend already reported this key as "not found"; return nil without
+    # repeating the blocking RPC. Cleared when a refresh applies fresh token data.
     return nil
-  let tokens = getTokensByKeys(@[key])
-  if tokens.len > 0:
-    # add newly found tokens to the groups of interest
-    self.addNewTokensToGroupsOfInterest(tokens)
-
-    self.tokensOfInterestByKey[key] = tokens[0]
-    return self.tokensOfInterestByKey[key]
-  self.notFoundKeys.incl(key)
-  return nil
+  of TokenLookupOutcome.NeedsFetch:
+    # No synchronous backend RPC on the GUI thread: enqueue the key
+    # for a coalesced async batch and return nil now. When the batch completes the
+    # service updates its caches/markers and emits SIGNAL_TOKENS_LIST_UPDATED, so
+    # consumers re-read and the token resolves (placeholder -> value).
+    if self.pendingTokenFetch.enqueue(key):
+      self.scheduleMissingTokenKeysFetch()
+    return nil
 
 proc getTokenByChainAddress*(self: Service, chainId: int, address: string): TokenItem =
   let key = common_utils.createTokenKey(chainId, address)
-  return self.getTokenByKey(key)
+  result = self.getTokenByKey(key)
+  if result.isNil and address.toLowerAscii == common_wallet_constants.ZERO_ADDRESS:
+    # Native tokens are well-known: resolve them synchronously so paths like the
+    # message transaction details never see a nil-first. Once a refresh
+    # caches the backend's richer native token, getTokenByKey Hits it instead.
+    result = createNativeTokenItem(chainId)
 
 proc getTokensByGroupKey*(self: Service, groupKey: string): seq[TokenItem] =
   if not self.groupsOfInterestByKey.hasKey(groupKey):

--- a/src/app_service/service/token/service_main.nim
+++ b/src/app_service/service/token/service_main.nim
@@ -200,15 +200,19 @@ proc scheduleMissingTokenKeysFetch(self: Service) =
   self.missingTokenKeysFetchDebouncer.call()
 
 proc onAsyncFetchMissingTokensDone(self: Service, response: string) {.slot.} =
+  # Decode the envelope and release the batch's keys from the in-flight set
+  # regardless of outcome — an undecodable envelope must not leave its keys
+  # wedged as permanently in flight (they could never re-enqueue).
+  let (env, decodeError) = decodeAndCompleteBatch(self.pendingTokenFetch, response)
+  if decodeError.len > 0:
+    error "error decoding async fetch missing tokens response", msg = decodeError
+    return
+  if env.error.len > 0:
+    # Transient backend failure: leave the keys unmarked so a later lookup retries
+    # (async, off the GUI thread) rather than caching a false "missing".
+    error "async fetch missing tokens failed", errDescription = env.error
+    return
   try:
-    let env = Json.decode(response, FetchMissingTokensResponse, allowUnknownFields = true)
-    # Release the batch's keys from the in-flight set regardless of outcome.
-    self.pendingTokenFetch.completeBatch(env.requestedKeys)
-    if env.error.len > 0:
-      # Transient backend failure: leave the keys unmarked so a later lookup retries
-      # (async, off the GUI thread) rather than caching a false "missing".
-      error "async fetch missing tokens failed", errDescription = env.error
-      return
     # Index the returned tokens by their (lower-cased) key so each requested key is
     # cached under the exact string that was looked up. This preserves the old
     # getTokenByKey semantics (store under the requested key) even when the request

--- a/src/app_service/service/token/service_main.nim
+++ b/src/app_service/service/token/service_main.nim
@@ -28,8 +28,10 @@ proc addNewTokensToGroupsOfInterest(self: Service, tokens: seq[TokenItem]) =
   createTokenGroupsFromTokens(tokens, self.groupsOfInterestByKey)
   self.groupsOfInterest = toSeq(self.groupsOfInterestByKey.values)
 
-proc applyAllTokenListsData(self: Service, tokenListsDtos: seq[TokenListDto]) =
-  self.allTokenLists = tokenListsDtos.map(tl => createTokenListItem(tl))
+proc applyAllTokenListsResult(self: Service, res: AllTokenListsApplyResult) =
+  # Slim GUI-thread apply: the worker already built the token-list items; MOVE
+  # them in (never copy — see applyRefreshTokensResult).
+  self.allTokenLists = move res.allTokenLists
 
 proc prefetchParaswapSupport(self: Service) =
   let chainIds = self.networkService.getEnabledChainIds()
@@ -97,43 +99,39 @@ proc prefetchLiFiSupportRetrieved(self: Service, response: string) {.slot.} =
   except Exception as ex:
     error "prefetchLiFiSupportRetrieved", err = ex.msg
 
-proc applyRefreshTokensData(self: Service, tokenDtos: seq[TokenDtoSafe], allTokenDtos: seq[TokenDtoSafe], tokenPrefsNode: JsonNode) =
-  let tokens = tokenDtos.map(t => createTokenItem(t))
-
-  if shouldReplaceTokensCache(tokens.len, self.groupsOfInterestByKey.len):
-    # Build the replacement state aside and swap it in, rather than clear-then-fill:
-    # a wiped-then-refilled table would leave a window where every key lookup misses.
-    var newGroupsByKey = initTable[string, TokenGroupItem]()
-    createTokenGroupsFromTokens(tokens, newGroupsByKey)
-    self.tokensOfInterestByKey = buildTokensByKey(tokens)
-    self.groupsOfInterestByKey = newGroupsByKey
-    self.groupsOfInterest = toSeq(self.groupsOfInterestByKey.values)
+proc applyRefreshTokensResult(self: Service, res: RefreshTokensApplyResult) =
+  # Slim GUI-thread apply: swap in the structures the worker already built
+  # off-thread — same swap-not-clear gate, same knownMissingKeys.clear() on a real
+  # tokens-of-interest refresh, same preferences merge, same market rebuild and
+  # events. The heavy decode + token-model build no longer runs on the GUI thread.
+  # MOVE the worker-built containers into service state — never copy. `res` is
+  # exclusively owned after takeTyped, so a copy would be pure waste: it re-refcounts
+  # every TokenItem/TokenGroupItem (O(graph)) and (before the {.acyclic.} fix on
+  # those types) walked the ORC cycle collector on each ref, which SIGSEGV'd on
+  # Android for this cross-thread graph. `move` transfers each container's storage
+  # in O(1) and does no per-element work.
+  if shouldReplaceTokensCache(res.tokensOfInterestCount, self.groupsOfInterestByKey.len):
+    # Swap the pre-built replacement in atomically, rather than clear-then-fill: a
+    # wiped-then-refilled table would leave a window where every key lookup misses.
+    self.tokensOfInterestByKey = move res.tokensOfInterestByKey
+    self.groupsOfInterestByKey = move res.groupsOfInterestByKey
+    self.groupsOfInterest = move res.groupsOfInterest
     # Fresh token data invalidates prior "not found" markers: a key that was
     # missing before may now resolve.
     self.knownMissingKeys.clear()
   else:
     debug "ignoring empty tokens-of-interest refresh; keeping existing token groups cache"
 
-  # Keep tokenPreferencesJson as the backend array string for QML; fill table from decoded DTOs.
-  self.tokenPreferencesJson = "[]"
-  if not tokenPrefsNode.isNil and tokenPrefsNode.kind == JArray:
-    self.tokenPreferencesJson = $tokenPrefsNode
-    for preferences in tokenPrefsNode:
-      let dto = Json.decode($preferences, TokenPreferencesDto, allowUnknownFields = true)
-      self.tokenPreferencesTable[dto.key] = TokenPreferencesItem(
-        key: dto.key,
-        position: dto.position,
-        groupPosition: dto.groupPosition,
-        visible: dto.visible,
-        communityId: dto.communityId)
+  # Keep tokenPreferencesJson as the backend array string for QML; the worker
+  # already decoded the rows — move them into the table (same merge as before).
+  self.tokenPreferencesJson = move res.tokenPreferencesJson
+  for preferences in res.tokenPreferences.mitems:
+    let key = preferences.key
+    self.tokenPreferencesTable[key] = move preferences
 
-  if shouldReplaceTokensCache(allTokenDtos.len, self.allTokensByGroupKey.len):
+  if shouldReplaceTokensCache(res.allTokensCount, self.allTokensByGroupKey.len):
     # Same swap-not-clear discipline as the tokens-of-interest cache above.
-    var newAllTokensByGroupKey = initTable[string, seq[TokenItem]]()
-    for dto in allTokenDtos:
-      let item = createTokenItem(dto)
-      newAllTokensByGroupKey.mgetOrPut(item.groupKey, @[]).add(item)
-    self.allTokensByGroupKey = newAllTokensByGroupKey
+    self.allTokensByGroupKey = move res.allTokensByGroupKey
   else:
     debug "ignoring empty all-tokens refresh; keeping existing all tokens cache"
   self.rebuildMarketData()
@@ -143,17 +141,14 @@ proc applyRefreshTokensData(self: Service, tokenDtos: seq[TokenDtoSafe], allToke
   self.events.emit(SIGNAL_TOKEN_PREFERENCES_UPDATED, Args())
 
 proc onAsyncRefreshTokensDone(self: Service, response: string) {.slot.} =
-  var env: RefreshTokensResponse
-  var decodeOk = false
-  try:
-    env = Json.decode(response, RefreshTokensResponse, allowUnknownFields = true)
-    decodeOk = true
-  except Exception as e:
-    error "error processing async refresh tokens", msg = e.msg
-  # Always advance the coordinator so a failed/undecodable completion never wedges
-  # the in-flight gate. On decode failure use the in-flight generation (not a stale
-  # sentinel) so a persistently undecodable response cannot re-fire forever.
-  let completedGen = if decodeOk: env.requestId else: self.refreshTokensGen.currentGeneration
+  # The worker already decoded the RPC responses AND built the token structures;
+  # claim the ready object by handle — no GUI-thread JSON parse or token-model
+  # build. `res` is nil only if the handoff was drained at shutdown.
+  let res = takeTyped[RefreshTokensApplyResult](response)
+  # Always advance the coordinator so a failed/nil completion never wedges the
+  # in-flight gate. On a nil handoff use the in-flight generation (not a stale
+  # sentinel) so it cannot re-fire forever.
+  let completedGen = if not res.isNil: res.generation else: self.refreshTokensGen.currentGeneration
   let c = self.refreshTokensGen.onCompletion(completedGen)
   if c.action == rcaDropAndRefire:
     debug "dropping stale async refresh tokens response; re-firing newest",
@@ -166,22 +161,16 @@ proc onAsyncRefreshTokensDone(self: Service, response: string) {.slot.} =
     self.startRefreshTokensTask(c.gen, refireFetchAllTokens)
     return
   # rcaApply: this is the newest generation.
-  if not decodeOk:
+  if res.isNil:
     return
-  if env.error.len > 0:
-    error "async refresh tokens failed", errDescription = env.error
+  if res.error.len > 0:
+    error "async refresh tokens failed", errDescription = res.error
     return
-  self.applyRefreshTokensData(env.tokensOfInterest, env.allTokens, env.tokenPreferences)
+  self.applyRefreshTokensResult(res)
 
 proc onAsyncFetchAllTokenListsDone(self: Service, response: string) {.slot.} =
-  var env: FetchAllTokenListsResponse
-  var decodeOk = false
-  try:
-    env = Json.decode(response, FetchAllTokenListsResponse, allowUnknownFields = true)
-    decodeOk = true
-  except Exception as e:
-    error "error processing async fetch all token lists", msg = e.msg
-  let completedGen = if decodeOk: env.requestId else: self.fetchAllTokenListsGen.currentGeneration
+  let res = takeTyped[AllTokenListsApplyResult](response)
+  let completedGen = if not res.isNil: res.generation else: self.fetchAllTokenListsGen.currentGeneration
   let c = self.fetchAllTokenListsGen.onCompletion(completedGen)
   if c.action == rcaDropAndRefire:
     debug "dropping stale async fetch all token lists response; re-firing newest",
@@ -190,12 +179,12 @@ proc onAsyncFetchAllTokenListsDone(self: Service, response: string) {.slot.} =
     return
   # rcaApply: newest generation, nothing more in flight.
   self.tokenListsLoading = false
-  if not decodeOk:
+  if res.isNil:
     return
-  if env.error.len > 0:
-    error "async fetch all token lists failed", errDescription = env.error
+  if res.error.len > 0:
+    error "async fetch all token lists failed", errDescription = res.error
     return
-  self.applyAllTokenListsData(env.allTokenLists)
+  self.applyAllTokenListsResult(res)
   self.events.emit(SIGNAL_TOKEN_LISTS_LOADED, Args())
 
 proc fetchPendingMissingTokenKeys(self: Service) =

--- a/src/app_service/service/token/service_main.nim
+++ b/src/app_service/service/token/service_main.nim
@@ -27,6 +27,7 @@ proc sortTokenGroupsByName(groups: var seq[TokenGroupItem]) =
 proc addNewTokensToGroupsOfInterest(self: Service, tokens: seq[TokenItem]) =
   createTokenGroupsFromTokens(tokens, self.groupsOfInterestByKey)
   self.groupsOfInterest = toSeq(self.groupsOfInterestByKey.values)
+  sortTokenGroupsByKey(self.groupsOfInterest)  # deterministic order
 
 proc applyAllTokenListsResult(self: Service, res: AllTokenListsApplyResult) =
   # Slim GUI-thread apply: the worker already built the token-list items; MOVE
@@ -232,7 +233,7 @@ proc onAsyncFetchMissingTokensDone(self: Service, response: string) {.slot.} =
         foundKeys.incl(requestedKey)
     if foundTokens.len > 0:
       self.addNewTokensToGroupsOfInterest(foundTokens)
-    # Keys the backend did not return are genuinely missing -> feed the 0001 markers.
+    # Keys the backend did not return are genuinely missing -> feed the negative-cache markers.
     for key in missingFromBatch(env.requestedKeys, foundKeys):
       self.knownMissingKeys.incl(key)
     if foundTokens.len > 0:

--- a/src/app_service/service/token/token_apply_builder.nim
+++ b/src/app_service/service/token/token_apply_builder.nim
@@ -3,7 +3,7 @@
 ## Given the raw RPC response JSON, produce the COMPLETE finished structures the
 ## GUI slot currently builds inline in `applyRefreshTokensData` /
 ## `applyAllTokenListsData` (service_main.nim). Running this on the threadpool and
-## handing the result to the GUI slot via the 0005 typed-completion primitive
+## handing the result to the GUI slot via the typed-completion primitive
 ## (finishTyped/takeTyped) removes the multi-MB JSON decode + token-model build
 ## from the GUI thread.
 ##
@@ -25,7 +25,7 @@ import token_lookup_cache
 
 type
   RefreshTokensApplyResult* = ref object of RootObj
-    generation*: int                                     ## 0004 stamp, echoed to the slot's onCompletion
+    generation*: int                                     ## generation stamp, echoed to the slot's onCompletion
     error*: string                                       ## non-empty -> slot skips apply (after onCompletion)
     tokensOfInterestCount*: int                          ## gate input for the slot
     tokensOfInterestByKey*: Table[string, TokenItem]
@@ -73,6 +73,7 @@ proc buildRefreshTokensApply*(tokensOfInterestNode, allTokensNode, tokenPrefsNod
   createTokenGroupsFromTokens(tokens, groupsByKey)
   result.groupsOfInterestByKey = groupsByKey
   result.groupsOfInterest = toSeq(groupsByKey.values)
+  sortTokenGroupsByKey(result.groupsOfInterest)  # deterministic order
 
   # Preferences: keep the backend array string for QML; decode rows for the table.
   # Matches applyRefreshTokensData exactly (including the "[]" default).
@@ -107,15 +108,15 @@ proc buildAllTokenListsApply*(allTokenListsNode: JsonNode): AllTokenListsApplyRe
 # These wrap the pure builders with the transport concerns (generation stamp,
 # error passthrough) and — critically — GUARANTEE a non-nil result even on an RPC
 # error or a build exception. The worker always calls finishTyped(result), so the
-# GUI slot always runs and the 0004 generation coordinator never wedges its
+# GUI slot always runs and the generation coordinator never wedges its
 # in-flight gate (deadlock-safety). Building here also keeps the heavy decode +
-# token-model construction off the GUI thread (fix A).
+# token-model construction off the GUI thread.
 
 # The build catches `Exception`, NOT `CatchableError`: a Defect (e.g. OutOfMemDefect
-# building the 3.5+4.1MB token model on a memory-pressured wake — exactly this
+# building the multi-MB token model on a memory-pressured wake — exactly this
 # path) is not a CatchableError. With --panics:off it is catchable as Exception, so
 # catching Exception keeps the result non-nil there too. If a Defect escaped
-# assemble*, the worker would skip finishTyped and the 0004 in-flight gate would
+# assemble*, the worker would skip finishTyped and the in-flight gate would
 # wedge permanently (no more token refreshes until app restart). The worker adds a
 # structural finally as a second guarantee (see async_tasks.nim).
 

--- a/src/app_service/service/token/token_apply_builder.nim
+++ b/src/app_service/service/token/token_apply_builder.nim
@@ -1,0 +1,142 @@
+## Pure worker-side token-apply builder.
+##
+## Given the raw RPC response JSON, produce the COMPLETE finished structures the
+## GUI slot currently builds inline in `applyRefreshTokensData` /
+## `applyAllTokenListsData` (service_main.nim). Running this on the threadpool and
+## handing the result to the GUI slot via the 0005 typed-completion primitive
+## (finishTyped/takeTyped) removes the multi-MB JSON decode + token-model build
+## from the GUI thread.
+##
+## Byte-identical contract: this replicates the current GUI-thread build exactly
+## on the same inputs, so a token-model dump is identical pre/post migration. The
+## swap-vs-keep decision (shouldReplaceTokensCache) stays on the GUI slot because
+## it depends on the live prior-cache size; the builder therefore builds
+## unconditionally and carries `tokensOfInterestCount` / `allTokensCount` so the
+## slot can run that cheap gate before swapping.
+##
+## Pure: no Service, no threadpool, no backend — unit-testable against fixture JSON.
+
+import json, tables, sequtils, sugar
+import json_serialization
+
+import items/token, items/token_group, items/token_list, items/preferences
+import dto/token, dto/token_list, dto/token_preferences
+import token_lookup_cache
+
+type
+  RefreshTokensApplyResult* = ref object of RootObj
+    generation*: int                                     ## 0004 stamp, echoed to the slot's onCompletion
+    error*: string                                       ## non-empty -> slot skips apply (after onCompletion)
+    tokensOfInterestCount*: int                          ## gate input for the slot
+    tokensOfInterestByKey*: Table[string, TokenItem]
+    groupsOfInterestByKey*: Table[string, TokenGroupItem]
+    groupsOfInterest*: seq[TokenGroupItem]
+    tokenPreferencesJson*: string                        ## backend array verbatim, for QML
+    tokenPreferences*: seq[TokenPreferencesItem]         ## decoded rows, slot merges into its table
+    allTokensCount*: int                                 ## gate input for the slot
+    allTokensByGroupKey*: Table[string, seq[TokenItem]]
+
+  AllTokenListsApplyResult* = ref object of RootObj
+    generation*: int
+    error*: string
+    allTokenLists*: seq[TokenListItem]
+
+proc createTokenGroupsFromTokens(tokens: seq[TokenItem], groupsByKey: var Table[string, TokenGroupItem]) =
+  # Byte-identical replica of the private helper in service_main.nim (grouping by
+  # token.groupKey; the group inherits the first token's name/symbol/decimals/logo).
+  for token in tokens:
+    let groupKey = token.groupKey
+    if not groupsByKey.hasKey(groupKey):
+      groupsByKey[groupKey] = TokenGroupItem(
+        key: groupKey,
+        name: token.name,
+        symbol: token.symbol,
+        decimals: token.decimals,
+        logoUri: token.logoUri
+      )
+    groupsByKey[groupKey].addToken(token)
+
+proc decodeTokens(node: JsonNode): seq[TokenDtoSafe] =
+  if node.isNil or node.kind != JArray or node.len == 0:
+    return @[]
+  Json.decode($node, seq[TokenDtoSafe], allowUnknownFields = true)
+
+proc buildRefreshTokensApply*(tokensOfInterestNode, allTokensNode, tokenPrefsNode: JsonNode): RefreshTokensApplyResult =
+  ## Build the finished tokens-of-interest / groups / preferences / all-tokens
+  ## structures from the three raw RPC response nodes.
+  result = RefreshTokensApplyResult()
+
+  let tokens = decodeTokens(tokensOfInterestNode).map(t => createTokenItem(t))
+  result.tokensOfInterestCount = tokens.len
+  result.tokensOfInterestByKey = buildTokensByKey(tokens)
+  var groupsByKey = initTable[string, TokenGroupItem]()
+  createTokenGroupsFromTokens(tokens, groupsByKey)
+  result.groupsOfInterestByKey = groupsByKey
+  result.groupsOfInterest = toSeq(groupsByKey.values)
+
+  # Preferences: keep the backend array string for QML; decode rows for the table.
+  # Matches applyRefreshTokensData exactly (including the "[]" default).
+  result.tokenPreferencesJson = "[]"
+  if not tokenPrefsNode.isNil and tokenPrefsNode.kind == JArray:
+    result.tokenPreferencesJson = $tokenPrefsNode
+    for preferences in tokenPrefsNode:
+      let dto = Json.decode($preferences, TokenPreferencesDto, allowUnknownFields = true)
+      result.tokenPreferences.add TokenPreferencesItem(
+        key: dto.key,
+        position: dto.position,
+        groupPosition: dto.groupPosition,
+        visible: dto.visible,
+        communityId: dto.communityId)
+
+  let allTokens = decodeTokens(allTokensNode).map(t => createTokenItem(t))
+  result.allTokensCount = allTokens.len
+  var newAllByGroup = initTable[string, seq[TokenItem]]()
+  for item in allTokens:
+    newAllByGroup.mgetOrPut(item.groupKey, @[]).add(item)
+  result.allTokensByGroupKey = newAllByGroup
+
+proc buildAllTokenListsApply*(allTokenListsNode: JsonNode): AllTokenListsApplyResult =
+  ## Build the finished token-list items from the raw all-token-lists RPC node.
+  result = AllTokenListsApplyResult()
+  if allTokenListsNode.isNil or allTokenListsNode.kind != JArray or allTokenListsNode.len == 0:
+    return
+  let dtos = Json.decode($allTokenListsNode, seq[TokenListDto], allowUnknownFields = true)
+  result.allTokenLists = dtos.map(tl => createTokenListItem(tl))
+
+# --- Worker-side assembly: what the threadpool task hands to finishTyped ----------
+# These wrap the pure builders with the transport concerns (generation stamp,
+# error passthrough) and — critically — GUARANTEE a non-nil result even on an RPC
+# error or a build exception. The worker always calls finishTyped(result), so the
+# GUI slot always runs and the 0004 generation coordinator never wedges its
+# in-flight gate (deadlock-safety). Building here also keeps the heavy decode +
+# token-model construction off the GUI thread (fix A).
+
+# The build catches `Exception`, NOT `CatchableError`: a Defect (e.g. OutOfMemDefect
+# building the 3.5+4.1MB token model on a memory-pressured wake — exactly this
+# path) is not a CatchableError. With --panics:off it is catchable as Exception, so
+# catching Exception keeps the result non-nil there too. If a Defect escaped
+# assemble*, the worker would skip finishTyped and the 0004 in-flight gate would
+# wedge permanently (no more token refreshes until app restart). The worker adds a
+# structural finally as a second guarantee (see async_tasks.nim).
+
+proc assembleRefreshResult*(tokensOfInterestNode, allTokensNode, tokenPrefsNode: JsonNode,
+                            generation: int, rpcError: string): RefreshTokensApplyResult =
+  if rpcError.len > 0:
+    result = RefreshTokensApplyResult(error: rpcError)
+  else:
+    try:
+      result = buildRefreshTokensApply(tokensOfInterestNode, allTokensNode, tokenPrefsNode)
+    except Exception as e:
+      result = RefreshTokensApplyResult(error: "Error building refresh tokens result: " & e.msg)
+  result.generation = generation
+
+proc assembleAllTokenListsResult*(allTokenListsNode: JsonNode,
+                                  generation: int, rpcError: string): AllTokenListsApplyResult =
+  if rpcError.len > 0:
+    result = AllTokenListsApplyResult(error: rpcError)
+  else:
+    try:
+      result = buildAllTokenListsApply(allTokenListsNode)
+    except Exception as e:
+      result = AllTokenListsApplyResult(error: "Error building token lists result: " & e.msg)
+  result.generation = generation

--- a/src/app_service/service/token/token_apply_builder.nim
+++ b/src/app_service/service/token/token_apply_builder.nim
@@ -16,7 +16,7 @@
 ##
 ## Pure: no Service, no threadpool, no backend — unit-testable against fixture JSON.
 
-import json, tables, sequtils, sugar
+import json, tables, sequtils, sugar, algorithm
 import json_serialization
 
 import items/token, items/token_group, items/token_list, items/preferences
@@ -40,6 +40,13 @@ type
     generation*: int
     error*: string
     allTokenLists*: seq[TokenListItem]
+
+  TokenGroupsApplyResult* = ref object of RootObj
+    ## Finished, name-sorted token groups for the two on-demand group fetches
+    ## (getTokensByChain / getTokensForActiveNetworksMode). No generation stamp:
+    ## those tasks gate on a plain loading bool, not the refresh coordinator.
+    error*: string                                       ## non-empty -> slot skips apply
+    groups*: seq[TokenGroupItem]
 
 proc createTokenGroupsFromTokens(tokens: seq[TokenItem], groupsByKey: var Table[string, TokenGroupItem]) =
   # Byte-identical replica of the private helper in service_main.nim (grouping by
@@ -96,6 +103,16 @@ proc buildRefreshTokensApply*(tokensOfInterestNode, allTokensNode, tokenPrefsNod
     newAllByGroup.mgetOrPut(item.groupKey, @[]).add(item)
   result.allTokensByGroupKey = newAllByGroup
 
+proc buildTokenGroupsApply*(tokensNode: JsonNode): seq[TokenGroupItem] =
+  ## Byte-identical replica of the group build the onAsyncBuildGroupsForChainDone /
+  ## onAsyncFetchAllTokenGroupsDone slots ran inline (decode + createTokenItem +
+  ## group + sort-by-name), moved here so it runs on the threadpool.
+  let tokens = decodeTokens(tokensNode).map(t => createTokenItem(t))
+  var groupsByKey = initTable[string, TokenGroupItem]()
+  createTokenGroupsFromTokens(tokens, groupsByKey)
+  result = toSeq(groupsByKey.values)
+  result.sort(proc(a, b: TokenGroupItem): int = a.name.cmp(b.name))
+
 proc buildAllTokenListsApply*(allTokenListsNode: JsonNode): AllTokenListsApplyResult =
   ## Build the finished token-list items from the raw all-token-lists RPC node.
   result = AllTokenListsApplyResult()
@@ -130,6 +147,18 @@ proc assembleRefreshResult*(tokensOfInterestNode, allTokensNode, tokenPrefsNode:
     except Exception as e:
       result = RefreshTokensApplyResult(error: "Error building refresh tokens result: " & e.msg)
   result.generation = generation
+
+proc assembleTokenGroupsResult*(tokensNode: JsonNode, rpcError: string): TokenGroupsApplyResult =
+  ## Same non-nil / never-raise guarantee as the refresh assembler: the worker
+  ## always finishTyped's a result, so the loading bool the slot clears never
+  ## stays stuck true (no permanently-spinning picker).
+  if rpcError.len > 0:
+    result = TokenGroupsApplyResult(error: rpcError)
+  else:
+    try:
+      result = TokenGroupsApplyResult(groups: buildTokenGroupsApply(tokensNode))
+    except Exception as e:
+      result = TokenGroupsApplyResult(error: "Error building token groups result: " & e.msg)
 
 proc assembleAllTokenListsResult*(allTokenListsNode: JsonNode,
                                   generation: int, rpcError: string): AllTokenListsApplyResult =

--- a/src/app_service/service/token/token_lookup_cache.nim
+++ b/src/app_service/service/token/token_lookup_cache.nim
@@ -39,6 +39,7 @@ proc buildTokensByKey*(tokens: seq[TokenItem]): Table[string, TokenItem] =
   ## Build the replacement by-key lookup table aside so the caller can swap it in
   ## atomically. Never clear-then-fill the live table: that would expose a window
   ## where every lookup misses.
-  result = initTable[string, TokenItem](tokens.len)
+  var byKey = initTable[string, TokenItem](tokens.len)
   for token in tokens:
-    result[token.key] = token
+    byKey[token.key] = token
+  return byKey

--- a/src/app_service/service/token/token_lookup_cache.nim
+++ b/src/app_service/service/token/token_lookup_cache.nim
@@ -1,0 +1,44 @@
+## Pure helpers for the wallet token-service lookup cache.
+##
+## A by-key token lookup that finds nothing must cache that negative result;
+## otherwise every repeat lookup of a missing key re-fires a blocking GUI-thread
+## RPC. These helpers make negative results first-class and keep the refresh-apply
+## path swap-not-clear, so they can be unit-tested without the backend or a live
+## Service.
+
+import tables, sets
+
+import items/token
+
+type TokenLookupOutcome* {.pure.} = enum
+  Hit          ## token is cached -> return it, no RPC
+  KnownMissing ## backend already reported "not found" -> return nil, no RPC
+  NeedsFetch   ## nothing known about the key -> a backend fetch is required
+
+proc classifyTokenLookup*(
+    tokensByKey: Table[string, TokenItem],
+    knownMissingKeys: HashSet[string],
+    key: string): TokenLookupOutcome =
+  ## Decide what a by-key lookup should do. A key that resolved to "not found"
+  ## on a previous lookup is remembered in `knownMissingKeys`, so it never costs
+  ## another RPC until the caches are refreshed.
+  if tokensByKey.hasKey(key):
+    return TokenLookupOutcome.Hit
+  if key in knownMissingKeys:
+    return TokenLookupOutcome.KnownMissing
+  return TokenLookupOutcome.NeedsFetch
+
+proc shouldReplaceTokensCache*(newTokenCount: int, priorCacheCount: int): bool =
+  ## Swap-not-clear guard for applying a token refresh. Replace the cache only
+  ## when the refresh actually carries data, or when the cache is empty anyway
+  ## (first fill). An empty/failed refresh with an existing cache is ignored so
+  ## the previous state is preserved rather than wiped.
+  newTokenCount > 0 or priorCacheCount == 0
+
+proc buildTokensByKey*(tokens: seq[TokenItem]): Table[string, TokenItem] =
+  ## Build the replacement by-key lookup table aside so the caller can swap it in
+  ## atomically. Never clear-then-fill the live table: that would expose a window
+  ## where every lookup misses.
+  result = initTable[string, TokenItem](tokens.len)
+  for token in tokens:
+    result[token.key] = token

--- a/src/app_service/service/token/token_missing_fetch.nim
+++ b/src/app_service/service/token/token_missing_fetch.nim
@@ -23,11 +23,13 @@ proc decodeAndCompleteBatch*(fetch: var PendingTokenFetch, response: string):
   ## envelope itself was undecodable. The keys are released on EVERY outcome:
   ## a key left in flight can never re-enqueue, so it would wedge (stop
   ## resolving) for the rest of the session.
+  var decoded: tuple[env: FetchMissingTokensResponse, decodeError: string]
   try:
-    result.env = Json.decode(response, FetchMissingTokensResponse, allowUnknownFields = true)
-    fetch.completeBatch(result.env.requestedKeys)
+    decoded.env = Json.decode(response, FetchMissingTokensResponse, allowUnknownFields = true)
+    fetch.completeBatch(decoded.env.requestedKeys)
   except Exception as e:
     # The batch's own key list is unknown when its envelope is undecodable, so
     # drain the whole in-flight set (see drainInFlight for why that is safe).
     fetch.drainInFlight()
-    result.decodeError = e.msg
+    decoded.decodeError = e.msg
+  return decoded

--- a/src/app_service/service/token/token_missing_fetch.nim
+++ b/src/app_service/service/token/token_missing_fetch.nim
@@ -1,0 +1,33 @@
+## Pure decode-and-release step for the async missing-tokens batch fetch.
+##
+## The GUI slot (onAsyncFetchMissingTokensDone) receives the worker's finished
+## batch as a string envelope; this module decodes it and releases the batch's
+## keys from the in-flight set. Split out of the slot so the release contract is
+## unit-testable without a live Service or backend — same pattern as
+## token_pending_fetch / token_apply_builder.
+
+import json_serialization
+
+import dto/token
+import token_pending_fetch
+
+type FetchMissingTokensResponse* = object
+  requestedKeys*: seq[string] # echoed back so the slot knows which keys were asked for
+  tokens*: seq[TokenDtoSafe]  # the subset the backend actually resolved
+  error*: string
+
+proc decodeAndCompleteBatch*(fetch: var PendingTokenFetch, response: string):
+    tuple[env: FetchMissingTokensResponse, decodeError: string] =
+  ## Decode a finished batch's envelope and release its keys from the in-flight
+  ## set. Returns the decoded envelope, or a non-empty decodeError when the
+  ## envelope itself was undecodable. The keys are released on EVERY outcome:
+  ## a key left in flight can never re-enqueue, so it would wedge (stop
+  ## resolving) for the rest of the session.
+  try:
+    result.env = Json.decode(response, FetchMissingTokensResponse, allowUnknownFields = true)
+    fetch.completeBatch(result.env.requestedKeys)
+  except Exception as e:
+    # The batch's own key list is unknown when its envelope is undecodable, so
+    # drain the whole in-flight set (see drainInFlight for why that is safe).
+    fetch.drainInFlight()
+    result.decodeError = e.msg

--- a/src/app_service/service/token/token_pending_fetch.nim
+++ b/src/app_service/service/token/token_pending_fetch.nim
@@ -31,10 +31,11 @@ proc takeBatch*(self: var PendingTokenFetch): seq[string] =
   ## Drain the pending keys into the in-flight set and return them as the batch to
   ## fetch. Draining is atomic from the GUI thread's view: after this the pending
   ## set is empty and the same keys will not be re-enqueued while in flight.
-  result = toSeq(self.pending)
-  for key in result:
+  let batch = toSeq(self.pending)
+  for key in batch:
     self.inFlight.incl(key)
   self.pending.clear()
+  return batch
 
 proc completeBatch*(self: var PendingTokenFetch, keys: seq[string]) =
   ## Release the keys of a finished batch from the in-flight set. After this a
@@ -54,6 +55,8 @@ proc drainInFlight*(self: var PendingTokenFetch) =
 proc missingFromBatch*(requestedKeys: seq[string], foundKeys: HashSet[string]): seq[string] =
   ## The requested keys the backend did not return — these become negative
   ## markers so they cost no further RPC until a refresh. Order follows the request.
+  var missing: seq[string]
   for key in requestedKeys:
     if key notin foundKeys:
-      result.add(key)
+      missing.add(key)
+  return missing

--- a/src/app_service/service/token/token_pending_fetch.nim
+++ b/src/app_service/service/token/token_pending_fetch.nim
@@ -1,0 +1,51 @@
+## Pure pending-fetch set for the wallet token service.
+##
+## Replaces the synchronous GUI-thread `getTokensByKeys` RPC in getTokenByKey: a
+## miss enqueues the key here and returns nil immediately; the service drains the
+## set in a coalesced batch on a worker thread. This module holds only the
+## dedup/coalescing bookkeeping so it can be unit-tested without a live Service or
+## backend — no scheduling, threadpool, or IO here.
+
+import sequtils, sets
+
+type PendingTokenFetch* = object
+  pending: HashSet[string]  ## keys awaiting the next batch fetch
+  inFlight: HashSet[string] ## keys handed to a batch already running (dedup across the fetch window)
+
+proc initPendingTokenFetch*(): PendingTokenFetch =
+  PendingTokenFetch(pending: initHashSet[string](), inFlight: initHashSet[string]())
+
+proc enqueue*(self: var PendingTokenFetch, key: string): bool =
+  ## Record a missing key. Returns true only when the key is newly pending — the
+  ## caller uses that to schedule (debounce) a batch exactly once per burst. Keys
+  ## already pending or already in flight dedup and return false.
+  if key in self.pending or key in self.inFlight:
+    return false
+  self.pending.incl(key)
+  return true
+
+proc hasPending*(self: PendingTokenFetch): bool =
+  self.pending.len > 0
+
+proc takeBatch*(self: var PendingTokenFetch): seq[string] =
+  ## Drain the pending keys into the in-flight set and return them as the batch to
+  ## fetch. Draining is atomic from the GUI thread's view: after this the pending
+  ## set is empty and the same keys will not be re-enqueued while in flight.
+  result = toSeq(self.pending)
+  for key in result:
+    self.inFlight.incl(key)
+  self.pending.clear()
+
+proc completeBatch*(self: var PendingTokenFetch, keys: seq[string]) =
+  ## Release the keys of a finished batch from the in-flight set. After this a
+  ## fresh miss of the same key may enqueue again (the caches/markers updated by
+  ## the completion normally make that unnecessary).
+  for key in keys:
+    self.inFlight.excl(key)
+
+proc missingFromBatch*(requestedKeys: seq[string], foundKeys: HashSet[string]): seq[string] =
+  ## The requested keys the backend did not return — these become negative
+  ## markers so they cost no further RPC until a refresh. Order follows the request.
+  for key in requestedKeys:
+    if key notin foundKeys:
+      result.add(key)

--- a/src/app_service/service/token/token_pending_fetch.nim
+++ b/src/app_service/service/token/token_pending_fetch.nim
@@ -43,6 +43,14 @@ proc completeBatch*(self: var PendingTokenFetch, keys: seq[string]) =
   for key in keys:
     self.inFlight.excl(key)
 
+proc drainInFlight*(self: var PendingTokenFetch) =
+  ## Release every in-flight key. For the failure path where a batch's own key
+  ## list is unknown (its envelope was undecodable): the batch cannot be
+  ## released by completeBatch, so drain everything rather than leave its keys
+  ## wedged as permanently in flight. Over-releasing a concurrently running
+  ## batch is benign — worst case one duplicate fetch of its keys.
+  self.inFlight.clear()
+
 proc missingFromBatch*(requestedKeys: seq[string], foundKeys: HashSet[string]): seq[string] =
   ## The requested keys the backend did not return — these become negative
   ## markers so they cost no further RPC until a refresh. Order follows the request.

--- a/src/app_service/service/token/token_refresh_generation.nim
+++ b/src/app_service/service/token/token_refresh_generation.nim
@@ -1,0 +1,56 @@
+## Pure generation coordinator for the token service's heavy async tasks:
+## refresh-tokens and fetch-all-token-lists.
+##
+## Without coalescing, each queued trigger starts its own task and every
+## completion applies. This coordinator gives one task kind a generation:
+##  - each trigger bumps the desired generation;
+##  - a task is started only when none is in flight;
+##  - the in-flight completion re-fires once if newer triggers arrived while it
+##    ran, and its own (now stale) result is dropped without applying.
+## Net: N queued triggers -> exactly one apply of the newest data. Pure, so it is
+## unit-tested without a live Service; the service owns the actual task start/apply.
+
+type RefreshCompletionAction* = enum
+  rcaApply          ## the completed result is the newest — apply it
+  rcaDropAndRefire  ## the completed result is stale — drop it and start a fresh task
+
+type RefreshGenerationState* = object
+  desiredGen: int   ## bumped on every trigger; the newest generation wanted
+  inFlightState: bool
+  inFlightGen: int  ## the generation the currently-running task was started with
+
+proc initRefreshGenerationState*(): RefreshGenerationState =
+  RefreshGenerationState(desiredGen: 0, inFlightState: false, inFlightGen: 0)
+
+proc inFlight*(self: RefreshGenerationState): bool =
+  self.inFlightState
+
+proc currentGeneration*(self: RefreshGenerationState): int =
+  ## The generation of the task currently in flight. Callers pass this to
+  ## onCompletion when a completion cannot be decoded (so it is treated as the
+  ## in-flight generation, not an always-stale sentinel — which would re-fire
+  ## forever on a persistently undecodable response).
+  self.inFlightGen
+
+proc requestRefresh*(self: var RefreshGenerationState): tuple[shouldStart: bool, gen: int] =
+  ## Called on a trigger. Advances the desired generation. Returns shouldStart=true
+  ## (with the generation to stamp the task) only when no task is in flight; when
+  ## one is already running it returns false — that task will re-fire on completion.
+  inc self.desiredGen
+  if self.inFlightState:
+    return (shouldStart: false, gen: self.desiredGen)
+  self.inFlightState = true
+  self.inFlightGen = self.desiredGen
+  return (shouldStart: true, gen: self.desiredGen)
+
+proc onCompletion*(self: var RefreshGenerationState,
+    completedGen: int): tuple[action: RefreshCompletionAction, gen: int] =
+  ## Called when a task completes. If newer triggers arrived while it ran, its
+  ## result is stale: drop it and re-fire once with the newest generation.
+  ## Otherwise it is the newest: apply it and go idle.
+  if completedGen < self.desiredGen:
+    self.inFlightState = true
+    self.inFlightGen = self.desiredGen
+    return (action: rcaDropAndRefire, gen: self.desiredGen)
+  self.inFlightState = false
+  return (action: rcaApply, gen: completedGen)

--- a/test/nim/grouped_account_assets_model_test.nim
+++ b/test/nim/grouped_account_assets_model_test.nim
@@ -1,0 +1,158 @@
+## Conversion tests for grouped_account_assets_model + balances_model
+## (setItemsWithSync + self-updating nested BalancesModel). Compile -d:QT_MODEL_SPY.
+##
+## Acceptance gate coverage: a stable-set refresh emits NO reset / NO move / NO
+## dataChanged; a per-token balance change emits a single BalancesModel dataChanged
+## and NO parent reset; group add/remove emit minimal insert/remove; the service's
+## Table-hash order churn is absorbed by the key-sort so survivors don't move.
+##
+## The QtModelSpy is global and records ops from BOTH the parent grouped model and
+## the nested BalancesModels (both go through setItemsWithSync), so assertions are on
+## aggregate op counts across the whole refresh.
+
+import unittest, sequtils, stint
+import nimqml
+
+import app/modules/main/wallet_section/assets/grouped_account_assets_model
+import app/modules/main/wallet_section/assets/balances_model
+import app/modules/main/wallet_section/assets/io_interface
+import app_service/service/wallet_account/dto/asset_group_item
+import app/modules/shared/qt_model_spy
+
+var gGroups: seq[AssetGroupItem] = @[]
+
+proc dataSource(): GroupedAccountAssetsDataSource =
+  (
+    getGroupedAssetsList: proc(): var seq[AssetGroupItem] = gGroups,
+  )
+
+proc mkBalance(tokenKey, account: string, balance: int, loading = false): BalanceItem =
+  BalanceItem(
+    account: account, groupKey: "", tokenKey: tokenKey,
+    chainId: 1, tokenAddress: tokenKey, balance: u256(balance), loading: loading)
+
+proc mkGroup(key: string, balances: seq[BalanceItem] = @[]): AssetGroupItem =
+  let bs = if balances.len > 0: balances else: @[mkBalance(key & "-t", "acc", 100)]
+  AssetGroupItem(key: key, balancesPerAccount: bs)
+
+proc newTestModel(): Model =
+  newModel(dataSource())
+
+proc moves(spy: QtModelSpy): int = spy.calls.filterIt(it.kind == BeginMoveRows).len
+
+suite "grouped_account_assets_model - granular refresh, no reset":
+
+  setup:
+    let spy = newQtModelSpy()
+    spy.enable()
+
+  teardown:
+    spy.disable()
+
+  test "stable set, same balances: no reset, no move, no dataChanged":
+    gGroups = @[mkGroup("a"), mkGroup("b")]
+    let m = newTestModel()
+    m.modelsUpdated()
+    spy.clear()
+
+    gGroups = @[mkGroup("a"), mkGroup("b")]
+    m.modelsUpdated()
+
+    check m.groupKeysInOrder() == @["a", "b"]
+    check spy.countResets() == 0
+    check spy.moves() == 0
+    check spy.countInserts() == 0
+    check spy.countRemoves() == 0
+    check spy.countDataChanged() == 0
+
+  test "balance change on one token: child dataChanged only, no reset/move/insert/remove":
+    gGroups = @[mkGroup("a", @[mkBalance("a-t", "acc", 100)]),
+                mkGroup("b", @[mkBalance("b-t", "acc", 100)])]
+    let m = newTestModel()
+    m.modelsUpdated()
+    spy.clear()
+
+    gGroups = @[mkGroup("a", @[mkBalance("a-t", "acc", 250)]),  # a's balance changed
+                mkGroup("b", @[mkBalance("b-t", "acc", 100)])]
+    m.modelsUpdated()
+
+    check spy.countResets() == 0
+    check spy.moves() == 0
+    check spy.countInserts() == 0
+    check spy.countRemoves() == 0
+    check spy.countDataChanged() == 1   # only a's BalancesModel row
+    check m.balancesModelForKey("a").balanceAtForTest(0) == "250"
+    check m.balancesModelForKey("b").balanceAtForTest(0) == "100"
+
+  test "loading flip: child dataChanged, no reset":
+    gGroups = @[mkGroup("a", @[mkBalance("a-t", "acc", 100, loading = true)])]
+    let m = newTestModel()
+    m.modelsUpdated()
+    spy.clear()
+
+    gGroups = @[mkGroup("a", @[mkBalance("a-t", "acc", 100, loading = false)])]
+    m.modelsUpdated()
+
+    check spy.countDataChanged() == 1
+    check spy.countResets() == 0
+
+  test "group added: parent insert (sorted), no reset, new group has its balances":
+    gGroups = @[mkGroup("a"), mkGroup("c")]
+    let m = newTestModel()
+    m.modelsUpdated()
+    spy.clear()
+
+    gGroups = @[mkGroup("a"), mkGroup("b"), mkGroup("c")]  # b inserted in the middle
+    m.modelsUpdated()
+
+    check m.groupKeysInOrder() == @["a", "b", "c"]
+    check spy.countInserts() == 1
+    check spy.moves() == 0     # sorted-by-key: survivors don't reshuffle
+    check spy.countResets() == 0
+    check not m.balancesModelForKey("b").isNil
+    check m.balancesModelForKey("b").balanceCountForTest() == 1
+
+  test "group removed: parent remove, no reset, key dropped":
+    gGroups = @[mkGroup("a"), mkGroup("b"), mkGroup("c")]
+    let m = newTestModel()
+    m.modelsUpdated()
+    spy.clear()
+
+    gGroups = @[mkGroup("a"), mkGroup("c")]  # remove b
+    m.modelsUpdated()
+
+    check m.groupKeysInOrder() == @["a", "c"]
+    check spy.countRemoves() == 1
+    check spy.moves() == 0
+    check spy.countResets() == 0
+    check m.balancesModelForKey("b").isNil
+
+  test "service hash-order churn absorbed by key-sort: no moves, no reset":
+    gGroups = @[mkGroup("a"), mkGroup("b"), mkGroup("c")]
+    let m = newTestModel()
+    m.modelsUpdated()
+    spy.clear()
+
+    gGroups = @[mkGroup("c"), mkGroup("a"), mkGroup("b")]  # same keys, different service order
+    m.modelsUpdated()
+
+    check m.groupKeysInOrder() == @["a", "b", "c"]   # re-sorted stable
+    check spy.moves() == 0
+    check spy.countResets() == 0
+    check spy.countInserts() == 0
+    check spy.countRemoves() == 0
+
+  test "balance row added to a group: child insert on that group, no parent reset":
+    gGroups = @[mkGroup("a", @[mkBalance("a-t1", "acc", 100)])]
+    let m = newTestModel()
+    m.modelsUpdated()
+    spy.clear()
+
+    gGroups = @[mkGroup("a", @[mkBalance("a-t1", "acc", 100),
+                               mkBalance("a-t2", "acc", 50)])]  # second chain balance
+    m.modelsUpdated()
+
+    check spy.countResets() == 0
+    check spy.countInserts() == 1   # child BalancesModel insert
+    check spy.countRemoves() == 0
+    check m.balancesModelForKey("a").balanceCountForTest() == 2

--- a/test/nim/grouped_account_assets_model_test.nim
+++ b/test/nim/grouped_account_assets_model_test.nim
@@ -142,6 +142,38 @@ suite "grouped_account_assets_model - granular refresh, no reset":
     check spy.countInserts() == 0
     check spy.countRemoves() == 0
 
+  test "removed group's BalancesModel outlives the parent remove signal (no UAF)":
+    # The dropped child is balancesByKey's SOLE ORC owner. If reconcileBalances frees
+    # it before modelSync emits beginRemoveRows, QML delegates holding the raw
+    # BalancesModel* returned by data(Balances) deref freed memory during their own
+    # row teardown. Assert the child is destroyed only AFTER the remove signal fired.
+    # ORC-gated: destruction is deterministic only under --mm:orc (the production mm);
+    # under refc the finalizer runs non-deterministically so the ordering is moot.
+    when defined(gcOrc):
+      # b carries a sentinel balance (777) so the delete hook recognises it by VALUE
+      # without holding a ref (a captured ref — even via cast[int] — would keep it
+      # ORC-alive and mask the very free we want to observe).
+      gGroups = @[mkGroup("a", @[mkBalance("a-t", "acc", 100)]),
+                  mkGroup("b", @[mkBalance("b-t", "acc", 777)]),
+                  mkGroup("c", @[mkBalance("c-t", "acc", 100)])]
+      let m = newTestModel()
+      m.modelsUpdated()
+
+      var removesWhenBFreed = -1
+      onBalancesModelDeleted = proc(self: BalancesModel) =
+        if self.balanceCountForTest() > 0 and self.balanceAtForTest(0) == "777":
+          removesWhenBFreed = spy.countRemoves()
+
+      spy.clear()
+      gGroups = @[mkGroup("a", @[mkBalance("a-t", "acc", 100)]),
+                  mkGroup("c", @[mkBalance("c-t", "acc", 100)])]  # remove b
+      m.modelsUpdated()
+      onBalancesModelDeleted = nil
+
+      check spy.countRemoves() == 1
+      # b must be freed only AFTER the remove signal fired (== 1), never before (0).
+      check removesWhenBFreed == 1
+
   test "balance row added to a group: child insert on that group, no parent reset":
     gGroups = @[mkGroup("a", @[mkBalance("a-t1", "acc", 100)])]
     let m = newTestModel()

--- a/test/nim/last_tokens_update_parse_test.nim
+++ b/test/nim/last_tokens_update_parse_test.nim
@@ -1,0 +1,32 @@
+## The `lastTokensUpdate` settings timestamp can arrive in formats that a single
+## strict parse would reject, raising a TimeParseError on the GUI thread at wake
+## (e.g. a "Z"-suffixed or fraction-less timestamp). The settings read paths route
+## through the robust `timestampToUnix`, which normalizes the formats seen in the
+## field and never raises on the hot path (returns 0 on failure). Expected epochs
+## below are independent ground truth (computed with `date -u`), not recomputed
+## via `parse`.
+
+import unittest
+
+import app_service/common/utils
+
+suite "robust lastTokensUpdate timestamp parsing":
+  test "empty string returns 0 without raising":
+    check timestampToUnix("") == 0
+    check timestampToUnix("   ") == 0
+
+  test "the full field format (6-digit fraction + offset) parses":
+    # 2024-01-15T10:30:00 UTC == 1705314600
+    check timestampToUnix("2024-01-15T10:30:00.000000+00:00") == 1705314600
+
+  test "a Z-suffixed timestamp with no fractional seconds parses (was TimeParseError)":
+    check timestampToUnix("2024-01-15T10:30:00Z") == 1705314600
+
+  test "a Z-suffixed timestamp with fractional seconds parses":
+    check timestampToUnix("2023-06-01T00:00:00.123Z") == 1685577600
+
+  test "a space-separated timestamp parses":
+    check timestampToUnix("2023-06-01 00:00:00Z") == 1685577600
+
+  test "garbage input returns 0 without raising":
+    check timestampToUnix("not-a-timestamp") == 0

--- a/test/nim/token_apply_builder_test.nim
+++ b/test/nim/token_apply_builder_test.nim
@@ -1,0 +1,171 @@
+## Unit tests for the pure worker-side token-apply builder.
+##
+## This is the off-GUI-thread core that will feed the 0005 typed-completion
+## handoff: given the raw RPC response JSON (tokens-of-interest, all-tokens,
+## token-preferences, token-lists), it produces the COMPLETE finished structures
+## the GUI slot currently builds inline in applyRefreshTokensData /
+## applyAllTokenListsData — token items, groups-of-interest, the preferences
+## rows, and the all-tokens-by-group index — so the slot reduces to a swap+emit.
+## Pure: no Service, no threadpool, no backend. Byte-identical to the current
+## GUI-thread build (same inputs -> same structures).
+
+import unittest, json, tables, sequtils, algorithm
+
+import app_service/service/token/token_apply_builder
+import app_service/service/token/items/token
+import app_service/service/token/items/token_group
+import app_service/service/token/items/token_list
+
+# --- fixtures: real payload shapes (field names match the DTO serializedFieldName) ---
+# Two tokens share a crossChainId (one group); a third has an empty crossChainId
+# (its own key becomes its group key).
+const tokenA = """{"chainId":1,"address":"0xAAAA000000000000000000000000000000000001",
+  "name":"Alpha","symbol":"ALP","decimals":18,"logoUri":"logoA","custom":false,
+  "crossChainId":"grp-eth","communityData":{"id":"","name":"","color":"","image":""}}"""
+const tokenB = """{"chainId":10,"address":"0xBBBB000000000000000000000000000000000002",
+  "name":"Alpha","symbol":"ALP","decimals":18,"logoUri":"logoB","custom":false,
+  "crossChainId":"grp-eth","communityData":{"id":"","name":"","color":"","image":""}}"""
+const tokenC = """{"chainId":1,"address":"0xCCCC000000000000000000000000000000000003",
+  "name":"Gamma","symbol":"GAM","decimals":6,"logoUri":"logoC","custom":true,
+  "crossChainId":"","communityData":{"id":"comm-1","name":"Comm","color":"#fff","image":"img"}}"""
+
+proc arr(items: varargs[string]): JsonNode =
+  result = newJArray()
+  for it in items:
+    result.add parseJson(it)
+
+const prefsJson = """[{"key":"grp-eth","position":0,"groupPosition":2,"visible":true,"communityId":""},
+  {"key":"other","position":1,"groupPosition":0,"visible":false,"communityId":"comm-1"}]"""
+
+proc symbolsOf(items: seq[TokenItem]): seq[string] =
+  items.mapIt(it.symbol).sorted()
+
+suite "token apply builder — refresh tokens":
+
+  test "builds by-key table, groups-of-interest, and all-tokens index":
+    let res = buildRefreshTokensApply(arr(tokenA, tokenB, tokenC), arr(tokenA, tokenC),
+                                      parseJson(prefsJson))
+    # tokens-of-interest: 3 distinct keys
+    check res.tokensOfInterestCount == 3
+    check res.tokensOfInterestByKey.len == 3
+    check symbolsOf(toSeq(res.tokensOfInterestByKey.values)) == @["ALP", "ALP", "GAM"]
+    # groups: A+B collapse into "grp-eth"; C forms its own group
+    check res.groupsOfInterestByKey.len == 2
+    check res.groupsOfInterest.len == 2
+    check res.groupsOfInterestByKey.hasKey("grp-eth")
+    check res.groupsOfInterestByKey["grp-eth"].tokens.len == 2
+    let cGroupKey = toSeq(res.groupsOfInterestByKey.keys).filterIt(it != "grp-eth")[0]
+    check res.groupsOfInterestByKey[cGroupKey].tokens.len == 1
+    check res.groupsOfInterestByKey[cGroupKey].tokens[0].symbol == "GAM"
+    # all-tokens index: grouped by group key, count reflects the all-tokens input
+    check res.allTokensCount == 2
+    check res.allTokensByGroupKey.len == 2
+    check res.allTokensByGroupKey["grp-eth"].len == 1
+    check res.allTokensByGroupKey["grp-eth"][0].symbol == "ALP"
+
+  test "preferences are parsed to rows and the raw array is preserved":
+    let res = buildRefreshTokensApply(arr(tokenA), arr(tokenA), parseJson(prefsJson))
+    check res.tokenPreferences.len == 2
+    let byKey = res.tokenPreferences.mapIt((it.key, it)).toTable
+    check byKey["grp-eth"].groupPosition == 2
+    check byKey["grp-eth"].visible
+    check byKey["other"].visible == false
+    check byKey["other"].communityId == "comm-1"
+    # tokenPreferencesJson is the backend array verbatim (round-trips to the same node)
+    check parseJson(res.tokenPreferencesJson) == parseJson(prefsJson)
+
+  test "empty / missing preferences yield an empty rows list and [] json":
+    let res = buildRefreshTokensApply(arr(tokenA), arr(tokenA), newJArray())
+    check res.tokenPreferences.len == 0
+    check res.tokenPreferencesJson == "[]"
+
+  test "empty refresh builds empty structures (slot then keeps prior via swap-not-clear)":
+    let res = buildRefreshTokensApply(newJArray(), newJArray(), newJArray())
+    check res.tokensOfInterestCount == 0
+    check res.allTokensCount == 0
+    check res.tokensOfInterestByKey.len == 0
+    check res.groupsOfInterestByKey.len == 0
+    check res.allTokensByGroupKey.len == 0
+
+  test "deterministic: same input builds structurally identical output":
+    let a = buildRefreshTokensApply(arr(tokenA, tokenB, tokenC), arr(tokenA), parseJson(prefsJson))
+    let b = buildRefreshTokensApply(arr(tokenA, tokenB, tokenC), arr(tokenA), parseJson(prefsJson))
+    check toSeq(a.tokensOfInterestByKey.keys).sorted == toSeq(b.tokensOfInterestByKey.keys).sorted
+    check toSeq(a.groupsOfInterestByKey.keys).sorted == toSeq(b.groupsOfInterestByKey.keys).sorted
+
+suite "token apply builder — all token lists":
+
+  test "builds token-list items with version, source and nested tokens":
+    let listJson = """[{"id":"list1","name":"List One","timestamp":"1700000000",
+      "fetchedTimestamp":"1700000001","source":"uniswap","version":{"major":1,"minor":2,"patch":3},
+      "logoUri":"L","tokens":[""" & tokenA & "," & tokenC & """]}]"""
+    let res = buildAllTokenListsApply(parseJson(listJson))
+    check res.allTokenLists.len == 1
+    let item = res.allTokenLists[0]
+    check item.id == "list1"
+    check item.name == "List One"
+    check item.source == "uniswap"
+    check item.version == "1.2.3"
+    check item.tokens.len == 2
+    check symbolsOf(item.tokens) == @["ALP", "GAM"]
+
+  test "empty token-lists input yields no items":
+    let res = buildAllTokenListsApply(newJArray())
+    check res.allTokenLists.len == 0
+
+# The worker calls assemble*Result, then finishTyped(result). These must ALWAYS
+# return a non-nil result carrying the generation stamp — even on an RPC error or
+# a build exception — so the GUI slot always runs and the 0004 generation
+# coordinator never wedges (deadlock-safety).
+const badToken = """{"chainId":0,"address":"","name":"Bad","symbol":"BAD","decimals":0,
+  "custom":false,"crossChainId":"","communityData":{"id":"","name":"","color":"","image":""}}"""
+
+suite "token apply builder — worker result assembly (deadlock-safe)":
+
+  test "refresh: success carries generation and the built structures":
+    let res = assembleRefreshResult(arr(tokenA, tokenB), arr(tokenA), parseJson(prefsJson),
+                                    generation = 7, rpcError = "")
+    check res != nil
+    check res.generation == 7
+    check res.error == ""
+    check res.tokensOfInterestCount == 2
+
+  test "refresh: an RPC error is passed through, no build, still stamped":
+    let res = assembleRefreshResult(newJArray(), newJArray(), newJArray(),
+                                    generation = 3, rpcError = "getTokens failed")
+    check res != nil
+    check res.generation == 3
+    check res.error == "getTokens failed"
+    check res.tokensOfInterestCount == 0
+
+  test "refresh: a build exception becomes an error, never raises, still stamped":
+    # A malformed token dto makes createTokenItem raise (ValueError) inside the build.
+    # assemble* catches `Exception` (not `CatchableError`) so that a Defect — e.g.
+    # OutOfMemDefect building the multi-MB model on a memory-pressured wake — is also
+    # turned into a stamped, non-nil result rather than escaping and wedging the 0004
+    # in-flight gate. A real Defect has no clean injection seam in
+    # this build path, so the Defect case is covered by the `except Exception` choice
+    # plus the worker's structural try/finally (async_tasks.nim); this test exercises
+    # the catch/stamp/non-nil contract via the reachable CatchableError path.
+    let res = assembleRefreshResult(arr(badToken), arr(badToken), newJArray(),
+                                    generation = 9, rpcError = "")
+    check res != nil
+    check res.generation == 9
+    check res.error.len > 0
+    check res.tokensOfInterestCount == 0
+
+  test "token lists: success carries generation and items":
+    let listJson = """[{"id":"l","name":"L","timestamp":"1","fetchedTimestamp":"1","source":"s",
+      "version":{"major":1,"minor":0,"patch":0},"logoUri":"","tokens":[]}]"""
+    let res = assembleAllTokenListsResult(parseJson(listJson), generation = 4, rpcError = "")
+    check res != nil
+    check res.generation == 4
+    check res.error == ""
+    check res.allTokenLists.len == 1
+
+  test "token lists: an RPC error is passed through, no build, still stamped":
+    let res = assembleAllTokenListsResult(newJArray(), generation = 2, rpcError = "boom")
+    check res != nil
+    check res.generation == 2
+    check res.error == "boom"
+    check res.allTokenLists.len == 0

--- a/test/nim/token_apply_builder_test.nim
+++ b/test/nim/token_apply_builder_test.nim
@@ -178,3 +178,36 @@ suite "token apply builder — worker result assembly (deadlock-safe)":
     check res.generation == 2
     check res.error == "boom"
     check res.allTokenLists.len == 0
+
+suite "token apply builder — token groups (by-chain / all-groups)":
+
+  test "builds name-sorted groups, collapsing a shared crossChainId":
+    # C ("Gamma") then the A/B group ("Alpha") -> sorted by name = Alpha, Gamma.
+    let groups = buildTokenGroupsApply(arr(tokenC, tokenA, tokenB))
+    check groups.len == 2
+    check groups.mapIt(it.name) == @["Alpha", "Gamma"]
+    let alpha = groups.filterIt(it.name == "Alpha")[0]
+    check alpha.key == "grp-eth"
+    check alpha.tokens.len == 2   # A + B collapsed
+    check groups.filterIt(it.name == "Gamma")[0].tokens.len == 1
+
+  test "empty tokens node yields no groups":
+    check buildTokenGroupsApply(newJArray()).len == 0
+
+  test "assemble: success carries the built groups, no error":
+    let res = assembleTokenGroupsResult(arr(tokenA, tokenB, tokenC), rpcError = "")
+    check res != nil
+    check res.error == ""
+    check res.groups.len == 2
+
+  test "assemble: an RPC error is passed through, no build":
+    let res = assembleTokenGroupsResult(newJArray(), rpcError = "getTokensByChain failed")
+    check res != nil
+    check res.error == "getTokensByChain failed"
+    check res.groups.len == 0
+
+  test "assemble: a build exception becomes an error, never raises":
+    let res = assembleTokenGroupsResult(arr(badToken), rpcError = "")
+    check res != nil
+    check res.error.len > 0
+    check res.groups.len == 0

--- a/test/nim/token_apply_builder_test.nim
+++ b/test/nim/token_apply_builder_test.nim
@@ -1,6 +1,6 @@
 ## Unit tests for the pure worker-side token-apply builder.
 ##
-## This is the off-GUI-thread core that will feed the 0005 typed-completion
+## This is the off-GUI-thread core that will feed the typed-completion
 ## handoff: given the raw RPC response JSON (tokens-of-interest, all-tokens,
 ## token-preferences, token-lists), it produces the COMPLETE finished structures
 ## the GUI slot currently builds inline in applyRefreshTokensData /
@@ -93,6 +93,15 @@ suite "token apply builder — refresh tokens":
     check toSeq(a.tokensOfInterestByKey.keys).sorted == toSeq(b.tokensOfInterestByKey.keys).sorted
     check toSeq(a.groupsOfInterestByKey.keys).sorted == toSeq(b.groupsOfInterestByKey.keys).sorted
 
+  test "groups-of-interest is ordered deterministically by group key":
+    let res = buildRefreshTokensApply(arr(tokenA, tokenB, tokenC), arr(tokenA), parseJson(prefsJson))
+    let orderKeys = res.groupsOfInterest.mapIt(it.key)
+    # the exposed group seq is sorted by key (not Table hash order)...
+    check orderKeys == orderKeys.sorted
+    # ...and its order is exactly the by-key set (the getId diffs on) in sorted
+    # order, so a structural change only inserts/removes and never reshuffles survivors.
+    check orderKeys == toSeq(res.groupsOfInterestByKey.keys).sorted
+
 suite "token apply builder — all token lists":
 
   test "builds token-list items with version, source and nested tokens":
@@ -115,7 +124,7 @@ suite "token apply builder — all token lists":
 
 # The worker calls assemble*Result, then finishTyped(result). These must ALWAYS
 # return a non-nil result carrying the generation stamp — even on an RPC error or
-# a build exception — so the GUI slot always runs and the 0004 generation
+# a build exception — so the GUI slot always runs and the generation
 # coordinator never wedges (deadlock-safety).
 const badToken = """{"chainId":0,"address":"","name":"Bad","symbol":"BAD","decimals":0,
   "custom":false,"crossChainId":"","communityData":{"id":"","name":"","color":"","image":""}}"""
@@ -142,7 +151,7 @@ suite "token apply builder — worker result assembly (deadlock-safe)":
     # A malformed token dto makes createTokenItem raise (ValueError) inside the build.
     # assemble* catches `Exception` (not `CatchableError`) so that a Defect — e.g.
     # OutOfMemDefect building the multi-MB model on a memory-pressured wake — is also
-    # turned into a stamped, non-nil result rather than escaping and wedging the 0004
+    # turned into a stamped, non-nil result rather than escaping and wedging the
     # in-flight gate. A real Defect has no clean injection seam in
     # this build path, so the Defect case is covered by the `except Exception` choice
     # plus the worker's structural try/finally (async_tasks.nim); this test exercises

--- a/test/nim/token_groups_model_test.nim
+++ b/test/nim/token_groups_model_test.nim
@@ -1,0 +1,164 @@
+## Conversion tests for token_groups_model (setItemsWithSync + Table-keyed
+## market details). Compile with -d:QT_MODEL_SPY.
+##
+## Covers the acceptance gate: identity preservation of MarketDetailsItem across
+## insert+remove+reorder; reorder read-back (remove+insert, no moves) + no reset;
+## stable-set refresh emits no reset / no move / no spurious churn.
+
+import unittest, tables, sequtils
+import nimqml
+
+import app/modules/main/wallet_section/all_tokens/token_groups_model
+import app/modules/main/wallet_section/all_tokens/io_interface
+import app/modules/shared/qt_model_spy
+import app_service/service/token/items/token_group
+
+var gGroups: seq[TokenGroupItem] = @[]
+
+proc groupsDataSource(): TokenGroupsModelDataSource =
+  (
+    getAllTokenGroups: proc(): var seq[TokenGroupItem] = gGroups,
+    getTokenDetails: proc(tokenKey: string): TokenDetailsItem = default(TokenDetailsItem),
+    getTokenPreferences: proc(groupKey: string): TokenPreferencesItem = default(TokenPreferencesItem),
+    getCommunityTokenDescription: proc(chainId: int, address: string): string = "",
+    getTokensDetailsLoading: proc(): bool = false,
+    getTokensMarketValuesLoading: proc(): bool = false,
+  )
+
+proc marketValuesDataSource(): TokenMarketValuesDataSource =
+  (
+    getMarketValuesForToken: proc(tokenKey: string): TokenMarketValuesItem = default(TokenMarketValuesItem),
+    getPriceForToken: proc(tokenKey: string): float64 = 0.0,
+    getCurrentCurrencyFormat: proc(): CurrencyFormatDto = default(CurrencyFormatDto),
+    getTokensMarketValuesLoading: proc(): bool = false,
+  )
+
+proc mkGroup(key: string, name: string = ""): TokenGroupItem =
+  let tok = createTokenItem(TokenDto(
+    chainId: 1, address: "0x" & key, crossChainId: key,
+    name: (if name.len > 0: name else: key), symbol: key, decimals: 18))
+  TokenGroupItem(
+    key: key, name: (if name.len > 0: name else: key), symbol: key,
+    decimals: 18, logoUri: "", tokens: @[tok])
+
+proc newModel(): TokenGroupsModel =
+  newTokenGroupsModel(groupsDataSource(), marketValuesDataSource())
+
+proc moves(spy: QtModelSpy): int = spy.calls.filterIt(it.kind == BeginMoveRows).len
+
+suite "token_groups_model - identity, reorder, stable-set":
+
+  setup:
+    let spy = newQtModelSpy()
+    spy.enable()
+
+  teardown:
+    spy.disable()
+
+  test "MarketDetailsItem identity preserved across insert+remove+reorder":
+    gGroups = @[mkGroup("a"), mkGroup("b"), mkGroup("c")]
+    let m = newModel()
+    m.modelsUpdated()
+    let mdA = m.marketDetailsItemForKey("a")
+    let mdB = m.marketDetailsItemForKey("b")
+    check not mdA.isNil
+    check not mdB.isNil
+
+    # remove c, insert x, reorder survivors -> [b, x, a]
+    gGroups = @[mkGroup("b"), mkGroup("x"), mkGroup("a")]
+    m.modelsUpdated()
+
+    check m.groupKeysInOrder() == @["b", "x", "a"]     # order matches target
+    check m.marketDetailsItemForKey("a") == mdA        # SAME instance (identity)
+    check m.marketDetailsItemForKey("b") == mdB        # SAME instance
+    check m.marketDetailsItemForKey("c").isNil         # removed key dropped
+    check not m.marketDetailsItemForKey("x").isNil     # new key -> new object
+    check m.marketDetailsItemForKey("x") != mdA        # not an aliased survivor
+
+    # market-values signal path must still find/update objects by key post-reorder
+    m.tokensMarketValuesUpdated()
+    check m.marketDetailsItemForKey("a") == mdA
+
+  test "reorder (hash-order change): reads back in target order, remove+insert, no move, no reset":
+    gGroups = @[mkGroup("a"), mkGroup("b"), mkGroup("c"), mkGroup("d")]
+    let m = newModel()
+    m.modelsUpdated()
+    spy.clear()
+
+    gGroups = @[mkGroup("d"), mkGroup("c"), mkGroup("b"), mkGroup("a")]
+    m.modelsUpdated()
+
+    check m.groupKeysInOrder() == @["d", "c", "b", "a"]
+    check spy.moves() == 0
+    check spy.countResets() == 0
+    check spy.countInserts() > 0
+    check spy.countRemoves() > 0
+
+  test "stable set, no metadata change: no reset, no move, no churn":
+    gGroups = @[mkGroup("a"), mkGroup("b")]
+    let m = newModel()
+    m.modelsUpdated()
+    spy.clear()
+
+    gGroups = @[mkGroup("a"), mkGroup("b")]  # same keys, same order, same metadata
+    m.modelsUpdated()
+
+    check m.groupKeysInOrder() == @["a", "b"]
+    check spy.countResets() == 0
+    check spy.moves() == 0
+    check spy.countInserts() == 0
+    check spy.countRemoves() == 0
+    check spy.countDataChanged() == 0  # TokenItem has no balance -> truly no-op
+
+  test "metadata change on one group: dataChanged for that row only, no reset/move":
+    gGroups = @[mkGroup("a"), mkGroup("b")]
+    let m = newModel()
+    m.modelsUpdated()
+    spy.clear()
+
+    gGroups = @[mkGroup("a", name = "Renamed"), mkGroup("b")]
+    m.modelsUpdated()
+
+    check spy.countDataChanged() > 0
+    check spy.countResets() == 0
+    check spy.moves() == 0
+    check spy.countInserts() == 0
+    check spy.countRemoves() == 0
+
+  test "pure add and pure remove":
+    gGroups = @[mkGroup("a"), mkGroup("b")]
+    let m = newModel()
+    m.modelsUpdated()
+    spy.clear()
+
+    gGroups = @[mkGroup("a"), mkGroup("b"), mkGroup("c")]  # add (sorted source order)
+    m.modelsUpdated()
+    check spy.countInserts() == 1
+    check spy.moves() == 0     # deterministic source order -> survivors don't reshuffle
+    check spy.countResets() == 0
+
+    spy.clear()
+    gGroups = @[mkGroup("a"), mkGroup("c")]  # remove b
+    m.modelsUpdated()
+    check spy.countRemoves() == 1
+    check spy.moves() == 0     # pure remove, no reshuffle
+    check spy.countResets() == 0
+    check m.marketDetailsItemForKey("b").isNil
+
+  test "F1: group-set grows -> every row incl the new ones has market details (no empty window)":
+    gGroups = @[mkGroup("a"), mkGroup("b")]
+    let m = newModel()
+    m.modelsUpdated()
+    spy.clear()
+
+    gGroups = @[mkGroup("a"), mkGroup("b"), mkGroup("c"), mkGroup("d")]  # set grows
+    m.modelsUpdated()
+
+    check spy.countInserts() > 0
+    check spy.countResets() == 0
+    # Every displayed row — including the newly inserted c, d — must have its
+    # market-details key present. F1 fix builds the keys BEFORE setItemsWithSync
+    # announces the inserts, so data(MarketDetails) is populated for a new row
+    # within this same modelsUpdated call rather than empty until a later signal.
+    for key in m.groupKeysInOrder():
+      check not m.marketDetailsItemForKey(key).isNil

--- a/test/nim/token_groups_model_test.nim
+++ b/test/nim/token_groups_model_test.nim
@@ -10,6 +10,7 @@ import nimqml
 
 import app/modules/main/wallet_section/all_tokens/token_groups_model
 import app/modules/main/wallet_section/all_tokens/io_interface
+import app/modules/main/wallet_section/all_tokens/market_details_item
 import app/modules/shared/qt_model_spy
 import app_service/service/token/items/token_group
 
@@ -78,6 +79,42 @@ suite "token_groups_model - identity, reorder, stable-set":
     # market-values signal path must still find/update objects by key post-reorder
     m.tokensMarketValuesUpdated()
     check m.marketDetailsItemForKey("a") == mdA
+
+  test "surviving group whose representative token changes updates MarketDetailsItem.tokenKey":
+    # priceForTokenGroup picks the FIRST token with price>0 as the group's market
+    # representative. reconcileByKey keeps a survivor's MarketDetailsItem instance;
+    # if it does not refresh the stored representative tokenKey, tokensMarketValuesUpdated
+    # later fetches price/values for the STALE representative -> wrong market data on a
+    # surviving row. The tokenKey must follow the new representative.
+    let t1 = createTokenItem(TokenDto(chainId: 1, address: "0xt1", crossChainId: "g",
+      name: "g", symbol: "g", decimals: 18))
+    let t2 = createTokenItem(TokenDto(chainId: 1, address: "0xt2", crossChainId: "g",
+      name: "g", symbol: "g", decimals: 18))
+    proc mkTwoTokenGroup(): TokenGroupItem =
+      TokenGroupItem(key: "g", name: "g", symbol: "g", decimals: 18, logoUri: "",
+        tokens: @[t1, t2])
+
+    var prices = initTable[string, float64]()
+    prices[t1.key] = 0.0      # t1 unpriced -> representative is t2
+    prices[t2.key] = 5.0
+    proc mvSource(): TokenMarketValuesDataSource =
+      (
+        getMarketValuesForToken: proc(tokenKey: string): TokenMarketValuesItem = default(TokenMarketValuesItem),
+        getPriceForToken: proc(tokenKey: string): float64 = prices.getOrDefault(tokenKey, 0.0),
+        getCurrentCurrencyFormat: proc(): CurrencyFormatDto = default(CurrencyFormatDto),
+        getTokensMarketValuesLoading: proc(): bool = false,
+      )
+
+    gGroups = @[mkTwoTokenGroup()]
+    let m = newTokenGroupsModel(groupsDataSource(), mvSource())
+    m.modelsUpdated()
+    check m.marketDetailsItemForKey("g").tokenKey == t2.key   # first priced = t2
+
+    # t1 gains a price -> it becomes the representative for the SAME surviving key.
+    prices[t1.key] = 10.0
+    gGroups = @[mkTwoTokenGroup()]
+    m.modelsUpdated()
+    check m.marketDetailsItemForKey("g").tokenKey == t1.key   # rep must follow to t1
 
   test "reorder (hash-order change): reads back in target order, remove+insert, no move, no reset":
     gGroups = @[mkGroup("a"), mkGroup("b"), mkGroup("c"), mkGroup("d")]

--- a/test/nim/token_lookup_cache_test.nim
+++ b/test/nim/token_lookup_cache_test.nim
@@ -1,0 +1,69 @@
+## Unit tests for the pure token-lookup cache helpers.
+## These cover the negative-cache decision that gates the blocking backend RPC and
+## the swap-not-clear guard used when a token refresh is applied. No Qt/backend
+## required — the helpers operate on plain tables/sets and TokenItems.
+
+import unittest, tables, sets
+
+import app_service/service/token/token_lookup_cache
+import app_service/service/token/items/token
+import app_service/service/token/dto/token as token_dto
+
+proc testToken(chainId: int, address: string): TokenItem =
+  var dto: token_dto.TokenDto
+  dto.chainId = chainId
+  dto.address = address
+  dto.name = "Test"
+  dto.symbol = "TST"
+  dto.decimals = 18
+  return createTokenItem(dto)
+
+suite "token negative-cache lookup classification":
+  test "unknown key needs a fetch; once marked missing the next lookup skips the RPC":
+    let key = "1-0xdead"
+    var byKey = initTable[string, TokenItem]()
+    var missing = initHashSet[string]()
+
+    # First lookup: nothing is known about the key -> a backend fetch is required.
+    check classifyTokenLookup(byKey, missing, key) == TokenLookupOutcome.NeedsFetch
+
+    # The backend returned nothing, so the caller records the miss.
+    missing.incl(key)
+
+    # Second lookup of the same key must NOT ask for another fetch.
+    check classifyTokenLookup(byKey, missing, key) == TokenLookupOutcome.KnownMissing
+
+  test "a cached key is a hit and never fetched, even if also marked missing":
+    let key = "1-0xbeef"
+    var byKey = {key: testToken(1, "0xbeef")}.toTable
+    var missing = initHashSet[string]()
+
+    check classifyTokenLookup(byKey, missing, key) == TokenLookupOutcome.Hit
+
+    # A stale/defensive missing marker must never shadow real data.
+    missing.incl(key)
+    check classifyTokenLookup(byKey, missing, key) == TokenLookupOutcome.Hit
+
+suite "token refresh swap-not-clear guard":
+  test "a refresh carrying tokens replaces the cache":
+    check shouldReplaceTokensCache(newTokenCount = 5, priorCacheCount = 3)
+
+  test "an empty/failed refresh preserves an existing cache":
+    check not shouldReplaceTokensCache(newTokenCount = 0, priorCacheCount = 3)
+
+  test "an empty refresh still applies when the cache is empty (first fill)":
+    check shouldReplaceTokensCache(newTokenCount = 0, priorCacheCount = 0)
+
+  test "the replacement table is fully built before it is swapped in":
+    # The refresh must build the new lookup table aside and hand it back complete,
+    # so assigning it is an atomic swap with no observable empty-cache window.
+    let tokens = @[testToken(1, "0xaaa"), testToken(1, "0xbbb"), testToken(10, "0xaaa")]
+    let byKey = buildTokensByKey(tokens)
+
+    check byKey.len == 3
+    for token in tokens:
+      check byKey.hasKey(token.key)
+      check byKey[token.key].key == token.key
+
+  test "building from no tokens yields an empty table":
+    check buildTokensByKey(newSeq[TokenItem]()).len == 0

--- a/test/nim/token_missing_fetch_test.nim
+++ b/test/nim/token_missing_fetch_test.nim
@@ -1,0 +1,54 @@
+## Unit tests for the decode-and-release step of the async missing-tokens batch.
+##
+## This is the slot-side half of the batched fetch: the worker's envelope comes
+## back as a string, and whatever the outcome the batch's keys must leave the
+## in-flight set — a key stuck in flight can never re-enqueue, so the token
+## wedges (stops resolving) for the rest of the session. No Qt/backend.
+
+import unittest
+
+import app_service/service/token/token_missing_fetch
+import app_service/service/token/token_pending_fetch
+
+suite "missing-tokens batch — decoded envelope":
+  test "a clean envelope yields its keys and releases them from the in-flight set":
+    var p = initPendingTokenFetch()
+    discard p.enqueue("1-0xaaa")
+    discard p.takeBatch()                 # 1-0xaaa is now in flight
+    let response = """{"requestedKeys":["1-0xaaa"],"tokens":[],"error":""}"""
+    let (env, decodeError) = decodeAndCompleteBatch(p, response)
+    check decodeError.len == 0
+    check env.requestedKeys == @["1-0xaaa"]
+    check env.error.len == 0
+    check p.enqueue("1-0xaaa") == true    # released -> a fresh miss may re-enqueue
+
+  test "a backend-error envelope still releases the batch's keys":
+    var p = initPendingTokenFetch()
+    discard p.enqueue("1-0xaaa")
+    discard p.takeBatch()
+    let response = """{"requestedKeys":["1-0xaaa"],"tokens":[],"error":"boom"}"""
+    let (env, decodeError) = decodeAndCompleteBatch(p, response)
+    check decodeError.len == 0
+    check env.error == "boom"
+    check p.enqueue("1-0xaaa") == true    # transient failure -> retry allowed
+
+suite "missing-tokens batch — undecodable envelope":
+  test "a raised decode still releases the in-flight keys instead of wedging them":
+    var p = initPendingTokenFetch()
+    discard p.enqueue("1-0xaaa")
+    discard p.takeBatch()                 # 1-0xaaa is now in flight
+    let (env, decodeError) = decodeAndCompleteBatch(p, "not json at all")
+    check decodeError.len > 0
+    check env.requestedKeys.len == 0
+    # The batch's keys are unknown when the envelope itself is undecodable, so
+    # everything in flight must be released — otherwise these keys stay "in
+    # flight" forever and can never be fetched again this session.
+    check p.enqueue("1-0xaaa") == true
+
+  test "an empty response (drained handoff) releases the in-flight keys too":
+    var p = initPendingTokenFetch()
+    discard p.enqueue("10-0xbbb")
+    discard p.takeBatch()
+    let (_, decodeError) = decodeAndCompleteBatch(p, "")
+    check decodeError.len > 0
+    check p.enqueue("10-0xbbb") == true

--- a/test/nim/token_pending_fetch_test.nim
+++ b/test/nim/token_pending_fetch_test.nim
@@ -47,6 +47,16 @@ suite "pending token fetch — in-flight window":
     check p.enqueue("1-0xaaa") == true     # a fresh miss of the same key is allowed again
     check p.hasPending()
 
+  test "draining the in-flight set releases every key but leaves pending keys queued":
+    var p = initPendingTokenFetch()
+    discard p.enqueue("1-0xaaa")
+    discard p.takeBatch()                  # 1-0xaaa in flight
+    discard p.enqueue("10-0xbbb")          # queued for the NEXT batch
+    p.drainInFlight()                      # failure path: batch keys unknown
+    check p.enqueue("1-0xaaa") == true     # released -> may re-enqueue
+    check p.enqueue("10-0xbbb") == false   # still pending -> still dedups
+    check p.takeBatch().len == 2
+
 suite "pending token fetch — negative-marker feed":
   test "keys requested but not returned by a batch are the ones to mark missing":
     let requested = @["1-0xaaa", "1-0xbbb", "10-0xccc"]

--- a/test/nim/token_pending_fetch_test.nim
+++ b/test/nim/token_pending_fetch_test.nim
@@ -1,0 +1,59 @@
+## Unit tests for the pure pending-fetch set.
+## This is the coalescing/dedup core of the async batched fetch that replaces the
+## synchronous GUI-thread token RPC: a miss enqueues a key, a burst of lookups for
+## the same key collapses to one batch entry, a batch is drained atomically, and
+## keys not returned by a batch feed the 0001 negative markers. No Qt/backend.
+
+import unittest, sequtils, sets
+
+import app_service/service/token/token_pending_fetch
+
+suite "pending token fetch — enqueue and batching":
+  test "the first enqueue of a key schedules; repeats within the same window dedup":
+    var p = initPendingTokenFetch()
+    check p.enqueue("1-0xaaa") == true   # newly pending -> caller schedules a batch
+    check p.enqueue("1-0xaaa") == false  # already pending -> no second schedule
+    check p.hasPending()
+
+  test "a burst of lookups for the same key yields a single batch entry":
+    var p = initPendingTokenFetch()
+    for _ in 0 ..< 5:
+      discard p.enqueue("1-0xbbb")
+    let batch = p.takeBatch()
+    check batch == @["1-0xbbb"]
+    check not p.hasPending()  # draining clears the pending set
+
+  test "takeBatch returns every distinct pending key":
+    var p = initPendingTokenFetch()
+    discard p.enqueue("1-0xaaa")
+    discard p.enqueue("10-0xbbb")
+    let batch = p.takeBatch()
+    check batch.toHashSet == ["1-0xaaa", "10-0xbbb"].toHashSet
+    check not p.hasPending()
+
+suite "pending token fetch — in-flight window":
+  test "a key in flight does not re-enqueue while its batch is running":
+    var p = initPendingTokenFetch()
+    discard p.enqueue("1-0xaaa")
+    discard p.takeBatch()                 # 1-0xaaa is now in flight
+    check p.enqueue("1-0xaaa") == false   # a repeat lookup mid-flight must not re-fetch
+    check not p.hasPending()
+
+  test "completing a batch releases its keys so a later miss can re-enqueue":
+    var p = initPendingTokenFetch()
+    discard p.enqueue("1-0xaaa")
+    let batch = p.takeBatch()
+    p.completeBatch(batch)                 # batch done -> in-flight cleared
+    check p.enqueue("1-0xaaa") == true     # a fresh miss of the same key is allowed again
+    check p.hasPending()
+
+suite "pending token fetch — negative-marker feed":
+  test "keys requested but not returned by a batch are the ones to mark missing":
+    let requested = @["1-0xaaa", "1-0xbbb", "10-0xccc"]
+    let found = ["1-0xbbb"].toHashSet
+    # Only 1-0xbbb resolved; the other two feed the 0001 negative cache.
+    check missingFromBatch(requested, found) == @["1-0xaaa", "10-0xccc"]
+
+  test "a fully-resolved batch leaves nothing to mark missing":
+    let requested = @["1-0xaaa"]
+    check missingFromBatch(requested, ["1-0xaaa"].toHashSet).len == 0

--- a/test/nim/token_refresh_generation_test.nim
+++ b/test/nim/token_refresh_generation_test.nim
@@ -1,0 +1,84 @@
+## Unit tests for the pure refresh-generation coordinator.
+## Coalesces the token service's heavy async tasks: while one is in flight new
+## triggers do not start another; the in-flight completion re-fires once if newer
+## triggers arrived, and stale completions are dropped without applying. Net: N
+## queued triggers -> exactly one apply of the newest data. No Qt/backend.
+
+import unittest
+
+import app_service/service/token/token_refresh_generation
+
+suite "refresh generation — starting and coalescing":
+  test "the first trigger starts a task stamped with generation 1":
+    var g = initRefreshGenerationState()
+    let r = g.requestRefresh()
+    check r.shouldStart
+    check r.gen == 1
+    check g.inFlight
+
+  test "a trigger while a task is in flight does not start another":
+    var g = initRefreshGenerationState()
+    discard g.requestRefresh()          # starts gen 1
+    let r = g.requestRefresh()          # in flight -> coalesce
+    check not r.shouldStart
+    check r.gen == 2                     # desired generation still advances
+    check g.inFlight
+
+suite "refresh generation — completion":
+  test "completing the latest generation applies and clears in-flight":
+    var g = initRefreshGenerationState()
+    let r = g.requestRefresh()          # gen 1, in flight
+    let c = g.onCompletion(r.gen)
+    check c.action == rcaApply
+    check not g.inFlight
+
+  test "a trigger during flight makes the stale completion drop and re-fire once":
+    var g = initRefreshGenerationState()
+    let r1 = g.requestRefresh()         # gen 1
+    discard g.requestRefresh()          # gen 2, coalesced
+    let c1 = g.onCompletion(r1.gen)     # gen 1 completes while gen 2 desired
+    check c1.action == rcaDropAndRefire
+    check c1.gen == 2                    # re-fire with the newest generation
+    check g.inFlight
+    let c2 = g.onCompletion(c1.gen)     # gen 2 completes, nothing newer
+    check c2.action == rcaApply
+    check not g.inFlight
+
+  test "three rapid triggers yield exactly one apply":
+    var g = initRefreshGenerationState()
+    let r1 = g.requestRefresh()
+    discard g.requestRefresh()
+    discard g.requestRefresh()          # desired = 3, only gen 1 started
+    var applies = 0
+    var c = g.onCompletion(r1.gen)      # gen 1 stale -> drop + refire gen 3
+    if c.action == rcaApply: inc applies
+    check c.action == rcaDropAndRefire
+    c = g.onCompletion(c.gen)           # gen 3 completes
+    if c.action == rcaApply: inc applies
+    check applies == 1
+
+  test "a fresh trigger after completion starts a new task":
+    var g = initRefreshGenerationState()
+    let r1 = g.requestRefresh()
+    discard g.onCompletion(r1.gen)      # applied, idle
+    let r2 = g.requestRefresh()
+    check r2.shouldStart
+    check r2.gen == 2
+
+  test "an undecodable completion, replayed via currentGeneration, does not re-fire forever":
+    # The service passes currentGeneration() when a completion cannot be decoded.
+    # With no newer trigger this must resolve to apply (go idle), not loop.
+    var g = initRefreshGenerationState()
+    discard g.requestRefresh()          # gen 1 in flight
+    check g.currentGeneration == 1
+    let c = g.onCompletion(g.currentGeneration)
+    check c.action == rcaApply           # no newer trigger -> idle, bounded
+    check not g.inFlight
+
+  test "an undecodable completion still re-fires once when newer triggers arrived":
+    var g = initRefreshGenerationState()
+    discard g.requestRefresh()          # gen 1 in flight
+    discard g.requestRefresh()          # gen 2 desired
+    let c = g.onCompletion(g.currentGeneration)  # currentGeneration == 1 < 2
+    check c.action == rcaDropAndRefire
+    check c.gen == 2

--- a/ui/StatusQ/src/wallet/managetokenscontroller.cpp
+++ b/ui/StatusQ/src/wallet/managetokenscontroller.cpp
@@ -4,6 +4,22 @@
 
 #include <QJsonObject>
 #include <QElapsedTimer>
+#include <QTimer>
+
+namespace
+{
+// Source roles whose changes are pure passthrough to token cells: they never
+// affect which model a token lives in, group membership/metadata, group
+// child-counts, or sort order. A dataChanged limited to these can be applied
+// in place; anything else forces a full re-parse.
+const QSet<QByteArray> kDataOnlyRoleNames{
+    kEnabledNetworkBalanceRoleName,
+    kEnabledNetworkCurrencyBalanceRoleName,
+    kBalancesRoleName,
+    kDecimalsRoleName,
+    kMarketDetailsRoleName,
+};
+} // namespace
 
 ManageTokensController::ManageTokensController(QObject* parent)
     : QObject(parent)
@@ -19,6 +35,11 @@ ManageTokensController::ManageTokensController(QObject* parent)
         connect(model, &ManageTokensModel::dirtyChanged, this, &ManageTokensController::dirtyChanged);
     }
 
+    m_sourceUpdateBatchTimer = new QTimer(this);
+    m_sourceUpdateBatchTimer->setSingleShot(true);
+    m_sourceUpdateBatchTimer->setInterval(0);
+    connect(m_sourceUpdateBatchTimer, &QTimer::timeout, this, &ManageTokensController::flushPendingSourceUpdates);
+
     connect(this, &ManageTokensController::sourceModelChanged, this, [this]() {
         if (!m_sourceModel) {
             m_modelConnectionsInitialized = false;
@@ -30,6 +51,13 @@ ManageTokensController::ManageTokensController(QObject* parent)
                 &QAbstractItemModel::rowsInserted,
                 this,
                 [this](const QModelIndex& parent, int first, int last) {
+                    Q_UNUSED(parent)
+                    // A structural change interleaving with queued in-place updates
+                    // shifts row indices; fall back to a correct full re-parse.
+                    if (hasPendingSourceUpdates()) {
+                        parseSourceModel();
+                        return;
+                    }
 #ifdef QT_DEBUG
                     QElapsedTimer t;
                     t.start();
@@ -49,7 +77,7 @@ ManageTokensController::ManageTokensController(QObject* parent)
 #endif
                 });
         connect(m_sourceModel, &QAbstractItemModel::rowsRemoved, this, &ManageTokensController::parseSourceModel);
-        connect(m_sourceModel, &QAbstractItemModel::dataChanged, this, &ManageTokensController::parseSourceModel);
+        connect(m_sourceModel, &QAbstractItemModel::dataChanged, this, &ManageTokensController::onSourceDataChanged);
         m_modelConnectionsInitialized = true;
     });
 }
@@ -359,6 +387,7 @@ void ManageTokensController::setSourceModel(QAbstractItemModel* newSourceModel)
 
     if (!newSourceModel) {
         disconnect(sourceModel());
+        cancelPendingSourceUpdates();
         // clear all the models
         for (auto model : m_allModels)
             model->clear();
@@ -390,6 +419,10 @@ void ManageTokensController::parseSourceModel()
     if (!m_sourceModel)
         return;
 
+    // A full re-parse rebuilds everything from scratch, superseding any queued
+    // in-place updates.
+    cancelPendingSourceUpdates();
+
     disconnect(m_sourceModel, &QAbstractItemModel::rowsInserted, this, &ManageTokensController::parseSourceModel);
 
 #ifdef QT_DEBUG
@@ -415,6 +448,124 @@ void ManageTokensController::parseSourceModel()
 #endif
 
     emit sourceModelChanged();
+}
+
+bool ManageTokensController::hasPendingSourceUpdates() const
+{
+    return m_pendingFullReparse || !m_pendingChangedRows.isEmpty();
+}
+
+void ManageTokensController::cancelPendingSourceUpdates()
+{
+    if (m_sourceUpdateBatchTimer)
+        m_sourceUpdateBatchTimer->stop();
+    m_pendingFullReparse = false;
+    m_pendingChangedRows.clear();
+    m_pendingChangedRoleNames.clear();
+}
+
+void ManageTokensController::scheduleSourceUpdateFlush()
+{
+    if (m_sourceUpdateBatchTimer && !m_sourceUpdateBatchTimer->isActive())
+        m_sourceUpdateBatchTimer->start();
+}
+
+void ManageTokensController::onSourceDataChanged(const QModelIndex& topLeft,
+                                                 const QModelIndex& bottomRight,
+                                                 const QList<int>& roles)
+{
+    if (!m_sourceModel)
+        return;
+
+    // An empty roles list means "every role changed" — treat as structural.
+    if (roles.isEmpty()) {
+        m_pendingFullReparse = true;
+    } else if (!m_pendingFullReparse) {
+        const auto sourceRoleNames = m_sourceModel->roleNames();
+        for (const auto roleId : roles) {
+            const auto roleName = sourceRoleNames.value(roleId);
+            if (kDataOnlyRoleNames.contains(roleName))
+                m_pendingChangedRoleNames.insert(roleName);
+            else
+                m_pendingFullReparse = true;
+        }
+    }
+
+    if (!m_pendingFullReparse) {
+        for (int row = topLeft.row(); row <= bottomRight.row(); ++row)
+            m_pendingChangedRows.insert(row);
+    }
+
+    scheduleSourceUpdateFlush();
+}
+
+void ManageTokensController::flushPendingSourceUpdates()
+{
+    if (!m_sourceModel) {
+        cancelPendingSourceUpdates();
+        return;
+    }
+
+    if (m_pendingFullReparse) {
+        parseSourceModel(); // clears pending state itself
+        return;
+    }
+
+    const auto rows = m_pendingChangedRows;
+    for (const auto row : rows)
+        applyIncrementalDataUpdate(row);
+
+    cancelPendingSourceUpdates();
+}
+
+void ManageTokensController::applyIncrementalDataUpdate(int sourceRow)
+{
+    if (!m_sourceModel || sourceRow < 0 || sourceRow >= m_sourceModel->rowCount())
+        return;
+
+    const auto sourceRoleNames = m_sourceModel->roleNames();
+    const auto srcIndex = m_sourceModel->index(sourceRow, 0);
+    const auto key = srcIndex.data(sourceRoleNames.key(kKeyRoleName, -1)).toString();
+    if (key.isEmpty())
+        return;
+
+    // The token lives in exactly one leaf model. Group models are aggregates that
+    // don't display these data-only roles, so they need no update here.
+    for (auto model : {m_regularTokensModel, m_communityTokensModel, m_hiddenTokensModel}) {
+        const auto row = model->rowForKey(key);
+        if (row < 0)
+            continue;
+
+        TokenData& token = model->itemAt(row);
+        QList<int> changedRoles;
+
+        const auto dataForRole = [&](const QByteArray& rolename) {
+            return srcIndex.data(sourceRoleNames.key(rolename, -1));
+        };
+
+        for (const auto& roleName : m_pendingChangedRoleNames) {
+            if (roleName == kEnabledNetworkBalanceRoleName) {
+                token.balance = dataForRole(kEnabledNetworkBalanceRoleName);
+                changedRoles << ManageTokensModel::BalanceRole;
+            } else if (roleName == kEnabledNetworkCurrencyBalanceRoleName) {
+                token.currencyBalance = dataForRole(kEnabledNetworkCurrencyBalanceRoleName);
+                changedRoles << ManageTokensModel::CurrencyBalanceRole;
+            } else if (roleName == kBalancesRoleName) {
+                token.balances = dataForRole(kBalancesRoleName);
+                changedRoles << ManageTokensModel::TokenBalancesRole;
+            } else if (roleName == kDecimalsRoleName) {
+                token.decimals = dataForRole(kDecimalsRoleName);
+                changedRoles << ManageTokensModel::TokenDecimalsRole;
+            } else if (roleName == kMarketDetailsRoleName) {
+                token.marketDetails = dataForRole(kMarketDetailsRoleName);
+                changedRoles << ManageTokensModel::TokenMarketDetailsRole;
+            }
+        }
+
+        if (!changedRoles.isEmpty())
+            model->notifyItemChanged(row, changedRoles);
+        return;
+    }
 }
 
 void ManageTokensController::rebuildModels()

--- a/ui/StatusQ/src/wallet/managetokenscontroller.h
+++ b/ui/StatusQ/src/wallet/managetokenscontroller.h
@@ -1,5 +1,6 @@
 #include <QObject>
 #include <QQmlParserStatus>
+#include <QSet>
 #include <QSettings>
 
 #include <array>
@@ -7,6 +8,7 @@
 #include "managetokensmodel.h"
 
 class QAbstractItemModel;
+class QTimer;
 
 /// @brief Controller for managing visibility and order for all kind of tokens and groups.
 ///
@@ -115,6 +117,23 @@ private:
     void rebuildModels();
 
     void addItem(int index);
+
+    // Incremental source-model dataChanged handling: instead of re-parsing the
+    // whole source model on every dataChanged, accumulate the changed rows,
+    // coalesce a storm into a single batched pass, and update only the affected
+    // token rows in place. A change touching any role the partitioning/grouping/
+    // ordering depends on falls back to a full re-parse.
+    void onSourceDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight, const QList<int>& roles);
+    void scheduleSourceUpdateFlush();
+    void flushPendingSourceUpdates();
+    void applyIncrementalDataUpdate(int sourceRow);
+    void cancelPendingSourceUpdates();
+    bool hasPendingSourceUpdates() const;
+
+    QTimer* m_sourceUpdateBatchTimer{nullptr};
+    QSet<int> m_pendingChangedRows;
+    QSet<QByteArray> m_pendingChangedRoleNames;
+    bool m_pendingFullReparse{false};
 
     ManageTokensModel* m_regularTokensModel{nullptr};
     QAbstractItemModel* regularTokensModel() const { return m_regularTokensModel; }

--- a/ui/StatusQ/src/wallet/managetokensmodel.cpp
+++ b/ui/StatusQ/src/wallet/managetokensmodel.cpp
@@ -76,6 +76,23 @@ QList<TokenData> ManageTokensModel::takeAllItems(const QString& groupId)
     return result;
 }
 
+int ManageTokensModel::rowForKey(const QString& key) const
+{
+    for (int i = 0; i < m_data.size(); ++i) {
+        if (m_data.at(i).key == key)
+            return i;
+    }
+    return -1;
+}
+
+void ManageTokensModel::notifyItemChanged(int row, const QList<int>& roles)
+{
+    if (row < 0 || row >= m_data.size())
+        return;
+    const auto idx = index(row, 0);
+    emit dataChanged(idx, idx, roles);
+}
+
 void ManageTokensModel::clear()
 {
     beginResetModel();

--- a/ui/StatusQ/src/wallet/managetokensmodel.h
+++ b/ui/StatusQ/src/wallet/managetokensmodel.h
@@ -96,6 +96,11 @@ public:
     const TokenData& itemAt(int row) const { return m_data.at(row); }
     TokenData& itemAt(int row) { return m_data[row]; }
 
+    /// Row holding the item with the given key, or -1 if absent.
+    int rowForKey(const QString& key) const;
+    /// Emit dataChanged for a single already-mutated row (used for in-place updates).
+    void notifyItemChanged(int row, const QList<int>& roles);
+
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QHash<int, QByteArray> roleNames() const override;
     QVariant data(const QModelIndex &index, int role) const override;

--- a/ui/StatusQ/tests/CMakeLists.txt
+++ b/ui/StatusQ/tests/CMakeLists.txt
@@ -60,3 +60,10 @@ target_link_libraries(MarkdownParserBenchmark PRIVATE Qt::Test StatusQ)
 # auto-tunes to many iterations + calibration). Enough for a stable-enough reference number.
 add_test(NAME MarkdownParserBenchmark COMMAND MarkdownParserBenchmark -iterations 5)
 set_tests_properties(MarkdownParserBenchmark PROPERTIES LABELS "benchmark")
+
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test REQUIRED)
+
+add_executable(TestManageTokensController tst_ManageTokensController.cpp)
+target_link_libraries(TestManageTokensController PRIVATE Qt::Test Qt::Gui Qt::Qml StatusQ)
+target_include_directories(TestManageTokensController PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/wallet)
+add_test(NAME TestManageTokensController COMMAND TestManageTokensController)

--- a/ui/StatusQ/tests/tst_ManageTokensController.cpp
+++ b/ui/StatusQ/tests/tst_ManageTokensController.cpp
@@ -276,10 +276,10 @@ private slots:
 
         for (int i = 0; i < 5; i++)
             source.updateCell(0, "enabledNetworkBalance", QString::number(100 + i));
-        QTest::qWait(1); // flush any batched updates
 
-        QCOMPARE(dataForKey(model(controller, "regularTokensModel"), "eth", "enabledNetworkBalance").toString(),
-                 QStringLiteral("104"));
+        // Poll for the batched update to land rather than a fixed 1ms sleep.
+        QTRY_COMPARE(dataForKey(model(controller, "regularTokensModel"), "eth", "enabledNetworkBalance").toString(),
+                     QStringLiteral("104"));
     }
 
     // --- New incremental behavior (fails before the fix, passes after) ---
@@ -298,10 +298,11 @@ private slots:
         QSignalSpy changedSpy(regular, &QAbstractItemModel::dataChanged);
 
         source.updateCell(0, "enabledNetworkBalance", QStringLiteral("42"));
-        QTest::qWait(1);
 
+        // Wait for the batched dataChanged to land (the co-occurring positive), then
+        // assert the negatives: a QTRY cannot prove "no reset happened".
+        QTRY_VERIFY(changedSpy.count() >= 1);
         QCOMPARE(resetSpy.count(), 0);
-        QVERIFY(changedSpy.count() >= 1);
         QCOMPARE(dataForKey(regular, "eth", "enabledNetworkBalance").toString(), QStringLiteral("42"));
         // untouched row keeps its value and the row set is unchanged
         QCOMPARE(keysOf(regular), (QStringList{"eth", "dai"}));
@@ -324,11 +325,13 @@ private slots:
         constexpr int M = 20;
         for (int i = 0; i < M; i++)
             source.updateCell(0, "enabledNetworkBalance", QString::number(i));
-        QTest::qWait(1); // let the batch flush
 
+        // Poll for the final value to land, THEN assert the negatives (exactly one
+        // coalesced dataChanged, no reset). Polling the count directly could pass at
+        // the first emit and miss a later increment if coalescing were broken.
+        QTRY_COMPARE(dataForKey(regular, "eth", "enabledNetworkBalance").toString(), QString::number(M - 1));
         QCOMPARE(resetSpy.count(), 0);
         QCOMPARE(changedSpy.count(), 1); // coalesced
-        QCOMPARE(dataForKey(regular, "eth", "enabledNetworkBalance").toString(), QString::number(M - 1));
     }
 
     // A data-only change to a regular token must not churn the community/hidden
@@ -347,8 +350,12 @@ private slots:
         QSignalSpy hiddenReset(hidden, &QAbstractItemModel::modelReset);
 
         source.updateCell(0, "enabledNetworkBalance", QStringLiteral("99"));
-        QTest::qWait(1);
 
+        // The change targets the regular "eth" token; wait for THAT to land (the
+        // co-occurring positive), then assert the community/hidden models were not
+        // touched. A QTRY on the spies could not prove they stay at zero.
+        QTRY_COMPARE(dataForKey(model(controller, "regularTokensModel"), "eth", "enabledNetworkBalance").toString(),
+                     QStringLiteral("99"));
         QCOMPARE(communityReset.count(), 0);
         QCOMPARE(communityChanged.count(), 0);
         QCOMPARE(hiddenReset.count(), 0);
@@ -369,9 +376,9 @@ private slots:
 
         // "cat" becomes a community token
         source.updateCells(1, {{"communityId", "community_1"}, {"communityName", "community_1"}});
-        QTest::qWait(1);
 
-        QCOMPARE(keysOf(model(controller, "regularTokensModel")), (QStringList{"eth"}));
+        // Poll for the repartition to complete (single reparse moves cat across).
+        QTRY_COMPARE(keysOf(model(controller, "regularTokensModel")), (QStringList{"eth"}));
         QCOMPARE(keysOf(model(controller, "communityTokensModel")), (QStringList{"cat"}));
     }
 };

--- a/ui/StatusQ/tests/tst_ManageTokensController.cpp
+++ b/ui/StatusQ/tests/tst_ManageTokensController.cpp
@@ -1,0 +1,380 @@
+#include <QAbstractItemModelTester>
+#include <QAbstractListModel>
+#include <QSignalSpy>
+#include <QTest>
+
+#include "managetokenscontroller.h"
+#include "managetokensmodel.h"
+#include "tokendata.h"
+
+// Minimal source model mirroring the roles ManageTokensController::addItem reads.
+// Rows are role-name -> value maps; role integers are assigned once from a fixed
+// ordered role list so roleNames() is stable and non-empty from construction
+// (the controller has a separate code path for models whose roles appear late).
+class SourceModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    explicit SourceModel(QObject* parent = nullptr) : QAbstractListModel(parent)
+    {
+        const QList<QByteArray> names{"key",
+                                      "tokenKey",
+                                      "crossChainId",
+                                      "symbol",
+                                      "name",
+                                      "communityId",
+                                      "communityName",
+                                      "communityImage",
+                                      "collectionUid",
+                                      "collectionName",
+                                      "enabledNetworkBalance",
+                                      "enabledNetworkCurrencyBalance",
+                                      "imageUrl",
+                                      "image",
+                                      "mediaUrl",
+                                      "backgroundColor",
+                                      "balances",
+                                      "decimals",
+                                      "marketDetails"};
+        int role = Qt::UserRole + 1;
+        for (const auto& n : names) {
+            m_roleForName.insert(n, role);
+            m_nameForRole.insert(role, n);
+            role++;
+        }
+    }
+
+    int rowCount(const QModelIndex& parent = {}) const override
+    {
+        return parent.isValid() ? 0 : m_rows.size();
+    }
+
+    QHash<int, QByteArray> roleNames() const override { return m_nameForRole; }
+
+    QVariant data(const QModelIndex& index, int role) const override
+    {
+        if (!checkIndex(index, CheckIndexOption::IndexIsValid | CheckIndexOption::ParentIsInvalid))
+            return {};
+        return m_rows.at(index.row()).value(m_nameForRole.value(role));
+    }
+
+    // --- test-side mutation API ---
+
+    void appendRow(const QHash<QByteArray, QVariant>& row)
+    {
+        const int r = m_rows.size();
+        beginInsertRows({}, r, r);
+        m_rows.append(row);
+        endInsertRows();
+    }
+
+    void removeRow(int row)
+    {
+        beginRemoveRows({}, row, row);
+        m_rows.removeAt(row);
+        endRemoveRows();
+    }
+
+    void resetWith(const QList<QHash<QByteArray, QVariant>>& rows)
+    {
+        beginResetModel();
+        m_rows = rows;
+        endResetModel();
+    }
+
+    // Change a single cell and notify with exactly the given role (data-only churn).
+    void updateCell(int row, const QByteArray& roleName, const QVariant& value)
+    {
+        m_rows[row].insert(roleName, value);
+        const auto idx = index(row, 0);
+        emit dataChanged(idx, idx, {m_roleForName.value(roleName)});
+    }
+
+    // Change several cells on one row, notify with the union of their roles.
+    void updateCells(int row, const QHash<QByteArray, QVariant>& changes)
+    {
+        QList<int> roles;
+        for (auto it = changes.cbegin(); it != changes.cend(); ++it) {
+            m_rows[row].insert(it.key(), it.value());
+            roles.append(m_roleForName.value(it.key()));
+        }
+        const auto idx = index(row, 0);
+        emit dataChanged(idx, idx, roles);
+    }
+
+    int roleFor(const QByteArray& name) const { return m_roleForName.value(name, -1); }
+
+private:
+    QList<QHash<QByteArray, QVariant>> m_rows;
+    QHash<QByteArray, int> m_roleForName;
+    QHash<int, QByteArray> m_nameForRole;
+};
+
+namespace
+{
+using Row = QHash<QByteArray, QVariant>;
+
+Row regularToken(const QString& key, const QString& balance = "0")
+{
+    return {{"key", key}, {"symbol", key.toUpper()}, {"name", key}, {"enabledNetworkBalance", balance}};
+}
+
+Row communityToken(const QString& key, const QString& communityId, const QString& balance = "0")
+{
+    return {{"key", key},
+            {"symbol", key.toUpper()},
+            {"name", key},
+            {"communityId", communityId},
+            {"communityName", communityId},
+            {"enabledNetworkBalance", balance}};
+}
+
+Row collectionToken(const QString& key, const QString& collectionUid, const QString& balance = "0")
+{
+    return {{"key", key},
+            {"symbol", key.toUpper()},
+            {"name", key},
+            {"collectionUid", collectionUid},
+            {"collectionName", collectionUid},
+            {"enabledNetworkBalance", balance}};
+}
+
+QStringList keysOf(QAbstractItemModel* model)
+{
+    QStringList result;
+    const auto keyRole = model->roleNames().key("key", -1);
+    for (int i = 0; i < model->rowCount(); i++)
+        result << model->data(model->index(i, 0), keyRole).toString();
+    return result;
+}
+
+QVariant dataForKey(QAbstractItemModel* model, const QString& key, const QByteArray& roleName)
+{
+    const auto keyRole = model->roleNames().key("key", -1);
+    const auto role = model->roleNames().key(roleName, -1);
+    for (int i = 0; i < model->rowCount(); i++) {
+        if (model->data(model->index(i, 0), keyRole).toString() == key)
+            return model->data(model->index(i, 0), role);
+    }
+    return {};
+}
+} // namespace
+
+class TestManageTokensController : public QObject
+{
+    Q_OBJECT
+
+    // Boilerplate: build a controller wired to `source` and run the initial parse.
+    // Returns the controller; caller owns nothing extra (source outlives it).
+    static void populate(ManageTokensController& controller, SourceModel& source)
+    {
+        controller.setProperty("sourceModel", QVariant::fromValue<QAbstractItemModel*>(&source));
+        QMetaObject::invokeMethod(&controller, "loadingFinished", Q_ARG(QString, QString()));
+    }
+
+    static QAbstractItemModel* model(ManageTokensController& c, const char* name)
+    {
+        return c.property(name).value<QAbstractItemModel*>();
+    }
+
+private slots:
+
+    // --- Characterization: observable end-state that must survive the refactor ---
+
+    void initialParsePartitionsByCommunity()
+    {
+        SourceModel source;
+        source.resetWith({regularToken("eth"), communityToken("cat", "community_1"), regularToken("dai")});
+
+        ManageTokensController controller;
+        populate(controller, source);
+
+        QCOMPARE(keysOf(model(controller, "regularTokensModel")), (QStringList{"eth", "dai"}));
+        QCOMPARE(keysOf(model(controller, "communityTokensModel")), (QStringList{"cat"}));
+        QCOMPARE(model(controller, "hiddenTokensModel")->rowCount(), 0);
+    }
+
+    void communityGroupsModelReflectsChildCount()
+    {
+        SourceModel source;
+        source.resetWith({communityToken("cat", "community_1"),
+                          communityToken("dog", "community_1"),
+                          communityToken("fox", "community_2")});
+
+        ManageTokensController controller;
+        populate(controller, source);
+
+        auto groups = model(controller, "communityTokenGroupsModel");
+        QCOMPARE(groups->rowCount(), 2);
+        // group's childCount is exposed through the "enabledNetworkBalance" role
+        QCOMPARE(dataForKey(groups, "cat", "enabledNetworkBalance").toInt(), 2);
+        QCOMPARE(dataForKey(groups, "fox", "enabledNetworkBalance").toInt(), 1);
+    }
+
+    void collectionGroupsModelReflectsChildCount()
+    {
+        SourceModel source;
+        source.resetWith({collectionToken("punk1", "punks"),
+                          collectionToken("punk2", "punks"),
+                          collectionToken("ape1", "apes")});
+
+        ManageTokensController controller;
+        populate(controller, source);
+
+        auto groups = model(controller, "collectionGroupsModel");
+        QCOMPARE(groups->rowCount(), 2);
+        QCOMPARE(dataForKey(groups, "punk1", "enabledNetworkBalance").toInt(), 2);
+    }
+
+    void sourceResetReparses()
+    {
+        SourceModel source;
+        source.resetWith({regularToken("eth"), regularToken("dai")});
+        ManageTokensController controller;
+        populate(controller, source);
+        QCOMPARE(model(controller, "regularTokensModel")->rowCount(), 2);
+
+        source.resetWith({regularToken("btc")});
+        QCOMPARE(keysOf(model(controller, "regularTokensModel")), (QStringList{"btc"}));
+    }
+
+    void rowInsertedAppendsToRegularModel()
+    {
+        SourceModel source;
+        source.resetWith({regularToken("eth")});
+        ManageTokensController controller;
+        populate(controller, source);
+
+        source.appendRow(regularToken("dai"));
+        QCOMPARE(keysOf(model(controller, "regularTokensModel")), (QStringList{"eth", "dai"}));
+    }
+
+    // QAbstractItemModelTester validates the model contract (index ranges, signal
+    // ordering, role validity) on every output model across a data-change storm.
+    void outputModelsSatisfyModelContractThroughStorm()
+    {
+        SourceModel source;
+        source.resetWith({regularToken("eth", "1"),
+                          communityToken("cat", "community_1", "2"),
+                          collectionToken("punk1", "punks", "3")});
+
+        ManageTokensController controller;
+
+        const QList<const char*> names{"regularTokensModel",
+                                       "communityTokensModel",
+                                       "communityTokenGroupsModel",
+                                       "hiddenTokensModel",
+                                       "hiddenCommunityTokenGroupsModel",
+                                       "collectionGroupsModel",
+                                       "hiddenCollectionGroupsModel"};
+        std::vector<std::unique_ptr<QAbstractItemModelTester>> testers;
+        for (auto n : names)
+            testers.push_back(std::make_unique<QAbstractItemModelTester>(model(controller, n)));
+
+        populate(controller, source);
+
+        for (int i = 0; i < 5; i++)
+            source.updateCell(0, "enabledNetworkBalance", QString::number(100 + i));
+        QTest::qWait(1); // flush any batched updates
+
+        QCOMPARE(dataForKey(model(controller, "regularTokensModel"), "eth", "enabledNetworkBalance").toString(),
+                 QStringLiteral("104"));
+    }
+
+    // --- New incremental behavior (fails before the fix, passes after) ---
+
+    // A data-only dataChanged updates the affected token in place: the holding
+    // model emits a narrow dataChanged and is NOT reset.
+    void dataOnlyChangeUpdatesInPlaceWithoutReset()
+    {
+        SourceModel source;
+        source.resetWith({regularToken("eth", "1"), regularToken("dai", "2")});
+        ManageTokensController controller;
+        populate(controller, source);
+
+        auto regular = model(controller, "regularTokensModel");
+        QSignalSpy resetSpy(regular, &QAbstractItemModel::modelReset);
+        QSignalSpy changedSpy(regular, &QAbstractItemModel::dataChanged);
+
+        source.updateCell(0, "enabledNetworkBalance", QStringLiteral("42"));
+        QTest::qWait(1);
+
+        QCOMPARE(resetSpy.count(), 0);
+        QVERIFY(changedSpy.count() >= 1);
+        QCOMPARE(dataForKey(regular, "eth", "enabledNetworkBalance").toString(), QStringLiteral("42"));
+        // untouched row keeps its value and the row set is unchanged
+        QCOMPARE(keysOf(regular), (QStringList{"eth", "dai"}));
+        QCOMPARE(dataForKey(regular, "dai", "enabledNetworkBalance").toString(), QStringLiteral("2"));
+    }
+
+    // A storm of data-only dataChanged events coalesces into a single batched
+    // update instead of one full re-parse per event.
+    void stormOfDataChangesCoalesces()
+    {
+        SourceModel source;
+        source.resetWith({regularToken("eth", "0")});
+        ManageTokensController controller;
+        populate(controller, source);
+
+        auto regular = model(controller, "regularTokensModel");
+        QSignalSpy resetSpy(regular, &QAbstractItemModel::modelReset);
+        QSignalSpy changedSpy(regular, &QAbstractItemModel::dataChanged);
+
+        constexpr int M = 20;
+        for (int i = 0; i < M; i++)
+            source.updateCell(0, "enabledNetworkBalance", QString::number(i));
+        QTest::qWait(1); // let the batch flush
+
+        QCOMPARE(resetSpy.count(), 0);
+        QCOMPARE(changedSpy.count(), 1); // coalesced
+        QCOMPARE(dataForKey(regular, "eth", "enabledNetworkBalance").toString(), QString::number(M - 1));
+    }
+
+    // A data-only change to a regular token must not churn the community/hidden
+    // models at all.
+    void dataOnlyChangeDoesNotTouchOtherModels()
+    {
+        SourceModel source;
+        source.resetWith({regularToken("eth", "1"), communityToken("cat", "community_1", "2")});
+        ManageTokensController controller;
+        populate(controller, source);
+
+        auto community = model(controller, "communityTokensModel");
+        auto hidden = model(controller, "hiddenTokensModel");
+        QSignalSpy communityReset(community, &QAbstractItemModel::modelReset);
+        QSignalSpy communityChanged(community, &QAbstractItemModel::dataChanged);
+        QSignalSpy hiddenReset(hidden, &QAbstractItemModel::modelReset);
+
+        source.updateCell(0, "enabledNetworkBalance", QStringLiteral("99"));
+        QTest::qWait(1);
+
+        QCOMPARE(communityReset.count(), 0);
+        QCOMPARE(communityChanged.count(), 0);
+        QCOMPARE(hiddenReset.count(), 0);
+        // community token unchanged
+        QCOMPARE(dataForKey(community, "cat", "enabledNetworkBalance").toString(), QStringLiteral("2"));
+    }
+
+    // A structural change (token moves communities) still lands correctly via the
+    // full-reparse fallback: end-state partitioning must be right.
+    void structuralChangeRepartitionsToken()
+    {
+        SourceModel source;
+        source.resetWith({regularToken("eth"), regularToken("cat")});
+        ManageTokensController controller;
+        populate(controller, source);
+        QCOMPARE(keysOf(model(controller, "regularTokensModel")), (QStringList{"eth", "cat"}));
+        QCOMPARE(model(controller, "communityTokensModel")->rowCount(), 0);
+
+        // "cat" becomes a community token
+        source.updateCells(1, {{"communityId", "community_1"}, {"communityName", "community_1"}});
+        QTest::qWait(1);
+
+        QCOMPARE(keysOf(model(controller, "regularTokensModel")), (QStringList{"eth"}));
+        QCOMPARE(keysOf(model(controller, "communityTokensModel")), (QStringList{"cat"}));
+    }
+};
+
+QTEST_GUILESS_MAIN(TestManageTokensController)
+#include "tst_ManageTokensController.moc"


### PR DESCRIPTION
Token-service rework (2/5 in the stack, on top of the model-sync/typed-handoff core PR):

- **Token refresh storm fixes** — coalesces repeated `refreshTokens` triggers around login/wake (generation tracking + pending-fetch/lookup-cache with negative markers): one refresh instead of a burst.
- **Parse token results on the worker** — `wallet_getTokens*` completions no longer `parseJson` multi-MB payloads on the GUI thread; the worker decodes AND builds the token structures, the GUI slot MOVEs them in via the typed handoff.
- **Granular token model updates** — token group/list models (token groups, balances, grouped account assets) apply worker snapshots through the `modelSync` one-liner instead of `beginResetModel` (market details as keyed child QObjects via `reconcileByKey`); delegates survive periodic refreshes.
- **Incremental ManageTokensController updates** (StatusQ/C++) — same reset→granular conversion on the C++ side.
- **Typed handoff for by-chain / all-token-group fetches** — remaining string-envelope token tasks converted; also covers the destination-chain (`…ForChainTo`) fetch added by the lifi bridge feature.

**Why**: root cause of the multi-second black screen on Android app wake — async token completions parsed giant JSON on the GUI thread while models reset underneath the UI.

**Numbers (host, debug)**: GUI-thread apply of a 10k-token refresh ~125 ms decode+build → sub-ms MOVE apply; model refresh full reset → minimal per-row dataChanged.

**How to review**: commits in order: storm fixes → worker parsing → granular models → C++ controller → task conversions; unit tests per commit.

**Measured vs current master** (host, offscreen bench, 10k-token chain catalog): the `wallet_getTokensByChain` completion path drops from ~33 ms GUI-thread stall (master: JSON decode + group build on the GUI thread) to ~1.5 ms (typed handoff: worker builds, GUI moves) — ~20×.

