### PR TITLE
perf(wallet): swap/send modal open fixes

### DIFF
--- a/storybook/qmlTests/tests/tst_SimpleSendModal.qml
+++ b/storybook/qmlTests/tests/tst_SimpleSendModal.qml
@@ -490,10 +490,8 @@ Item {
             compare(accountSelectorAssetContent.asset.color, Utils.getColorForId(palette, defaultAccountItem.colorId))
             compare(accountSelectorTextContent.text, defaultAccountItem.name)
 
-            // Sticky Header should not be visible when not scrolling
-            const stickySendModalHeader = findChild(controlUnderTest, "stickySendModalHeader")
-            verify(!!stickySendModalHeader)
-            compare(stickySendModalHeader.height, 0)
+            // Sticky Header is deferred and not instantiated until the first scroll
+            verify(!findChild(controlUnderTest, "stickySendModalHeader"))
 
             // Regular Header
             const sendModalHeader = findChild(controlUnderTest, "sendModalHeader")
@@ -582,10 +580,8 @@ Item {
             compare(accountSelectorAssetContent.asset.color, Utils.getColorForId(palette, selectedAccount.colorId))
             compare(accountSelectorTextContent.text, selectedAccount.name)
 
-            // Sticky Header should not be visible when not scrolling
-            const stickySendModalHeader = findChild(controlUnderTest, "stickySendModalHeader")
-            verify(!!stickySendModalHeader)
-            compare(stickySendModalHeader.height, 0)
+            // Sticky Header is deferred and not instantiated until the first scroll
+            verify(!findChild(controlUnderTest, "stickySendModalHeader"))
 
             // Regular Header
             const sendModalHeader = findChild(controlUnderTest, "sendModalHeader")
@@ -731,33 +727,8 @@ Item {
             // Default network item from model at 0th position
             const defaultNetworkItem = SQUtils.ModelUtils.get(controlUnderTest.networksModel, 0)
 
-            // Sticky Header should not be visible when not scrolling
-            const stickySendModalHeader = findChild(controlUnderTest, "stickySendModalHeader")
-            verify(!!stickySendModalHeader)
-            verify(stickySendModalHeader.height === 0)
-
-            // Sticky Header Title
-            const stickyHeaderTitleText = findChild(stickySendModalHeader, "sendModalTitleText")
-            verify(!!stickyHeaderTitleText)
-            compare(stickyHeaderTitleText.text, qsTr("Send"))
-
-            // Sticky Header Token Selector
-            const stickyHeaderTokenSelector = findChild(stickySendModalHeader, "tokenSelector")
-            verify(!!stickyHeaderTokenSelector)
-            const  stickyHeaderTokenSelectorButton = findChild(stickySendModalHeader, "tokenSelectorButton")
-            verify(!!stickyHeaderTokenSelectorButton)
-            const  stickyHeaderTokenSelectorDropdown = findChild(stickySendModalHeader, "dropdown")
-            verify(!!stickyHeaderTokenSelectorDropdown)
-
-            verify(!stickyHeaderTokenSelectorButton.selected)
-            compare(stickyHeaderTokenSelectorButton.name, "")
-            compare(stickyHeaderTokenSelectorButton.icon, "")
-            compare(stickyHeaderTokenSelectorButton.text, qsTr("Select token"))
-
-            // Sticky Header Network picker
-            const  stickyHeaderNetworkFilter = findChild(stickySendModalHeader, "networkFilter")
-            verify(!!stickyHeaderNetworkFilter)
-            compare(stickyHeaderNetworkFilter.selection, [defaultNetworkItem.chainId])
+            // Sticky Header is deferred and not instantiated until the first scroll
+            verify(!findChild(controlUnderTest, "stickySendModalHeader"))
 
             // Regular Header
             const sendModalHeader = findChild(controlUnderTest, "sendModalHeader")
@@ -796,9 +767,35 @@ Item {
             verify(!!scrollView)
             scrollView.scrollEnd()
 
-            // the opened popup should be closed and sticky header should become visible
+            // the opened popup should be closed and the sticky header should now be
+            // instantiated and become visible
             tryCompare(tokenSelectorDropdown, "opened", false)
+            const stickySendModalHeader = findChild(controlUnderTest, "stickySendModalHeader")
+            verify(!!stickySendModalHeader)
             tryVerify(() => stickySendModalHeader.height > 0)
+
+            // Sticky Header Title
+            const stickyHeaderTitleText = findChild(stickySendModalHeader, "sendModalTitleText")
+            verify(!!stickyHeaderTitleText)
+            compare(stickyHeaderTitleText.text, qsTr("Send"))
+
+            // Sticky Header Token Selector
+            const stickyHeaderTokenSelector = findChild(stickySendModalHeader, "tokenSelector")
+            verify(!!stickyHeaderTokenSelector)
+            const stickyHeaderTokenSelectorButton = findChild(stickySendModalHeader, "tokenSelectorButton")
+            verify(!!stickyHeaderTokenSelectorButton)
+            const stickyHeaderTokenSelectorDropdown = findChild(stickySendModalHeader, "dropdown")
+            verify(!!stickyHeaderTokenSelectorDropdown)
+
+            verify(!stickyHeaderTokenSelectorButton.selected)
+            compare(stickyHeaderTokenSelectorButton.name, "")
+            compare(stickyHeaderTokenSelectorButton.icon, "")
+            compare(stickyHeaderTokenSelectorButton.text, qsTr("Select token"))
+
+            // Sticky Header Network picker
+            const stickyHeaderNetworkFilter = findChild(stickySendModalHeader, "networkFilter")
+            verify(!!stickyHeaderNetworkFilter)
+            compare(stickyHeaderNetworkFilter.selection, [defaultNetworkItem.chainId])
 
             stickyHeaderTokenSelectorButton.clicked()
             verify(stickyHeaderTokenSelectorDropdown.opened)
@@ -821,10 +818,10 @@ Item {
             compare(networkFilter.selection, [10])
 
             // Check sticky header
-            verify(tokenSelectorButton.selected)
-            compare(tokenSelectorButton.name, selectedToken.symbol)
-            compare(tokenSelectorButton.icon, Constants.tokenIcon(selectedToken.symbol))
-            compare(networkFilter.selection, [10])
+            verify(stickyHeaderTokenSelectorButton.selected)
+            compare(stickyHeaderTokenSelectorButton.name, selectedToken.symbol)
+            compare(stickyHeaderTokenSelectorButton.icon, Constants.tokenIcon(selectedToken.symbol))
+            compare(stickyHeaderNetworkFilter.selection, [10])
         }
 
         function test_set_interactive_false() {
@@ -832,9 +829,14 @@ Item {
             controlUnderTest.open()
             tryVerify(() => controlUnderTest.opened)
 
-            // waitForRendering(controlUnderTest.contentItem)
+            waitForRendering(controlUnderTest.contentItem)
 
             controlUnderTest.interactive = false
+
+            // Scroll to instantiate the deferred sticky header
+            const scrollView = findChild(controlUnderTest, "scrollView")
+            verify(!!scrollView)
+            scrollView.scrollEnd()
 
             // Sticky Header
             const stickySendModalHeader = findChild(controlUnderTest, "stickySendModalHeader")
@@ -892,6 +894,13 @@ Item {
             verify(!!controlUnderTest)
             controlUnderTest.open()
             tryVerify(() => controlUnderTest.opened)
+
+            waitForRendering(controlUnderTest.contentItem)
+
+            // Scroll to instantiate the deferred sticky header
+            const scrollView = findChild(controlUnderTest, "scrollView")
+            verify(!!scrollView)
+            scrollView.scrollEnd()
 
             const stickySendModalHeader = findChild(controlUnderTest, "stickySendModalHeader")
             verify(!!stickySendModalHeader)

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -352,7 +352,7 @@ FetchContent_Declare(
   QtModelsToolkit
 
   GIT_REPOSITORY https://github.com/status-im/QtModelsToolkit.git
-  GIT_TAG b249dc22be1e1e728acce90065f943d7db3636e5
+  GIT_TAG d8b0542011425496b917b8b1e26ad568116d49ce
 )
 
 FetchContent_MakeAvailable(QtModelsToolkit)

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
@@ -26,25 +26,46 @@ QtObject {
         if (!model)
             return []
 
-        if (roles === undefined)
+        // When the caller asks for a subset of roles, fetch only those roles per
+        // row via the single-role ModelQuery.get overload. The all-roles get
+        // materializes EVERY role (incl. submodel roles like "balances") into a
+        // QVariantMap and marshals it to JS on every row, even when the caller reads
+        // just one role (e.g. joinModelEntries(model, "key")) — O(N * allRoles). The
+        // per-role path is O(N * requestedRoles). With no roles given we still want
+        // every role, and the single all-roles get is the cheaper way to get them.
+        const explicitRoles = roles !== undefined
+        if (!explicitRoles)
             roles = roleNames(model)
 
         const count = model.rowCount()
         const array = []
 
         for (let i = 0; i < count; i++) {
-            const modelItem = QtMT.ModelQuery.get(model, i)
             const arrayItem = {}
 
-            roles.forEach(role => {
-                const entry = modelItem[role]
-                const isModel = QtMT.ModelQuery.isModel(entry)
+            if (explicitRoles) {
+                roles.forEach(role => {
+                    const entry = QtMT.ModelQuery.get(model, i, role)
+                    const isModel = QtMT.ModelQuery.isModel(entry)
 
-                if (isModel)
-                    arrayItem[role] = modelToArray(entry)
-                else if (entry !== undefined)
-                    arrayItem[role] = entry
-            })
+                    if (isModel)
+                        arrayItem[role] = modelToArray(entry)
+                    else if (entry !== undefined)
+                        arrayItem[role] = entry
+                })
+            } else {
+                const modelItem = QtMT.ModelQuery.get(model, i)
+
+                roles.forEach(role => {
+                    const entry = modelItem[role]
+                    const isModel = QtMT.ModelQuery.isModel(entry)
+
+                    if (isModel)
+                        arrayItem[role] = modelToArray(entry)
+                    else if (entry !== undefined)
+                        arrayItem[role] = entry
+                })
+            }
 
             array.push(arrayItem)
         }

--- a/ui/StatusQ/tests/TestUtils/tst_ModelUtils.qml
+++ b/ui/StatusQ/tests/TestUtils/tst_ModelUtils.qml
@@ -1,0 +1,112 @@
+import QtQml
+import QtQuick
+import QtTest
+
+import StatusQ.Core.Utils
+import StatusQ.TestHelpers
+
+Item {
+    id: root
+    width: 200
+    height: 200
+
+    Component {
+        id: flatComponent
+
+        QtObject {
+            readonly property ListModel source: ListModel {
+                id: flatModel
+                ListElement { key: "k0"; name: "Zero"; extra: "e0" }
+                ListElement { key: "k1"; name: "One";  extra: "e1" }
+                ListElement { key: "k2"; name: "Two";  extra: "e2" }
+            }
+
+            property var accessedRoles: []
+
+            readonly property ModelAccessObserverProxy observer: ModelAccessObserverProxy {
+                sourceModel: flatModel
+                onDataAccessed: (row, role, value) => accessedRoles.push(role)
+            }
+        }
+    }
+
+    Component {
+        id: nestedComponent
+
+        QtObject {
+            readonly property ListModel source: ListModel {
+                id: nestedModel
+                ListElement {
+                    key: "k0"
+                    sub: [ ListElement { v: 1 }, ListElement { v: 2 } ]
+                }
+                ListElement {
+                    key: "k1"
+                    sub: [ ListElement { v: 3 } ]
+                }
+            }
+        }
+    }
+
+    TestCase {
+        name: "ModelUtils"
+
+        // The join asks for one role; the fix must fetch ONLY that role per row via
+        // the single-role ModelQuery.get, not the all-roles get. The observer counts
+        // one data() access per row (== rowCount), not one per (row, role): on the
+        // old all-roles path this model would report rowCount * 3.
+        function test_joinModelEntries_fetches_only_requested_role() {
+            const obj = createTemporaryObject(flatComponent, root)
+
+            const joined = ModelUtils.joinModelEntries(obj.observer, "key", "$$")
+
+            compare(joined, "k0$$k1$$k2")
+            compare(obj.accessedRoles.length, obj.source.rowCount(),
+                    "join over one role must access exactly one role per row")
+        }
+
+        // modelToFlatArray / modelToArray with an explicit subset of roles.
+        function test_modelToFlatArray_subset() {
+            const obj = createTemporaryObject(flatComponent, root)
+            const keys = ModelUtils.modelToFlatArray(obj.observer, "key")
+            compare(keys, ["k0", "k1", "k2"])
+        }
+
+        function test_modelToArray_explicit_two_roles() {
+            const obj = createTemporaryObject(flatComponent, root)
+            const arr = ModelUtils.modelToArray(obj.source, ["key", "name"])
+            compare(arr.length, 3)
+            compare(arr[0].key, "k0")
+            compare(arr[0].name, "Zero")
+            verify(arr[0].extra === undefined, "unrequested role must not be present")
+        }
+
+        // With no roles given, every role is returned (the single all-roles get path).
+        function test_modelToArray_all_roles_default() {
+            const obj = createTemporaryObject(flatComponent, root)
+            const arr = ModelUtils.modelToArray(obj.source)
+            compare(arr.length, 3)
+            compare(arr[1].key, "k1")
+            compare(arr[1].name, "One")
+            compare(arr[1].extra, "e1")
+        }
+
+        // A submodel role fetched via the single-role path must still be detected as a
+        // model and recursed into.
+        function test_modelToArray_submodel_role_recurses() {
+            const obj = createTemporaryObject(nestedComponent, root)
+            const arr = ModelUtils.modelToArray(obj.source, ["key", "sub"])
+            compare(arr.length, 2)
+            compare(arr[0].key, "k0")
+            compare(arr[0].sub.length, 2)
+            compare(arr[0].sub[0].v, 1)
+            compare(arr[0].sub[1].v, 2)
+            compare(arr[1].sub.length, 1)
+            compare(arr[1].sub[0].v, 3)
+        }
+
+        function test_modelToArray_null_model() {
+            compare(ModelUtils.modelToArray(null, ["key"]), [])
+        }
+    }
+}

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -240,6 +240,15 @@ StatusDialog {
             }
         }
         property bool stickyHeaderVisible: false
+        // The sticky header duplicates the token-selector header and is invisible
+        // until the user first scrolls; it is deferred (Loader) to keep it off the
+        // modal-open instantiation path. This latch keeps it loaded once revealed,
+        // and the token cache replays the pre-load selection into it on creation.
+        property bool stickyHeaderActivated: false
+        onStickyHeaderVisibleChanged: if (stickyHeaderVisible) d.stickyHeaderActivated = true
+        property string lastTokenName: ""
+        property string lastTokenIcon: ""
+        property string lastTokenKey: ""
 
         // Used to get asset entry if selected token is an asset
         readonly property var selectedAssetEntry: ModelEntry {
@@ -346,8 +355,12 @@ StatusDialog {
         }
 
         function setTokenOnBothHeaders(name, icon, key) {
+            d.lastTokenName = name
+            d.lastTokenIcon = icon
+            d.lastTokenKey = key
             sendModalHeader.setToken(name, icon, key)
-            stickySendModalHeader.setToken(name, icon, key)
+            if (stickyHeaderLoader.item)
+                stickyHeaderLoader.item.setToken(name, icon, key)
         }
 
         readonly property var debounceResetTokenSelector: Backpressure.debounce(root, 200, function() {
@@ -589,39 +602,55 @@ StatusDialog {
             clip: true
             z: 1
 
-            StickySendModalHeader {
-                id: stickySendModalHeader
-
-                objectName: "stickySendModalHeader"
+            // Deferred until the user first scrolls the sticky header into view
+            // (d.stickyHeaderActivated); building it eagerly costs ~15ms of the
+            // modal's open-time instantiation for a view that is initially hidden.
+            Loader {
+                id: stickyHeaderLoader
 
                 width: parent.width
-                blurSource: scrollView.contentItem
+                active: d.stickyHeaderActivated
 
-                stickyHeaderVisible: d.stickyHeaderVisible
+                sourceComponent: StickySendModalHeader {
+                    objectName: "stickySendModalHeader"
 
-                interactive: root.interactive && !root.transferOwnership
-                displayOnlyAssets: root.displayOnlyAssets
-                tokenSelectorTab: d.lastTabSettings.lastSelectedTab
+                    width: stickyHeaderLoader.width
+                    blurSource: scrollView.contentItem
 
-                networksModel: root.networksModel
-                assetsModel: root.assetsModel
-                collectiblesModel: root.collectiblesModel
-                formatCurrencyBalance: (amount) => root.fnFormatCurrencyAmount(amount, root.currentCurrency)
+                    // Start hidden so the first reveal animates via the height
+                    // Behavior instead of popping to full height on Loader creation.
+                    property bool initialRevealDone: false
+                    stickyHeaderVisible: d.stickyHeaderVisible && initialRevealDone
 
-                selectedChainId: root.selectedChainId
+                    interactive: root.interactive && !root.transferOwnership
+                    displayOnlyAssets: root.displayOnlyAssets
+                    tokenSelectorTab: d.lastTabSettings.lastSelectedTab
 
-                onCollectibleSelected: (key) => {
-                                           d.setSelectedCollectible(key)
+                    networksModel: root.networksModel
+                    assetsModel: root.assetsModel
+                    collectiblesModel: root.collectiblesModel
+                    formatCurrencyBalance: (amount) => root.fnFormatCurrencyAmount(amount, root.currentCurrency)
+
+                    selectedChainId: root.selectedChainId
+
+                    onCollectibleSelected: (key) => {
+                                               d.setSelectedCollectible(key)
+                                           }
+                    onCollectionSelected: (key) => {
+                                              d.setSelectedCollectible(key)
+                                          }
+                    onAssetSelected: (key) => {
+                                         d.setSelectedAsset(key)
+                                     }
+                    onNetworkSelected: (chainId) => {
+                                           root.selectedChainId = chainId
                                        }
-                onCollectionSelected: (key) => {
-                                          d.setSelectedCollectible(key)
-                                      }
-                onAssetSelected: (key) => {
-                                     d.setSelectedAsset(key)
-                                 }
-                onNetworkSelected: (chainId) => {
-                                       root.selectedChainId = chainId
-                                   }
+                    // Replay the token selected before this header was created.
+                    Component.onCompleted: {
+                        setToken(d.lastTokenName, d.lastTokenIcon, d.lastTokenKey)
+                        Qt.callLater(() => initialRevealDone = true)
+                    }
+                }
             }
         }
 

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -55,6 +55,13 @@ StatusDialog {
 
         readonly property string mandatoryKeysSeparator: "$$"
 
+        // Guards the double rebuildGroupsForChain per open (Component.onCompleted +
+        // the chain-changed handler both fire for the same chain): skip the redundant
+        // harvest + async fetch when the chain hasn't changed. One guard per side
+        // (source pay chain / destination bridge chain).
+        property int lastRequestedChainId: -1
+        property int lastRequestedChainIdTo: -1
+
         // One terminal picker model per side ({ model, id }); released on modal
         // destruction so the producer stops tracking them (avoids a per-open leak).
         // The receive side has two: the source-chain picker (plain swap) and the
@@ -121,6 +128,16 @@ StatusDialog {
                 return
             }
 
+            // Skip the redundant harvest + async fetch when this side's chain hasn't
+            // changed (Component.onCompleted + the chain-changed handler both fire for
+            // the same chain on open). Tracked per side; reset on close.
+            if (isToSide) {
+                if (chainId === d.lastRequestedChainIdTo)
+                    return
+            } else if (chainId === d.lastRequestedChainId) {
+                return
+            }
+
             const walletTokensStore = root.swapAdaptor.walletAssetsStore.walletTokensStore
             const chainAvailableForSwap = walletTokensStore.isChainSupportedForSwapViaParaswap(chainId)
                                        || walletTokensStore.isChainSupportedForSwapViaLiFi(chainId)
@@ -142,6 +159,10 @@ StatusDialog {
                 return
             }
 
+            if (isToSide)
+                d.lastRequestedChainIdTo = chainId
+            else
+                d.lastRequestedChainId = chainId
             const keys = SQUtils.ModelUtils.joinModelEntries(root.swapAdaptor.walletAssetsStore.groupedAccountAssetsModel, "key", d.mandatoryKeysSeparator)
             if (isToSide)
                 walletTokensStore.buildGroupsForChainTo(chainId, keys)
@@ -211,6 +232,8 @@ StatusDialog {
         payPanel.forceActiveFocus()
     }
     onClosed: {
+        d.lastRequestedChainId = -1
+        d.lastRequestedChainIdTo = -1
         root.swapAdaptor.resetData()
     }
 

--- a/ui/app/mainui/Handlers/SwapModalHandler.qml
+++ b/ui/app/mainui/Handlers/SwapModalHandler.qml
@@ -21,48 +21,58 @@ QtObject {
     function openSendModal(params = {}, callback = null) {
         d.swapInputParams.resetFormData()
 
-        // don't set from and to group keys, cause they will be eveluated from the default keys, just rebind them
-        d.swapInputParams.fromGroupKey = Qt.binding(() => d.swapInputParams.defaultFromGroupKey)
-        d.swapInputParams.toGroupKey = Qt.binding(() => d.swapInputParams.defaultToGroupKey)
-
-        if (d.isValidParameter(params.selectedNetworkChainId)) {
-            d.swapInputParams.selectedNetworkChainId = params.selectedNetworkChainId
-        }
-        // optional pre-filled destination chain (defaults to the source chain)
-        if (d.isValidParameter(params.toNetworkChainId)) {
-            d.swapInputParams.toNetworkChainId = params.toNetworkChainId
-        }
-        if (d.isValidParameter(params.defaultFromGroupKey)) {
-            d.swapInputParams.defaultFromGroupKey = params.defaultFromGroupKey
-        }
-        if (d.isValidParameter(params.defaultToGroupKey)) {
-            d.swapInputParams.defaultToGroupKey = params.defaultToGroupKey
-        } else {
-            // this is important cause it reevaluates token on the receiver side based on the token on the sender side (e.g. eth selected for sender)
-            d.swapInputParams.defaultToGroupKey = d.swapInputParams.getDefaultToGroupKey(d.swapInputParams.selectedNetworkChainId)
-        }
-        if (d.isValidParameter(params.autoRefreshTime)) {
-            d.swapInputParams.autoRefreshTime = params.autoRefreshTime
-        }
-        if (d.isValidParameter(params.selectedSlippage)) {
-            d.swapInputParams.selectedSlippage = params.selectedSlippage
-        }
-        if (d.isValidParameter(params.selectedAccountAddress)) {
-            d.swapInputParams.selectedAccountAddress = params.selectedAccountAddress
-        }
-
-        if (d.isValidParameter(params.fromTokenAmount)) {
-            d.swapInputParams.fromTokenAmount = params.fromTokenAmount
-        }
-        if (d.isValidParameter(params.toTokenAmount)) {
-            d.swapInputParams.toTokenAmount = params.toTokenAmount
-        }
-
         let swapModalInst = swapModalComponent.createObject(popupParent)
         swapModalInst.open()
 
         if (callback)
             callback(swapModalInst)
+
+        const setup = (params) => {
+            // don't set from and to group keys, cause they will be eveluated from the default keys, just rebind them
+            d.swapInputParams.fromGroupKey = Qt.binding(() => d.swapInputParams.defaultFromGroupKey)
+            d.swapInputParams.toGroupKey = Qt.binding(() => d.swapInputParams.defaultToGroupKey)
+
+            if (d.isValidParameter(params.selectedNetworkChainId)) {
+                d.swapInputParams.selectedNetworkChainId = params.selectedNetworkChainId
+            }
+            // optional pre-filled destination chain (defaults to the source chain)
+            if (d.isValidParameter(params.toNetworkChainId)) {
+                d.swapInputParams.toNetworkChainId = params.toNetworkChainId
+            }
+            if (d.isValidParameter(params.defaultFromGroupKey)) {
+                d.swapInputParams.defaultFromGroupKey = params.defaultFromGroupKey
+            }
+            if (d.isValidParameter(params.defaultToGroupKey)) {
+                d.swapInputParams.defaultToGroupKey = params.defaultToGroupKey
+            } else {
+                // this is important cause it reevaluates token on the receiver side based on the token on the sender side (e.g. eth selected for sender)
+                d.swapInputParams.defaultToGroupKey = d.swapInputParams.getDefaultToGroupKey(d.swapInputParams.selectedNetworkChainId)
+            }
+            if (d.isValidParameter(params.autoRefreshTime)) {
+                d.swapInputParams.autoRefreshTime = params.autoRefreshTime
+            }
+            if (d.isValidParameter(params.selectedSlippage)) {
+                d.swapInputParams.selectedSlippage = params.selectedSlippage
+            }
+            if (d.isValidParameter(params.selectedAccountAddress)) {
+                d.swapInputParams.selectedAccountAddress = params.selectedAccountAddress
+            }
+
+            if (d.isValidParameter(params.fromTokenAmount)) {
+                d.swapInputParams.fromTokenAmount = params.fromTokenAmount
+            }
+            if (d.isValidParameter(params.toTokenAmount)) {
+                d.swapInputParams.toTokenAmount = params.toTokenAmount
+            }
+        } 
+
+        if (swapModalInst.opened) {
+            setup(params)
+        } else {
+            swapModalInst.onOpened.connect(() => {
+                Qt.callLater(() => setup(params))
+            })
+        }
     }
 
     readonly property QtObject _d: QtObject {


### PR DESCRIPTION
Swap/send modal-open fixes (4/5 in the stack):

- **StatusQ `ModelUtils.modelToArray`** fetches only the requested roles — `ModelQuery::get` was materializing EVERY role of every row (O(N×allRoles) QVariant→JS) when callers asked for one.
- **SwapModal**: `rebuildGroupsForChain` deduped per open (ran twice: init + selectedNetworkChainIdChanged) with per-side guards (source + destination, lifi bridge aware); swap configuration moved to after the modal opens so the open animation doesn't compete with setup.
- **SimpleSendModal**: the sticky header (a full duplicate header) is Loader-deferred until first scroll, first reveal animated post-load; tests updated.
- Translations: context reattribution after the adaptor retirement (no string changes).

**Numbers (host)**: swap open GUI-thread stall @10k tokens 43.6 ms → 16 ms floor (one frame); send modal instantiation ~57 ms → ~41 ms (plus the eager 208 ms collectibles adaptor build removed from open by the terminal-models PR).

**Measured vs current master** (host): `ModelUtils.modelToFlatArray` @5k rows drops ~41 ms → ~17 ms (2.3×) from the role-restricted fetch. Note: overall swap-modal *open* time on device is not expected to change vs recent internal builds — the completion-path win above lands in the token-service PR, and the remaining device open cost is QML tree instantiation plus lifi provider setup (new on master), outside this PR's scope.
