### PR TITLE
test(bench): offscreen model benches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ mobile/fastlane/Preview.html
 mobile/fastlane/screenshots/
 mobile/fastlane/test_output/
 mobile/fastlane/result
+
+# Benchmark output (regenerated locally, never committed)
+test/nim/benchmarks/results/

--- a/Makefile
+++ b/Makefile
@@ -1089,6 +1089,16 @@ nim-test-run/test/nim/send_handler_lookup_bench.nim: | statusq
 nim-test-run/test/nim/send_handler_adaptors_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
 nim-test-run/test/nim/send_handler_adaptors_bench.nim: | statusq
 
+# collectibles_selector_bench drives the real CollectiblesSelectionAdaptor proxy
+# chain through two offscreen ListViews (RED baseline) -- links StatusQ.
+nim-test-run/test/nim/collectibles_selector_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
+nim-test-run/test/nim/collectibles_selector_bench.nim: | statusq
+
+# collectibles_selector_model_bench measures the GREEN terminal model directly
+# (context-injected, no proxies above it) -- links StatusQ for the offscreen engine.
+nim-test-run/test/nim/collectibles_selector_model_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
+nim-test-run/test/nim/collectibles_selector_model_bench.nim: | statusq
+
 # Model-spy tests call inspection accessors gated behind
 # `when defined(testing) or defined(QT_MODEL_SPY)` or assert on the granular
 # signals model_sync records only under QT_MODEL_SPY. The define is applied

--- a/Makefile
+++ b/Makefile
@@ -1066,6 +1066,11 @@ nim-test-run/test/nim/url_scheme_event_test.nim: | statusq
 nim-test-run/test/nim/typed_completion_test.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
 nim-test-run/test/nim/typed_completion_test.nim: | statusq
 
+# asset_proxy_chain_bench stands up the real StatusQ/SFPM proxy chain in an
+# offscreen QML engine, so it links StatusQ and needs the installed QML modules.
+nim-test-run/test/nim/asset_proxy_chain_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
+nim-test-run/test/nim/asset_proxy_chain_bench.nim: | statusq
+
 # Model-spy tests call inspection accessors gated behind
 # `when defined(testing) or defined(QT_MODEL_SPY)` or assert on the granular
 # signals model_sync records only under QT_MODEL_SPY. The define is applied
@@ -1079,6 +1084,9 @@ nim-test-run/test/nim/model_sync_move_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
 nim-test-run/test/nim/model_sync_unified_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
 nim-test-run/test/nim/token_groups_model_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
 nim-test-run/test/nim/grouped_account_assets_model_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
+# Exception among benches: its GREEN gates assert structural propagation shape
+# (bounded inserts, zero resets) via the spy counters.
+nim-test-run/test/nim/token_selector_model_bench.nim: NIM_PARAMS += -d:QT_MODEL_SPY
 
 ifneq ($(mkspecs),win32)
 nim-test-run/%: NIM_PARAMS += --passL:"$(QT_SEAQT_EXTRA_LIBS)"

--- a/Makefile
+++ b/Makefile
@@ -1071,6 +1071,24 @@ nim-test-run/test/nim/typed_completion_test.nim: | statusq
 nim-test-run/test/nim/asset_proxy_chain_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
 nim-test-run/test/nim/asset_proxy_chain_bench.nim: | statusq
 
+# swap_key_harvest_bench drives the real QtMT.ModelQuery (registerStatusQTypes) in an
+# offscreen QML engine, so it links StatusQ.
+nim-test-run/test/nim/swap_key_harvest_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
+nim-test-run/test/nim/swap_key_harvest_bench.nim: | statusq
+
+# send_modal_instantiation_bench loads the real SimpleSendModal QML tree, and
+# send_handler_lookup_bench drives the real ModelUtils/ModelQuery -- both link StatusQ.
+nim-test-run/test/nim/send_modal_instantiation_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
+nim-test-run/test/nim/send_modal_instantiation_bench.nim: | statusq
+
+nim-test-run/test/nim/send_handler_lookup_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
+nim-test-run/test/nim/send_handler_lookup_bench.nim: | statusq
+
+# send_handler_adaptors_bench builds the real CollectiblesSelectionAdaptor /
+# WalletAccountsSelectorAdaptor / RecipientViewAdaptor proxy chains offscreen -- links StatusQ.
+nim-test-run/test/nim/send_handler_adaptors_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
+nim-test-run/test/nim/send_handler_adaptors_bench.nim: | statusq
+
 # Model-spy tests call inspection accessors gated behind
 # `when defined(testing) or defined(QT_MODEL_SPY)` or assert on the granular
 # signals model_sync records only under QT_MODEL_SPY. The define is applied

--- a/test/nim/asset_proxy_chain_bench.nim
+++ b/test/nim/asset_proxy_chain_bench.nim
@@ -56,12 +56,14 @@ QtObject:
     rows: seq[Row]
     finished: bool
 
-  proc delete(self: Bench) =
-    self.QObject.delete
+  proc delete(self: Bench)
 
   proc newBench(): Bench =
     new(result, delete)
     result.QObject.setup
+
+  proc delete(self: Bench) =
+    self.QObject.delete
 
   proc nowNs(self: Bench): float {.slot.} =
     (getMonoTime() - MonoTime()).inNanoseconds.float

--- a/test/nim/asset_proxy_chain_bench.nim
+++ b/test/nim/asset_proxy_chain_bench.nim
@@ -1,0 +1,153 @@
+## Proxy-chain propagation benchmark (RED baseline).
+##
+## Boots an offscreen QQmlApplicationEngine, registers the real StatusQ / SFPM /
+## QtModelsToolkit types, and loads asset_proxy_chain_scene.qml — which stands up
+## the full WalletAssetsStore graph: two chained LeftJoinModels (tokenGroups ⋈
+## communities, then grouped-assets ⋈ that) feeding AssetsView's terminal chain
+## (a visible-filter SortFilterProxyModel plus the terminal SortFilterProxyModel
+## carrying AssetsView's 3 FastExpressionRoles + 2 RoleSorters with
+## dynamicSortFilter), driving a ListView with a counting delegate.
+##
+## For each token-universe size (100 / 1k / 5k, multi-chain) and update class
+## (single market-detail change, single balance update, add token, remove token,
+## source reorder, sort flip, full refresh) the scene records: wall time,
+## terminal-model signal counts (dataChanged / summed dataChanged row-span /
+## layoutChanged / modelReset / rowsInserted / rowsRemoved) and delegate
+## create/destroy counts. Results print as a machine-readable table and are saved
+## (gitignored) under test/nim/benchmarks/results/.
+##
+## The join layers are real (not pre-joined): a right-model cell change makes
+## LeftJoinModel emit a WHOLE-model dataChanged (leftjoinmodel.cpp:285), so the
+## market-detail / balance edits — driven through the right-joined tokenGroups
+## model — reproduce the ×N amplification the terminal model removes.
+##
+## Faithful reduction (stated for honesty):
+##   - ManageTokensController's ObjectProxyModel + settings persistence is the
+##     visible-filter SortFilterProxyModel (same propagation depth, no Global
+##     singletons / settings I/O offscreen).
+##
+## The committed structural assertions gate the invariants that hold today,
+## including the RED baseline that market-detail / balance edits amplify into a
+## whole-model dataChanged; the terminal model flips those.
+
+import os, times, strformat
+import nimqml
+from seaqt/qcoreapplication import QCoreApplication, processEvents
+import std/monotimes
+
+{.compile: "bench_statusq_register.cpp".}
+proc bench_registerStatusQTypes() {.importc.}
+
+type Row = object
+  size: int
+  scenario: string
+  wallMs: float
+  dataChanged: int
+  dataChangedRows: int
+  layoutChanged: int
+  resets: int
+  inserted: int
+  removed: int
+  delegatesCreated: int
+  delegatesDestroyed: int
+
+QtObject:
+  type Bench = ref object of QObject
+    rows: seq[Row]
+    finished: bool
+
+  proc delete(self: Bench) =
+    self.QObject.delete
+
+  proc newBench(): Bench =
+    new(result, delete)
+    result.QObject.setup
+
+  proc nowNs(self: Bench): float {.slot.} =
+    (getMonoTime() - MonoTime()).inNanoseconds.float
+
+  proc record(self: Bench, size: int, scenario: string, wallMs: float,
+      dataChanged: int, dataChangedRows: int, layoutChanged: int, resets: int,
+      inserted: int, removed: int,
+      delegatesCreated: int, delegatesDestroyed: int) {.slot.} =
+    self.rows.add(Row(size: size, scenario: scenario, wallMs: wallMs,
+      dataChanged: dataChanged, dataChangedRows: dataChangedRows,
+      layoutChanged: layoutChanged, resets: resets,
+      inserted: inserted, removed: removed,
+      delegatesCreated: delegatesCreated, delegatesDestroyed: delegatesDestroyed))
+    stderr.writeLine(&"[bench] size={size} {scenario} {wallMs:.2f}ms dataChangedRows={dataChangedRows}")
+    stderr.flushFile()
+
+  proc pump(self: Bench) {.slot.} =
+    ## Flush queued work (SFPM deferred invalidation, ListView delegate
+    ## realization) so a synchronous measurement observes the settled state.
+    for _ in 0 ..< 8:
+      QCoreApplication.processEvents()
+
+  proc done(self: Bench) {.slot.} =
+    self.finished = true
+
+proc formatTable(rows: seq[Row]): string =
+  result = "size\tscenario\twall_ms\tdataChanged\tdataChangedRows\tlayoutChanged\tresets\tinserted\tremoved\tdelegatesCreated\tdelegatesDestroyed\n"
+  for r in rows:
+    result.add(&"{r.size}\t{r.scenario}\t{r.wallMs:.4f}\t{r.dataChanged}\t{r.dataChangedRows}\t{r.layoutChanged}\t{r.resets}\t{r.inserted}\t{r.removed}\t{r.delegatesCreated}\t{r.delegatesDestroyed}\n")
+
+when isMainModule:
+  putEnv("QT_QPA_PLATFORM", "offscreen")
+
+  let app = newQApplication()
+  bench_registerStatusQTypes()
+
+  let bench = newBench()
+  let benchVariant = newQVariant(bench)
+
+  let engine = newQQmlApplicationEngine()
+  engine.addImportPath(getCurrentDir() / "ui" / "StatusQ" / "src")
+  engine.setRootContextProperty("bench", benchVariant)
+
+  let sceneFile = getCurrentDir() / "test" / "nim" / "benchmarks" / "asset_proxy_chain_scene.qml"
+  engine.loadData(readFile(sceneFile))
+
+  var spins = 0
+  while not bench.finished and spins < 100000:
+    QCoreApplication.processEvents()
+    inc spins
+
+  if bench.rows.len == 0:
+    # The StatusQ / SFPM QML modules could not be resolved in this environment
+    # (needs a `make statusq` install tree on the import path). Skip rather than
+    # fail the unit-test sweep; the baseline is produced on the macOS host.
+    echo "SKIP: proxy-chain scene did not load (StatusQ QML modules unavailable)"
+    quit(0)
+
+  let table = formatTable(bench.rows)
+  echo "\n===== proxy-chain propagation baseline ====="
+  echo table
+
+  let resultsDir = getCurrentDir() / "test" / "nim" / "benchmarks" / "results"
+  createDir(resultsDir)
+  let stamp = now().format("yyyyMMdd'T'HHmmss")
+  let outFile = resultsDir / ("proxy_chain_baseline_" & stamp & ".tsv")
+  writeFile(outFile, table)
+  echo "saved: ", outFile
+
+  # Structural gate. Invariants that hold TODAY:
+  #   - no scenario except full_refresh resets the terminal model (rows survive);
+  #   - a stable-set single-cell change (market detail / balance) adds/removes no
+  #     rows.
+  # RED baseline (the terminal model flips these): a single-cell
+  # market-detail / balance edit fans out through the outer LeftJoinModel into a
+  # WHOLE-model dataChanged — the terminal re-touches ~every row, so the summed
+  # dataChanged row-span is on the order of the universe size, not O(1).
+  for r in bench.rows:
+    if r.scenario != "full_refresh":
+      doAssert r.resets == 0,
+        &"unexpected model reset in scenario '{r.scenario}' at size {r.size}"
+    if r.scenario in ["market_detail_change", "balance_update"]:
+      doAssert r.inserted == 0 and r.removed == 0,
+        &"stable-set scenario '{r.scenario}' changed the row set at size {r.size}"
+      # RED: whole-model amplification (to be flipped green by the terminal model).
+      doAssert r.dataChangedRows >= r.size,
+        &"expected whole-model dataChanged amplification for '{r.scenario}' at size {r.size} (got {r.dataChangedRows} rows)"
+
+  echo "structural assertions passed"

--- a/test/nim/asset_terminal_model_bench.nim
+++ b/test/nim/asset_terminal_model_bench.nim
@@ -1,0 +1,265 @@
+## Terminal-model propagation benchmark (GREEN counterpart of
+## asset_proxy_chain_bench.nim).
+##
+## Boots an offscreen QQmlApplicationEngine, context-injects a real
+## AssetsAdaptorModel, and loads asset_terminal_model_scene.qml — a ListView
+## bound DIRECTLY to the model (no proxies). The Nim driver builds the same
+## synthetic universe as the proxy baseline and applies the same update classes
+## (single market-detail change, balance update, add/remove token, source
+## reorder, sort flip, full refresh) by calling setSourceItems / sortBy; the
+## scene forwards the model's granular signals + delegate churn to the native
+## `bench` object.
+##
+## GREEN gate (flips the proxy baseline's RED): a stable-set single-cell change
+## propagates as O(1) work — the summed dataChanged row-span is a small constant
+## instead of the universe size, no scenario resets the model, and no scenario
+## emits layoutChanged. The market/balance edits re-sort in O(1) (the changed
+## row moves) instead of the proxy chain's whole-model dataChanged + re-sort.
+
+import os, times, strformat
+import nimqml
+from seaqt/qcoreapplication import QCoreApplication, processEvents
+import std/monotimes
+
+import app/modules/shared_models/assets_adaptor_model
+
+type Row = object
+  size: int
+  scenario: string
+  wallMs: float
+  dataChanged: int
+  dataChangedRows: int
+  layoutChanged: int
+  resets: int
+  inserted: int
+  removed: int
+  delegatesCreated: int
+  delegatesDestroyed: int
+
+QtObject:
+  type Bench = ref object of QObject
+    rows: seq[Row]
+    ready: bool
+    finished: bool
+    cDataChanged: int
+    cDataChangedRows: int
+    cLayoutChanged: int
+    cReset: int
+    cInserted: int
+    cRemoved: int
+    cDelegatesCreated: int
+    cDelegatesDestroyed: int
+
+  proc delete(self: Bench) =
+    self.QObject.delete
+
+  proc newBench(): Bench =
+    new(result, delete)
+    result.QObject.setup
+
+  proc requestRelayout(self: Bench) {.signal.}
+
+  proc onSceneReady(self: Bench) {.slot.} = self.ready = true
+  proc onDelegateCreated(self: Bench) {.slot.} = inc self.cDelegatesCreated
+  proc onDelegateDestroyed(self: Bench) {.slot.} = inc self.cDelegatesDestroyed
+  proc onDataChanged(self: Bench, first: int, last: int) {.slot.} =
+    inc self.cDataChanged
+    self.cDataChangedRows += (last - first + 1)
+  proc onLayoutChanged(self: Bench) {.slot.} = inc self.cLayoutChanged
+  proc onModelReset(self: Bench) {.slot.} = inc self.cReset
+  proc onRowsInserted(self: Bench) {.slot.} = inc self.cInserted
+  proc onRowsRemoved(self: Bench) {.slot.} = inc self.cRemoved
+
+  proc nowNs(self: Bench): float =
+    (getMonoTime() - MonoTime()).inNanoseconds.float
+
+  proc resetCounters(self: Bench) =
+    self.cDataChanged = 0
+    self.cDataChangedRows = 0
+    self.cLayoutChanged = 0
+    self.cReset = 0
+    self.cInserted = 0
+    self.cRemoved = 0
+    self.cDelegatesCreated = 0
+    self.cDelegatesDestroyed = 0
+
+  proc pump(self: Bench) =
+    ## Flush the ListView layout + delegate realization so a synchronous
+    ## measurement observes the settled state.
+    self.requestRelayout()
+    for _ in 0 ..< 8:
+      QCoreApplication.processEvents()
+
+  proc record(self: Bench, size: int, scenario: string, wallMs: float) =
+    self.rows.add(Row(size: size, scenario: scenario, wallMs: wallMs,
+      dataChanged: self.cDataChanged, dataChangedRows: self.cDataChangedRows,
+      layoutChanged: self.cLayoutChanged, resets: self.cReset,
+      inserted: self.cInserted, removed: self.cRemoved,
+      delegatesCreated: self.cDelegatesCreated,
+      delegatesDestroyed: self.cDelegatesDestroyed))
+    stderr.writeLine(&"[bench] size={size} {scenario} {wallMs:.2f}ms dataChangedRows={self.cDataChangedRows}")
+    stderr.flushFile()
+
+proc makeItem(i, numChains: int): AssetItem =
+  let chain = i mod numChains
+  let bal = float(i mod 1000) + 1.5
+  AssetItem(
+    key: "tok_" & $i & "_c" & $chain,
+    name: "Token " & $i,
+    symbol: "T" & $i,
+    balance: bal,
+    balanceText: $bal,
+    balanceLoading: false,
+    marketPrice: 1.0 + float(i mod 500) * 0.01,
+    marketChangePct24hour: float((i mod 40) - 20) * 0.5,
+    marketDetailsAvailable: true,
+    marketDetailsLoading: false,
+    canBeHidden: true,
+    position: i,
+    visible: true,
+  )
+
+proc buildUniverse(numTokens, numChains: int): seq[AssetItem] =
+  result = @[]
+  for i in 0 ..< numTokens:
+    result.add(makeItem(i, numChains))
+
+proc formatTable(rows: seq[Row]): string =
+  result = "size\tscenario\twall_ms\tdataChanged\tdataChangedRows\tlayoutChanged\tresets\tinserted\tremoved\tdelegatesCreated\tdelegatesDestroyed\n"
+  for r in rows:
+    result.add(&"{r.size}\t{r.scenario}\t{r.wallMs:.4f}\t{r.dataChanged}\t{r.dataChangedRows}\t{r.layoutChanged}\t{r.resets}\t{r.inserted}\t{r.removed}\t{r.delegatesCreated}\t{r.delegatesDestroyed}\n")
+
+when isMainModule:
+  putEnv("QT_QPA_PLATFORM", "offscreen")
+
+  let app = newQApplication()
+  let model = newAssetsAdaptorModel()
+  model.sortBy("marketBalance", 1) # Qt.DescendingOrder — matches the proxy scene default
+  let modelVariant = newQVariant(model)
+
+  let bench = newBench()
+  let benchVariant = newQVariant(bench)
+
+  let engine = newQQmlApplicationEngine()
+  engine.setRootContextProperty("assetsModel", modelVariant)
+  engine.setRootContextProperty("bench", benchVariant)
+
+  let sceneFile = getCurrentDir() / "test" / "nim" / "benchmarks" / "asset_terminal_model_scene.qml"
+  engine.loadData(readFile(sceneFile))
+
+  var spins = 0
+  while not bench.ready and spins < 100000:
+    QCoreApplication.processEvents()
+    inc spins
+
+  if not bench.ready:
+    echo "SKIP: terminal-model scene did not load"
+    quit(0)
+
+  let chains = 5
+  var universe: seq[AssetItem]
+
+  proc measure(size: int, scenario: string, mutate: proc()) =
+    bench.resetCounters()
+    let t0 = bench.nowNs()
+    mutate()
+    bench.pump()
+    let t1 = bench.nowNs()
+    bench.record(size, scenario, (t1 - t0) / 1000000.0)
+
+  proc runSize(size: int) =
+    universe = buildUniverse(size, chains)
+    model.setSourceItems(universe)
+    bench.pump() # settle the initial load before measuring
+
+    measure(size, "market_detail_change", proc() =
+      let i = universe.len div 2
+      universe[i].marketPrice = universe[i].marketPrice + 1.0
+      universe[i].marketChangePct24hour = universe[i].marketChangePct24hour + 0.25
+      model.setSourceItems(universe))
+
+    measure(size, "balance_update", proc() =
+      let i = universe.len div 2
+      universe[i].balance = universe[i].balance + 1.0
+      universe[i].balanceText = $universe[i].balance
+      model.setSourceItems(universe))
+
+    measure(size, "add_token", proc() =
+      var it = makeItem(universe.len, chains)
+      it.key = "added_" & $universe.len
+      universe.add(it)
+      model.setSourceItems(universe))
+
+    measure(size, "remove_token", proc() =
+      universe.delete(universe.len div 2)
+      model.setSourceItems(universe))
+
+    measure(size, "source_reorder", proc() =
+      # Reorder the raw source without changing the set. The terminal model
+      # sorts internally, so display order is unaffected -> zero ops.
+      if universe.len >= 4:
+        let a = universe[0]
+        universe.delete(0)
+        universe.add(a)
+      model.setSourceItems(universe))
+
+    measure(size, "all_prices_change", proc() =
+      # Honest worst case: every token's market detail changes in one tick and
+      # the new prices reshuffle the marketBalance ranking wholesale (global
+      # re-rank). No amplification to remove here — the work is inherent — so
+      # this is the row where terminal and proxy costs converge; the win the
+      # series claims is on the single-cell scenarios above, not this one.
+      for i in 0 ..< universe.len:
+        universe[i].marketPrice = float((universe.len - i) mod 500) * 0.02 + 0.5
+        universe[i].marketChangePct24hour = universe[i].marketChangePct24hour + 0.5
+      model.setSourceItems(universe))
+
+    measure(size, "sort_flip", proc() =
+      model.sortBy("marketBalance", 0)) # flip to ascending
+
+    measure(size, "full_refresh", proc() =
+      # Re-apply the (unchanged) universe: the diff finds nothing -> zero ops,
+      # where the proxy chain rebuilds and resets.
+      model.setSourceItems(universe))
+
+    # restore descending sort for the next size
+    model.sortBy("marketBalance", 1)
+
+  runSize(100)
+  runSize(1000)
+  runSize(5000)
+
+  let table = formatTable(bench.rows)
+  echo "\n===== terminal-model propagation (GREEN) ====="
+  echo table
+
+  let resultsDir = getCurrentDir() / "test" / "nim" / "benchmarks" / "results"
+  createDir(resultsDir)
+  let stamp = now().format("yyyyMMdd'T'HHmmss")
+  writeFile(resultsDir / ("terminal_model_" & stamp & ".tsv"), table)
+
+  # GREEN structural gate: flips the proxy baseline's RED asserts.
+  for r in bench.rows:
+    doAssert r.resets == 0,
+      &"terminal model reset in scenario '{r.scenario}' at size {r.size}"
+    # model_sync never emits layoutChanged (it diffs into insert/remove/dataChanged);
+    # this assert only carries meaning against the SFPM proxy baseline, which does.
+    doAssert r.layoutChanged == 0,
+      &"terminal model emitted layoutChanged in '{r.scenario}' at size {r.size}"
+    if r.scenario in ["market_detail_change", "balance_update"]:
+      # RED was dataChangedRows >= size (whole-model amplification). GREEN: O(1).
+      doAssert r.dataChangedRows <= 4,
+        &"expected O(1) propagation for '{r.scenario}' at size {r.size} (got {r.dataChangedRows} rows)"
+      doAssert r.inserted <= 1 and r.removed <= 1,
+        &"expected O(1) row churn for '{r.scenario}' at size {r.size}"
+    if r.scenario == "add_token":
+      doAssert r.inserted == 1 and r.removed == 0,
+        &"add_token should be a single insert at size {r.size}"
+    if r.scenario == "remove_token":
+      doAssert r.removed == 1 and r.inserted == 0,
+        &"remove_token should be a single remove at size {r.size}"
+    if r.scenario == "full_refresh":
+      doAssert r.dataChangedRows == 0 and r.inserted == 0 and r.removed == 0,
+        &"unchanged full_refresh should be a no-op at size {r.size}"
+
+  echo "structural assertions passed"

--- a/test/nim/asset_terminal_model_bench.nim
+++ b/test/nim/asset_terminal_model_bench.nim
@@ -50,12 +50,14 @@ QtObject:
     cDelegatesCreated: int
     cDelegatesDestroyed: int
 
-  proc delete(self: Bench) =
-    self.QObject.delete
+  proc delete(self: Bench)
 
   proc newBench(): Bench =
     new(result, delete)
     result.QObject.setup
+
+  proc delete(self: Bench) =
+    self.QObject.delete
 
   proc requestRelayout(self: Bench) {.signal.}
 

--- a/test/nim/bench_statusq_register.cpp
+++ b/test/nim/bench_statusq_register.cpp
@@ -1,0 +1,4 @@
+// Bridges StatusQ's C++ registerStatusQTypes() to a C-linkage symbol the
+// (C-compiled) Nim benchmark can call.
+extern void registerStatusQTypes();
+extern "C" void bench_registerStatusQTypes() { registerStatusQTypes(); }

--- a/test/nim/benchmarks/asset_proxy_chain_scene.qml
+++ b/test/nim/benchmarks/asset_proxy_chain_scene.qml
@@ -1,0 +1,335 @@
+// Benchmark scene: drives the full WalletAssetsStore model graph over synthetic
+// source models and reports per-scenario measurements to the native `bench`
+// object.
+//
+// Chain (mirrors ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml then
+// ui/imports/shared/views/AssetsView.qml, terminal roles/sorters verbatim):
+//
+//   tokenGroups ─┐
+//                ├─ LeftJoin(joinRole "communityId") = tokenGroupsJoined ─┐
+//   communities ─┘                                                        │
+//                                                          leftAssets ─────┤
+//                                                                          ├─ LeftJoin(joinRole "key") = assets
+//                                                                          │
+//   assets ── SFPM(visible filter) ── SFPM(FastExpressionRoles + RoleSorters, dynamicSort) ── ListView
+//
+// Why two real LeftJoinModels:
+// a right-model cell change makes LeftJoinModel emit a WHOLE-model dataChanged
+// (leftjoinmodel.cpp:285), the ×N amplification the terminal model
+// removes. tokenGroups feeds the inner join, whose output is the RIGHT model of
+// the outer join, so market-detail / balance edits on tokenGroups exercise that
+// whole-model emission exactly as production does.
+//
+// LeftJoinModel::initializeIfReady bails while either source reports empty
+// roleNames (a QML ListModel is role-less until its first row), so every source
+// carries a seed ListElement declaring its roles up front; the join is live
+// before the universe is built and stays live across clear()/append().
+//
+// Reduction vs production: ManageTokensController's ObjectProxyModel + settings
+// persistence is the SFPM(visible) filter (same propagation depth, no I/O).
+
+import QtQuick
+import QtQuick.Window
+
+import StatusQ
+import SortFilterProxyModel
+import QtModelsToolkit
+
+Window {
+    id: root
+    width: 420
+    height: 900
+    visible: true // realize the offscreen surface so the ListView creates delegates
+
+    // --- dynamic sort control (mirrors AssetsView's RoleSorter binding) ---
+    property string sortRole: "marketBalance"
+    property int sortOrder: Qt.DescendingOrder
+
+    // --- signal + delegate churn counters (reset per scenario) ---
+    property int cDataChanged: 0
+    property int cDataChangedRows: 0   // summed row-span of terminal dataChanged (amplification magnitude)
+    property int cLayoutChanged: 0
+    property int cReset: 0
+    property int cInserted: 0
+    property int cRemoved: 0
+    property int cDelegatesCreated: 0
+    property int cDelegatesDestroyed: 0
+
+    function resetCounters() {
+        cDataChanged = 0; cDataChangedRows = 0; cLayoutChanged = 0; cReset = 0
+        cInserted = 0; cRemoved = 0
+        cDelegatesCreated = 0; cDelegatesDestroyed = 0
+    }
+
+    // ---- source models (each seeded so its roleNames are non-empty at load) ----
+    // Grouped account assets (outer-join LEFT): the row set + per-account fields.
+    ListModel {
+        id: leftAssets
+        ListElement {
+            key: "seed"; visible: false; position: 0; canBeHidden: true; error: ""
+        }
+    }
+    // Token groups incl. market details (inner-join LEFT, i.e. outer-join RIGHT
+    // once joined with communities): balance + marketPrice live here so both the
+    // market-detail and balance edits flow through the amplifying right side.
+    ListModel {
+        id: tokenGroups
+        ListElement {
+            key: "seed"; name: "seed"; symbol: "seed"; logoUri: ""
+            balance: 0.0; balanceText: "0"; balanceLoading: false
+            marketPrice: 0.0; marketChangePct24hour: 0.0
+            marketDetailsAvailable: false; marketDetailsLoading: false
+            communityId: ""
+        }
+    }
+    // Communities (inner-join RIGHT).
+    ListModel {
+        id: communities
+        ListElement {
+            communityId: ""; communityName: ""; communityImage: ""; communityDescription: ""
+        }
+    }
+
+    LeftJoinModel {
+        id: tokenGroupsJoined
+        leftModel: tokenGroups
+        rightModel: communities
+        joinRole: "communityId"
+    }
+
+    LeftJoinModel {
+        id: assets
+        objectName: "groupedAccountAssetsModel"
+        leftModel: leftAssets
+        rightModel: tokenGroupsJoined
+        joinRole: "key"
+    }
+
+    SortFilterProxyModel {
+        id: visibleSfpm
+        sourceModel: assets
+        filters: ValueFilter { roleName: "visible"; value: true }
+    }
+
+    SortFilterProxyModel {
+        id: terminal
+        sourceModel: visibleSfpm
+
+        proxyRoles: [
+            FastExpressionRole {
+                name: "isCommunity"
+                expression: !!model.communityId ? "community" : ""
+                expectedRoles: ["communityId"]
+            },
+            FastExpressionRole {
+                name: "marketBalance"
+                expression: model.balance * model.marketPrice
+                expectedRoles: ["balance", "marketPrice"]
+            },
+            FastExpressionRole {
+                name: "change1DayFiat"
+                expression: model.marketBalance * (1 - (1 / (model.marketChangePct24hour / 100 + 1)))
+                expectedRoles: ["marketBalance", "marketChangePct24hour"]
+            }
+        ]
+
+        sorters: [
+            RoleSorter { roleName: "isCommunity" },
+            RoleSorter { roleName: root.sortRole; sortOrder: root.sortOrder }
+        ]
+    }
+
+    Connections {
+        target: terminal
+        function onDataChanged(topLeft, bottomRight, roles) {
+            root.cDataChanged++
+            root.cDataChangedRows += (bottomRight.row - topLeft.row + 1)
+        }
+        function onLayoutChanged() { root.cLayoutChanged++ }
+        function onModelReset() { root.cReset++ }
+        function onRowsInserted() { root.cInserted++ }
+        function onRowsRemoved() { root.cRemoved++ }
+    }
+
+    ListView {
+        id: listView
+        anchors.fill: parent
+        model: terminal
+        cacheBuffer: 0
+        delegate: Rectangle {
+            width: ListView.view.width
+            height: 44
+            // read the same roles AssetsView's TokenDelegate binds
+            property string _k: model.key
+            property real _mb: model.marketBalance
+            property real _c1d: model.change1DayFiat
+            property string _n: model.name
+            Component.onCompleted: root.cDelegatesCreated++
+            Component.onDestruction: root.cDelegatesDestroyed++
+        }
+    }
+
+    // ---- universe construction ----
+    function makeAssetRow(i, numChains) {
+        const chain = i % numChains
+        return {
+            key: "tok_" + i + "_c" + chain,
+            visible: true,
+            position: i,
+            canBeHidden: true,
+            error: ""
+        }
+    }
+
+    function makeGroupRow(i, numChains) {
+        const chain = i % numChains
+        return {
+            key: "tok_" + i + "_c" + chain,
+            name: "Token " + i,
+            symbol: "T" + i,
+            logoUri: "",
+            balance: (i % 1000) + 1.5,
+            balanceText: String((i % 1000) + 1.5),
+            balanceLoading: false,
+            marketPrice: 1.0 + (i % 500) * 0.01,
+            marketChangePct24hour: ((i % 40) - 20) * 0.5,
+            marketDetailsAvailable: true,
+            marketDetailsLoading: false,
+            communityId: ""
+        }
+    }
+
+    function buildUniverse(numTokens, numChains) {
+        // Detach the joins, fully populate the sources, then reattach so the
+        // rebuild costs one O(N) initialization each (this is the reviewer's
+        // "pre-populate the sources before assigning them to the LeftJoinModel"
+        // rule): while attached, every append to a right-joined source fires a
+        // whole-model dataChanged, so an incremental build is O(N^2).
+        assets.leftModel = null
+        assets.rightModel = null
+        tokenGroupsJoined.leftModel = null
+        tokenGroupsJoined.rightModel = null
+
+        // communities is never cleared: emptying it would drop its roleNames and
+        // de-initialize the inner join. Its single seed row (communityId "")
+        // carries the roles and matches the no-community tokens harmlessly.
+        leftAssets.clear()
+        tokenGroups.clear()
+        for (let i = 0; i < numTokens; i++) {
+            tokenGroups.append(makeGroupRow(i, numChains))
+            leftAssets.append(makeAssetRow(i, numChains))
+        }
+
+        // Reattach inner join first so its roleNames exist before the outer join
+        // takes it as a right model.
+        tokenGroupsJoined.leftModel = tokenGroups
+        tokenGroupsJoined.rightModel = communities
+        assets.leftModel = leftAssets
+        assets.rightModel = tokenGroupsJoined
+        listView.forceLayout()
+    }
+
+    // ---- update classes ----
+    // Market details live on the right-joined tokenGroups model -> a single-cell
+    // edit fans out to a whole-model dataChanged through the outer join.
+    function doMarketDetailChange() {
+        const i = Math.floor(tokenGroups.count / 2)
+        tokenGroups.setProperty(i, "marketPrice", tokenGroups.get(i).marketPrice + 1.0)
+        tokenGroups.setProperty(i, "marketChangePct24hour", tokenGroups.get(i).marketChangePct24hour + 0.25)
+    }
+
+    function doBalanceUpdate() {
+        const i = Math.floor(tokenGroups.count / 2)
+        const cur = tokenGroups.get(i).balance
+        tokenGroups.setProperty(i, "balance", cur + 1.0)
+        tokenGroups.setProperty(i, "balanceText", String(cur + 1.0))
+    }
+
+    // Every token's market detail changes in one tick, reshuffling the
+    // marketBalance ranking wholesale (global re-rank worst case). Each
+    // setProperty on the right-joined tokenGroups fans out to a whole-model
+    // dataChanged, so this is O(N^2) row-touches through the proxy chain.
+    function doAllPricesChange() {
+        const n = tokenGroups.count
+        for (let i = 0; i < n; i++) {
+            tokenGroups.setProperty(i, "marketPrice", ((n - i) % 500) * 0.02 + 0.5)
+            tokenGroups.setProperty(i, "marketChangePct24hour", tokenGroups.get(i).marketChangePct24hour + 0.5)
+        }
+    }
+
+    // Add/remove operate on the outer-join LEFT (the row-set driver); a matching
+    // group row keeps marketBalance defined, mirroring "new asset + its group".
+    function doAddToken() {
+        const i = leftAssets.count
+        const grp = makeGroupRow(i, 5)
+        grp.key = "added_" + i
+        const asset = makeAssetRow(i, 5)
+        asset.key = "added_" + i
+        tokenGroups.append(grp)
+        leftAssets.append(asset)
+    }
+
+    function doRemoveToken() {
+        leftAssets.remove(Math.floor(leftAssets.count / 2))
+    }
+
+    // Reorder the source rows without changing the set (distinct from sort_flip,
+    // which flips the terminal sorter). Exercises left-model move/layoutChanged.
+    function doSourceReorder() {
+        const n = leftAssets.count
+        if (n < 4)
+            return
+        leftAssets.move(0, n - 1, 1)
+        leftAssets.move(Math.floor(n / 3), Math.floor((2 * n) / 3), 1)
+    }
+
+    function doFullRefresh(numTokens, numChains) {
+        buildUniverse(numTokens, numChains)
+    }
+
+    function doSortFlip() {
+        root.sortOrder = (root.sortOrder === Qt.DescendingOrder)
+            ? Qt.AscendingOrder : Qt.DescendingOrder
+    }
+
+    function measure(size, chains, scenario, fn) {
+        resetCounters()
+        const t0 = bench.nowNs()
+        fn()
+        listView.forceLayout()
+        bench.pump() // flush deferred SFPM invalidation + delegate realization
+        const t1 = bench.nowNs()
+        bench.record(size, scenario, (t1 - t0) / 1000000.0,
+            cDataChanged, cDataChangedRows, cLayoutChanged, cReset, cInserted, cRemoved,
+            cDelegatesCreated, cDelegatesDestroyed)
+    }
+
+    function runSize(size, chains) {
+        buildUniverse(size, chains)
+        bench.pump() // settle the initial load before measuring
+        measure(size, chains, "market_detail_change", () => doMarketDetailChange())
+        measure(size, chains, "balance_update", () => doBalanceUpdate())
+        measure(size, chains, "add_token", () => doAddToken())
+        measure(size, chains, "remove_token", () => doRemoveToken())
+        measure(size, chains, "source_reorder", () => doSourceReorder())
+        measure(size, chains, "all_prices_change", () => doAllPricesChange())
+        measure(size, chains, "sort_flip", () => doSortFlip())
+        measure(size, chains, "full_refresh", () => doFullRefresh(size, chains))
+    }
+
+    // Run after the window is exposed and the first frame is rendered, so the
+    // ListView realizes delegates and the proxy chain is live (running in
+    // Component.onCompleted fires during load, before the surface exists).
+    Timer {
+        interval: 50
+        running: true
+        repeat: false
+        onTriggered: {
+            const chains = 5
+            runSize(100, chains)
+            runSize(1000, chains)
+            runSize(5000, chains)
+            bench.done()
+        }
+    }
+}

--- a/test/nim/benchmarks/asset_terminal_model_scene.qml
+++ b/test/nim/benchmarks/asset_terminal_model_scene.qml
@@ -1,0 +1,63 @@
+// Terminal-model benchmark scene: binds a ListView DIRECTLY to the
+// context-injected AssetsAdaptorModel (no proxies above it) and forwards the
+// model's granular signals + delegate churn to the native `bench` object.
+//
+// The Nim harness drives the updates (setSourceItems / sortBy) — AssetItem is a
+// Nim value DTO not exposable to QML — while this scene measures exactly what a
+// real ListView sees. Compare against asset_proxy_chain_scene.qml: same
+// universe sizes and update classes, proxy chain replaced by the terminal model.
+
+import QtQuick
+import QtQuick.Window
+
+Window {
+    id: root
+    width: 420
+    height: 900
+    visible: true // realize the offscreen surface so the ListView creates delegates
+
+    ListView {
+        id: listView
+        anchors.fill: parent
+        model: assetsModel
+        cacheBuffer: 0
+        delegate: Rectangle {
+            width: ListView.view.width
+            height: 44
+            // read the same roles AssetsView's TokenDelegate binds
+            property string _k: model.key
+            property real _mb: model.marketBalance
+            property real _c1d: model.change1DayFiat
+            property string _n: model.name
+            Component.onCompleted: bench.onDelegateCreated()
+            Component.onDestruction: bench.onDelegateDestroyed()
+        }
+
+    }
+
+    Connections {
+        target: assetsModel
+        function onDataChanged(topLeft, bottomRight, roles) {
+            bench.onDataChanged(topLeft.row, bottomRight.row)
+        }
+        function onLayoutChanged() { bench.onLayoutChanged() }
+        function onModelReset() { bench.onModelReset() }
+        function onRowsInserted() { bench.onRowsInserted() }
+        function onRowsRemoved() { bench.onRowsRemoved() }
+    }
+
+    // Nim driver asks for a synchronous layout pass so delegate realization is
+    // measured within the scenario window.
+    Connections {
+        target: bench
+        function onRequestRelayout() { listView.forceLayout() }
+    }
+
+    // Signal the driver once the surface exists and the first frame is rendered.
+    Timer {
+        interval: 50
+        running: true
+        repeat: false
+        onTriggered: bench.onSceneReady()
+    }
+}

--- a/test/nim/benchmarks/collectibles_selector_model_scene.qml
+++ b/test/nim/benchmarks/collectibles_selector_model_scene.qml
@@ -1,0 +1,95 @@
+// GREEN scene: two ListViews bound DIRECTLY to the context-injected
+// CollectiblesSelectorModel (no proxies above it) + its filteredFlatModel
+// companion, the exact delegates the RED scene (collectibles_selector_scene.qml)
+// drives against the real adaptor. The Nim harness owns the update classes
+// (setSource / setAccountKey / setEnabledChainIds) because CollectibleItem is a
+// Nim value DTO not exposable to QML; this scene measures what a real ListView
+// sees.
+
+import QtQuick
+import QtQuick.Window
+
+Window {
+    id: root
+    width: 480
+    height: 900
+    visible: true // realize the offscreen surface so the ListViews create delegates
+
+    ListView {
+        id: groupedView
+        width: parent.width / 2
+        height: parent.height
+        model: collectiblesModel
+        cacheBuffer: 0
+        delegate: Item {
+            width: ListView.view.width
+            height: 40
+            property string _g: model.groupName
+            property string _t: model.type
+            property url _i: model.icon
+            property int _sc: model.subitems ? model.subitems.count : 0
+            Component.onCompleted: bench.onDelegateCreated(0)
+            Component.onDestruction: bench.onDelegateDestroyed(0)
+        }
+    }
+
+    ListView {
+        id: flatView
+        anchors.left: groupedView.right
+        width: parent.width / 2
+        height: parent.height
+        model: collectiblesModel.filteredFlatModel
+        cacheBuffer: 0
+        delegate: Item {
+            width: ListView.view.width
+            height: 40
+            property string _k: model.key
+            property int _c: model.chainId
+            property string _n: model.name
+            property int _b: model.balance
+            property url _ic: model.iconUrl ?? ""
+            Component.onCompleted: bench.onDelegateCreated(1)
+            Component.onDestruction: bench.onDelegateDestroyed(1)
+        }
+    }
+
+    Connections {
+        target: collectiblesModel
+        function onDataChanged(tl, br, roles) { bench.onDataChanged(0, tl.row, br.row) }
+        function onModelReset() { bench.onModelReset(0) }
+        function onRowsInserted() { bench.onRowsInserted(0) }
+        function onRowsRemoved() { bench.onRowsRemoved(0) }
+    }
+
+    Connections {
+        target: collectiblesModel.filteredFlatModel
+        function onDataChanged(tl, br, roles) { bench.onDataChanged(1, tl.row, br.row) }
+        function onModelReset() { bench.onModelReset(1) }
+        function onRowsInserted() { bench.onRowsInserted(1) }
+        function onRowsRemoved() { bench.onRowsRemoved(1) }
+    }
+
+    Connections {
+        target: bench
+        function onRequestRelayout() {
+            groupedView.forceLayout()
+            flatView.forceLayout()
+            bench.reportCounts(collectiblesModel.filteredFlatModel.rowCount(),
+                               collectiblesModel.rowCount())
+        }
+    }
+
+    Timer {
+        interval: 16
+        running: true
+        repeat: true
+        onTriggered: bench.onStallTick()
+    }
+
+    Timer {
+        interval: 50
+        running: true
+        repeat: false
+        onTriggered: bench.onSceneReady()
+    }
+}

--- a/test/nim/benchmarks/collectibles_selector_scene.qml
+++ b/test/nim/benchmarks/collectibles_selector_scene.qml
@@ -1,0 +1,242 @@
+// RED scene: the real CollectiblesSelectionAdaptor proxy chain driving two REAL
+// ListViews, the way the send modal's collectibles picker consumes it.
+//
+//   adaptor.model           -> grouped ListView (sections + per-group subitems
+//                              count, mirroring SearchableCollectiblesPanel)
+//   adaptor.filteredFlatModel-> flat ListView (key/chainId/name/balance/iconUrl,
+//                              the shape deep-link resolution + delegates read)
+//
+// The universe is the user's REAL shape: a large GLOBAL collectibles set, but the
+// probed account owns only ~30. Ownership is spread so three probe accounts each
+// own ~30 and the bulk is owned by a whale account -- so an account switch keeps
+// the OUTPUT at ~30 while the adaptor still re-filters O(GLOBAL) rows (the RED
+// cost this bench exposes).
+//
+// The Nim harness (collectibles_selector_bench.nim) calls the scenario functions
+// and reads the models' granular signal counts + delegate churn forwarded to the
+// native `bench` object.
+
+import QtQuick
+import QtQuick.Window
+import QtQml.Models
+
+import AppLayouts.Wallet.adaptors
+
+import QtModelsToolkit
+import SortFilterProxyModel
+
+import utils
+
+Window {
+    id: root
+    width: 480
+    height: 900
+    visible: true // realize the offscreen surface so the ListViews create delegates
+
+    readonly property var probeAccounts: ["acc_0", "acc_1", "acc_2"]
+    readonly property string whaleAccount: "acc_whale"
+    readonly property var chains: [1, 10, 42161, 8453, 56]
+
+    property int ownedPerAccount: 30
+
+    // ownerOf(i): first `ownedPerAccount*probeAccounts.length` items are split
+    // among the probe accounts (~30 each); the rest belong to the whale. Keeps
+    // every probe account's OWNED output ~constant while GLOBAL scales.
+    function ownerOf(i) {
+        const probed = root.probeAccounts.length * root.ownedPerAccount
+        if (i < probed)
+            return root.probeAccounts[Math.floor(i / root.ownedPerAccount)]
+        return root.whaleAccount
+    }
+
+    function makeRow(i) {
+        const isComm = (i % 10 === 0)          // ~10% community collectibles
+        const comm = Math.floor(i / 300)       // a community spans 300 items
+        const coll = Math.floor(i / 4)         // ~4 items per collection
+        return {
+            key: "col_" + i,
+            chainId: root.chains[i % root.chains.length],
+            contractAddress: "contract_" + coll,
+            collectionUid: isComm ? ("ccoll_" + Math.floor(i / 40)) : ("coll_" + coll),
+            collectionName: isComm ? ("CCollection " + Math.floor(i / 40)) : ("Collection " + coll),
+            name: "Collectible " + i,
+            tokenId: "" + i,
+            mediaUrl: "",
+            imageUrl: "",
+            communityId: isComm ? ("community_" + comm) : "",
+            communityName: isComm ? ("Community " + comm) : "",
+            communityImage: "",
+            communityPrivilegesLevel: Constants.TokenPrivilegesLevel.Community,
+            soulbound: false,
+            tokenType: 2,
+            ownership: [{ accountAddress: root.ownerOf(i), balance: 1 }]
+        }
+    }
+
+    // Raw source model, mutated by the append / balance-update scenarios.
+    ListModel { id: collectiblesSrc }
+
+    function fillSource(n) {
+        const rows = []
+        for (let i = 0; i < n; i++)
+            rows.push(root.makeRow(i))
+        collectiblesSrc.clear()
+        collectiblesSrc.append(rows)
+    }
+
+    ListModel {
+        id: netSrc
+        Component.onCompleted: {
+            const names = { 1: "Mainnet", 10: "Optimism", 42161: "Arbitrum", 8453: "Base", 56: "BSC" }
+            const rows = []
+            for (const c of root.chains)
+                rows.push({ chainId: c, chainName: names[c], iconUrl: "network/ethereum" })
+            append(rows)
+        }
+    }
+
+    property string currentAccount: "acc_0"
+    property var currentChainIds: []
+
+    CollectiblesSelectionAdaptor {
+        id: adaptor
+        accountKey: root.currentAccount
+        enabledChainIds: root.currentChainIds
+        networksModel: netSrc
+        // mirror SendModalHandler: soulbound items filtered out before the adaptor
+        collectiblesModel: SortFilterProxyModel {
+            sourceModel: collectiblesSrc
+            filters: ValueFilter { roleName: "soulbound"; value: false }
+        }
+        filterCommunityOwnerAndMasterTokens: true
+    }
+
+    // --- grouped view: sections + per-group subitem count (panel shape) --------
+    ListView {
+        id: groupedView
+        width: parent.width / 2
+        height: parent.height
+        model: adaptor.model
+        cacheBuffer: 0
+        delegate: Item {
+            width: ListView.view.width
+            height: 40
+            property string _g: model.groupName
+            property string _t: model.type
+            property url _i: model.icon
+            // realize the nested submodel object (ModelCount), like the panel's
+            // `subitemsCount` -- without drilling into every subitem delegate
+            property int _sc: model.subitems ? model.subitems.ModelCount.count : 0
+            Component.onCompleted: bench.onDelegateCreated(0)
+            Component.onDestruction: bench.onDelegateDestroyed(0)
+        }
+    }
+
+    // --- flat view: the input-shaped rows deep-link resolution reads -----------
+    ListView {
+        id: flatView
+        anchors.left: groupedView.right
+        width: parent.width / 2
+        height: parent.height
+        model: adaptor.filteredFlatModel
+        cacheBuffer: 0
+        delegate: Item {
+            width: ListView.view.width
+            height: 40
+            property string _k: model.key
+            property int _c: model.chainId
+            property string _n: model.name
+            property int _b: model.balance
+            property url _ic: model.iconUrl ?? ""
+            Component.onCompleted: bench.onDelegateCreated(1)
+            Component.onDestruction: bench.onDelegateDestroyed(1)
+        }
+    }
+
+    Connections {
+        target: adaptor.model
+        function onDataChanged(tl, br, roles) { bench.onDataChanged(0, tl.row, br.row) }
+        function onModelReset() { bench.onModelReset(0) }
+        function onRowsInserted() { bench.onRowsInserted(0) }
+        function onRowsRemoved() { bench.onRowsRemoved(0) }
+    }
+
+    Connections {
+        target: adaptor.filteredFlatModel
+        function onDataChanged(tl, br, roles) { bench.onDataChanged(1, tl.row, br.row) }
+        function onModelReset() { bench.onModelReset(1) }
+        function onRowsInserted() { bench.onRowsInserted(1) }
+        function onRowsRemoved() { bench.onRowsRemoved(1) }
+    }
+
+    // --- scenario driver -------------------------------------------------------
+    function outputCounts() {
+        return [adaptor.filteredFlatModel.rowCount(), adaptor.model.rowCount()]
+    }
+
+    // 0 = build (fillSource with the requested size); others mutate in place.
+    function runScenario(kind, arg) {
+        switch (kind) {
+        case 0: // initial build
+            root.currentAccount = "acc_0"
+            root.currentChainIds = []
+            root.fillSource(arg)
+            break
+        case 1: // account switch
+            root.currentAccount = (root.currentAccount === "acc_0") ? "acc_1" : "acc_0"
+            break
+        case 2: // enabledChainIds change
+            root.currentChainIds = (root.currentChainIds.length === 0) ? [1, 10] : []
+            break
+        case 3: { // batch append of 50 rows owned by the current probe account
+            const start = collectiblesSrc.count
+            const rows = []
+            for (let i = 0; i < 50; i++) {
+                const r = root.makeRow(start + i)
+                r.ownership = [{ accountAddress: root.currentAccount, balance: 1 }]
+                rows.push(r)
+            }
+            collectiblesSrc.append(rows)
+            break
+        }
+        case 4: { // single ownership balance update on a displayed collectible
+            // bump the ERC-1155 balance of the first item owned by the current
+            // account -> its SumAggregator recomputes and fans through the chain
+            for (let i = 0; i < collectiblesSrc.count; i++) {
+                const own = collectiblesSrc.get(i).ownership
+                if (own.count > 0 && own.get(0).accountAddress === root.currentAccount) {
+                    own.setProperty(0, "balance", own.get(0).balance + 1)
+                    break
+                }
+            }
+            break
+        }
+        }
+    }
+
+    function relayout() {
+        groupedView.forceLayout()
+        flatView.forceLayout()
+        bench.reportCounts(adaptor.filteredFlatModel.rowCount(), adaptor.model.rowCount())
+    }
+
+    Connections {
+        target: bench
+        function onRequestScenario(kind, arg) { root.runScenario(kind, arg) }
+        function onRequestRelayout() { root.relayout() }
+    }
+
+    Timer {
+        interval: 16
+        running: true
+        repeat: true
+        onTriggered: bench.onStallTick()
+    }
+
+    Timer {
+        interval: 50
+        running: true
+        repeat: false
+        onTriggered: bench.onSceneReady()
+    }
+}

--- a/test/nim/benchmarks/send_handler_adaptors_scene.qml
+++ b/test/nim/benchmarks/send_handler_adaptors_scene.qml
@@ -1,0 +1,329 @@
+// Real-adaptor scene for the send modal's HANDLER-side cost. SendModalHandler
+// eagerly builds three adaptors when the modal opens; only the recipient/accounts
+// ones feed the initially-visible ASSETS tab, while CollectiblesSelectionAdaptor
+// (a LeftJoin + SFPM + nested per-group ObjectProxyModel chain over the full
+// cross-chain collectibles model) is pure waste in the open window.
+//
+// This scene instantiates each adaptor with REALISTIC stub inputs and times:
+//  - createObject wall (the synchronous structural build the open pays),
+//  - the GUI-thread block via a 16ms stall monitor,
+//  - time-until-populated ("settle"): keep pumping events until the adaptor's
+//    output row counts stop changing (ObjectProxyModel chains build per-row and
+//    per-group submodels which may land after createObject returns).
+//
+// Collectibles are measured at 200 / 1000 / 3000 items across 5 chains, ~40%
+// community collectibles (exercises the expensive nested community->collection
+// regrouping), all owned by the probed account so nothing is filtered out.
+//
+// NOTE: stub-model ids carry a `Src` suffix so they never collide with the
+// adaptor property names they feed (e.g. `networksModel: netSrc`); a matching
+// name would self-reference the adaptor's own (still-undefined) property.
+
+import QtQuick
+import QtQml.Models
+
+import StatusQ.Core.Theme
+
+import AppLayouts.Wallet.adaptors
+
+import QtModelsToolkit
+import SortFilterProxyModel
+
+import utils
+
+Item {
+    id: root
+    width: 400
+    height: 400
+    visible: true
+
+    readonly property string probedAccount: "acc_0"
+    readonly property var chains: [1, 10, 42161, 8453, 56]
+
+    // --- collectibles source models (raw, prebuilt; not part of measured cost) ---
+    function genCollectibles(model, n) {
+        const rows = []
+        for (let i = 0; i < n; i++) {
+            const isComm = (i % 5 < 2) // ~40% community collectibles
+            const g = Math.floor(i / 8) // ~8 items per collection
+            const comm = Math.floor(i / 40) // community groups
+            rows.push({
+                key: "col_" + i,
+                symbol: "C" + i,
+                chainId: root.chains[i % root.chains.length],
+                contractAddress: "contract_" + g,
+                collectionUid: "collection_" + g,
+                collectionName: "Collection " + g,
+                name: "Collectible " + i,
+                mediaUrl: "",
+                imageUrl: "",
+                communityId: isComm ? ("community_" + comm) : "",
+                communityName: isComm ? ("Community " + comm) : "",
+                communityImage: "",
+                communityPrivilegesLevel: Constants.TokenPrivilegesLevel.Community,
+                soulbound: false,
+                tokenType: 2,
+                ownership: [{ accountAddress: root.probedAccount, balance: 1 }]
+            })
+        }
+        model.append(rows)
+    }
+
+    ListModel { id: collectibles200Src; Component.onCompleted: root.genCollectibles(this, 200) }
+    ListModel { id: collectibles1000Src; Component.onCompleted: root.genCollectibles(this, 1000) }
+    ListModel { id: collectibles3000Src; Component.onCompleted: root.genCollectibles(this, 3000) }
+
+    // --- networks (LeftJoin right side) ---
+    ListModel {
+        id: netSrc
+        Component.onCompleted: {
+            const names = { 1: "Mainnet", 10: "Optimism", 42161: "Arbitrum", 8453: "Base", 56: "BSC" }
+            const rows = []
+            for (const c of root.chains)
+                rows.push({ chainId: c, chainName: names[c], iconUrl: "network/ethereum",
+                            chainColor: "#627EEA", shortName: names[c], layer: (c === 1 ? 1 : 2) })
+            append(rows)
+        }
+    }
+
+    // --- accounts / assets / recipients stubs (for the other two adaptors) ---
+    ListModel {
+        id: accountsSrc
+        Component.onCompleted: {
+            const rows = []
+            for (let i = 0; i < 15; i++)
+                rows.push({ address: "acc_" + i, name: "Account " + i, color: "#C78F67",
+                            colorId: "camel", emoji: "🔑", ens: "acc" + i + ".eth",
+                            canSend: true, position: i, walletType: "key",
+                            currencyBalance: { amount: 1000 - i * 10, symbol: "USD", displayDecimals: 2, stripTrailingZeroes: false },
+                            migratedToColdWallet: false })
+            append(rows)
+        }
+    }
+
+    ListModel {
+        id: assetsSrc
+        Component.onCompleted: {
+            const rows = []
+            for (let t = 0; t < 50; t++) {
+                const balances = []
+                for (const c of root.chains)
+                    balances.push({ chainId: c, account: "acc_0", balance: "1000", rawBalance: "1000000000000000000",
+                                    iconUrl: "network/ethereum" })
+                rows.push({ key: "tok_" + t, tokensKey: "tok_" + t, symbol: "TK" + t, name: "Token " + t,
+                            decimals: 18, communityId: "",
+                            marketDetails: { currencyPrice: { amount: 1.0, symbol: "USD" } },
+                            currencyBalance: { amount: 100, symbol: "USD", displayDecimals: 2, stripTrailingZeroes: false },
+                            balances: balances })
+            }
+            append(rows)
+        }
+    }
+
+    ListModel {
+        id: tokenGroupsSrc
+        Component.onCompleted: {
+            const rows = []
+            for (let t = 0; t < 50; t++)
+                rows.push({ key: "tok_" + t, symbol: "TK" + t, name: "Token " + t, decimals: 18 })
+            append(rows)
+        }
+    }
+
+    ListModel {
+        id: savedSrc
+        Component.onCompleted: {
+            const rows = []
+            for (let i = 0; i < 50; i++)
+                rows.push({ address: "saved_" + i, name: "Saved " + i, colorId: "army", emoji: "🚗",
+                            ens: "saved" + i + ".eth" })
+            append(rows)
+        }
+    }
+
+    ListModel {
+        id: recentsSrc
+        Component.onCompleted: {
+            const rows = []
+            for (let i = 0; i < 100; i++)
+                rows.push({ activityEntry: { sender: "acc_0", recipient: "recent_" + i,
+                                             txType: Constants.TransactionType.Send } })
+            append(rows)
+        }
+    }
+
+    function fnFmt(a, s, o) { return "" }
+    function fnFmtBig(a, s, d) { return "" }
+
+    // --- adaptor catalog ---------------------------------------------------
+    Component {
+        id: collectiblesComp
+        CollectiblesSelectionAdaptor {
+            required property var source
+            accountKey: root.probedAccount
+            enabledChainIds: [] // all chains -> full pipeline (per-row build is chain-independent)
+            networksModel: netSrc
+            // mirror SendModalHandler: soulbound items filtered out before the adaptor
+            collectiblesModel: SortFilterProxyModel {
+                sourceModel: source
+                filters: ValueFilter { roleName: "soulbound"; value: false }
+            }
+            filterCommunityOwnerAndMasterTokens: true
+        }
+    }
+
+    Component {
+        id: accountsComp
+        WalletAccountsSelectorAdaptor {
+            accounts: accountsSrc
+            assetsModel: assetsSrc
+            tokenGroupsModel: tokenGroupsSrc
+            filteredFlatNetworksModel: netSrc
+            selectedGroupKey: "tok_0"
+            selectedNetworkChainId: 1
+            fnFormatCurrencyAmountFromBigInt: root.fnFmtBig
+        }
+    }
+
+    Component {
+        id: recipientsComp
+        RecipientViewAdaptor {
+            savedAddressesModel: savedSrc
+            accountsModel: accountsSrc
+            recentRecipientsModel: recentsSrc
+            selectedRecipientType: 0
+            searchPattern: ""
+            selectedSenderAddress: ""
+        }
+    }
+
+    // Mirrors the GREEN fix in SendModalHandler: the collectibles adaptor lives
+    // behind a Loader gated on `collectiblesNeeded`. Inactive at open (assets tab),
+    // activated when the user first opens the collectibles tab.
+    Component {
+        id: deferredCollectiblesComp
+        Loader {
+            property var source
+            active: false
+            sourceComponent: CollectiblesSelectionAdaptor {
+                accountKey: root.probedAccount
+                enabledChainIds: []
+                networksModel: netSrc
+                collectiblesModel: SortFilterProxyModel {
+                    sourceModel: source
+                    filters: ValueFilter { roleName: "soulbound"; value: false }
+                }
+                filterCommunityOwnerAndMasterTokens: true
+            }
+        }
+    }
+
+    function createFor(kind) {
+        switch (kind) {
+        case 0: return collectiblesComp.createObject(root, { source: collectibles200Src })
+        case 1: return collectiblesComp.createObject(root, { source: collectibles1000Src })
+        case 2: return collectiblesComp.createObject(root, { source: collectibles3000Src })
+        case 3: return accountsComp.createObject(root)
+        case 4: return recipientsComp.createObject(root)
+        }
+        return null
+    }
+
+    // output row counts used for settle detection (sum must stabilize)
+    function outputCounts(kind, obj) {
+        switch (kind) {
+        case 0: case 1: case 2:
+            return [obj.filteredFlatModel.rowCount(), obj.model.rowCount()]
+        case 3: return [obj.processedWalletAccounts.rowCount(), 0]
+        case 4: return [obj.recipientsModel.rowCount(), 0]
+        case 5: return obj.item ? [obj.item.filteredFlatModel.rowCount(), obj.item.model.rowCount()] : [0, 0]
+        }
+        return [0, 0]
+    }
+
+    property var _held: []
+
+    // settle state
+    property var _settleObj: null
+    property int _settleKind: -1
+    property real _settleStart: 0
+    property int _settleLastSum: -1
+    property int _settleStable: 0
+
+    function runKind(kind) {
+        // Deferred collectibles: createObject is the OPEN-window cost (Loader
+        // inactive -> adaptor not built); the settle timing then measures the
+        // FIRST-TAB-OPEN cost when the gate flips active.
+        if (kind === 5) {
+            const dt0 = bench.nowMs()
+            const loader = deferredCollectiblesComp.createObject(root, { source: collectibles3000Src })
+            const dt1 = bench.nowMs()
+            if (!loader) { bench.reportInstantiation(kind, -1, "no-comp"); bench.reportSettle(kind, 0, 0, 0); return }
+            _held.push(loader)
+            bench.reportInstantiation(kind, dt1 - dt0, "") // open-window cost (~0)
+
+            _settleObj = loader
+            _settleKind = kind
+            _settleStart = bench.nowMs()
+            _settleLastSum = -1
+            _settleStable = 0
+            loader.active = true // user opens the collectibles tab
+            settleTimer.restart()
+            return
+        }
+
+        const t0 = bench.nowMs()
+        const obj = createFor(kind)
+        const t1 = bench.nowMs()
+        if (!obj) { bench.reportInstantiation(kind, -1, "no-comp"); bench.reportSettle(kind, 0, 0, 0); return }
+        _held.push(obj)
+        bench.reportInstantiation(kind, t1 - t0, "")
+
+        // begin settle polling
+        _settleObj = obj
+        _settleKind = kind
+        _settleStart = t1
+        _settleLastSum = -1
+        _settleStable = 0
+        settleTimer.restart()
+    }
+
+    Timer {
+        id: settleTimer
+        interval: 1
+        repeat: true
+        onTriggered: {
+            const c = root.outputCounts(root._settleKind, root._settleObj)
+            const sum = c[0] + c[1]
+            if (sum === root._settleLastSum) {
+                root._settleStable++
+                if (root._settleStable >= 8 || (bench.nowMs() - root._settleStart) > 6000) {
+                    settleTimer.stop()
+                    bench.reportSettle(root._settleKind, bench.nowMs() - root._settleStart, c[0], c[1])
+                }
+            } else {
+                root._settleLastSum = sum
+                root._settleStable = 0
+            }
+        }
+    }
+
+    Connections {
+        target: bench
+        function onRequestKind(kind) { root.runKind(kind) }
+    }
+
+    Timer {
+        interval: 16
+        running: true
+        repeat: true
+        onTriggered: bench.onStallTick()
+    }
+
+    Timer {
+        interval: 50
+        running: true
+        repeat: false
+        onTriggered: bench.onSceneReady()
+    }
+}

--- a/test/nim/benchmarks/send_handler_lookup_scene.qml
+++ b/test/nim/benchmarks/send_handler_lookup_scene.qml
@@ -1,0 +1,85 @@
+// Handler-lookup scene. SendModalHandler / SimpleSendModal run a set of
+// SQUtils.ModelUtils lookups over the wallet's tokenGroups / collectibles models
+// around open (SendModalHandler.qml sendToken :263, openTokenPaymentRequest :307,
+// marketDataNotAvailable :487; SimpleSendModal isSelectedAssetAvailableInSelected
+// Network :283). This scene drives the REAL ModelUtils / ModelQuery against an
+// injected tokenGroups-shaped model in the distinct fetch regimes, so their cost
+// is attributed against the model size:
+//   getByKey_norole      = getByKey(m,"key",v)        -> all-roles get of 1 matched row
+//   getByKey_role        = getByKey(m,"key",v,"symbol") -> single-role get of 1 row
+//   get_loop_allroles    = openTokenPaymentRequest's for-loop of get(m,i) (all roles)
+//   getFirstModelEntryIf = full scan, all-roles get + predicate per row (worst case)
+//   modelToFlatArray     = modelToFlatArray(m,"chainId") (role-restricted, fixed)
+// Timing is taken via the native bench clock (excludes model construction).
+
+import QtQuick
+import QtQuick.Window
+import StatusQ.Core.Utils 0.1 as SQUtils
+import QtModelsToolkit as QtMT
+
+Window {
+    id: root
+    width: 320
+    height: 480
+    visible: true
+
+    property int reps: 5
+
+    // The key of the LAST row, so index-based scans (indexOf / get-loop / predicate)
+    // pay the full O(N) walk -- the worst case the handler hits on a miss/last hit.
+    function lastKey() { return "grp_" + (lookupModel.rowCount() - 1) }
+
+    function do_getByKey_norole() {
+        return SQUtils.ModelUtils.getByKey(lookupModel, "key", root.lastKey())
+    }
+    function do_getByKey_role() {
+        return SQUtils.ModelUtils.getByKey(lookupModel, "key", root.lastKey(), "symbol")
+    }
+    function do_get_loop_allroles() {
+        // openTokenPaymentRequest: for i { get(model, i); read fields } until match.
+        const target = root.lastKey()
+        const count = lookupModel.rowCount()
+        let hit = null
+        for (let i = 0; i < count; i++) {
+            const g = QtMT.ModelQuery.get(lookupModel, i)  // all roles per row
+            if (g["key"] === target) { hit = g; break }
+        }
+        return hit
+    }
+    function do_getFirstModelEntryIf() {
+        return SQUtils.ModelUtils.getFirstModelEntryIf(lookupModel, (g) => g.key === "__none__")
+    }
+    function do_modelToFlatArray() {
+        return SQUtils.ModelUtils.modelToFlatArray(lookupModel, "chainId")
+    }
+
+    function runOne(name, fn) {
+        let best = Number.MAX_VALUE
+        for (let r = 0; r < root.reps; r++) {
+            const t0 = bench.nowMs()
+            fn()
+            const t1 = bench.nowMs()
+            if (t1 - t0 < best) best = t1 - t0
+        }
+        bench.reportLookup(name, best)
+    }
+
+    Connections {
+        target: bench
+        function onRequestLookups() {
+            runOne("getByKey_norole", root.do_getByKey_norole)
+            runOne("getByKey_role", root.do_getByKey_role)
+            runOne("get_loop_allroles", root.do_get_loop_allroles)
+            runOne("getFirstModelEntryIf", root.do_getFirstModelEntryIf)
+            runOne("modelToFlatArray", root.do_modelToFlatArray)
+            bench.lookupsDone()
+        }
+    }
+
+    Timer {
+        interval: 50
+        running: true
+        repeat: false
+        onTriggered: bench.onSceneReady()
+    }
+}

--- a/test/nim/benchmarks/send_modal_instantiation_scene.qml
+++ b/test/nim/benchmarks/send_modal_instantiation_scene.qml
@@ -1,0 +1,136 @@
+// Real-instantiation scene for the send modal. Unlike send_modal_open_scene (which
+// drives the Nim picker model in a synthetic sheet), this loads the ACTUAL
+// SimpleSendModal QML tree (and its major subtrees) under an offscreen engine with
+// StatusQ linked + the app import paths (ui/StatusQ/src, ui/imports, ui/app), and
+// times Component.createObject (the structural instantiation cost) + time-to-opened
+// + the GUI-thread block via a 16ms stall monitor.
+//
+// The dominant hypothesis for the ~1s device-side open is QML component
+// instantiation of this tree; this scene measures it directly and bisects it by
+// timing each major subtree's createObject standalone.
+
+import QtQuick
+import QtQuick.Window
+import QtQml.Models
+
+import StatusQ.Core.Theme
+
+import AppLayouts.Wallet.popups.simpleSend
+import AppLayouts.Wallet.panels
+import AppLayouts.Wallet.controls
+import AppLayouts.Wallet.views
+import shared.popups.send.views as SendViews
+
+Window {
+    id: root
+    width: 800
+    height: 1000
+    visible: true
+
+    // Empty stand-in models: instantiation of a list is structural (delegates are
+    // realized lazily on show), so model SIZE does not change the createObject cost
+    // measured here; the data-dependent handler-JS cost is measured separately in
+    // send_handler_lookup_bench.
+    ListModel { id: emptyModel }
+
+    function fnFmt(a, s, o) { return "" }
+
+    // --- component catalog: the full modal + its major subtrees ---------------
+    Component {
+        id: fullModalComp
+        SimpleSendModal {
+            accountsModel: emptyModel
+            assetsModel: emptyModel
+            groupedAccountAssetsModel: emptyModel
+            flatCollectiblesModel: emptyModel
+            collectiblesModel: emptyModel
+            networksModel: emptyModel
+            recipientsModel: emptyModel
+            recipientsFilterModel: emptyModel
+            currentCurrency: "USD"
+            fnFormatCurrencyAmount: root.fnFmt
+            fnResolveENS: function() {}
+        }
+    }
+
+    Component {
+        id: sendHeaderComp
+        SendModalHeader {
+            networksModel: emptyModel
+            assetsModel: emptyModel
+            collectiblesModel: emptyModel
+            formatCurrencyBalance: root.fnFmt
+        }
+    }
+
+    Component {
+        id: stickyHeaderComp
+        StickySendModalHeader {
+            networksModel: emptyModel
+            assetsModel: emptyModel
+            collectiblesModel: emptyModel
+            formatCurrencyBalance: root.fnFmt
+        }
+    }
+
+    Component {
+        id: amountComp
+        SendViews.AmountToSend {}
+    }
+
+    Component {
+        id: footerComp
+        SendModalFooter {}
+    }
+
+    function compFor(kind) {
+        switch (kind) {
+        case 0: return fullModalComp
+        case 1: return sendHeaderComp
+        case 2: return stickyHeaderComp
+        case 3: return amountComp
+        case 4: return footerComp
+        }
+        return null
+    }
+
+    property var _held: []   // keep created objects alive so GC doesn't skew timings
+
+    // Create `kind`, timing createObject (the structural instantiation cost the
+    // synchronous open pays). `opened` is not driven: offscreen the Popup enter
+    // transition never completes, so create time is the measurable term.
+    function runKind(kind) {
+        const comp = compFor(kind)
+        if (!comp) { bench.reportInstantiation(kind, -1, "no-comp"); return }
+
+        const t0 = bench.nowMs()
+        const obj = comp.createObject(root)
+        const t1 = bench.nowMs()
+
+        if (!obj) {
+            bench.reportInstantiation(kind, -1, comp.errorString())
+            return
+        }
+        _held.push(obj)
+        bench.reportInstantiation(kind, t1 - t0, "")
+    }
+
+    Connections {
+        target: bench
+        function onRequestKind(kind) { root.runKind(kind) }
+    }
+
+    Timer {
+        interval: 16
+        running: true
+        repeat: true
+        onTriggered: bench.onStallTick()
+    }
+
+    Timer {
+        interval: 50
+        running: true
+        repeat: false
+        onTriggered: bench.onSceneReady()
+    }
+}

--- a/test/nim/benchmarks/send_modal_open_scene.qml
+++ b/test/nim/benchmarks/send_modal_open_scene.qml
@@ -1,0 +1,147 @@
+// SimpleSendModal-open benchmark scene. Models what the send token picker does
+// when the modal opens: a sheet that animates in (the "open" window) while the
+// handler synchronously creates + seeds the REAL Nim send picker model
+// (TokenSelectorModel, Owned mode) the way SendModalHandler does at open
+// (createTokenSelectorModel(0) -> buildOwnedSource -> setOwnedSource +
+// updateSendSectionNames). A 16ms stall monitor turns any GUI-thread block during
+// the open window into a dropped-frame tick delta.
+//
+// The token field's dropdown is a real ListView bound DIRECTLY to the send picker
+// model (owned rows + a nested Repeater over the per-chain `balances` chips, the
+// two levels the send token delegate renders). It is Loader-gated: CLOSED during
+// the modal-open window (a real dropdown realizes no delegates until the user
+// opens it) and opened as a separate interaction, so the two costs are measured
+// apart: (1) the on-open model-seed burst, (2) the dropdown-open delegate churn.
+//
+// The Nim driver drives both regimes on the SAME real model + scene per owned-set
+// size and records what the render loop actually experiences.
+
+import QtQuick
+import QtQuick.Window
+
+Window {
+    id: root
+    width: 556
+    height: 900
+    visible: true // realize the offscreen surface so the ListView creates delegates
+
+    property bool paneOpen: false
+    property bool dropdownOpen: false
+
+    // Continuous activity so the render/event loop is genuinely busy during the
+    // open window (the real modal animates its height while data lands).
+    Rectangle {
+        id: spinner
+        width: 24; height: 24; radius: 12
+        color: "#4360df"
+        x: 8
+        NumberAnimation on rotation {
+            from: 0; to: 360; duration: 800
+            loops: Animation.Infinite; running: true
+        }
+    }
+
+    // The "modal" sheet: slides up when opened, matching StatusDialog's bottom sheet.
+    Rectangle {
+        id: pane
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: parent.height * 0.85
+        color: "#101014"
+        y: root.paneOpen ? parent.height - height : parent.height
+        Behavior on y { NumberAnimation { duration: 320; easing.type: Easing.OutCubic } }
+
+        // The token field (always present at open); its dropdown list is lazy.
+        Rectangle {
+            id: tokenField
+            anchors { left: parent.left; right: parent.right; top: parent.top; margins: 12 }
+            height: 56
+            radius: 8
+            color: "#1c1c22"
+        }
+
+        Loader {
+            id: dropdownLoader
+            anchors { left: parent.left; right: parent.right; margins: 12 }
+            anchors.top: tokenField.bottom
+            anchors.bottom: parent.bottom
+            active: root.dropdownOpen
+            sourceComponent: dropdownComponent
+        }
+    }
+
+    Component {
+        id: dropdownComponent
+        ListView {
+            id: listView
+            model: sendPickerModel
+            cacheBuffer: 0
+            delegate: Rectangle {
+                width: ListView.view.width
+                height: 48
+                color: "transparent"
+                // Roles the send token row binds.
+                property string _k: model.key
+                property string _n: model.name
+                property string _s: model.symbol
+                property string _l: model.logoUri
+                property real _cb: model.currentBalance
+                property real _fb: model.currencyBalance
+                property string _sec: model.sectionName
+                Component.onCompleted: bench.onDelegateCreated()
+                Component.onDestruction: bench.onDelegateDestroyed()
+                // The per-chain balance chips the delegate renders (nested submodel).
+                Row {
+                    Repeater {
+                        model: _balances
+                        delegate: Item {
+                            width: 20; height: 20
+                            property int _c: model.chainId
+                            property string _i: model.iconUrl
+                            property real _b: model.balance
+                            Component.onCompleted: bench.onChipCreated()
+                        }
+                    }
+                }
+                property var _balances: model.balances
+            }
+        }
+    }
+
+    // 16ms stall monitor: each tick reports to the driver, which computes the
+    // tick-to-tick delta. A synchronous GUI-thread block starves this timer.
+    Timer {
+        interval: 16
+        running: true
+        repeat: true
+        onTriggered: bench.onStallTick()
+    }
+
+    Connections {
+        target: sendPickerModel
+        function onModelReset() { bench.onModelReset() }
+        function onRowsInserted() { bench.onRowsInserted() }
+        function onRowsRemoved() { bench.onRowsRemoved() }
+        function onDataChanged(topLeft, bottomRight, roles) {
+            bench.onDataChanged(topLeft.row, bottomRight.row)
+        }
+    }
+
+    Connections {
+        target: bench
+        function onRequestOpen() { root.paneOpen = true }
+        function onRequestDropdownOpen() { root.dropdownOpen = true }
+        function onRequestDropdownClose() { root.dropdownOpen = false }
+        function onRequestRelayout() {
+            if (dropdownLoader.item)
+                dropdownLoader.item.forceLayout()
+        }
+    }
+
+    Timer {
+        interval: 50
+        running: true
+        repeat: false
+        onTriggered: bench.onSceneReady()
+    }
+}

--- a/test/nim/benchmarks/swap_key_harvest_scene.qml
+++ b/test/nim/benchmarks/swap_key_harvest_scene.qml
@@ -1,0 +1,77 @@
+// Request-side harvest scene. SwapModal.rebuildGroupsForChain harvests the owned
+// groups' keys via SQUtils.ModelUtils.joinModelEntries(groupedAccountAssetsModel,
+// "key") -> modelToArray(model, ["key"]) -> QtMT.ModelQuery.get(model, i). The
+// all-roles get fetches EVERY role per row (incl. the "balances" submodel) and
+// marshals it to JS, even though only "key" is read. This scene measures that hot
+// loop in both regimes on the real ModelQuery against the injected owned model:
+//   mode 0 (all-roles)   = the old modelToArray
+//   mode 1 (single-role) = the fixed modelToArray (get(model, i, "key"))
+// Timing is taken via the native bench clock so it excludes model construction.
+
+import QtQuick
+import QtQuick.Window
+import QtModelsToolkit as QtMT
+
+Window {
+    id: root
+    width: 320
+    height: 480
+    visible: true
+
+    // reps harvests per invocation, so the Nim driver needs only one signal emit per
+    // mode (the offscreen engine is fragile under many signal round-trips); the
+    // reported time is the best single-pass wall time.
+    property int reps: 5
+
+    function harvestAllRoles() {
+        const count = ownedModel.rowCount()
+        const out = []
+        for (let i = 0; i < count; i++) {
+            const item = QtMT.ModelQuery.get(ownedModel, i)  // fetches EVERY role per row
+            if (item["key"] !== undefined)
+                out.push(item["key"])
+        }
+        return out.join("$$")
+    }
+
+    function harvestSingleRole() {
+        const count = ownedModel.rowCount()
+        const out = []
+        for (let i = 0; i < count; i++) {
+            const entry = QtMT.ModelQuery.get(ownedModel, i, "key")  // fetches only key
+            if (entry !== undefined)
+                out.push(entry)
+        }
+        return out.join("$$")
+    }
+
+    function measureMode(mode) {
+        let best = Number.MAX_VALUE
+        let joined = ""
+        for (let r = 0; r < root.reps; r++) {
+            const t0 = bench.nowMs()
+            joined = (mode === 0) ? root.harvestAllRoles() : root.harvestSingleRole()
+            const t1 = bench.nowMs()
+            if (t1 - t0 < best)
+                best = t1 - t0
+        }
+        bench.reportResult(mode, best, joined.length)
+    }
+
+    // One regime per process (harvestMode injected from the environment): the
+    // offscreen engine corrupts under an in-process all-roles -> single-role
+    // transition, so the parent runs this bench once per mode as a child process.
+    Connections {
+        target: bench
+        function onRequestHarvest() {
+            root.measureMode(harvestMode)
+        }
+    }
+
+    Timer {
+        interval: 50
+        running: true
+        repeat: false
+        onTriggered: bench.onSceneReady()
+    }
+}

--- a/test/nim/benchmarks/swap_modal_open_scene.qml
+++ b/test/nim/benchmarks/swap_modal_open_scene.qml
@@ -1,0 +1,101 @@
+// SwapModal-open benchmark scene. Models the real thing the picker sees when the
+// swap token selector opens: a panel that animates in (the "open" window) with a
+// ListView bound DIRECTLY to the real Nim `groupsForChainModel` (the
+// tokenGroupsForChainModel a swap uses, lazy-loaded, NoMarketDetails), plus a
+// looping animation and a 16ms stall monitor so a GUI-thread block during the
+// open window shows up as a dropped-frame tick delta.
+//
+// The Nim driver opens the panel and, mid-window, injects the by-chain completion
+// exactly as the token service does on the GUI thread (decode + build groups +
+// modelsUpdated), then re-runs it in the typed-handoff regime (build off-window,
+// only the model reset on-window). This scene measures what the ListView + render
+// loop actually experience in each regime.
+
+import QtQuick
+import QtQuick.Window
+
+Window {
+    id: root
+    width: 480
+    height: 900
+    visible: true // realize the offscreen surface so the ListView creates delegates
+
+    // Continuous activity so the render/event loop is genuinely busy during the
+    // open window (a real modal animates while data lands).
+    Rectangle {
+        id: spinner
+        width: 24; height: 24; radius: 12
+        color: "#4360df"
+        x: 8
+        NumberAnimation on rotation {
+            from: 0; to: 360; duration: 800
+            loops: Animation.Infinite; running: true
+        }
+    }
+
+    // The "modal" panel: slides up when opened, matching a sheet/modal enter.
+    Rectangle {
+        id: pane
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: parent.height * 0.85
+        color: "#101014"
+        y: root.paneOpen ? parent.height - height : parent.height
+        Behavior on y { NumberAnimation { duration: 320; easing.type: Easing.OutCubic } }
+
+        ListView {
+            id: listView
+            anchors.fill: parent
+            anchors.margins: 8
+            model: groupsForChainModel
+            cacheBuffer: 0
+            delegate: Rectangle {
+                width: ListView.view.width
+                height: 48
+                color: "transparent"
+                // Read the roles the swap token row binds.
+                property string _k: model.key
+                property string _n: model.name
+                property string _s: model.symbol
+                property string _l: model.logoUri
+                Component.onCompleted: bench.onDelegateCreated()
+                Component.onDestruction: bench.onDelegateDestroyed()
+            }
+        }
+    }
+
+    property bool paneOpen: false
+
+    // 16ms stall monitor: each tick reports to the driver, which computes the
+    // tick-to-tick delta. A synchronous GUI-thread block starves this timer, so
+    // the tick right after the block records the stall.
+    Timer {
+        interval: 16
+        running: true
+        repeat: true
+        onTriggered: bench.onStallTick()
+    }
+
+    Connections {
+        target: groupsForChainModel
+        function onModelReset() { bench.onModelReset() }
+        function onRowsInserted() { bench.onRowsInserted() }
+        function onRowsRemoved() { bench.onRowsRemoved() }
+        function onDataChanged(topLeft, bottomRight, roles) {
+            bench.onDataChanged(topLeft.row, bottomRight.row)
+        }
+    }
+
+    Connections {
+        target: bench
+        function onRequestOpen() { root.paneOpen = true }
+        function onRequestRelayout() { listView.forceLayout() }
+    }
+
+    Timer {
+        interval: 50
+        running: true
+        repeat: false
+        onTriggered: bench.onSceneReady()
+    }
+}

--- a/test/nim/collectibles_selector_bench.nim
+++ b/test/nim/collectibles_selector_bench.nim
@@ -1,0 +1,220 @@
+## RED baseline for the send modal's collectibles picker.
+##
+## The picker renders off CollectiblesSelectionAdaptor (ui/app/AppLayouts/Wallet/
+## adaptors/CollectiblesSelectionAdaptor.qml): a LeftJoin(networks) feeding an
+## ObjectProxyModel that builds THREE QObjects PER GLOBAL ROW (a delegate + a
+## per-row ownership SortFilterProxyModel + a SumAggregator), then a RangeFilter
+## (balance>=1) + sort + GroupingModel + a second ObjectProxyModel with nested
+## per-community GroupingModels. Its cost is O(GLOBAL collectibles universe) even
+## though the user owns ~30 per account.
+##
+## This bench loads the REAL adaptor (collectibles_selector_scene.qml) under an
+## offscreen engine with StatusQ linked, drives its `model` + `filteredFlatModel`
+## through two REAL ListViews, and measures the update classes the modal pays:
+##   build                - first fill of the GLOBAL universe (initial structural build)
+##   account_switch        - flip the probed account (re-filters O(GLOBAL) rows)
+##   chain_filter          - toggle enabledChainIds
+##   append_50             - paging churn: append 50 rows
+##   balance_update        - one ERC-1155 ownership balance bump on a shown row
+## For each: wall ms, worst 16ms-tick GUI stall, model resets/inserts/dataChanged
+## rows (grouped + flat), and delegate create/destroy churn.
+##
+## RED expectation (documented, not asserted as a target): build + account_switch
+## scale with the GLOBAL size, not the ~30 the account owns; a single balance
+## update fans a whole-model reset/dataChanged through the proxy chain and churns
+## delegates. The GREEN Nim terminal model (collectibles_selector_model_bench.nim)
+## flips these to O(displayed) with zero resets.
+##
+## Absolute host numbers sit below the device open, but the ATTRIBUTION RANKING
+## (a synchronous O(universe) build) transfers. Links StatusQ like the sibling
+## send benches.
+
+import os, times, strformat
+import nimqml
+from seaqt/qcoreapplication import QCoreApplication, processEvents
+import std/monotimes
+
+{.compile: "bench_statusq_register.cpp".}
+proc bench_registerStatusQTypes() {.importc.}
+
+type Row = object
+  size: int
+  scenario: string
+  wallMs: float
+  maxStallMs: float
+  # grouped model / flat model granular signal tallies
+  resetsG, resetsF: int
+  insertsG, insertsF: int
+  dcRowsG, dcRowsF: int
+  # ListView delegate churn (0 = grouped, 1 = flat)
+  delCreatedG, delDestroyedG: int
+  delCreatedF, delDestroyedF: int
+  countFlat, countGrouped: int
+  error: string
+
+QtObject:
+  type Bench = ref object of QObject
+    ready: bool
+    monitoring: bool
+    lastTickNs: float
+    maxStallMs: float
+    # per-model (0 grouped, 1 flat) tallies for the current window
+    resets: array[2, int]
+    inserts: array[2, int]
+    removes: array[2, int]
+    dcRows: array[2, int]
+    delCreated: array[2, int]
+    delDestroyed: array[2, int]
+    lastCountFlat: int
+    lastCountGrouped: int
+
+  proc newBench(): Bench =
+    new(result)
+    result.QObject.setup
+
+  proc requestScenario(self: Bench, kind: int, arg: int) {.signal.}
+  proc requestRelayout(self: Bench) {.signal.}
+
+  proc onSceneReady(self: Bench) {.slot.} = self.ready = true
+
+  proc nowMs(self: Bench): float {.slot.} =
+    (getMonoTime() - MonoTime()).inNanoseconds.float / 1_000_000.0
+
+  proc onDataChanged(self: Bench, which: int, top: int, bottom: int) {.slot.} =
+    if not self.monitoring: return
+    self.dcRows[which] += (bottom - top + 1)
+  proc onModelReset(self: Bench, which: int) {.slot.} =
+    if self.monitoring: inc self.resets[which]
+  proc onRowsInserted(self: Bench, which: int) {.slot.} =
+    if self.monitoring: inc self.inserts[which]
+  proc onRowsRemoved(self: Bench, which: int) {.slot.} =
+    if self.monitoring: inc self.removes[which]
+  proc onDelegateCreated(self: Bench, which: int) {.slot.} =
+    if self.monitoring: inc self.delCreated[which]
+  proc onDelegateDestroyed(self: Bench, which: int) {.slot.} =
+    if self.monitoring: inc self.delDestroyed[which]
+
+  proc reportCounts(self: Bench, flat: int, grouped: int) {.slot.} =
+    self.lastCountFlat = flat
+    self.lastCountGrouped = grouped
+
+  proc onStallTick(self: Bench) {.slot.} =
+    if not self.monitoring: return
+    let n = self.nowMs()
+    let delta = n - self.lastTickNs
+    if delta > self.maxStallMs: self.maxStallMs = delta
+    self.lastTickNs = n
+
+  proc resetWindow(self: Bench) =
+    self.maxStallMs = 0.0
+    for i in 0 .. 1:
+      self.resets[i] = 0; self.inserts[i] = 0; self.removes[i] = 0
+      self.dcRows[i] = 0; self.delCreated[i] = 0; self.delDestroyed[i] = 0
+  proc beginMonitor(self: Bench) =
+    self.resetWindow()
+    self.lastTickNs = self.nowMs()
+    self.monitoring = true
+  proc endMonitor(self: Bench) = self.monitoring = false
+
+  proc spinFor(self: Bench, ms: float) =
+    let deadline = self.nowMs() + ms
+    while self.nowMs() < deadline:
+      QCoreApplication.processEvents()
+
+proc formatTable(rows: seq[Row]): string =
+  result = "size\tscenario\twall_ms\tmax_stall_ms\tresetsG\tresetsF\tinsG\tinsF\tdcRowsG\tdcRowsF\tdelCreG\tdelDelG\tdelCreF\tdelDelF\tcountFlat\tcountGrouped\terror\n"
+  for r in rows:
+    result.add(&"{r.size}\t{r.scenario}\t{r.wallMs:.4f}\t{r.maxStallMs:.4f}\t{r.resetsG}\t{r.resetsF}\t{r.insertsG}\t{r.insertsF}\t{r.dcRowsG}\t{r.dcRowsF}\t{r.delCreatedG}\t{r.delDestroyedG}\t{r.delCreatedF}\t{r.delDestroyedF}\t{r.countFlat}\t{r.countGrouped}\t{r.error}\n")
+
+const scenarioNames = ["build", "account_switch", "chain_filter", "append_50", "balance_update"]
+const sizes = [200, 1000, 3000]
+
+when isMainModule:
+  putEnv("QT_QPA_PLATFORM", "offscreen")
+  let app = newQApplication()
+  bench_registerStatusQTypes()
+
+  let bench = newBench()
+  let engine = newQQmlApplicationEngine()
+  let base = getCurrentDir()
+  engine.addImportPath(base / "ui" / "StatusQ" / "src")
+  engine.addImportPath(base / "ui" / "imports")
+  engine.addImportPath(base / "ui" / "app")
+  engine.setRootContextProperty("bench", newQVariant(bench))
+
+  let sceneFile = base / "test" / "nim" / "benchmarks" / "collectibles_selector_scene.qml"
+  engine.loadData(readFile(sceneFile))
+
+  var spins = 0
+  while not bench.ready and spins < 500000:
+    QCoreApplication.processEvents(); inc spins
+  if not bench.ready:
+    echo "SKIP: collectibles selector scene did not load"
+    quit(0)
+
+  var rows: seq[Row] = @[]
+
+  # Drive one scenario: begin monitor, fire it, pump until the model row counts
+  # stabilize (the proxy chain lands per-row/per-group submodels after the call
+  # returns), force a layout so delegate churn is realized, record the window.
+  proc runScenario(size, kind, arg: int): Row =
+    bench.beginMonitor()
+    bench.spinFor(24)
+    let start = bench.nowMs()
+    bench.requestScenario(kind, arg)
+    # Settle: the proxy chain lands per-row/per-group submodels after the mutation
+    # returns. Pump + relayout until the accumulated signal/delegate activity stops
+    # changing for a stretch (quiescence), capped at 6s.
+    var lastActivity = -1
+    var stable = 0
+    while stable < 12 and (bench.nowMs() - start) < 6000:
+      QCoreApplication.processEvents()
+      bench.requestRelayout()
+      QCoreApplication.processEvents()
+      let activity = bench.dcRows[0] + bench.dcRows[1] + bench.inserts[0] +
+        bench.inserts[1] + bench.removes[0] + bench.removes[1] +
+        bench.delCreated[0] + bench.delCreated[1]
+      if activity == lastActivity: inc stable
+      else: (lastActivity = activity; stable = 0)
+    bench.spinFor(48)
+    bench.requestRelayout()
+    bench.spinFor(24)
+    bench.endMonitor()
+    result = Row(size: size, scenario: scenarioNames[kind],
+      wallMs: bench.nowMs() - start, maxStallMs: bench.maxStallMs,
+      resetsG: bench.resets[0], resetsF: bench.resets[1],
+      insertsG: bench.inserts[0], insertsF: bench.inserts[1],
+      dcRowsG: bench.dcRows[0], dcRowsF: bench.dcRows[1],
+      delCreatedG: bench.delCreated[0], delDestroyedG: bench.delDestroyed[0],
+      delCreatedF: bench.delCreated[1], delDestroyedF: bench.delDestroyed[1],
+      countFlat: bench.lastCountFlat, countGrouped: bench.lastCountGrouped)
+
+  for size in sizes:
+    # build first (fills the source with `size` rows on the fresh adaptor)
+    var r = runScenario(size, 0, size)
+    rows.add(r)
+    stderr.writeLine(&"[bench] size={size} build wall={r.wallMs:.1f}ms stall={r.maxStallMs:.1f} resetsF={r.resetsF} dcRowsF={r.dcRowsF} delCreF={r.delCreatedF}")
+    for kind in 1 .. 4:
+      r = runScenario(size, kind, 0)
+      rows.add(r)
+      stderr.writeLine(&"[bench] size={size} {scenarioNames[kind]} wall={r.wallMs:.1f}ms stall={r.maxStallMs:.1f} resetsF={r.resetsF} dcRowsF={r.dcRowsF} delCreF={r.delCreatedF} delDelF={r.delDestroyedF}")
+    stderr.flushFile()
+
+  let table = formatTable(rows)
+  echo "\n===== CollectiblesSelectionAdaptor proxy-chain cost (host, offscreen, RED) ====="
+  echo table
+
+  let resultsDir = base / "test" / "nim" / "benchmarks" / "results"
+  createDir(resultsDir)
+  let stamp = now().format("yyyyMMdd'T'HHmmss")
+  writeFile(resultsDir / ("collectibles_selector_red_" & stamp & ".tsv"), table)
+
+  # The bench must actually exercise the chain: the build at the largest size must
+  # have created flat delegates and the scenarios must have run without error.
+  proc rowFor(size: int, scenario: string): Row =
+    for r in rows:
+      if r.size == size and r.scenario == scenario: return r
+    doAssert false, &"missing {scenario}@{size}"
+  let build3k = rowFor(3000, "build")
+  doAssert build3k.delCreatedF > 0, "no flat delegates realized on build"
+  echo "RED bench ran"

--- a/test/nim/collectibles_selector_model_bench.nim
+++ b/test/nim/collectibles_selector_model_bench.nim
@@ -1,0 +1,268 @@
+## GREEN counterpart of collectibles_selector_bench.nim.
+##
+## Boots an offscreen QQmlApplicationEngine, context-injects a real
+## CollectiblesSelectorModel, and loads collectibles_selector_model_scene.qml --
+## two ListViews bound DIRECTLY to the model + its filteredFlatModel (no proxies).
+## The Nim driver builds the SAME synthetic universe as the RED adaptor bench
+## (large GLOBAL set, the probed account owns ~30) and applies the SAME update
+## classes (build / account switch / chain filter / append 50 / balance update)
+## by calling the model's producer seam; the scene forwards the models' granular
+## signals + delegate churn to the native `bench` object.
+##
+## GREEN gate (flips the adaptor baseline's RED): after the initial bulk load,
+## NO scenario resets the model; a single ERC-1155 balance tick propagates as
+## O(1) dataChanged rows with ZERO delegate churn; an account switch is bounded
+## by the ~30 displayed rows, not the GLOBAL universe. The build stays a single
+## bulk load whose cost tracks the pure O(global) scan, not the adaptor's
+## per-row-QObject construction (compare wall/stall to the RED table).
+
+import os, times, strformat
+import nimqml
+from seaqt/qcoreapplication import QCoreApplication, processEvents
+import std/monotimes
+
+import app/modules/shared_models/collectibles_selector_model
+
+type Row = object
+  size: int
+  scenario: string
+  wallMs: float
+  maxStallMs: float
+  resetsG, resetsF: int
+  insertsG, insertsF: int
+  dcRowsG, dcRowsF: int
+  delCreatedG, delDestroyedG: int
+  delCreatedF, delDestroyedF: int
+  countFlat, countGrouped: int
+
+QtObject:
+  type Bench = ref object of QObject
+    ready: bool
+    monitoring: bool
+    lastTickNs: float
+    maxStallMs: float
+    resets: array[2, int]
+    inserts: array[2, int]
+    removes: array[2, int]
+    dcRows: array[2, int]
+    delCreated: array[2, int]
+    delDestroyed: array[2, int]
+    lastCountFlat: int
+    lastCountGrouped: int
+
+  proc newBench(): Bench =
+    new(result)
+    result.QObject.setup
+
+  proc requestRelayout(self: Bench) {.signal.}
+
+  proc onSceneReady(self: Bench) {.slot.} = self.ready = true
+  proc nowMs(self: Bench): float {.slot.} =
+    (getMonoTime() - MonoTime()).inNanoseconds.float / 1_000_000.0
+
+  proc onDataChanged(self: Bench, which: int, top: int, bottom: int) {.slot.} =
+    if self.monitoring: self.dcRows[which] += (bottom - top + 1)
+  proc onModelReset(self: Bench, which: int) {.slot.} =
+    if self.monitoring: inc self.resets[which]
+  proc onRowsInserted(self: Bench, which: int) {.slot.} =
+    if self.monitoring: inc self.inserts[which]
+  proc onRowsRemoved(self: Bench, which: int) {.slot.} =
+    if self.monitoring: inc self.removes[which]
+  proc onDelegateCreated(self: Bench, which: int) {.slot.} =
+    if self.monitoring: inc self.delCreated[which]
+  proc onDelegateDestroyed(self: Bench, which: int) {.slot.} =
+    if self.monitoring: inc self.delDestroyed[which]
+  proc reportCounts(self: Bench, flat: int, grouped: int) {.slot.} =
+    self.lastCountFlat = flat
+    self.lastCountGrouped = grouped
+
+  proc onStallTick(self: Bench) {.slot.} =
+    if not self.monitoring: return
+    let n = self.nowMs()
+    let delta = n - self.lastTickNs
+    if delta > self.maxStallMs: self.maxStallMs = delta
+    self.lastTickNs = n
+
+  proc resetWindow(self: Bench) =
+    self.maxStallMs = 0.0
+    for i in 0 .. 1:
+      self.resets[i] = 0; self.inserts[i] = 0; self.removes[i] = 0
+      self.dcRows[i] = 0; self.delCreated[i] = 0; self.delDestroyed[i] = 0
+  proc beginMonitor(self: Bench) =
+    self.resetWindow()
+    self.lastTickNs = self.nowMs()
+    self.monitoring = true
+  proc endMonitor(self: Bench) = self.monitoring = false
+
+  proc pump(self: Bench) =
+    self.requestRelayout()
+    for _ in 0 ..< 8:
+      QCoreApplication.processEvents()
+
+# --- synthetic universe (mirrors the RED scene's makeRow / ownerOf) -----------
+
+const
+  chains = [1, 10, 42161, 8453, 56]
+  probeAccounts = ["acc_0", "acc_1", "acc_2"]
+  whaleAccount = "acc_whale"
+  ownedPerAccount = 30
+
+proc ownerOf(i: int): string =
+  let probed = probeAccounts.len * ownedPerAccount
+  if i < probed: probeAccounts[i div ownedPerAccount]
+  else: whaleAccount
+
+proc makeItem(i: int, owner = ""): CollectibleItem =
+  let isComm = (i mod 10 == 0)
+  let comm = i div 300
+  let coll = i div 4
+  let acc = if owner.len > 0: owner else: ownerOf(i)
+  CollectibleItem(
+    key: "col_" & $i,
+    chainId: chains[i mod chains.len],
+    collectionUid: if isComm: "ccoll_" & $(i div 40) else: "coll_" & $coll,
+    collectionName: if isComm: "CCollection " & $(i div 40) else: "Collection " & $coll,
+    contractAddress: "contract_" & $coll,
+    tokenId: $i,
+    name: "Collectible " & $i,
+    communityId: if isComm: "community_" & $comm else: "",
+    communityName: if isComm: "Community " & $comm else: "",
+    communityPrivilegesLevel: 2,
+    ownership: @[CollectibleOwnership(accountAddress: acc, balance: 1)])
+
+proc buildUniverse(n: int): seq[CollectibleItem] =
+  result = newSeqOfCap[CollectibleItem](n)
+  for i in 0 ..< n:
+    result.add(makeItem(i))
+
+let networks = @[
+  CollectiblesNetworkInfo(chainId: 1, chainName: "Mainnet", iconUrl: "network/ethereum"),
+  CollectiblesNetworkInfo(chainId: 10, chainName: "Optimism", iconUrl: "network/ethereum"),
+  CollectiblesNetworkInfo(chainId: 42161, chainName: "Arbitrum", iconUrl: "network/ethereum"),
+  CollectiblesNetworkInfo(chainId: 8453, chainName: "Base", iconUrl: "network/ethereum"),
+  CollectiblesNetworkInfo(chainId: 56, chainName: "BSC", iconUrl: "network/ethereum"),
+]
+
+proc formatTable(rows: seq[Row]): string =
+  result = "size\tscenario\twall_ms\tmax_stall_ms\tresetsG\tresetsF\tinsG\tinsF\tdcRowsG\tdcRowsF\tdelCreG\tdelDelG\tdelCreF\tdelDelF\tcountFlat\tcountGrouped\n"
+  for r in rows:
+    result.add(&"{r.size}\t{r.scenario}\t{r.wallMs:.4f}\t{r.maxStallMs:.4f}\t{r.resetsG}\t{r.resetsF}\t{r.insertsG}\t{r.insertsF}\t{r.dcRowsG}\t{r.dcRowsF}\t{r.delCreatedG}\t{r.delDestroyedG}\t{r.delCreatedF}\t{r.delDestroyedF}\t{r.countFlat}\t{r.countGrouped}\n")
+
+const sizes = [200, 1000, 3000]
+
+when isMainModule:
+  putEnv("QT_QPA_PLATFORM", "offscreen")
+  let app = newQApplication()
+
+  let model = newCollectiblesSelectorModel()
+  model.setParams(CollectiblesSelectorParams(accountKey: "acc_0",
+    enabledChainIds: @[], filterCommunityOwnerAndMasterTokens: true))
+
+  let bench = newBench()
+  let engine = newQQmlApplicationEngine()
+  engine.setRootContextProperty("collectiblesModel", newQVariant(model))
+  engine.setRootContextProperty("bench", newQVariant(bench))
+
+  let base = getCurrentDir()
+  let sceneFile = base / "test" / "nim" / "benchmarks" / "collectibles_selector_model_scene.qml"
+  engine.loadData(readFile(sceneFile))
+
+  var spins = 0
+  while not bench.ready and spins < 200000:
+    QCoreApplication.processEvents(); inc spins
+  if not bench.ready:
+    echo "SKIP: collectibles terminal-model scene did not load"
+    quit(0)
+
+  var rows: seq[Row] = @[]
+  var universe: seq[CollectibleItem]
+
+  proc capture(size: int, scenario: string, wallMs: float): Row =
+    Row(size: size, scenario: scenario, wallMs: wallMs, maxStallMs: bench.maxStallMs,
+      resetsG: bench.resets[0], resetsF: bench.resets[1],
+      insertsG: bench.inserts[0], insertsF: bench.inserts[1],
+      dcRowsG: bench.dcRows[0], dcRowsF: bench.dcRows[1],
+      delCreatedG: bench.delCreated[0], delDestroyedG: bench.delDestroyed[0],
+      delCreatedF: bench.delCreated[1], delDestroyedF: bench.delDestroyed[1],
+      countFlat: bench.lastCountFlat, countGrouped: bench.lastCountGrouped)
+
+  proc measure(size: int, scenario: string, mutate: proc()): Row =
+    bench.beginMonitor()
+    let t0 = bench.nowMs()
+    mutate()
+    bench.pump()
+    let wall = bench.nowMs() - t0
+    bench.endMonitor()
+    result = capture(size, scenario, wall)
+    rows.add(result)
+    stderr.writeLine(&"[bench] size={size} {scenario} wall={result.wallMs:.2f}ms stall={result.maxStallMs:.2f} resetsF={result.resetsF} dcRowsF={result.dcRowsF} insF={result.insertsF} delCreF={result.delCreatedF} delDelF={result.delDestroyedF} counts={result.countFlat}/{result.countGrouped}")
+    stderr.flushFile()
+
+  proc runSize(size: int) =
+    # fresh account/chain state per size
+    model.setAccountKey("acc_0")
+    model.setEnabledChainIds(@[])
+    universe = buildUniverse(size)
+
+    discard measure(size, "build", proc() = model.setSource(universe, networks))
+    discard measure(size, "account_switch", proc() = model.setAccountKey("acc_1"))
+    discard measure(size, "chain_filter", proc() = model.setEnabledChainIds(@[1, 10]))
+    # restore no chain filter before append so its output is comparable
+    model.setEnabledChainIds(@[])
+    bench.pump()
+    discard measure(size, "append_50", proc() =
+      let start = universe.len
+      for i in 0 ..< 50:
+        universe.add(makeItem(start + i, owner = "acc_1")) # owned by the current account
+      model.setSource(universe, networks))
+    discard measure(size, "balance_update", proc() =
+      # bump the ERC-1155 balance of the first item owned by the current account
+      for i in 0 ..< universe.len:
+        if universe[i].ownership.len > 0 and universe[i].ownership[0].accountAddress == "acc_1":
+          universe[i].ownership[0].balance += 1
+          break
+      model.setSource(universe, networks))
+
+  for size in sizes:
+    runSize(size)
+
+  let table = formatTable(rows)
+  echo "\n===== CollectiblesSelectorModel terminal-model cost (host, offscreen, GREEN) ====="
+  echo table
+
+  let resultsDir = base / "test" / "nim" / "benchmarks" / "results"
+  createDir(resultsDir)
+  let stamp = now().format("yyyyMMdd'T'HHmmss")
+  writeFile(resultsDir / ("collectibles_selector_green_" & stamp & ".tsv"), table)
+
+  proc rowFor(size: int, scenario: string): Row =
+    for r in rows:
+      if r.size == size and r.scenario == scenario: return r
+    doAssert false, &"missing {scenario}@{size}"
+
+  # GREEN structural gate: flips the adaptor baseline's RED.
+  for r in rows:
+    if r.scenario == "build":
+      # First bulk load is a single reset per view (empty -> N); allowed.
+      continue
+    doAssert r.resetsG == 0 and r.resetsF == 0,
+      &"terminal model reset in '{r.scenario}' at size {r.size}"
+  for size in sizes:
+    let bu = rowFor(size, "balance_update")
+    # a single ERC-1155 tick: O(1) dataChanged rows, and NO delegate churn (the
+    # shown balance updates in place; the group's subitem count is unchanged).
+    doAssert bu.dcRowsF <= 4 and bu.dcRowsG <= 4,
+      &"balance_update not O(1) at size {size} (flat {bu.dcRowsF}, grouped {bu.dcRowsG} rows)"
+    doAssert bu.delCreatedF == 0 and bu.delDestroyedF == 0,
+      &"balance_update churned flat delegates at size {size} ({bu.delCreatedF}/{bu.delDestroyedF})"
+    doAssert bu.delCreatedG == 0 and bu.delDestroyedG == 0,
+      &"balance_update churned grouped delegates at size {size}"
+    let ap = rowFor(size, "append_50")
+    doAssert ap.insertsF > 0 and ap.resetsF == 0,
+      &"append_50 should be a bounded insert (no reset) at size {size}"
+    # account switch output stays ~30 regardless of GLOBAL size (O(displayed)).
+    let asw = rowFor(size, "account_switch")
+    doAssert asw.countFlat > 0 and asw.countFlat < 200,
+      &"account_switch output not bounded to the account's ~30 at size {size} (got {asw.countFlat})"
+
+  echo "GREEN structural assertions passed"

--- a/test/nim/send_handler_adaptors_bench.nim
+++ b/test/nim/send_handler_adaptors_bench.nim
@@ -1,0 +1,194 @@
+## Handler-side adaptor benchmark for the send modal. SendModalHandler eagerly
+## builds three adaptors when the modal opens (SendModalHandler.qml): the
+## recipient + accounts adaptors feed the initially-visible ASSETS tab, while
+## CollectiblesSelectionAdaptor -- a LeftJoin + SFPM + nested per-group
+## ObjectProxyModel chain over the full cross-chain collectibles model -- is pure
+## waste in the open window (the modal opens on assets, not collectibles).
+##
+## This bench loads the REAL adaptor QML (send_handler_adaptors_scene.qml) under an
+## offscreen engine with StatusQ linked + the app import paths, and per adaptor
+## records:
+##   create_ms     - Component.createObject wall time (synchronous structural build)
+##   settle_ms     - create -> output row counts stabilize (per-row/per-group
+##                   submodels that land after createObject returns)
+##   max_stall_ms  - worst GUI-thread block over create+settle (16ms tick monitor)
+##   over32        - number of >32ms render-loop blocks in that window
+##   countA/countB - final output row counts (flat model / grouped model)
+##
+## Absolute host numbers sit far below the device's user-observed open, but the
+## ATTRIBUTION RANKING transfers: a synchronous O(collectibles) build is a fixed
+## structural cost a slower device's engine multiplies. Collectibles are measured
+## at 200 / 1000 / 3000 items; accounts + recipients at one realistic size for
+## completeness. Links StatusQ (registerStatusQTypes) like the sibling send benches.
+
+import os, times, strformat
+import nimqml
+from seaqt/qcoreapplication import QCoreApplication, processEvents
+import std/monotimes
+
+{.compile: "bench_statusq_register.cpp".}
+proc bench_registerStatusQTypes() {.importc.}
+
+type Row = object
+  kind: int
+  name: string
+  createMs: float
+  settleMs: float
+  maxStallMs: float
+  over32: int
+  countA: int
+  countB: int
+  error: string
+
+QtObject:
+  type Bench = ref object of QObject
+    ready: bool
+    monitoring: bool
+    lastTickNs: float
+    maxStallMs: float
+    over32: int
+    gotInstantiation: bool
+    gotSettle: bool
+    lastCreateMs: float
+    lastSettleMs: float
+    lastCountA: int
+    lastCountB: int
+    lastError: string
+
+  proc newBench(): Bench =
+    new(result)
+    result.QObject.setup
+
+  proc requestKind(self: Bench, kind: int) {.signal.}
+
+  proc onSceneReady(self: Bench) {.slot.} = self.ready = true
+
+  proc nowMs(self: Bench): float {.slot.} =
+    (getMonoTime() - MonoTime()).inNanoseconds.float / 1_000_000.0
+
+  proc reportInstantiation(self: Bench, kind: int, createMs: float, error: string) {.slot.} =
+    self.lastCreateMs = createMs
+    self.lastError = error
+    self.gotInstantiation = true
+
+  proc reportSettle(self: Bench, kind: int, settleMs: float, countA: int, countB: int) {.slot.} =
+    self.lastSettleMs = settleMs
+    self.lastCountA = countA
+    self.lastCountB = countB
+    self.gotSettle = true
+
+  proc onStallTick(self: Bench) {.slot.} =
+    if not self.monitoring: return
+    let n = self.nowMs()
+    let delta = n - self.lastTickNs
+    if delta > self.maxStallMs: self.maxStallMs = delta
+    if delta > 32.0: inc self.over32
+    self.lastTickNs = n
+
+  proc beginMonitor(self: Bench) =
+    self.maxStallMs = 0.0
+    self.over32 = 0
+    self.lastTickNs = self.nowMs()
+    self.monitoring = true
+  proc endMonitor(self: Bench) = self.monitoring = false
+
+  proc spinFor(self: Bench, ms: float) =
+    let deadline = self.nowMs() + ms
+    while self.nowMs() < deadline:
+      QCoreApplication.processEvents()
+
+proc formatTable(rows: seq[Row]): string =
+  result = "kind\tname\tcreate_ms\tsettle_ms\tmax_stall_ms\tover32\tcountA\tcountB\terror\n"
+  for r in rows:
+    result.add(&"{r.kind}\t{r.name}\t{r.createMs:.4f}\t{r.settleMs:.4f}\t{r.maxStallMs:.4f}\t{r.over32}\t{r.countA}\t{r.countB}\t{r.error}\n")
+
+const kindNames = [
+  "CollectiblesSelectionAdaptor@200",
+  "CollectiblesSelectionAdaptor@1000",
+  "CollectiblesSelectionAdaptor@3000",
+  "WalletAccountsSelectorAdaptor",
+  "RecipientViewAdaptor",
+  "Collectibles@3000 DEFERRED (open->activate)",
+]
+
+when isMainModule:
+  putEnv("QT_QPA_PLATFORM", "offscreen")
+  let app = newQApplication()
+  bench_registerStatusQTypes()
+
+  let bench = newBench()
+  let engine = newQQmlApplicationEngine()
+  let root = getCurrentDir()
+  engine.addImportPath(root / "ui" / "StatusQ" / "src")
+  engine.addImportPath(root / "ui" / "imports")
+  engine.addImportPath(root / "ui" / "app")
+  engine.setRootContextProperty("bench", newQVariant(bench))
+
+  let sceneFile = getCurrentDir() / "test" / "nim" / "benchmarks" / "send_handler_adaptors_scene.qml"
+  engine.loadData(readFile(sceneFile))
+
+  var spins = 0
+  while not bench.ready and spins < 500000:
+    QCoreApplication.processEvents(); inc spins
+  if not bench.ready:
+    echo "SKIP: send-handler adaptors scene did not load"
+    quit(0)
+
+  var rows: seq[Row] = @[]
+
+  proc measure(kind: int) =
+    # Warm the QML type caches once (first createObject pays one-time
+    # compilation), then measure a fresh instantiation + settle.
+    for pass in 0 .. 1:
+      bench.gotInstantiation = false
+      bench.gotSettle = false
+      bench.beginMonitor()
+      bench.spinFor(32)
+      bench.requestKind(kind)
+      var s = 0
+      while not bench.gotSettle and s < 2000000:
+        QCoreApplication.processEvents(); inc s
+      bench.spinFor(48) # let the post-settle tick delta register
+      bench.endMonitor()
+      if pass == 1:
+        rows.add(Row(kind: kind, name: kindNames[kind],
+          createMs: bench.lastCreateMs, settleMs: bench.lastSettleMs,
+          maxStallMs: bench.maxStallMs, over32: bench.over32,
+          countA: bench.lastCountA, countB: bench.lastCountB,
+          error: bench.lastError))
+        stderr.writeLine(&"[bench] {kindNames[kind]} create={bench.lastCreateMs:.2f}ms settle={bench.lastSettleMs:.2f}ms maxStall={bench.maxStallMs:.2f}ms over32={bench.over32} counts={bench.lastCountA}/{bench.lastCountB} err={bench.lastError}")
+        stderr.flushFile()
+
+  for kind in 0 .. 5:
+    measure(kind)
+
+  let table = formatTable(rows)
+  echo "\n===== SendModalHandler adaptor build cost (host, offscreen) ====="
+  echo table
+
+  let resultsDir = getCurrentDir() / "test" / "nim" / "benchmarks" / "results"
+  createDir(resultsDir)
+  let stamp = now().format("yyyyMMdd'T'HHmmss")
+  writeFile(resultsDir / ("send_handler_adaptors_" & stamp & ".tsv"), table)
+
+  proc rowFor(kind: int): Row =
+    for r in rows:
+      if r.kind == kind: return r
+    doAssert false, "missing kind " & $kind
+
+  # All adaptors must actually instantiate + populate (the point of the bench).
+  for kind in 0 .. 5:
+    let r = rowFor(kind)
+    doAssert r.error.len == 0, &"{r.name} failed to instantiate: {r.error}"
+    doAssert r.createMs >= 0.0, &"{r.name} createMs not measured: {r.createMs}"
+  # The 3000-item collectibles pipeline must produce the full flat model.
+  doAssert rowFor(2).countA == 3000,
+    &"collectibles@3000 flat model incomplete: {rowFor(2).countA}"
+  # GREEN: the deferred Loader builds nothing at open (open-window createMs well
+  # below the direct build), yet produces the full model once activated.
+  doAssert rowFor(5).countA == 3000,
+    &"deferred collectibles did not populate on activation: {rowFor(5).countA}"
+  doAssert rowFor(5).createMs < rowFor(2).createMs,
+    &"deferred open cost {rowFor(5).createMs} not below direct build {rowFor(2).createMs}"
+
+  echo "assertions passed"

--- a/test/nim/send_handler_lookup_bench.nim
+++ b/test/nim/send_handler_lookup_bench.nim
@@ -1,0 +1,173 @@
+## Handler-lookup benchmark: the SQUtils.ModelUtils lookups SendModalHandler /
+## SimpleSendModal run over the wallet tokenGroups model around open, driven on the
+## REAL ModelUtils / ModelQuery (registerStatusQTypes, like swap_key_harvest_bench)
+## against a tokenGroups-shaped Nim model at 500 / 2000 / 5000 groups.
+##
+## The tokenGroups model carries per-row `marketDetails` + `tokens` submodels; the
+## all-roles get marshals both to JS, the single-role/index paths do not. This
+## attributes the handler-JS term of the send-modal open against the picker seed
+## (send_modal_open_bench) and the tree instantiation (send_modal_instantiation_bench):
+##   getByKey_norole      getByKey(m,"key",v)          -- indexOf + 1 all-roles get
+##   getByKey_role        getByKey(m,"key",v,"symbol")  -- indexOf + 1 single-role get
+##   get_loop_allroles    for i { get(m,i) } to a miss  -- N all-roles gets (O(N*roles))
+##   getFirstModelEntryIf full scan + predicate/row      -- N all-roles gets
+##   modelToFlatArray     modelToFlatArray(m,"chainId")  -- role-restricted, O(N*1)
+##
+## An offscreen nimqml submodel can't be marshalled through ModelQuery.get's
+## all-roles QVariantMap->JS here (same harness limitation as swap_key_harvest),
+## so the marketDetails/tokens submodels are represented by heavy string value roles
+## (a serialized proxy). The all-roles fetch pays for them; the index/single-role
+## paths skip them -- the same differential the real submodel marshalling shows,
+## understated in absolute terms.
+
+import os, times, strformat, strutils, tables
+import nimqml
+from seaqt/qcoreapplication import QCoreApplication, processEvents
+import std/monotimes
+
+{.compile: "bench_statusq_register.cpp".}
+proc bench_registerStatusQTypes() {.importc.}
+
+# Heavy per-row proxies for the marketDetails + tokens submodels the all-roles get
+# marshals (a real tokenGroups row carries both).
+const marketDetailsBlob = """{"currencyPrice":{"amount":1234.56,"symbol":"USD"},"changePct24hour":-2.3,"marketCap":"12345678901","totalCoins":"210000000"}"""
+const tokensBlob = "[" & repeat("""{"key":"0xADDR00000000000000000000000000000000000000_1","chainId":1,"address":"0xADDR00000000000000000000000000000000000000","name":"Token","symbol":"TKN","decimals":18},""", 3) & "]"
+
+type GroupRole {.pure.} = enum
+  Key = UserRole + 1
+  Name
+  Symbol
+  LogoUri
+  Decimals
+  CommunityId
+  ChainId
+  MarketDetails
+  Tokens
+
+QtObject:
+  type TokenGroupsModel = ref object of QAbstractListModel
+    n: int
+
+  proc delete(self: TokenGroupsModel) = self.QAbstractListModel.delete
+  proc setup(self: TokenGroupsModel) = self.QAbstractListModel.setup
+  proc newTokenGroupsModel(n: int): TokenGroupsModel =
+    new(result, delete)
+    result.setup
+    result.n = n
+
+  method rowCount(self: TokenGroupsModel, index: QModelIndex = nil): int = self.n
+
+  method roleNames(self: TokenGroupsModel): Table[int, string] =
+    {GroupRole.Key.int: "key", GroupRole.Name.int: "name", GroupRole.Symbol.int: "symbol",
+     GroupRole.LogoUri.int: "logoUri", GroupRole.Decimals.int: "decimals",
+     GroupRole.CommunityId.int: "communityId", GroupRole.ChainId.int: "chainId",
+     GroupRole.MarketDetails.int: "marketDetails", GroupRole.Tokens.int: "tokens"}.toTable
+
+  method data(self: TokenGroupsModel, index: QModelIndex, role: int): QVariant =
+    if index.row < 0 or index.row >= self.n: return
+    case role.GroupRole:
+      of GroupRole.Key: newQVariant("grp_" & $index.row)
+      of GroupRole.Name: newQVariant("Token Number " & $index.row & " Wrapped Staked Asset")
+      of GroupRole.Symbol: newQVariant("TKN" & $index.row)
+      of GroupRole.LogoUri: newQVariant("https://raw.githubusercontent.com/status-im/assets/master/tokens/ethereum/0xADDR/logo.png")
+      of GroupRole.Decimals: newQVariant(18)
+      of GroupRole.CommunityId: newQVariant("")
+      of GroupRole.ChainId: newQVariant(1)
+      of GroupRole.MarketDetails: newQVariant(marketDetailsBlob)
+      of GroupRole.Tokens: newQVariant(tokensBlob)
+
+type Row = object
+  size: int
+  scenario: string
+  ms: float
+
+QtObject:
+  type Bench = ref object of QObject
+    ready: bool
+    done: bool
+    results: Table[string, float]
+
+  proc newBench(): Bench =
+    new(result)
+    result.QObject.setup
+    result.results = initTable[string, float]()
+
+  proc requestLookups(self: Bench) {.signal.}
+  proc onSceneReady(self: Bench) {.slot.} = self.ready = true
+  proc nowMs(self: Bench): float {.slot.} =
+    (getMonoTime() - MonoTime()).inNanoseconds.float / 1_000_000.0
+  proc reportLookup(self: Bench, name: string, ms: float) {.slot.} =
+    self.results[name] = ms
+  proc lookupsDone(self: Bench) {.slot.} = self.done = true
+
+proc formatTable(rows: seq[Row]): string =
+  result = "size\tscenario\tms\n"
+  for r in rows:
+    result.add(&"{r.size}\t{r.scenario}\t{r.ms:.4f}\n")
+
+const sizes = [500, 2000, 5000]
+const lookups = ["getByKey_norole", "getByKey_role", "get_loop_allroles",
+  "getFirstModelEntryIf", "modelToFlatArray"]
+
+when isMainModule:
+  putEnv("QT_QPA_PLATFORM", "offscreen")
+  let app = newQApplication()
+  bench_registerStatusQTypes()
+
+  let bench = newBench()
+  let engine = newQQmlApplicationEngine()
+  # ModelUtils is a StatusQ QML singleton -> needs the StatusQ source on the import
+  # path (QtModelsToolkit's ModelQuery is C++, registered by registerStatusQTypes).
+  engine.addImportPath(getCurrentDir() / "ui" / "StatusQ" / "src")
+  engine.setRootContextProperty("bench", newQVariant(bench))
+
+  var rows: seq[Row] = @[]
+  let sceneFile = getCurrentDir() / "test" / "nim" / "benchmarks" / "send_handler_lookup_scene.qml"
+
+  for size in sizes:
+    let model = newTokenGroupsModel(size)
+    engine.setRootContextProperty("lookupModel", newQVariant(model))
+    bench.ready = false
+    bench.done = false
+    bench.results.clear()
+    engine.loadData(readFile(sceneFile))
+    var spins = 0
+    while not bench.ready and spins < 500000:
+      QCoreApplication.processEvents(); inc spins
+    if not bench.ready:
+      echo "SKIP: send handler-lookup scene did not load"; quit(0)
+    bench.requestLookups()
+    var s = 0
+    while not bench.done and s < 2000000:
+      QCoreApplication.processEvents(); inc s
+    for name in lookups:
+      let ms = bench.results.getOrDefault(name, -1.0)
+      rows.add(Row(size: size, scenario: name, ms: ms))
+      stderr.writeLine(&"[bench] size={size} {name} {ms:.4f}ms")
+      stderr.flushFile()
+
+  let table = formatTable(rows)
+  echo "\n===== SendModalHandler open-path ModelUtils lookups (real ModelQuery) ====="
+  echo table
+
+  let resultsDir = getCurrentDir() / "test" / "nim" / "benchmarks" / "results"
+  createDir(resultsDir)
+  let stamp = now().format("yyyyMMdd'T'HHmmss")
+  writeFile(resultsDir / ("send_handler_lookup_" & stamp & ".tsv"), table)
+
+  proc rowFor(scenario: string, size: int): Row =
+    for r in rows:
+      if r.scenario == scenario and r.size == size: return r
+    doAssert false, "missing row " & scenario & " @" & $size
+
+  # The all-roles walks (get-loop / getFirstModelEntryIf) marshal every row's
+  # submodel proxies and grow with N; the role-restricted / single-row paths do
+  # not. Gate that the all-roles per-row scan is materially heavier than the
+  # role-restricted flat scan at the largest size.
+  let loopBig = rowFor("get_loop_allroles", 5000)
+  let flatBig = rowFor("modelToFlatArray", 5000)
+  doAssert loopBig.ms > flatBig.ms,
+    &"expected the all-roles get-loop to exceed the role-restricted scan @5000 " &
+    &"(get_loop {loopBig.ms:.2f}ms, modelToFlatArray {flatBig.ms:.2f}ms)"
+
+  echo "assertions passed"

--- a/test/nim/send_handler_lookup_bench.nim
+++ b/test/nim/send_handler_lookup_bench.nim
@@ -48,12 +48,15 @@ QtObject:
   type TokenGroupsModel = ref object of QAbstractListModel
     n: int
 
-  proc delete(self: TokenGroupsModel) = self.QAbstractListModel.delete
-  proc setup(self: TokenGroupsModel) = self.QAbstractListModel.setup
+  proc delete(self: TokenGroupsModel)
+  proc setup(self: TokenGroupsModel)
   proc newTokenGroupsModel(n: int): TokenGroupsModel =
     new(result, delete)
     result.setup
     result.n = n
+
+  proc delete(self: TokenGroupsModel) = self.QAbstractListModel.delete
+  proc setup(self: TokenGroupsModel) = self.QAbstractListModel.setup
 
   method rowCount(self: TokenGroupsModel, index: QModelIndex = nil): int = self.n
 

--- a/test/nim/send_modal_instantiation_bench.nim
+++ b/test/nim/send_modal_instantiation_bench.nim
@@ -1,0 +1,168 @@
+## Real-instantiation benchmark for the send modal: loads the ACTUAL
+## SimpleSendModal QML tree (and its major subtrees) under an offscreen engine with
+## StatusQ linked + the app import paths, and times Component.createObject (the
+## structural instantiation cost) + time-to-`opened` + the GUI-thread block via a
+## 16ms stall monitor (send_modal_instantiation_scene.qml).
+##
+## This isolates the dominant hypothesis for the user-observed ~1s open: how much
+## of it is QML component instantiation of the modal tree (as opposed to the Nim
+## picker seed measured by send_modal_open_bench, or the handler-JS model lookups
+## measured by send_handler_lookup_bench). Absolute host numbers are far below the
+## device's ~1s, but the ATTRIBUTION RANKING transfers: instantiation is a fixed
+## structural cost that a slower device's QML engine multiplies.
+##
+## Per component it records: create_ms (createObject wall time), open_ms (full
+## modal only: create->`opened`), max_stall_ms / over32 (the render-loop block the
+## synchronous createObject causes). A subtree that fails to instantiate standalone
+## reports create_ms = -1 with the QML error (the bisection then still ranks the
+## rest).
+##
+## Links StatusQ (registerStatusQTypes) like swap_key_harvest_bench.
+
+import os, times, strformat
+import nimqml
+from seaqt/qcoreapplication import QCoreApplication, processEvents
+import std/monotimes
+
+{.compile: "bench_statusq_register.cpp".}
+proc bench_registerStatusQTypes() {.importc.}
+
+type Row = object
+  kind: int
+  name: string
+  createMs: float
+  maxStallMs: float
+  over32: int
+  error: string
+
+QtObject:
+  type Bench = ref object of QObject
+    ready: bool
+    monitoring: bool
+    lastTickNs: float
+    maxStallMs: float
+    over32: int
+    # per-run handshake
+    gotInstantiation: bool
+    lastCreateMs: float
+    lastError: string
+
+  proc newBench(): Bench =
+    new(result)
+    result.QObject.setup
+
+  proc requestKind(self: Bench, kind: int) {.signal.}
+
+  proc onSceneReady(self: Bench) {.slot.} = self.ready = true
+
+  proc nowMs(self: Bench): float {.slot.} =
+    (getMonoTime() - MonoTime()).inNanoseconds.float / 1_000_000.0
+
+  proc reportInstantiation(self: Bench, kind: int, createMs: float, error: string) {.slot.} =
+    self.lastCreateMs = createMs
+    self.lastError = error
+    self.gotInstantiation = true
+
+  proc onStallTick(self: Bench) {.slot.} =
+    if not self.monitoring: return
+    let n = self.nowMs()
+    let delta = n - self.lastTickNs
+    if delta > self.maxStallMs: self.maxStallMs = delta
+    if delta > 32.0: inc self.over32
+    self.lastTickNs = n
+
+  proc beginMonitor(self: Bench) =
+    self.maxStallMs = 0.0
+    self.over32 = 0
+    self.lastTickNs = self.nowMs()
+    self.monitoring = true
+  proc endMonitor(self: Bench) = self.monitoring = false
+
+  proc spinFor(self: Bench, ms: float) =
+    let deadline = self.nowMs() + ms
+    while self.nowMs() < deadline:
+      QCoreApplication.processEvents()
+
+proc formatTable(rows: seq[Row]): string =
+  result = "kind\tname\tcreate_ms\tmax_stall_ms\tover32\terror\n"
+  for r in rows:
+    result.add(&"{r.kind}\t{r.name}\t{r.createMs:.4f}\t{r.maxStallMs:.4f}\t{r.over32}\t{r.error}\n")
+
+const kindNames = [
+  "SimpleSendModal(full)",
+  "SendModalHeader",
+  "StickySendModalHeader",
+  "AmountToSend",
+  "SendModalFooter",
+]
+
+when isMainModule:
+  putEnv("QT_QPA_PLATFORM", "offscreen")
+  let app = newQApplication()
+  bench_registerStatusQTypes()
+
+  let bench = newBench()
+  let engine = newQQmlApplicationEngine()
+  let root = getCurrentDir()
+  engine.addImportPath(root / "ui" / "StatusQ" / "src")
+  engine.addImportPath(root / "ui" / "imports")
+  engine.addImportPath(root / "ui" / "app")
+  engine.setRootContextProperty("bench", newQVariant(bench))
+
+  let sceneFile = getCurrentDir() / "test" / "nim" / "benchmarks" / "send_modal_instantiation_scene.qml"
+  engine.loadData(readFile(sceneFile))
+
+  var spins = 0
+  while not bench.ready and spins < 500000:
+    QCoreApplication.processEvents(); inc spins
+  if not bench.ready:
+    echo "SKIP: send-modal instantiation scene did not load"
+    quit(0)
+
+  var rows: seq[Row] = @[]
+
+  proc measure(kind: int) =
+    # Warm the QML type caches once (first createObject pays one-time compilation),
+    # then measure a fresh instantiation.
+    for pass in 0 .. 1:
+      bench.gotInstantiation = false
+      bench.beginMonitor()
+      bench.spinFor(32)
+      bench.requestKind(kind)
+      var s = 0
+      while not bench.gotInstantiation and s < 500000:
+        QCoreApplication.processEvents(); inc s
+      bench.spinFor(120)  # let the post-create tick delta register
+      bench.endMonitor()
+      if pass == 1:
+        rows.add(Row(kind: kind, name: kindNames[kind],
+          createMs: bench.lastCreateMs,
+          maxStallMs: bench.maxStallMs, over32: bench.over32, error: bench.lastError))
+        stderr.writeLine(&"[bench] {kindNames[kind]} create={bench.lastCreateMs:.2f}ms maxStall={bench.maxStallMs:.2f}ms over32={bench.over32} err={bench.lastError}")
+        stderr.flushFile()
+
+  for kind in 0 .. 4:
+    measure(kind)
+
+  let table = formatTable(rows)
+  echo "\n===== SimpleSendModal real instantiation cost (host, offscreen) ====="
+  echo table
+
+  let resultsDir = getCurrentDir() / "test" / "nim" / "benchmarks" / "results"
+  createDir(resultsDir)
+  let stamp = now().format("yyyyMMdd'T'HHmmss")
+  writeFile(resultsDir / ("send_modal_instantiation_" & stamp & ".tsv"), table)
+
+  proc rowFor(kind: int): Row =
+    for r in rows:
+      if r.kind == kind: return r
+    doAssert false, "missing kind " & $kind
+
+  # The full modal must actually instantiate (the whole point of this bench).
+  let full = rowFor(0)
+  doAssert full.error.len == 0,
+    &"SimpleSendModal failed to instantiate offscreen: {full.error}"
+  doAssert full.createMs > 0.0,
+    &"SimpleSendModal createMs was not measured: {full.createMs}"
+
+  echo "assertions passed"

--- a/test/nim/send_modal_open_bench.nim
+++ b/test/nim/send_modal_open_bench.nim
@@ -1,0 +1,323 @@
+## SimpleSendModal-open integration benchmark: the real Nim send picker model
+## (TokenSelectorModel, Owned mode) driven under a real offscreen
+## QQmlApplicationEngine with an animating sheet + a Loader-gated dropdown ListView
+## + a 16ms stall monitor (send_modal_open_scene.qml).
+##
+## What opening the send modal does today (the GUI-thread work this measures):
+## SendModalHandler instantiates the modal tree and, as part of that, its handler
+## QtObject synchronously creates the send picker model
+## (`WalletStores.RootStore.tokensStore.createTokenSelectorModel(0)`), which on the
+## Nim side runs `buildOwnedSource()` (walks the owned token groups + grouped
+## assets) then `setOwnedSource(groups, networks)` -> `recompute` ->
+## `buildDisplayItems` (filter owned + build per-chain chips) -> `setSourceItems`
+## (sort + diff + reconcileByKey: one nested balances model + one nested tokens
+## model PER group) -> row inserts; then `updateSendSectionNames()` -> a
+## whole-list section-name dataChanged. All of that lands on the GUI thread while
+## the sheet animates open.
+##
+## Two regimes are measured on the SAME real model + scene, per owned-set size
+## (a heavy user's holdings are ~50-200; 500 / 1000 / 2000 are stress points that
+## expose scaling of the reconcileByKey nested-QObject construction):
+##
+##   open_seed (the modal-open cost):  the dropdown is CLOSED (a real dropdown
+##     realizes no delegates until opened), and mid-open-window the seed burst
+##     (setOwnedSource + setSectionNames) runs. `compute_ms` isolates the pure
+##     buildDisplayItems aggregation; `inject_ms` is the full on-GUI-thread burst
+##     (aggregation + setSourceItems + nested-model construction + inserts +
+##     section-name dataChanged).
+##
+##   dropdown_open (the next interaction):  the model is seeded BEFORE the window;
+##     in the window the dropdown ListView is realized (outer owned rows + the
+##     nested chip Repeaters), measuring the picker-open delegate churn.
+##
+## Attribution: `compute_ms` vs `inject_ms` splits pure aggregation from model
+## machinery; `max_stall_ms` / `over32` are the frame-drop probe; delegates/chips
+## count the realized view; resets/inserted/dataChanged are the model emissions.
+##
+## Compile -d:QT_MODEL_SPY (pure-Nim model hooks, like token_selector_model_test).
+
+import os, times, strformat, strutils
+import stint
+import nimqml
+from seaqt/qcoreapplication import QCoreApplication, processEvents
+import std/monotimes
+
+import app/modules/shared_models/token_selector_model
+import app/modules/shared_models/token_selector_builder
+import app/modules/shared_models/assets_aggregator
+
+type Row = object
+  size: int
+  scenario: string
+  computeMs: float      # pure buildDisplayItems aggregation (owned filter + chips)
+  injectMs: float       # full synchronous GUI-thread seed burst
+  maxStallMs: float     # largest 16ms-timer tick-to-tick delta during the window
+  over32: int           # count of tick deltas > 32ms during the window
+  resets: int
+  inserted: int
+  dataChanged: int
+  delegatesCreated: int
+  chipsCreated: int
+
+# --- synthetic owned universe -------------------------------------------------
+# The send picker's base list is the user's OWNED token groups (createTokenSelector
+# model KIND_SEND, Owned mode). Each owned group carries per-chain balances that
+# become the delegate's chip submodel. Mainnet-shaped fields (42-char address in
+# the token key, full name, ~95-char logo URI) so the per-group build + marshal
+# cost is realistic.
+
+const chains = [1, 10, 42161, 8453, 11155111, 56, 137, 59144]
+
+proc addressFor(i: int): string = "0x" & toHex(i, 40)
+
+proc weiFor(i: int): UInt256 =
+  parse($((i mod 1000) + 1) & "000000000000000000", UInt256)
+
+proc ownedGroup(i: int): AggTokenGroup =
+  let addr0 = addressFor(i)
+  let addr1 = addressFor(i + 1_000_000)
+  let c0 = chains[i mod chains.len]
+  let c1 = chains[(i + 3) mod chains.len]
+  # Two per-chain balances => a 2-chip nested balances submodel per row.
+  AggTokenGroup(
+    key: "grp_" & addr0,
+    name: "Token Number " & $i & " Wrapped Staked Governance Asset",
+    symbol: "TKN" & $i,
+    logoUri: "https://raw.githubusercontent.com/status-im/assets/master/tokens/ethereum/" &
+      addr0 & "/logo.png",
+    decimals: 18,
+    communityId: "",
+    marketPrice: 1.0 + float(i mod 500) * 0.01,
+    balances: @[
+      AggBalance(account: "0xA", chainId: c0, balance: weiFor(i), loading: false),
+      AggBalance(account: "0xA", chainId: c1, balance: weiFor(i + 7), loading: false),
+    ],
+    tokens: @[
+      (key: "tok_" & addr0 & "_c" & $c0, chainId: c0),
+      (key: "tok_" & addr1 & "_c" & $c1, chainId: c1),
+    ])
+
+proc buildOwned(n: int): seq[AggTokenGroup] =
+  result = newSeqOfCap[AggTokenGroup](n)
+  for i in 0 ..< n:
+    result.add(ownedGroup(i))
+
+# Send picker params: a real account is selected, zero-balance default tokens
+# shown, community assets hidden, no chain filter (whole owned set).
+proc sendParams(): TokenSelectorParams =
+  TokenSelectorParams(
+    accountAddress: "0xA",
+    enabledChainIds: @[],
+    showZeroBalanceForDefaultTokens: true,
+    showCommunityAssets: false)
+
+QtObject:
+  type Bench = ref object of QObject
+    ready: bool
+    monitoring: bool
+    lastTickNs: float
+    maxStallMs: float
+    over32: int
+    cReset: int
+    cInserted: int
+    cDataChanged: int
+    cDelegatesCreated: int
+    cDelegatesDestroyed: int
+    cChipsCreated: int
+
+  proc newBench(): Bench =
+    # Run-once bench: no finalizer (the deprecated new(obj, finalizer) conflicts
+    # with the lifted =destroy under the default mm); the QObject lives for the
+    # whole process and is reclaimed at exit.
+    new(result)
+    result.QObject.setup
+
+  proc requestOpen(self: Bench) {.signal.}
+  proc requestDropdownOpen(self: Bench) {.signal.}
+  proc requestDropdownClose(self: Bench) {.signal.}
+  proc requestRelayout(self: Bench) {.signal.}
+
+  proc onSceneReady(self: Bench) {.slot.} = self.ready = true
+  proc onDelegateCreated(self: Bench) {.slot.} = inc self.cDelegatesCreated
+  proc onDelegateDestroyed(self: Bench) {.slot.} = inc self.cDelegatesDestroyed
+  proc onChipCreated(self: Bench) {.slot.} = inc self.cChipsCreated
+  proc onModelReset(self: Bench) {.slot.} = inc self.cReset
+  proc onRowsInserted(self: Bench) {.slot.} = inc self.cInserted
+  proc onDataChanged(self: Bench, first: int, last: int) {.slot.} = inc self.cDataChanged
+  proc onRowsRemoved(self: Bench) {.slot.} = discard
+
+  proc nowMs(self: Bench): float =
+    (getMonoTime() - MonoTime()).inNanoseconds.float / 1_000_000.0
+
+  proc onStallTick(self: Bench) {.slot.} =
+    if not self.monitoring:
+      return
+    let n = self.nowMs()
+    let delta = n - self.lastTickNs
+    if delta > self.maxStallMs:
+      self.maxStallMs = delta
+    if delta > 32.0:
+      inc self.over32
+    self.lastTickNs = n
+
+  proc beginMonitor(self: Bench) =
+    self.maxStallMs = 0.0
+    self.over32 = 0
+    self.lastTickNs = self.nowMs()
+    self.monitoring = true
+
+  proc endMonitor(self: Bench) = self.monitoring = false
+
+  proc resetCounters(self: Bench) =
+    self.cReset = 0; self.cInserted = 0; self.cDataChanged = 0
+    self.cDelegatesCreated = 0; self.cDelegatesDestroyed = 0; self.cChipsCreated = 0
+
+  proc spinFor(self: Bench, ms: float) =
+    ## Busy-drive the event loop for `ms` wall time so the 16ms stall timer fires.
+    let deadline = self.nowMs() + ms
+    while self.nowMs() < deadline:
+      QCoreApplication.processEvents()
+
+proc formatTable(rows: seq[Row]): string =
+  result = "size\tscenario\tcompute_ms\tinject_ms\tmax_stall_ms\tover32\tresets\tinserted\tdataChanged\tdelegatesCreated\tchipsCreated\n"
+  for r in rows:
+    result.add(&"{r.size}\t{r.scenario}\t{r.computeMs:.4f}\t{r.injectMs:.4f}\t{r.maxStallMs:.4f}\t{r.over32}\t{r.resets}\t{r.inserted}\t{r.dataChanged}\t{r.delegatesCreated}\t{r.chipsCreated}\n")
+
+when isMainModule:
+  putEnv("QT_QPA_PLATFORM", "offscreen")
+  let app = newQApplication()
+
+  let networks = @[
+    NetworkInfo(chainId: 1, chainName: "Mainnet", iconUrl: "network/Network=Ethereum"),
+    NetworkInfo(chainId: 10, chainName: "Optimism", iconUrl: "network/Network=Optimism"),
+    NetworkInfo(chainId: 42161, chainName: "Arbitrum", iconUrl: "network/Network=Arbitrum"),
+    NetworkInfo(chainId: 8453, chainName: "Base", iconUrl: "network/Network=Base"),
+    NetworkInfo(chainId: 11155111, chainName: "Sepolia", iconUrl: "network/Network=Sepolia"),
+    NetworkInfo(chainId: 56, chainName: "BSC", iconUrl: "network/Network=BSC"),
+    NetworkInfo(chainId: 137, chainName: "Polygon", iconUrl: "network/Network=Polygon"),
+    NetworkInfo(chainId: 59144, chainName: "Linea", iconUrl: "network/Network=Linea"),
+  ]
+
+  let model = newTokenSelectorModel(TokenSelectorMode.Owned)
+  var source: TokenSelectorSource  # send: no popular list; search/lazy unused at open
+  model.setSource(source)
+  let modelVariant = newQVariant(model)
+
+  let bench = newBench()
+  let benchVariant = newQVariant(bench)
+
+  let engine = newQQmlApplicationEngine()
+  engine.setRootContextProperty("sendPickerModel", modelVariant)
+  engine.setRootContextProperty("bench", benchVariant)
+
+  let sceneFile = getCurrentDir() / "test" / "nim" / "benchmarks" / "send_modal_open_scene.qml"
+  engine.loadData(readFile(sceneFile))
+
+  var spins = 0
+  while not bench.ready and spins < 500000:
+    QCoreApplication.processEvents()
+    inc spins
+  if not bench.ready:
+    echo "SKIP: send-modal-open scene did not load"
+    quit(0)
+
+  var rows: seq[Row] = @[]
+
+  proc runSize(size: int) =
+    let owned = buildOwned(size)
+    let params = sendParams()
+
+    # --- open_seed: the modal-open model-seed burst, dropdown CLOSED ----------
+    block:
+      bench.requestDropdownClose()
+      # Fresh empty model + closed sheet.
+      model.setOwnedSource(@[], networks)
+      model.setSectionNames("", "")
+      bench.resetCounters()
+
+      # Pure aggregation cost, isolated (no model emissions / nested construction).
+      let c0 = bench.nowMs()
+      let items = buildDisplayItems(owned, networks, params,
+        TokenSelectorMode.Owned, false, @[], @[])
+      let c1 = bench.nowMs()
+      doAssert items.len == size  # every owned group survives (non-zero balances)
+
+      # Open the sheet and let the enter animation get going.
+      bench.requestOpen()
+      bench.spinFor(120)
+
+      bench.beginMonitor()
+      bench.spinFor(48)  # a few baseline frames before the seed burst
+
+      let t0 = bench.nowMs()
+      model.setOwnedSource(owned, networks)
+      model.setSectionNames("Your assets on Mainnet", "Popular assets")
+      let t1 = bench.nowMs()
+
+      bench.spinFor(200)  # capture the post-seed tick delta
+      bench.endMonitor()
+
+      rows.add(Row(size: size, scenario: "open_seed",
+        computeMs: c1 - c0, injectMs: t1 - t0,
+        maxStallMs: bench.maxStallMs, over32: bench.over32,
+        resets: bench.cReset, inserted: bench.cInserted, dataChanged: bench.cDataChanged,
+        delegatesCreated: bench.cDelegatesCreated, chipsCreated: bench.cChipsCreated))
+      stderr.writeLine(&"[bench] size={size} open_seed compute={rows[^1].computeMs:.2f}ms inject={rows[^1].injectMs:.2f}ms maxStall={rows[^1].maxStallMs:.2f}ms over32={rows[^1].over32}")
+      stderr.flushFile()
+
+    # --- dropdown_open: realize the picker list (next interaction) ------------
+    block:
+      # Model already seeded above; sheet open, dropdown closed. Seed is off-window.
+      bench.requestDropdownClose()
+      bench.spinFor(48)
+      bench.resetCounters()
+
+      bench.beginMonitor()
+      bench.spinFor(16)
+      bench.requestDropdownOpen()   # Loader builds the ListView
+      bench.spinFor(48)
+      # forceLayout realizes the visible delegates + their chip Repeaters
+      # synchronously in one call -- time that, not the observation window.
+      let t0 = bench.nowMs()
+      bench.requestRelayout()
+      let t1 = bench.nowMs()
+      bench.spinFor(200)  # capture any post-realization tick delta
+      bench.endMonitor()
+
+      rows.add(Row(size: size, scenario: "dropdown_open",
+        computeMs: 0.0, injectMs: t1 - t0,
+        maxStallMs: bench.maxStallMs, over32: bench.over32,
+        resets: bench.cReset, inserted: bench.cInserted, dataChanged: bench.cDataChanged,
+        delegatesCreated: bench.cDelegatesCreated, chipsCreated: bench.cChipsCreated))
+      stderr.writeLine(&"[bench] size={size} dropdown_open maxStall={rows[^1].maxStallMs:.2f}ms over32={rows[^1].over32} delegates={rows[^1].delegatesCreated} chips={rows[^1].chipsCreated}")
+      stderr.flushFile()
+
+  runSize(50)
+  runSize(200)
+  runSize(500)
+  runSize(1000)
+  runSize(2000)
+
+  let table = formatTable(rows)
+  echo "\n===== SimpleSendModal open: GUI-thread cost of the send picker seed ====="
+  echo table
+
+  let resultsDir = getCurrentDir() / "test" / "nim" / "benchmarks" / "results"
+  createDir(resultsDir)
+  let stamp = now().format("yyyyMMdd'T'HHmmss")
+  writeFile(resultsDir / ("send_modal_open_" & stamp & ".tsv"), table)
+
+  proc rowFor(scenario: string, size: int): Row =
+    for r in rows:
+      if r.scenario == scenario and r.size == size: return r
+    doAssert false, "missing row " & scenario & " @" & $size
+
+  # At a realistic heavy-user owned set (~200) the on-open seed burst must not drop
+  # a frame -- the picker seed is NOT the source of the ~1s open at real sizes.
+  let seed200 = rowFor("open_seed", 200)
+  doAssert seed200.over32 == 0 and seed200.maxStallMs <= 32.0,
+    &"send picker open_seed dropped a frame @200 owned " &
+    &"(compute {seed200.computeMs:.2f}ms, inject {seed200.injectMs:.2f}ms, " &
+    &"maxStall {seed200.maxStallMs:.2f}ms, over32 {seed200.over32})"
+
+  echo "assertions passed"

--- a/test/nim/swap_key_harvest_bench.nim
+++ b/test/nim/swap_key_harvest_bench.nim
@@ -54,14 +54,17 @@ QtObject:
   type OwnedAssetsModel = ref object of QAbstractListModel
     keys: seq[string]
 
-  proc delete(self: OwnedAssetsModel) = self.QAbstractListModel.delete
-  proc setup(self: OwnedAssetsModel) = self.QAbstractListModel.setup
+  proc delete(self: OwnedAssetsModel)
+  proc setup(self: OwnedAssetsModel)
   proc newOwnedAssetsModel(n: int): OwnedAssetsModel =
     new(result, delete)
     result.setup
     result.keys = newSeqOfCap[string](n)
     for i in 0 ..< n:
       result.keys.add("grp_" & $i)
+
+  proc delete(self: OwnedAssetsModel) = self.QAbstractListModel.delete
+  proc setup(self: OwnedAssetsModel) = self.QAbstractListModel.setup
 
   method rowCount(self: OwnedAssetsModel, index: QModelIndex = nil): int = self.keys.len
 
@@ -97,10 +100,12 @@ QtObject:
     lenByMode: array[2, int]
     resultCount: int
 
-  proc delete(self: Bench) = self.QObject.delete
+  proc delete(self: Bench)
   proc newBench(): Bench =
     new(result, delete)
     result.QObject.setup
+
+  proc delete(self: Bench) = self.QObject.delete
 
   proc requestHarvest(self: Bench) {.signal.}
 

--- a/test/nim/swap_key_harvest_bench.nim
+++ b/test/nim/swap_key_harvest_bench.nim
@@ -1,0 +1,215 @@
+## Request-side harvest benchmark (companion to swap_modal_open_bench).
+##
+## SwapModal.rebuildGroupsForChain runs twice per open + on every in-modal network
+## switch, each time calling
+##   SQUtils.ModelUtils.joinModelEntries(groupedAccountAssetsModel, "key", "$$")
+## to build the mandatory-keys string. groupedAccountAssetsModel has two roles:
+## "key" and "balances" (a per-row submodel). The old modelToArray fetched EVERY
+## role per row via QtMT.ModelQuery.get(model, i) and marshalled the whole map
+## (incl. the balances submodel QObject) to JS, then read only "key" -> the
+## user-profiled ~250ms `modelToArray` stall.
+##
+## This bench builds a synthetic owned model of the same shape (key + a 7-role
+## balances submodel per row) and drives the REAL QtMT.ModelQuery through
+## swap_key_harvest_scene.qml in both regimes over 500 / 2000 / 5000 owned rows:
+##   all_roles   = old modelToArray(model, ["key"])
+##   single_role = fixed modelToArray (per-role get)
+## The scene reads the same "key" out of each; only the fetch strategy differs.
+##
+## RED: the all-roles harvest is many-fold slower than single-role and grows with
+## the owned-row count. GREEN target the ModelUtils fix delivers: the single-role
+## harvest is a small fraction of it (the balances submodel is never fetched).
+
+import os, osproc, times, strformat, strutils, tables
+import nimqml
+from seaqt/qcoreapplication import QCoreApplication, processEvents
+import std/monotimes
+
+{.compile: "bench_statusq_register.cpp".}
+proc bench_registerStatusQTypes() {.importc.}
+
+# --- synthetic owned model (shape of grouped_account_assets_model) ---
+#
+# The real groupedAccountAssetsModel exposes "key" plus a "balances" submodel whose
+# per-row marshalling to JS is what the all-roles get pays for and single-role skips.
+# An offscreen nimqml submodel can't be marshalled into ModelQuery.get's all-roles
+# QVariantMap->JS here (harness limitation), so the balances payload is flattened
+# into value roles led by a heavy "balances" blob (a serialized-balances proxy) plus
+# the balances submodel's own fields (account/chainId/tokenAddress/balance/loading).
+# The all-roles get fetches + marshals ALL of them per row; single-role fetches only
+# "key" — the same O(N*allRoles) vs O(N) differential the ModelUtils fix removes.
+
+const balancesBlob = "[" & repeat("""{"account":"0xACCOUNT000000000000000000000000000000000","chainId":1,"tokenAddress":"0xADDR00000000000000000000000000000000000000","balance":"123456789000000000000","loading":false},""", 6) & "]"
+
+type OwnedRole {.pure.} = enum
+  Key = UserRole + 1
+  Balances
+  Account
+  ChainId
+  TokenAddress
+  Balance
+  Loading
+
+QtObject:
+  type OwnedAssetsModel = ref object of QAbstractListModel
+    keys: seq[string]
+
+  proc delete(self: OwnedAssetsModel) = self.QAbstractListModel.delete
+  proc setup(self: OwnedAssetsModel) = self.QAbstractListModel.setup
+  proc newOwnedAssetsModel(n: int): OwnedAssetsModel =
+    new(result, delete)
+    result.setup
+    result.keys = newSeqOfCap[string](n)
+    for i in 0 ..< n:
+      result.keys.add("grp_" & $i)
+
+  method rowCount(self: OwnedAssetsModel, index: QModelIndex = nil): int = self.keys.len
+
+  method roleNames(self: OwnedAssetsModel): Table[int, string] =
+    {OwnedRole.Key.int: "key", OwnedRole.Balances.int: "balances",
+     OwnedRole.Account.int: "account", OwnedRole.ChainId.int: "chainId",
+     OwnedRole.TokenAddress.int: "tokenAddress", OwnedRole.Balance.int: "balance",
+     OwnedRole.Loading.int: "loading"}.toTable
+
+  method data(self: OwnedAssetsModel, index: QModelIndex, role: int): QVariant =
+    if index.row < 0 or index.row >= self.keys.len: return
+    case role.OwnedRole:
+      of OwnedRole.Key: newQVariant(self.keys[index.row])
+      of OwnedRole.Balances: newQVariant(balancesBlob)
+      of OwnedRole.Account: newQVariant("0xACCOUNT000000000000000000000000000000000")
+      of OwnedRole.ChainId: newQVariant(1)
+      of OwnedRole.TokenAddress: newQVariant("0xADDR00000000000000000000000000000000000000")
+      of OwnedRole.Balance: newQVariant("123456789000000000000")
+      of OwnedRole.Loading: newQVariant(false)
+
+# --- bench object driving the scene ---
+
+type Row = object
+  size: int
+  scenario: string
+  ms: float
+  joinedLen: int
+
+QtObject:
+  type Bench = ref object of QObject
+    ready: bool
+    msByMode: array[2, float]
+    lenByMode: array[2, int]
+    resultCount: int
+
+  proc delete(self: Bench) = self.QObject.delete
+  proc newBench(): Bench =
+    new(result, delete)
+    result.QObject.setup
+
+  proc requestHarvest(self: Bench) {.signal.}
+
+  proc onSceneReady(self: Bench) {.slot.} = self.ready = true
+  proc nowMs(self: Bench): float {.slot.} =
+    (getMonoTime() - MonoTime()).inNanoseconds.float / 1_000_000.0
+  proc reportResult(self: Bench, mode: int, ms: float, joinedLen: int) {.slot.} =
+    if mode in 0..1:
+      self.msByMode[mode] = ms
+      self.lenByMode[mode] = joinedLen
+      inc self.resultCount
+
+proc formatTable(rows: seq[Row]): string =
+  result = "size\tscenario\tms\tjoined_len\n"
+  for r in rows:
+    result.add(&"{r.size}\t{r.scenario}\t{r.ms:.4f}\t{r.joinedLen}\n")
+
+const sizes = [500, 2000, 5000]
+
+when isMainModule:
+  let modeEnv = getEnv("HARVEST_MODE")
+
+  # A QApplication is needed in BOTH roles (the child measures; the parent still
+  # links Qt). Kept at top scope so refc never collects it mid-run (a collected
+  # QApplication silently un-instantiates qApp -> "instantiate QApplication first").
+  putEnv("QT_QPA_PLATFORM", "offscreen")
+  let app {.used.} = newQApplication()
+  bench_registerStatusQTypes()
+
+  if modeEnv.len > 0:
+    # Child: measure one regime over all sizes, write RESULT lines to HARVEST_OUT.
+    let mode = parseInt(modeEnv)
+    let outPath = getEnv("HARVEST_OUT")
+    let bench = newBench()
+    let engine = newQQmlApplicationEngine()
+    engine.setRootContextProperty("bench", newQVariant(bench))
+    engine.setRootContextProperty("harvestMode", newQVariant(mode))
+
+    var outLines: seq[string] = @[]
+    for size in sizes:
+      let model = newOwnedAssetsModel(size)
+      engine.setRootContextProperty("ownedModel", newQVariant(model))
+      bench.ready = false
+      let sceneFile = getCurrentDir() / "test" / "nim" / "benchmarks" / "swap_key_harvest_scene.qml"
+      engine.loadData(readFile(sceneFile))
+      var spins = 0
+      while not bench.ready and spins < 500000:
+        QCoreApplication.processEvents(); inc spins
+      if not bench.ready:
+        writeFile(outPath, "SKIP\n"); quit(0)
+      bench.resultCount = 0
+      bench.requestHarvest()
+      var s = 0
+      while bench.resultCount < 1 and s < 500000:
+        QCoreApplication.processEvents(); inc s
+      outLines.add(&"RESULT\t{size}\t{mode}\t{bench.msByMode[mode]:.4f}\t{bench.lenByMode[mode]}")
+    writeFile(outPath, outLines.join("\n") & "\n")
+    quit(0)
+
+  # Parent: run each regime in its own child process (direct exec, no shell, so the
+  # child inherits DYLD_*); each child writes its RESULT lines to a temp file.
+  var rows: seq[Row] = @[]
+  let self = getAppFilename()
+  for mode in 0 .. 1:
+    let outPath = getTempDir() / ("swap_key_harvest_" & $mode & "_" & $getCurrentProcessId() & ".tsv")
+    putEnv("HARVEST_MODE", $mode)
+    putEnv("HARVEST_OUT", outPath)
+    let p = startProcess(self, options = {poParentStreams})  # direct exec keeps DYLD_*
+    let code = p.waitForExit()
+    p.close()
+    doAssert code == 0, &"harvest child (mode {mode}) failed (exit {code})"
+    for line in readFile(outPath).splitLines():
+      if not line.startsWith("RESULT\t"): continue
+      let f = line.split('\t')
+      let scenario = if f[2] == "0": "all_roles" else: "single_role"
+      rows.add(Row(size: parseInt(f[1]), scenario: scenario,
+        ms: parseFloat(f[3]), joinedLen: parseInt(f[4])))
+      stderr.writeLine(&"[bench] size={f[1]} {scenario} {f[3]}ms joinedLen={f[4]}")
+    removeFile(outPath)
+
+  let table = formatTable(rows)
+  echo "\n===== SwapModal request-side key harvest: all-roles vs single-role ====="
+  echo table
+
+  let resultsDir = getCurrentDir() / "test" / "nim" / "benchmarks" / "results"
+  createDir(resultsDir)
+  let stamp = now().format("yyyyMMdd'T'HHmmss")
+  writeFile(resultsDir / ("swap_key_harvest_" & stamp & ".tsv"), table)
+
+  proc rowFor(scenario: string, size: int): Row =
+    for r in rows:
+      if r.scenario == scenario and r.size == size: return r
+    doAssert false, "missing row " & scenario & " @" & $size
+
+  # Correctness: both regimes harvest the same "key" join (same string length).
+  for size in sizes:
+    doAssert rowFor("all_roles", size).joinedLen == rowFor("single_role", size).joinedLen,
+      &"harvest regimes disagree on the joined keys at size {size}"
+
+  # RED/GREEN: the all-roles harvest (old modelToArray) is materially slower than the
+  # single-role harvest (fixed modelToArray) at the largest owned-row count, because
+  # it fetches + marshals every role per row (in production the balances submodel) for
+  # nothing.
+  let redBig = rowFor("all_roles", 5000)
+  let greenBig = rowFor("single_role", 5000)
+  doAssert greenBig.ms < redBig.ms * 0.7,
+    &"expected single-role harvest materially faster @5000 (all_roles {redBig.ms:.2f}ms, single_role {greenBig.ms:.2f}ms)"
+
+  echo "assertions passed"
+  echo &"@5000: all-roles {redBig.ms:.1f}ms -> single-role {greenBig.ms:.1f}ms " &
+    &"({redBig.ms / greenBig.ms:.1f}x). NOTE: synthetic flattens the balances submodel " &
+    "into value roles; production's submodel marshalling makes the real gap larger."

--- a/test/nim/swap_modal_open_bench.nim
+++ b/test/nim/swap_modal_open_bench.nim
@@ -1,0 +1,339 @@
+## SwapModal-open integration benchmark: the real Nim `tokenGroupsForChainModel`
+## (lazy, NoMarketDetails) driven under a real offscreen QQmlApplicationEngine with
+## an animating "modal" panel + ListView + 16ms stall monitor
+## (swap_modal_open_scene.qml).
+##
+## What opening the swap token selector does today: SwapModal.onCompleted ->
+## TokensStore.buildGroupsForChain -> token service `buildGroupsForChain` fires
+## `asyncBuildGroupsForChainTask`, which ships the chain's tokens back as a RAW JSON
+## STRING envelope. The completion slot `onAsyncBuildGroupsForChainDone` then runs
+## ON THE GUI THREAD: Json.decode of the whole chain token list + createTokenItem
+## per token + group build + sort, and in the same tick emits
+## SIGNAL_GROUPS_FOR_CHAIN_LOADED -> view.onGroupsForChainLoaded ->
+## tokenGroupsForChainModel.modelsUpdated(resetModelSize = true, mandatoryKeys).
+## All of that lands mid-open-animation -> a visible freeze.
+##
+## This bench measures both regimes on the SAME real model + scene, per chain-token
+## universe size (2k / 5k / 10k):
+##
+##   open_string_envelope (today):  in the measured open window, decode the JSON
+##     envelope + build the groups + modelsUpdated. This is the GUI-thread work the
+##     string-envelope path performs.
+##
+##   open_typed_handoff (target):   the worker-built groups seq is prepared BEFORE
+##     the window (simulating the threadpool build); in the window only the seq swap
+##     + modelsUpdated runs — the residual GUI-thread fan-out the typed-handoff
+##     migration leaves behind.
+##
+## The model reset + mandatory-keys expansion (modelsUpdated) is the REAL production
+## code in both regimes, so open_typed_handoff also measures whether that residual
+## fan-out alone stalls (the O(K*N) mandatory-keys scan the migration does not
+## touch).
+##
+## RED  (documents the problem): open_string_envelope @10k blocks the GUI thread
+##      > 32ms (one dropped frame).
+## GREEN (the target to hold): open_typed_handoff @10k <= 32ms.
+##
+## Compile -d:QT_MODEL_SPY (pure-Nim model hooks, like token_groups_model_test).
+
+import os, times, strformat, strutils, tables, sequtils, sugar, algorithm, json
+import nimqml
+import json_serialization
+from seaqt/qcoreapplication import QCoreApplication, processEvents
+import std/monotimes
+
+import app/modules/main/wallet_section/all_tokens/token_groups_model
+import app/modules/main/wallet_section/all_tokens/io_interface
+import app_service/service/token/items/token_group
+import app_service/service/token/items/token
+import app_service/service/token/dto/token as token_dto
+
+# Faithful replica of the string-envelope decode the production slot performed
+# before the typed handoff: same DTO seq, same decode cost.
+type BenchGroupsForChainResponse = object
+  chainId: int
+  tokens: seq[TokenDto]
+  error: string
+
+type Row = object
+  size: int
+  scenario: string
+  injectMs: float       # wall time of the synchronous GUI-thread injection
+  maxStallMs: float     # largest 16ms-timer tick-to-tick delta during the window
+  over32: int           # count of tick deltas > 32ms during the window
+  resets: int
+  inserted: int
+  dataChanged: int
+  delegatesCreated: int
+  delegatesDestroyed: int
+
+# --- synthetic chain-token universe -------------------------------------------
+# getTokensByChain returns every token on one chain; on mainnet most tokens are a
+# distinct group (unique crossChainId), so N tokens -> N groups. The owned assets
+# SwapModal passes as mandatory keys are a bounded subset (a heavy user's holdings).
+
+const ownedCap = 250  # mandatory (owned) group keys SwapModal forces to the top
+
+# Mainnet-shaped token fields: a real getTokensByChain row carries a 42-char
+# checksummed address, a full asset name, and a ~95-char raw.githubusercontent
+# logo URI, so a chain's token list is ~250-300 bytes/token (~2.5-3MB @10k). The
+# synthetic payload matches that so the GUI-thread decode+build cost is realistic.
+proc addressFor(i: int): string = "0x" & toHex(i, 40)
+proc groupKeyFor(i: int): string = "grp_" & $i
+
+proc tokenDtoFor(i: int): TokenDto =
+  let tokenAddress = addressFor(i)
+  TokenDto(
+    crossChainId: groupKeyFor(i),
+    address: tokenAddress,
+    name: "Token Number " & $i & " Wrapped Staked Governance Asset",
+    symbol: "TKN" & $i,
+    decimals: 18,
+    chainId: 1,
+    logoUri: "https://raw.githubusercontent.com/status-im/assets/master/tokens/ethereum/" &
+      tokenAddress & "/logo.png",
+    customToken: false,
+  )
+
+proc buildEnvelopeJson(n: int): string =
+  ## The raw worker RPC output the string-envelope path ships to the GUI thread.
+  var arr = newJArray()
+  for i in 0 ..< n:
+    let d = tokenDtoFor(i)
+    arr.add(%*{
+      "crossChainId": d.crossChainId, "address": d.address, "name": d.name,
+      "symbol": d.symbol, "decimals": d.decimals, "chainId": d.chainId,
+      "logoUri": d.logoUri, "custom": d.customToken,
+      "communityData": {"id": "", "name": "", "color": "", "image": ""}})
+  $(%*{"chainId": 1, "tokens": arr, "error": ""})
+
+# Byte-identical replicas of the private service_main helpers the slot runs inline.
+proc benchCreateGroups(tokens: seq[TokenItem]): seq[TokenGroupItem] =
+  var groupsByKey = initTable[string, TokenGroupItem](tokens.len)
+  for token in tokens:
+    let groupKey = token.groupKey
+    if not groupsByKey.hasKey(groupKey):
+      groupsByKey[groupKey] = TokenGroupItem(key: groupKey, name: token.name,
+        symbol: token.symbol, decimals: token.decimals, logoUri: token.logoUri)
+    groupsByKey[groupKey].addToken(token)
+  result = toSeq(groupsByKey.values)
+  result.sort(proc(a, b: TokenGroupItem): int = a.name.cmp(b.name))
+
+proc buildGroupsFromEnvelope(envelope: string): seq[TokenGroupItem] =
+  ## Exactly what onAsyncBuildGroupsForChainDone does on the GUI thread today.
+  let env = Json.decode(envelope, BenchGroupsForChainResponse, allowUnknownFields = true)
+  let tokens = env.tokens.map(t => createTokenItem(t))
+  benchCreateGroups(tokens)
+
+# The model reads its source through this global (mirrors the service's
+# groupsForChain seq the view delegate returns).
+var gGroupsForChain: seq[TokenGroupItem] = @[]
+
+proc groupsForChainDataSource(): TokenGroupsModelDataSource =
+  (
+    getAllTokenGroups: proc(): var seq[TokenGroupItem] = gGroupsForChain,
+    getTokenDetails: proc(tokenKey: string): TokenDetailsItem = default(TokenDetailsItem),
+    getTokenPreferences: proc(groupKey: string): TokenPreferencesItem = default(TokenPreferencesItem),
+    getCommunityTokenDescription: proc(chainId: int, address: string): string = "",
+    getTokensDetailsLoading: proc(): bool = false,
+    getTokensMarketValuesLoading: proc(): bool = false,
+  )
+
+proc marketValuesDataSource(): TokenMarketValuesDataSource =
+  (
+    getMarketValuesForToken: proc(tokenKey: string): TokenMarketValuesItem = default(TokenMarketValuesItem),
+    getPriceForToken: proc(tokenKey: string): float64 = 0.0,
+    getCurrentCurrencyFormat: proc(): CurrencyFormatDto = default(CurrencyFormatDto),
+    getTokensMarketValuesLoading: proc(): bool = false,
+  )
+
+const
+  LAZY_BATCH = 100
+  LAZY_INITIAL = 100
+
+QtObject:
+  type Bench = ref object of QObject
+    ready: bool
+    monitoring: bool
+    lastTickNs: float
+    maxStallMs: float
+    over32: int
+    cReset: int
+    cInserted: int
+    cDataChanged: int
+    cDelegatesCreated: int
+    cDelegatesDestroyed: int
+
+  proc newBench(): Bench =
+    # Run-once bench: no finalizer (the deprecated new(obj, finalizer) conflicts
+    # with the lifted =destroy under the default mm); the QObject lives for the
+    # whole process and is reclaimed at exit.
+    new(result)
+    result.QObject.setup
+
+  proc requestOpen(self: Bench) {.signal.}
+  proc requestRelayout(self: Bench) {.signal.}
+
+  proc onSceneReady(self: Bench) {.slot.} = self.ready = true
+  proc onDelegateCreated(self: Bench) {.slot.} = inc self.cDelegatesCreated
+  proc onDelegateDestroyed(self: Bench) {.slot.} = inc self.cDelegatesDestroyed
+  proc onModelReset(self: Bench) {.slot.} = inc self.cReset
+  proc onRowsInserted(self: Bench) {.slot.} = inc self.cInserted
+  proc onDataChanged(self: Bench, first: int, last: int) {.slot.} = inc self.cDataChanged
+  proc onRowsRemoved(self: Bench) {.slot.} = discard
+
+  proc nowMs(self: Bench): float =
+    (getMonoTime() - MonoTime()).inNanoseconds.float / 1_000_000.0
+
+  proc onStallTick(self: Bench) {.slot.} =
+    if not self.monitoring:
+      return
+    let n = self.nowMs()
+    let delta = n - self.lastTickNs
+    if delta > self.maxStallMs:
+      self.maxStallMs = delta
+    if delta > 32.0:
+      inc self.over32
+    self.lastTickNs = n
+
+  proc beginMonitor(self: Bench) =
+    self.maxStallMs = 0.0
+    self.over32 = 0
+    self.lastTickNs = self.nowMs()
+    self.monitoring = true
+
+  proc endMonitor(self: Bench) = self.monitoring = false
+
+  proc resetCounters(self: Bench) =
+    self.cReset = 0; self.cInserted = 0; self.cDataChanged = 0
+    self.cDelegatesCreated = 0; self.cDelegatesDestroyed = 0
+
+  proc spinFor(self: Bench, ms: float) =
+    ## Busy-drive the event loop for `ms` wall time so the 16ms stall timer fires.
+    let deadline = self.nowMs() + ms
+    while self.nowMs() < deadline:
+      QCoreApplication.processEvents()
+
+proc formatTable(rows: seq[Row]): string =
+  result = "size\tscenario\tinject_ms\tmax_stall_ms\tover32\tresets\tinserted\tdataChanged\tdelegatesCreated\tdelegatesDestroyed\n"
+  for r in rows:
+    result.add(&"{r.size}\t{r.scenario}\t{r.injectMs:.4f}\t{r.maxStallMs:.4f}\t{r.over32}\t{r.resets}\t{r.inserted}\t{r.dataChanged}\t{r.delegatesCreated}\t{r.delegatesDestroyed}\n")
+
+when isMainModule:
+  putEnv("QT_QPA_PLATFORM", "offscreen")
+  let app = newQApplication()
+
+  let model = newTokenGroupsModel(
+    groupsForChainDataSource(), marketValuesDataSource(),
+    modelModes = @[ModelMode.NoMarketDetails, ModelMode.UseLazyLoading],
+    lazyLoadingBatchSize = LAZY_BATCH, lazyLoadingInitialCount = LAZY_INITIAL)
+  let modelVariant = newQVariant(model)
+
+  let bench = newBench()
+  let benchVariant = newQVariant(bench)
+
+  let engine = newQQmlApplicationEngine()
+  engine.setRootContextProperty("groupsForChainModel", modelVariant)
+  engine.setRootContextProperty("bench", benchVariant)
+
+  let sceneFile = getCurrentDir() / "test" / "nim" / "benchmarks" / "swap_modal_open_scene.qml"
+  engine.loadData(readFile(sceneFile))
+
+  var spins = 0
+  while not bench.ready and spins < 500000:
+    QCoreApplication.processEvents()
+    inc spins
+  if not bench.ready:
+    echo "SKIP: swap-modal-open scene did not load"
+    quit(0)
+
+  var rows: seq[Row] = @[]
+
+  proc runSize(size: int) =
+    let mandatoryKeys = collect(newSeq):
+      for i in 0 ..< min(size, ownedCap): groupKeyFor(i)
+
+    # A completion always follows an open. Reset the model to empty, open the pane,
+    # let the enter animation run, then inject the completion mid-window and measure.
+    proc measure(scenario: string, buildOffWindow: bool) =
+      # Fresh model + closed pane for each scenario.
+      gGroupsForChain = @[]
+      model.modelsUpdated(resetModelSize = true, @[])
+      bench.resetCounters()
+
+      # Pre-decode the raw worker output. In the typed-handoff regime the groups are
+      # built here (off the measured window); in the string-envelope regime only the
+      # raw JSON is prepared and the GUI thread decodes+builds inside the window.
+      let envelope = buildEnvelopeJson(size)
+      var prebuilt: seq[TokenGroupItem]
+      if buildOffWindow:
+        prebuilt = buildGroupsFromEnvelope(envelope)
+
+      # Open the pane and let the enter animation get going.
+      bench.requestOpen()
+      bench.spinFor(120)
+
+      bench.beginMonitor()
+      bench.spinFor(48)  # a few baseline frames before the injection
+
+      let t0 = bench.nowMs()
+      if buildOffWindow:
+        gGroupsForChain = move prebuilt
+      else:
+        gGroupsForChain = buildGroupsFromEnvelope(envelope)
+      model.modelsUpdated(resetModelSize = true, mandatoryKeys)
+      let t1 = bench.nowMs()
+
+      bench.requestRelayout()
+      bench.spinFor(200)  # capture the post-injection tick delta + delegate churn
+      bench.endMonitor()
+
+      rows.add(Row(size: size, scenario: scenario,
+        injectMs: t1 - t0, maxStallMs: bench.maxStallMs, over32: bench.over32,
+        resets: bench.cReset, inserted: bench.cInserted, dataChanged: bench.cDataChanged,
+        delegatesCreated: bench.cDelegatesCreated,
+        delegatesDestroyed: bench.cDelegatesDestroyed))
+      stderr.writeLine(&"[bench] size={size} {scenario} inject={rows[^1].injectMs:.2f}ms maxStall={rows[^1].maxStallMs:.2f}ms over32={rows[^1].over32} resets={rows[^1].resets}")
+      stderr.flushFile()
+
+    measure("open_string_envelope", buildOffWindow = false)
+    measure("open_typed_handoff", buildOffWindow = true)
+
+  runSize(2000)
+  runSize(5000)
+  runSize(10000)
+
+  let table = formatTable(rows)
+  echo "\n===== SwapModal open: GUI-thread stall by completion regime ====="
+  echo table
+
+  let resultsDir = getCurrentDir() / "test" / "nim" / "benchmarks" / "results"
+  createDir(resultsDir)
+  let stamp = now().format("yyyyMMdd'T'HHmmss")
+  writeFile(resultsDir / ("swap_modal_open_" & stamp & ".tsv"), table)
+
+  proc rowFor(scenario: string, size: int): Row =
+    for r in rows:
+      if r.scenario == scenario and r.size == size: return r
+    doAssert false, "missing row " & scenario & " @" & $size
+
+  # RED: the string-envelope path drops at least one frame at the 10k universe -- the
+  # render loop's 16ms tick opens a >32ms gap (the visible open freeze) because the
+  # decode + build blocks the GUI thread (inject_ms) mid-open. Gated on the observed
+  # frame gap (the brief's tick-to-tick metric); inject_ms is the pure-compute block.
+  let redRow = rowFor("open_string_envelope", 10000)
+  doAssert redRow.over32 >= 1 and redRow.maxStallMs > 32.0,
+    &"expected string-envelope open to drop a frame @10k " &
+    &"(maxStall {redRow.maxStallMs:.2f}ms, over32 {redRow.over32}, inject {redRow.injectMs:.2f}ms)"
+
+  # GREEN target the typed-handoff migration must hold: with the build moved off the
+  # GUI thread, the residual on-window fan-out (seq swap + modelsUpdated reset +
+  # mandatory-keys expansion) never blocks a frame -- no >32ms tick, and the pure
+  # GUI-thread block stays well within one frame.
+  let greenRow = rowFor("open_typed_handoff", 10000)
+  doAssert greenRow.over32 == 0 and greenRow.maxStallMs <= 32.0 and greenRow.injectMs <= 32.0,
+    &"typed-handoff open should not drop a frame @10k " &
+    &"(maxStall {greenRow.maxStallMs:.2f}ms, over32 {greenRow.over32}, inject {greenRow.injectMs:.2f}ms) -- " &
+    "residual GUI-thread fan-out (modelsUpdated reset / mandatory-keys scan) too heavy"
+
+  echo "assertions passed"

--- a/test/nim/token_selector_model_bench.nim
+++ b/test/nim/token_selector_model_bench.nim
@@ -1,0 +1,228 @@
+## Token-picker propagation benchmark: terminal TokenSelectorModel vs the retired
+## TokenSelectorViewAdaptor proxy graph.
+##
+## The pickers (send / swap / buy) used to render off a QML proxy chain
+## (TokenSelectorViewAdaptor: a LeftJoin of the grouped-owned assets with the
+## all-tokens/search lists feeding a SortFilterProxyModel). A single owned-balance
+## or market-price tick entered that chain through the right-joined groups model,
+## so the outer LeftJoinModel emitted a WHOLE-model dataChanged and the SFPM
+## re-sorted the whole set — the ×N amplification measured by
+## asset_proxy_chain_bench.nim (the picker's owned source is the SAME grouped
+## aggregator graph, so that file is the RED baseline for the owned scenarios).
+##
+## This file measures the GREEN terminal model directly (no proxies above it):
+## it context-drives a real TokenSelectorModel the way the producer does
+## (setOwnedSource + lazy popular/search closures + param setters) and applies the
+## five picker update classes — owned-balance update, market-price update,
+## search-results apply, chain-filter flip, page append — over 100 / 1k / 5k token
+## universes. For each it records wall time and the model's granular signal counts
+## (dataChanged / summed dataChanged row-span / resets / inserts / removes) via the
+## in-process QtModelSpy, prints a machine-readable table, and saves it (gitignored)
+## under test/nim/benchmarks/results/.
+##
+## GREEN structural gate (flips the proxy baseline's RED): a stable-set single-cell
+## change (owned balance / market price that keeps its rank) propagates as O(1)
+## work — the summed dataChanged row-span is a small constant, not the universe
+## size — and NO scenario resets the model. Page append is a bounded insert. The
+## set-swapping scenarios (search apply, chain-filter flip) are inherent
+## whole-list changes and are measured (not O(1)-asserted); they still never reset.
+##
+## Compile -d:QT_MODEL_SPY (pure-Nim model hooks, like token_selector_model_test).
+
+import os, times, strformat, strutils, tables
+import stint
+import nimqml
+from seaqt/qcoreapplication import QCoreApplication, processEvents
+import std/monotimes
+
+import app/modules/shared_models/token_selector_model
+import app/modules/shared_models/token_selector_builder
+import app/modules/shared_models/assets_aggregator
+import app/modules/shared/qt_model_spy
+
+type Row = object
+  size: int
+  scenario: string
+  wallMs: float
+  dataChanged: int
+  dataChangedRows: int
+  resets: int
+  inserted: int
+  removed: int
+
+proc dataChangedRows(spy: QtModelSpy): int =
+  for c in spy.calls:
+    if c.kind == DataChanged:
+      result += (c.bottomRight - c.topLeft + 1)
+
+proc dataChangedCount(spy: QtModelSpy): int =
+  for c in spy.calls:
+    if c.kind == DataChanged:
+      inc result
+
+# --- synthetic universe -------------------------------------------------------
+# Owned groups spread over `chains` chains, each with one per-chain balance, so
+# chain-filter and per-chip paths are exercised. Popular groups back the
+# AllTokens merge + page append; search returns a filtered slice of them.
+
+const chains = [1, 10, 42161, 8453, 11155111]
+
+proc weiFor(i: int): UInt256 =
+  # non-zero, varied; keeps every owned group with a balance
+  parse($((i mod 1000) + 1) & "000000000000000000", UInt256)
+
+proc ownedGroup(i: int): AggTokenGroup =
+  let chain = chains[i mod chains.len]
+  AggTokenGroup(
+    key: "tok_" & $i,
+    name: "Token " & $i,
+    symbol: "T" & $i,
+    logoUri: "",
+    decimals: 18,
+    communityId: "",
+    marketPrice: 1.0 + float(i mod 500) * 0.01,
+    balances: @[AggBalance(account: "0xA", chainId: chain, balance: weiFor(i), loading: false)],
+    tokens: @[(key: "tok_" & $i & "_c" & $chain, chainId: chain)])
+
+proc buildOwned(n: int): seq[AggTokenGroup] =
+  result = newSeqOfCap[AggTokenGroup](n)
+  for i in 0 ..< n:
+    result.add(ownedGroup(i))
+
+proc popularGroup(i: int): PopularGroup =
+  # Shares the owned key space (tok_i) so the all-tokens merge attaches owned
+  # balances to the displayed popular rows — an owned-cell edit then lands on a
+  # visible row (the O(1) propagation the benchmark measures).
+  let chain = chains[i mod chains.len]
+  PopularGroup(key: "tok_" & $i, name: "Token " & $i, symbol: "T" & $i,
+    logoUri: "", communityId: "", marketPrice: 1.0 + float(i mod 500) * 0.01,
+    tokens: @[(key: "tok_" & $i & "_c" & $chain, chainId: chain)])
+
+proc formatTable(rows: seq[Row]): string =
+  result = "size\tscenario\twall_ms\tdataChanged\tdataChangedRows\tresets\tinserted\tremoved\n"
+  for r in rows:
+    result.add(&"{r.size}\t{r.scenario}\t{r.wallMs:.4f}\t{r.dataChanged}\t{r.dataChangedRows}\t{r.resets}\t{r.inserted}\t{r.removed}\n")
+
+when isMainModule:
+  putEnv("QT_QPA_PLATFORM", "offscreen")
+  let app = newQApplication()
+
+  let networks = @[
+    NetworkInfo(chainId: 1, chainName: "Mainnet", iconUrl: ""),
+    NetworkInfo(chainId: 10, chainName: "Optimism", iconUrl: ""),
+    NetworkInfo(chainId: 42161, chainName: "Arbitrum", iconUrl: ""),
+    NetworkInfo(chainId: 8453, chainName: "Base", iconUrl: ""),
+    NetworkInfo(chainId: 11155111, chainName: "Sepolia", iconUrl: ""),
+  ]
+
+  let spy = newQtModelSpy()
+  spy.enable()
+
+  var rows: seq[Row] = @[]
+
+  proc pump() =
+    for _ in 0 ..< 4:
+      QCoreApplication.processEvents()
+
+  proc runSize(size: int) =
+    # Popular list grows in place on fetchMore; start with one page loaded.
+    let popularPage = 25
+    var popularLoaded = popularPage
+    let popularTotal = size
+
+    var source: TokenSelectorSource
+    source.getPopular = proc(): seq[PopularGroup] =
+      result = newSeqOfCap[PopularGroup](popularLoaded)
+      for i in 0 ..< min(popularLoaded, popularTotal): result.add(popularGroup(i))
+    source.getSearch = proc(): seq[PopularGroup] =
+      # a filtered slice of the popular universe
+      result = @[]
+      for i in 0 ..< popularTotal:
+        if (i mod 7) == 0: result.add(popularGroup(i))
+    source.doSearch = proc(keyword: string) = discard
+    source.fetchMore = proc(searching: bool) =
+      if not searching: popularLoaded = min(popularLoaded + popularPage, popularTotal)
+    source.hasMore = proc(searching: bool): bool =
+      (not searching) and popularLoaded < popularTotal
+    source.isLoadingMore = proc(searching: bool): bool = false
+
+    let m = newTokenSelectorModel(TokenSelectorMode.AllTokens)
+    m.setSectionNames("Your assets", "Popular assets")
+    m.setSource(source)
+    var owned = buildOwned(size)
+    m.setOwnedSource(owned, networks)
+    pump()
+
+    proc measure(scenario: string, mutate: proc()) =
+      spy.clear()
+      let t0 = getMonoTime()
+      mutate()
+      pump()
+      let t1 = getMonoTime()
+      rows.add(Row(size: size, scenario: scenario,
+        wallMs: (t1 - t0).inNanoseconds.float / 1_000_000.0,
+        dataChanged: spy.dataChangedCount(), dataChangedRows: spy.dataChangedRows(),
+        resets: spy.countResets(), inserted: spy.countInserts(), removed: spy.countRemoves()))
+      stderr.writeLine(&"[bench] size={size} {scenario} {rows[^1].wallMs:.2f}ms dataChangedRows={rows[^1].dataChangedRows} resets={rows[^1].resets}")
+      stderr.flushFile()
+
+    # 1) owned-balance update: nudge one displayed group's balance by 1 wei so it
+    # keeps its rank — the change should touch exactly that one row.
+    measure("owned_balance_update", proc() =
+      let i = 5  # a displayed row (within the initially loaded popular window)
+      owned[i].balances[0].balance = owned[i].balances[0].balance + parse("1", UInt256)
+      m.setOwnedSource(owned, networks))
+
+    # 2) market-price update: bump one group's price a little (keeps its rank).
+    measure("market_price_update", proc() =
+      let i = 5  # a displayed row (within the initially loaded popular window)
+      owned[i].marketPrice = owned[i].marketPrice + 0.001
+      m.setOwnedSource(owned, networks))
+
+    # 3) search-results apply: swap the list to the search slice (inherent).
+    measure("search_apply", proc() = m.search("pop"))
+
+    # restore the non-search list before the next measurement
+    m.search("")
+    pump()
+
+    # 4) chain-filter flip: scope to a single chain (inherent big filter).
+    measure("chain_filter_flip", proc() = m.setEnabledChainId(1))
+    m.setEnabledChainId(-1)
+    pump()
+
+    # 5) page append: grow the popular list by one page (bounded insert).
+    measure("page_append", proc() = m.fetchMore())
+
+  runSize(100)
+  runSize(1000)
+  runSize(5000)
+
+  let table = formatTable(rows)
+  echo "\n===== token-picker terminal-model propagation (GREEN) ====="
+  echo table
+
+  let resultsDir = getCurrentDir() / "test" / "nim" / "benchmarks" / "results"
+  createDir(resultsDir)
+  let stamp = now().format("yyyyMMdd'T'HHmmss")
+  writeFile(resultsDir / ("token_selector_model_" & stamp & ".tsv"), table)
+
+  # GREEN structural gate. The proxy baseline (asset_proxy_chain_bench) fanned a
+  # single owned-cell edit into a whole-model dataChanged (dataChangedRows >= N)
+  # and re-sorted the whole set; here a stable-set single-cell change is O(1) and
+  # neither the terminal model nor its preserved submodels reset. The set-swapping
+  # scenarios (search apply, chain-filter flip) are inherent whole-list changes —
+  # their nested submodels legitimately tear down, so they are measured, not gated.
+  for r in rows:
+    if r.scenario in ["owned_balance_update", "market_price_update"]:
+      doAssert r.dataChangedRows <= 8,
+        &"expected O(1) propagation for '{r.scenario}' at size {r.size} (got {r.dataChangedRows} rows)"
+      doAssert r.inserted == 0 and r.removed == 0,
+        &"stable-set '{r.scenario}' changed the row set at size {r.size}"
+      doAssert r.resets == 0,
+        &"stable-set '{r.scenario}' reset a model at size {r.size}"
+    if r.scenario == "page_append":
+      doAssert r.inserted > 0 and r.removed == 0 and r.resets == 0,
+        &"page_append should be a bounded insert (no removes/resets) at size {r.size}"
+
+  echo "structural assertions passed"


### PR DESCRIPTION
Benches (5/5 in the stack — review-optional). The measurement harness behind the numbers in the previous PRs:

- Offscreen QML bench harness (QQmlApplicationEngine + 16 ms-tick stall probe + counting delegates) and benches: model propagation proxy-vs-terminal, modal-open GUI stall (swap + send), collectibles picker RED (retired adaptor kept as bench fixture) vs GREEN (terminal model).
- Per-file bench Makefile targets; `QT_MODEL_SPY` define rules; TSV outputs gitignored. `token_selector_model_bench` doubles as a structural gate (bounded inserts / zero resets asserted via spy counters).

Nothing here ships in production paths. Benches build in CI terms but are run manually.


Usage example:

`make nim-test-run/test/nim/token_selector_model_bench.nim`
