### PR TITLE
fix(Onboarding): Remove blank space from profile dropdown and show welcome page after deleting all profiles

### DIFF
--- a/ui/app/AppLayouts/Onboarding/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingFlow.qml
@@ -98,11 +98,20 @@ OnboardingStackView {
         loginScreen.setBiometricResponse(secret, error)
     }
 
+    Connections {
+        target: root.loginAccountsModel?.ModelCount ?? null
+
+        function onCountChanged() {
+            d.showWelcomePageIfNoProfiles()
+        }
+    }
+
     QtObject {
         id: d
 
         property int flow
         property LoginScreen loginScreen: null
+        property var manageProfilesDialog: null
 
 
         function pushOrSkipBiometricsPage() {
@@ -133,7 +142,18 @@ OnboardingStackView {
         }
 
         function openManageProfilesPopup() {
-            manageProfilesPopup.createObject(root).open()
+            d.manageProfilesDialog = manageProfilesPopup.createObject(root)
+            d.manageProfilesDialog.open()
+        }
+
+        function showWelcomePageIfNoProfiles() {
+            if (!root.loginAccountsModel?.ModelCount.empty)
+                return
+
+            if (d.manageProfilesDialog)
+                d.manageProfilesDialog.close()
+
+            root.replace(null, welcomePage)
         }
 
         function openDeleteMultiaccountConfirmationDialog(keyUid, username) {

--- a/ui/app/AppLayouts/Onboarding/controls/LoginUserSelector.qml
+++ b/ui/app/AppLayouts/Onboarding/controls/LoginUserSelector.qml
@@ -36,11 +36,22 @@ Control {
         currentEntry.value = selection
     }
 
+    onModelChanged: Qt.callLater(() => setSelection(selectedProfileKeyId))
+
+    Connections {
+        target: root.model?.ModelCount ?? null
+
+        function onCountChanged() {
+            root.setSelection(root.selectedProfileKeyId)
+        }
+    }
+
     QtObject {
         id: d
 
         readonly property int maxPopupHeight: 300
         readonly property int delegateHeight: 64
+        readonly property int visibleProfilesCount: dropdownProfilesModel.count
     }
 
     ModelEntry {
@@ -49,6 +60,26 @@ Control {
         sourceModel: root.model
         key: "keyUid"
         value: ""
+    }
+
+    SortFilterProxyModel {
+        id: dropdownProfilesModel
+
+        sourceModel: root.model
+        sorters: RoleSorter {
+            roleName: "order"
+        }
+        filters: [
+            FastExpressionFilter {
+                expectedRoles: ["keyUid", "username"]
+                expression: !!model.keyUid && !!model.username
+            },
+            ValueFilter { // don't show the currently selected item
+                roleName: "keyUid"
+                value: root.selectedProfileKeyId
+                inverted: true
+            }
+        ]
     }
 
     contentItem: LoginUserSelectorDelegate {
@@ -103,45 +134,45 @@ Control {
 
         contentItem: ColumnLayout {
             spacing: 0
-            StatusListView {
+            StatusScrollView {
+                id: profilesScrollView
+
                 Layout.fillWidth: true
-                Layout.fillHeight: true
-                Layout.maximumHeight: d.maxPopupHeight
-                id: userSelectorPanel
-                model: SortFilterProxyModel {
-                    id: proxyModel
-                    sourceModel: root.model
-                    sorters: RoleSorter {
-                        roleName: "order"
-                    }
-                    filters: [
-                        ValueFilter { // don't show the currently selected item
-                            roleName: "keyUid"
-                            value: root.selectedProfileKeyId
-                            inverted: true
+                Layout.preferredHeight: Math.min(d.visibleProfilesCount * d.delegateHeight, d.maxPopupHeight)
+                visible: d.visibleProfilesCount > 0
+                contentWidth: availableWidth
+                padding: 0
+
+                ColumnLayout {
+                    width: profilesScrollView.availableWidth
+                    spacing: 0
+
+                    Repeater {
+                        model: dropdownProfilesModel
+
+                        LoginUserSelectorDelegate {
+                            readonly property bool hasProfileData: !!model.keyUid && !!model.username
+
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: hasProfileData ? d.delegateHeight : 0
+                            visible: hasProfileData
+                            label: model.username
+                            image: model.thumbnailImage
+                            colorId: model.colorId
+                            keycardCreatedAccount: model.keycardCreatedAccount
+                            keycardEnabled: root.isKeycardEnabled
+                            enabled: !model.keycardCreatedAccount ? true : root.isKeycardEnabled
+                            onClicked: {
+                                dropdown.close()
+                                root.setSelection(model.keyUid)
+                            }
                         }
-                    ]
-                }
-                implicitHeight: contentHeight
-                spacing: 0
-                delegate: LoginUserSelectorDelegate {
-                    width: ListView.view.width
-                    height: d.delegateHeight
-                    label: model.username
-                    image: model.thumbnailImage
-                    colorId: model.colorId
-                    keycardCreatedAccount: model.keycardCreatedAccount
-                    keycardEnabled: root.isKeycardEnabled
-                    enabled: !model.keycardCreatedAccount ? true : root.isKeycardEnabled
-                    onClicked: {
-                        dropdown.close()
-                        root.setSelection(model.keyUid)
                     }
                 }
             }
             StatusMenuSeparator {
                 Layout.fillWidth: true
-                visible: proxyModel.count > 0
+                visible: d.visibleProfilesCount > 0
             }
             LoginUserSelectorDelegate {
                 Layout.fillWidth: true


### PR DESCRIPTION
Closes #20222

### What does the PR do

1. Reworks the profile dropdown to avoid stale/blank rows after deleting profiles. The dropdown now uses a scrollable layout instead of `ListView`, while keeping `SortFilterProxyModel` for `order` sorting and selected-profile filtering.

2. When the last local profile is removed from Manage profiles, closes the dialog and returns to the welcome page instead of leaving the login flow in an empty state.

### Affected areas

Onboarding, returning login, profile management.

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/8b9da442-719a-4f21-a5be-5910ddcda748

### Impact on end user

Users no longer see blank/stale profile rows in the profile dropdown after removing profiles.

If all local profiles are removed, the app now returns to the fresh-account welcome page.

### How to test

1. Create or import at least 3 local profiles.
2. Open the profile dropdown from the returning login screen.
3. Go to Manage profiles.
4. Delete one profile and confirm the dropdown no longer shows a blank row.
5. Delete another profile and confirm the dropdown still only shows valid profiles/actions.
6. Delete the last remaining profile and confirm the app navigates to the welcome page.

### Risk

Low. Changes are limited to onboarding profile selection and profile deletion UI flow.

Main risk is around dropdown ordering/filtering after model updates, covered by preserving `SortFilterProxyModel` sorting by `order` and filtering invalid profile rows.