### PR TITLE
fix(community): fix issue where chat messages loaded forever

### DIFF
--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1167,7 +1167,6 @@ QtObject:
         chatDto.id = fullChatId
         # TODO find a way to populate missing infos like the color
         self.chatService.updateOrAddChat(chatDto)
-        self.messageService.asyncLoadInitialMessagesForChat(fullChatId)
 
       self.events.emit(SIGNAL_COMMUNITIES_UPDATE, CommunitiesArgs(communities: @[updatedCommunity]))
       self.events.emit(SIGNAL_COMMUNITY_SPECTATED, CommunityArgs(community: updatedCommunity, fromUserAction: true, isPendingOwnershipRequest: (ownerTokenNotification != nil)))


### PR DESCRIPTION
cherry-pick of https://github.com/status-im/status-app/pull/21507
See video there ^

There was an issue where when you spectate a community for the first time, the fetched messages would be impossible to view sometimes because the loading never went away. The problem was that when a community is discovered/spectated, it was immediately calling message initialization for every new chat before that chat’s content module had loaded. But the messages module only subscribes when the chat content is actually loaded in module.nim:75, with the messages submodule starting at module.nim:102. That means the first fetch could be “consumed” early, populate service-side state, and then the first real channel open would see no messages. After app restart, that in-memory state is gone, so the channel looks fine again.