### PR TITLE
fix(cherry-pick): StatusModal header has no contentHeight

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
@@ -197,6 +197,7 @@ StatusDialog {
 
     header: ToolBar {
         position: ToolBar.Top
+        contentHeight: headerImpl.implicitHeight
         background: StatusDialogBackground {
             implicitHeight: headerImpl.implicitHeight
         }


### PR DESCRIPTION
### What does the PR do

Cherry-pick https://github.com/status-im/status-app/pull/21443

Closes #https://github.com/status-im/status-app/issues/21436