### PR TITLE
perf(StatusQ): lazy creation for text-field menus, scrollbar thumbs, tooltips and loading shimmers

### DIFF
--- a/storybook/qmlTests/tests/tst_LoadingComponent.qml
+++ b/storybook/qmlTests/tests/tst_LoadingComponent.qml
@@ -1,0 +1,66 @@
+import QtQuick
+import QtQuick.Controls
+import QtTest
+
+import StatusQ.Components
+
+Item {
+    id: root
+    width: 200
+    height: 200
+
+    Component {
+        id: loadingComp
+        LoadingComponent {
+            width: 120
+            height: 16
+            radius: 4
+        }
+    }
+
+    TestCase {
+        name: "LoadingComponent"
+        when: windowShown
+
+        // --- Cycle 1: animation lifecycle seam ---
+
+        // (1) not visible -> NO running animation object materialized.
+        // The heavy shimmer subtree (gradient + animator) must not exist while
+        // the placeholder is hidden, so the render thread can park (no forced
+        // 60fps whole-scene repaint).
+        function test_shimmer_absent_when_not_visible() {
+            const comp = createTemporaryObject(loadingComp, root, {visible: false})
+            verify(!!comp)
+            verify(!findChild(comp, "shimmerSweep"),
+                   "shimmer sweep must not be materialized while hidden")
+            verify(!findChild(comp, "shimmerAnimator"),
+                   "no animation object should exist while hidden")
+        }
+
+        // (2) visible -> shimmer materialized and animating.
+        function test_shimmer_present_and_running_when_visible() {
+            const comp = createTemporaryObject(loadingComp, root, {visible: true})
+            verify(!!comp)
+
+            tryVerify(() => !!findChild(comp, "shimmerSweep"), 1000,
+                      "shimmer sweep must be materialized while visible")
+            const anim = findChild(comp, "shimmerAnimator")
+            verify(!!anim, "animation object must exist while visible")
+            compare(anim.running, true, "shimmer must be animating while visible")
+        }
+
+        // (3) becomes hidden -> shimmer + animation torn down (placeholder gone).
+        function test_shimmer_stops_and_is_removed_when_hidden() {
+            const comp = createTemporaryObject(loadingComp, root, {visible: true})
+            verify(!!comp)
+            tryVerify(() => !!findChild(comp, "shimmerSweep"), 1000)
+
+            comp.visible = false
+
+            tryVerify(() => !findChild(comp, "shimmerSweep"), 1000,
+                      "shimmer sweep must be torn down once hidden")
+            verify(!findChild(comp, "shimmerAnimator"),
+                   "no animation object should linger once hidden")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_StatusDotsLoadingIndicator.qml
+++ b/storybook/qmlTests/tests/tst_StatusDotsLoadingIndicator.qml
@@ -1,0 +1,71 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Components
+
+Item {
+    id: root
+    width: 200
+    height: 200
+
+    Component {
+        id: dotsComp
+        StatusDotsLoadingIndicator {
+            dotsDiameter: 5
+            duration: 500
+        }
+    }
+
+    // A wrapper hidden via an ancestor: the indicator's own `visible` is
+    // effectively false even though it is not set locally.
+    Component {
+        id: hiddenHostComp
+        Item {
+            visible: false
+            property alias indicator: dots
+            StatusDotsLoadingIndicator {
+                id: dots
+                dotsDiameter: 5
+                duration: 500
+            }
+        }
+    }
+
+    TestCase {
+        name: "StatusDotsLoadingIndicator"
+        when: windowShown
+
+        // (2) visible -> the blink animation runs.
+        function test_dots_animate_when_visible() {
+            const dots = createTemporaryObject(dotsComp, root, {visible: true})
+            verify(!!dots)
+            const anim = findChild(dots, "dotBlinkAnimation")
+            verify(!!anim, "the dots must have a blink animation")
+            compare(anim.running, true, "dot blink must run while visible")
+        }
+
+        // (1) not visible (via hidden ancestor) -> NO running blink animation.
+        // Guards the regression where Component.onCompleted.start() overrode the
+        // running-when-visible binding, leaving hidden dots animating forever.
+        function test_dots_do_not_animate_when_hidden() {
+            const host = createTemporaryObject(hiddenHostComp, root)
+            verify(!!host)
+            const anim = findChild(host.indicator, "dotBlinkAnimation")
+            verify(!!anim)
+            compare(anim.running, false,
+                    "dot blink must not run while the indicator is hidden")
+        }
+
+        // (3) becomes hidden after being visible -> animation stops.
+        function test_dots_stop_when_becoming_hidden() {
+            const dots = createTemporaryObject(dotsComp, root, {visible: true})
+            verify(!!dots)
+            const anim = findChild(dots, "dotBlinkAnimation")
+            verify(!!anim)
+
+            dots.visible = false
+            tryCompare(anim, "running", false, 1000,
+                       "dot blink must stop once the indicator is hidden")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_StatusLoadingIndicator.qml
+++ b/storybook/qmlTests/tests/tst_StatusLoadingIndicator.qml
@@ -1,0 +1,59 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Components
+
+Item {
+    id: root
+    width: 200
+    height: 200
+
+    Component {
+        id: spinnerComp
+        StatusLoadingIndicator {}
+    }
+
+    Component {
+        id: hiddenHostComp
+        Item {
+            visible: false
+            property alias spinner: spinner
+            StatusLoadingIndicator { id: spinner }
+        }
+    }
+
+    TestCase {
+        name: "StatusLoadingIndicator"
+        when: windowShown
+
+        // (2) visible -> the spinner rotation runs.
+        function test_spinner_runs_when_visible() {
+            const spinner = createTemporaryObject(spinnerComp, root, {visible: true})
+            verify(!!spinner)
+            const anim = findChild(spinner, "spinnerAnimator")
+            verify(!!anim, "the spinner must have a rotation animation")
+            compare(anim.running, true, "spinner must rotate while visible")
+        }
+
+        // (1) not visible (via hidden ancestor) -> rotation does not run.
+        function test_spinner_idle_when_hidden() {
+            const host = createTemporaryObject(hiddenHostComp, root)
+            verify(!!host)
+            const anim = findChild(host.spinner, "spinnerAnimator")
+            verify(!!anim)
+            compare(anim.running, false, "spinner must not rotate while hidden")
+        }
+
+        // (3) becomes hidden -> rotation stops.
+        function test_spinner_stops_when_becoming_hidden() {
+            const spinner = createTemporaryObject(spinnerComp, root, {visible: true})
+            verify(!!spinner)
+            const anim = findChild(spinner, "spinnerAnimator")
+            verify(!!anim)
+
+            spinner.visible = false
+            tryCompare(anim, "running", false, 1000,
+                       "spinner must stop rotating once hidden")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_StatusScrollBar.qml
+++ b/storybook/qmlTests/tests/tst_StatusScrollBar.qml
@@ -28,6 +28,21 @@ Item {
         }
     }
 
+    // A StatusListView whose content overflows vertically: the vertical scrollbar
+    // is needed. Its thumb should appear only once the bar becomes active.
+    Component {
+        id: overflowingListView
+        StatusListView {
+            width: 200
+            height: 200
+            model: 50
+            delegate: Item {
+                width: 200
+                height: 40
+            }
+        }
+    }
+
     TestCase {
         name: "StatusScrollBar"
         when: windowShown
@@ -49,6 +64,29 @@ Item {
                    "vertical thumb should not be materialized at instantiation")
             verify(!findChild(view.ScrollBar.horizontal, "scrollBarThumb"),
                    "horizontal thumb should not be materialized at instantiation")
+        }
+
+        // --- Cycle 2: materialize + become opaque once the bar is active ---
+        function test_thumb_materializes_and_shows_when_active() {
+            const view = createTemporaryObject(overflowingListView, root)
+            verify(!!view)
+
+            const bar = view.verticalScrollBar
+            tryCompare(bar, "visible", true, 1000,
+                       "vertical scrollbar should be visible for overflowing content")
+
+            // Idle: thumb still not materialized.
+            verify(!findChild(bar, "scrollBarThumb"),
+                   "thumb should stay lazy while the bar is idle")
+
+            // User starts scrolling -> bar becomes active.
+            bar.active = true
+
+            tryVerify(() => !!findChild(bar, "scrollBarThumb"), 1000,
+                      "thumb should materialize once the bar is active")
+            const thumb = findChild(bar, "scrollBarThumb")
+            tryCompare(thumb, "opacity", 1.0, 1000,
+                       "thumb should be fully opaque while the bar is active")
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_StatusScrollBar.qml
+++ b/storybook/qmlTests/tests/tst_StatusScrollBar.qml
@@ -88,5 +88,28 @@ Item {
             tryCompare(thumb, "opacity", 1.0, 1000,
                        "thumb should be fully opaque while the bar is active")
         }
+
+        // --- Cycle 3: preserve the transient fade-out ---
+        // After the bar goes idle again the thumb must stay alive so its opacity
+        // can animate back to 0 (fade-out), matching the released UX.
+        function test_thumb_fades_out_and_persists_when_bar_goes_idle() {
+            const view = createTemporaryObject(overflowingListView, root)
+            verify(!!view)
+
+            const bar = view.verticalScrollBar
+            tryCompare(bar, "visible", true, 1000)
+
+            bar.active = true
+            tryVerify(() => !!findChild(bar, "scrollBarThumb"), 1000)
+
+            bar.active = false
+
+            // Thumb must remain instantiated to play the fade-out animation...
+            verify(!!findChild(bar, "scrollBarThumb"),
+                   "thumb should persist after the bar goes idle so it can fade out")
+            // ...and settle to fully transparent.
+            tryCompare(findChild(bar, "scrollBarThumb"), "opacity", 0.0, 1000,
+                       "thumb should fade out to transparent when the bar goes idle")
+        }
     }
 }

--- a/storybook/qmlTests/tests/tst_StatusScrollBar.qml
+++ b/storybook/qmlTests/tests/tst_StatusScrollBar.qml
@@ -1,0 +1,54 @@
+import QtQuick
+import QtQuick.Controls
+import QtTest
+
+import StatusQ.Core
+import StatusQ.Controls
+
+Item {
+    id: root
+    width: 400
+    height: 400
+
+    // A StatusScrollView whose content does NOT overflow: no scrollbar is needed.
+    Component {
+        id: nonOverflowingScrollView
+        StatusScrollView {
+            width: 200
+            height: 200
+            padding: 0
+            contentWidth: 100
+            contentHeight: 100
+
+            Rectangle {
+                implicitWidth: 100
+                implicitHeight: 100
+                color: "transparent"
+            }
+        }
+    }
+
+    TestCase {
+        name: "StatusScrollBar"
+        when: windowShown
+
+        // --- Cycle 1: laziness seam (b) ---
+        // The scrollbar thumb (visual content) must not be materialized while the
+        // content fits and nobody has interacted with the scrollbar.
+        function test_thumb_absent_when_content_fits_and_idle() {
+            const view = createTemporaryObject(nonOverflowingScrollView, root)
+            verify(!!view)
+
+            // Let layout settle so scrollbar geometry/policy are resolved.
+            tryCompare(view.ScrollBar.vertical, "visible", false,
+                       1000, "vertical scrollbar should not be visible for non-overflowing content")
+            tryCompare(view.ScrollBar.horizontal, "visible", false,
+                       1000, "horizontal scrollbar should not be visible for non-overflowing content")
+
+            verify(!findChild(view.ScrollBar.vertical, "scrollBarThumb"),
+                   "vertical thumb should not be materialized at instantiation")
+            verify(!findChild(view.ScrollBar.horizontal, "scrollBarThumb"),
+                   "horizontal thumb should not be materialized at instantiation")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_StatusScrollBar.qml
+++ b/storybook/qmlTests/tests/tst_StatusScrollBar.qml
@@ -43,6 +43,18 @@ Item {
         }
     }
 
+    // A standalone StatusScrollBar forced always-on: its thumb must be shown
+    // permanently, from the very first frame.
+    Component {
+        id: alwaysOnBar
+        StatusScrollBar {
+            width: 14
+            height: 200
+            size: 0.5
+            policy: ScrollBar.AlwaysOn
+        }
+    }
+
     TestCase {
         name: "StatusScrollBar"
         when: windowShown
@@ -110,6 +122,40 @@ Item {
             // ...and settle to fully transparent.
             tryCompare(findChild(bar, "scrollBarThumb"), "opacity", 0.0, 1000,
                        "thumb should fade out to transparent when the bar goes idle")
+        }
+
+        // --- Cycle 4: AlwaysOn policy shows the thumb immediately ---
+        function test_alwaysOn_thumb_present_and_opaque_at_instantiation() {
+            const bar = createTemporaryObject(alwaysOnBar, root)
+            verify(!!bar)
+
+            const thumb = findChild(bar, "scrollBarThumb")
+            verify(!!thumb, "AlwaysOn thumb must be materialized at instantiation")
+            tryCompare(thumb, "opacity", 1.0, 1000,
+                       "AlwaysOn thumb must be fully opaque")
+        }
+
+        // --- Cycle 5: resolveVisibility (AsNeeded) contract is preserved ---
+        // The bar's `visible` still flips on when content grows to overflow, yet
+        // the thumb stays lazy until the user actually interacts (parity with the
+        // released opacity-0-until-hover behaviour, now zero-cost).
+        function test_visible_tracks_overflow_while_thumb_stays_lazy() {
+            const view = createTemporaryObject(nonOverflowingScrollView, root)
+            verify(!!view)
+
+            const bar = view.ScrollBar.vertical
+            tryCompare(bar, "visible", false, 1000,
+                       "not visible while content fits")
+            verify(!findChild(bar, "scrollBarThumb"))
+
+            // Content grows past the viewport -> AsNeeded makes the bar visible.
+            view.contentHeight = 500
+            tryCompare(bar, "visible", true, 1000,
+                       "visible once content overflows")
+
+            // ...but nobody has scrolled yet, so the thumb is still not built.
+            verify(!findChild(bar, "scrollBarThumb"),
+                   "thumb stays lazy for a visible-but-untouched AsNeeded bar")
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_StatusToolTip.qml
+++ b/storybook/qmlTests/tests/tst_StatusToolTip.qml
@@ -1,0 +1,109 @@
+import QtQuick
+import QtQuick.Controls
+import QtTest
+
+import StatusQ.Core
+import StatusQ.Controls
+
+Item {
+    id: root
+    width: 400
+    height: 400
+
+    // A bare StatusToolTip, parented to an anchor rectangle so it can be shown.
+    Component {
+        id: toolTipComponent
+        StatusToolTip {
+            text: "Hello tooltip"
+        }
+    }
+
+    Rectangle {
+        id: anchorItem
+        width: 80
+        height: 30
+    }
+
+    // A control (StatusButton) that declares a tooltip through StatusBaseButton:
+    // creating the button must NOT build the tooltip's visual subtree.
+    Component {
+        id: buttonComponent
+        StatusButton {
+            text: "Btn"
+            tooltip.text: "Btn tip"
+        }
+    }
+
+    TestCase {
+        name: "StatusToolTip"
+        when: windowShown
+
+        // --- Cycle 1: laziness seam ---
+        // A freshly created tooltip that has never been shown must not materialize
+        // its expensive positioning/content subtree (arrow x/y bindings + text).
+        function test_content_absent_until_shown() {
+            const tip = createTemporaryObject(toolTipComponent, root,
+                                              { parent: anchorItem })
+            verify(!!tip)
+            verify(!tip.visible, "tooltip should start hidden")
+
+            verify(!findChild(tip, "statusToolTipText"),
+                   "text content must not be materialized before the tooltip is shown")
+            verify(!findChild(tip, "statusToolTipArrow"),
+                   "arrow must not be materialized before the tooltip is shown")
+        }
+
+        // A control that merely declares a tooltip (StatusButton) must not pay for
+        // the tooltip subtree at creation time either.
+        function test_control_with_tooltip_has_no_eager_tooltip_subtree() {
+            const button = createTemporaryObject(buttonComponent, root)
+            verify(!!button)
+
+            verify(!findChild(button, "statusToolTipText"),
+                   "declaring a tooltip on a button must not build its text at creation")
+            verify(!findChild(button, "statusToolTipArrow"),
+                   "declaring a tooltip on a button must not build its arrow at creation")
+        }
+
+        // --- Cycle 2: materialize with correct text + position once shown ---
+        function test_content_materializes_on_show() {
+            const tip = createTemporaryObject(toolTipComponent, root,
+                                              { parent: anchorItem })
+            verify(!!tip)
+
+            tip.visible = true
+
+            tryVerify(() => !!findChild(tip, "statusToolTipText"), 1000,
+                      "text content must materialize once the tooltip is shown")
+            const label = findChild(tip, "statusToolTipText")
+            compare(label.text, "Hello tooltip", "shown tooltip must carry the correct text")
+
+            const arrow = findChild(tip, "statusToolTipArrow")
+            verify(!!arrow, "arrow must materialize once the tooltip is shown")
+
+            // Top orientation (default): the arrow is horizontally centered on the
+            // background (offset defaults to 0). Proves the deferred x binding is live.
+            const bg = tip.background
+            fuzzyCompare(arrow.x, bg.width / 2 - arrow.width / 2, 1.0,
+                         "arrow must be centered for the default Top orientation")
+        }
+
+        // --- Cycle 3: hide on unshow, timing config preserved ---
+        function test_hides_and_preserves_timing() {
+            const tip = createTemporaryObject(toolTipComponent, root,
+                                              { parent: anchorItem })
+            verify(!!tip)
+
+            // Deferral must not alter the show/hide timing contract.
+            compare(tip.delay, 200, "desktop show delay must be preserved")
+            compare(tip.timeout, -1, "desktop timeout must be preserved")
+
+            tip.visible = true
+            tryVerify(() => !!findChild(tip, "statusToolTipText"), 1000)
+
+            tip.visible = false
+            tryCompare(tip, "visible", false, 1000,
+                       "tooltip must hide when unshown")
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Components/LoadingComponent.qml
+++ b/ui/StatusQ/src/StatusQ/Components/LoadingComponent.qml
@@ -37,42 +37,25 @@ Control {
     background: null
 
     contentItem: Item {
-        property real contentItemWidth: 0
-        onWidthChanged: {
-            contentItemWidth = width
-            animation.restart()
-        }
+        id: content
+
         Rectangle {
             id: rect
             anchors.fill: parent
             color: Theme.palette.statusLoadingHighlight
             radius: root.radius
-            visible: false
+            visible: false // used only as the OpacityMask source
 
-            LinearGradient {
-                id: gradient
-                width: 100
-                height: 2*parent.height
-                x: -width
-                y: -height/4
-                start: Qt.point(0, height)
-                end: Qt.point(width, height)
-                gradient: Gradient {
-                    GradientStop { position: 0.2; color: "transparent"}
-                    GradientStop { position: 0.5; color: Theme.palette.statusLoadingHighlight2 }
-                    GradientStop { position: 0.8; color: "transparent"}
-                }
-                rotation: 20
-                XAnimator on x {
-                    id: animation
-                    easing.type: Easing.Linear
-                    loops: Animation.Infinite
-                    running: root.visible
-                    from: -gradient.width
-                    to: contentItem.contentItemWidth + gradient.width
-                    duration: 1000
-                    easing.period: 2
-                }
+            // The animated sweep is materialized only while the placeholder is
+            // effectively visible. When hidden, the Loader is inactive so no
+            // animation object exists and the render thread can park instead of
+            // repainting the whole scene at 60fps for a hidden shimmer.
+            Loader {
+                id: sweepLoader
+                width: rect.width
+                height: rect.height
+                active: root.visible
+                sourceComponent: sweepComponent
             }
         }
 
@@ -86,5 +69,46 @@ Control {
             }
         }
     }
-}
 
+    // Native Rectangle gradient sweep — no Qt5Compat LinearGradient (which is an
+    // extra ShaderEffectSource pass). Only the rounded OpacityMask pass remains.
+    Component {
+        id: sweepComponent
+
+        Rectangle {
+            id: sweep
+            objectName: "shimmerSweep"
+
+            width: 100
+            height: 2 * sweepLoader.height
+            x: -width
+            y: -height / 4
+            rotation: 20
+
+            gradient: Gradient {
+                orientation: Gradient.Horizontal
+                GradientStop { position: 0.2; color: "transparent" }
+                GradientStop { position: 0.5; color: Theme.palette.statusLoadingHighlight2 }
+                GradientStop { position: 0.8; color: "transparent" }
+            }
+
+            XAnimator on x {
+                id: sweepAnimator
+                objectName: "shimmerAnimator"
+                easing.type: Easing.Linear
+                loops: Animation.Infinite
+                running: true
+                from: -sweep.width
+                to: sweepLoader.width + sweep.width
+                duration: 1000
+            }
+
+            // Restart the sweep when the placeholder is resized, matching the
+            // original behaviour (avoids a stale sweep span for one cycle).
+            Connections {
+                target: sweepLoader
+                function onWidthChanged() { sweepAnimator.restart() }
+            }
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Components/LoadingComponent.qml
+++ b/ui/StatusQ/src/StatusQ/Components/LoadingComponent.qml
@@ -72,6 +72,8 @@ Control {
 
     // Native Rectangle gradient sweep — no Qt5Compat LinearGradient (which is an
     // extra ShaderEffectSource pass). Only the rounded OpacityMask pass remains.
+    // The sweep reads its geometry from `parent` (the Loader) so it needs no
+    // reference to outer-scope ids.
     Component {
         id: sweepComponent
 
@@ -80,7 +82,7 @@ Control {
             objectName: "shimmerSweep"
 
             width: 100
-            height: 2 * sweepLoader.height
+            height: 2 * sweep.parent.height
             x: -width
             y: -height / 4
             rotation: 20
@@ -99,14 +101,14 @@ Control {
                 loops: Animation.Infinite
                 running: true
                 from: -sweep.width
-                to: sweepLoader.width + sweep.width
+                to: sweep.parent.width + sweep.width
                 duration: 1000
             }
 
             // Restart the sweep when the placeholder is resized, matching the
             // original behaviour (avoids a stale sweep span for one cycle).
             Connections {
-                target: sweepLoader
+                target: sweep.parent
                 function onWidthChanged() { sweepAnimator.restart() }
             }
         }

--- a/ui/StatusQ/src/StatusQ/Components/LoadingComponent.qml
+++ b/ui/StatusQ/src/StatusQ/Components/LoadingComponent.qml
@@ -89,9 +89,9 @@ Control {
 
             gradient: Gradient {
                 orientation: Gradient.Horizontal
-                GradientStop { position: 0.2; color: "transparent" }
+                GradientStop { position: 0.2; color: StatusColors.transparent }
                 GradientStop { position: 0.5; color: Theme.palette.statusLoadingHighlight2 }
-                GradientStop { position: 0.8; color: "transparent" }
+                GradientStop { position: 0.8; color: StatusColors.transparent }
             }
 
             XAnimator on x {

--- a/ui/StatusQ/src/StatusQ/Components/StatusLoadingIndicator.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLoadingIndicator.qml
@@ -10,11 +10,12 @@ StatusIcon {
     width: 20
 
     RotationAnimator {
+        objectName: "spinnerAnimator"
         target: root
         from: 0
         to: 360
         duration: 1200
-        running: visible
+        running: root.visible
         loops: Animation.Infinite
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/private/LoadingDotItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/LoadingDotItem.qml
@@ -17,12 +17,11 @@ Rectangle {
 
     SequentialAnimation {
         id: blinkingAnimation
+        objectName: "dotBlinkAnimation"
 
         loops: Animation.Infinite
         running: visible
         NumberAnimation { target: root; property: "opacity"; to: 0; duration: root.duration }
         NumberAnimation { target: root; property: "opacity"; to: root.maxOpacity; duration: root.duration }
     }
-
-    Component.onCompleted: blinkingAnimation.start()
 }

--- a/ui/StatusQ/src/StatusQ/Components/private/LoadingDotItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/LoadingDotItem.qml
@@ -20,7 +20,7 @@ Rectangle {
         objectName: "dotBlinkAnimation"
 
         loops: Animation.Infinite
-        running: visible
+        running: root.visible
         NumberAnimation { target: root; property: "opacity"; to: 0; duration: root.duration }
         NumberAnimation { target: root; property: "opacity"; to: root.maxOpacity; duration: root.duration }
     }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusScrollBar.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusScrollBar.qml
@@ -46,6 +46,12 @@ T.ScrollBar {
         // forced on. Outside of that it renders nothing, so it need not exist.
         readonly property bool thumbActive:
             root.enabled && (root.hovered || root.active || root.policy === T.ScrollBar.AlwaysOn)
+
+        // Latch: once the thumb has been shown, keep it instantiated so its
+        // opacity can animate back to 0 (fade-out) and later interactions stay
+        // cheap. Instantiation happens the first time the thumb is needed.
+        property bool thumbShown: false
+        onThumbActiveChanged: if (thumbActive) thumbShown = true
     }
 
     // TODO: add this sizes to Theme
@@ -57,7 +63,7 @@ T.ScrollBar {
     }
 
     contentItem: Loader {
-        active: d.thumbActive
+        active: d.thumbShown
 
         sourceComponent: Rectangle {
             objectName: "scrollBarThumb"

--- a/ui/StatusQ/src/StatusQ/Controls/StatusScrollBar.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusScrollBar.qml
@@ -47,11 +47,16 @@ T.ScrollBar {
         width: 0 // Needed to prevent a white background from showing on Windows
     }
 
-    contentItem: Rectangle {
-        color: root.Theme.palette.primaryColor2
-        opacity: enabled && (root.hovered || root.active || (root.policy === T.ScrollBar.AlwaysOn)) ? 1.0 : 0.0
-        radius: Math.min(width, height) / 2
+    contentItem: Loader {
+        active: false
 
-        Behavior on opacity { NumberAnimation { duration: ThemeUtils.AnimationDuration.Fast } }
+        sourceComponent: Rectangle {
+            objectName: "scrollBarThumb"
+            color: root.Theme.palette.primaryColor2
+            opacity: enabled && (root.hovered || root.active || (root.policy === T.ScrollBar.AlwaysOn)) ? 1.0 : 0.0
+            radius: Math.min(width, height) / 2
+
+            Behavior on opacity { NumberAnimation { duration: ThemeUtils.AnimationDuration.Fast } }
+        }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusScrollBar.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusScrollBar.qml
@@ -39,6 +39,15 @@ T.ScrollBar {
         }
     }
 
+    QtObject {
+        id: d
+
+        // The thumb is only opaque (visible) while the bar is interacted with or
+        // forced on. Outside of that it renders nothing, so it need not exist.
+        readonly property bool thumbActive:
+            root.enabled && (root.hovered || root.active || root.policy === T.ScrollBar.AlwaysOn)
+    }
+
     // TODO: add this sizes to Theme
     implicitWidth: 14
     implicitHeight: 14
@@ -48,7 +57,7 @@ T.ScrollBar {
     }
 
     contentItem: Loader {
-        active: false
+        active: d.thumbActive
 
         sourceComponent: Rectangle {
             objectName: "scrollBarThumb"

--- a/ui/StatusQ/src/StatusQ/Controls/StatusScrollBar.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusScrollBar.qml
@@ -68,7 +68,7 @@ T.ScrollBar {
         sourceComponent: Rectangle {
             objectName: "scrollBarThumb"
             color: root.Theme.palette.primaryColor2
-            opacity: enabled && (root.hovered || root.active || (root.policy === T.ScrollBar.AlwaysOn)) ? 1.0 : 0.0
+            opacity: d.thumbActive ? 1.0 : 0.0
             radius: Math.min(width, height) / 2
 
             Behavior on opacity { NumberAnimation { duration: ThemeUtils.AnimationDuration.Fast } }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -33,6 +33,8 @@ TextField {
     HoverHandler {
         id: hoverHandler
         enabled: root.enabled
+        // Build the edit context menu on first hover (see contextMenuLoader).
+        onHoveredChanged: if (hovered && !Utils.isAndroid) contextMenuLoader.active = true
     }
 
     background: Rectangle {
@@ -65,39 +67,51 @@ TextField {
             deselect()
     }
 
-    StatusMenu {
-        id: contextMenu
+    // The edit context menu (Cut/Copy/Paste/Select All) is only reachable via a
+    // right-click or long-press, both always preceded by the pointer entering the
+    // field or the field gaining focus. Building it eagerly per field is a
+    // dominant instantiation cost (a full StatusMenu with materialised items),
+    // paid even when the field is never interacted with — and on Android it is not
+    // even attached (see below). So build it lazily on first interaction, never on
+    // Android. The menu is null until then; a right-click cannot happen before the
+    // triggering hover/focus, so the menu is always present by the time it opens.
+    onActiveFocusChanged: if (activeFocus && !Utils.isAndroid) contextMenuLoader.active = true
 
-        hideDisabledItems: false
-        popupType: Utils.isIOS ? Popup.Native : Popup.Item
+    Loader {
+        id: contextMenuLoader
+        active: false
+        sourceComponent: StatusMenu {
+            hideDisabledItems: false
+            popupType: Utils.isIOS ? Popup.Native : Popup.Item
 
-        StatusAction {
-            text: qsTr("Cut")
-            enabled: !noSelection
-            onTriggered: root.cut()
-        }
-        StatusAction {
-            text: qsTr("Copy")
-            enabled: !noSelection
-            onTriggered: root.copy()
-        }
-        StatusAction {
-            text: qsTr("Paste")
-            // On iOS, never read the clipboard for UI enablement: reading
-            // canPaste touches UIPasteboard and triggers the system
-            // "paste from..." prompt. Keep Paste always enabled there and let
-            // the actual paste() be the only (user-initiated) clipboard read.
-            // On desktop, reading canPaste is free and keeps the disabled state.
-            enabled: Utils.isIOS || root.canPaste
-            onTriggered: root.paste()
-        }
-        StatusMenuSeparator {}
-        StatusAction {
-            text: qsTr("Select All")
-            enabled: !noSelection
-            onTriggered: root.selectAll()
+            StatusAction {
+                text: qsTr("Cut")
+                enabled: !root.noSelection
+                onTriggered: root.cut()
+            }
+            StatusAction {
+                text: qsTr("Copy")
+                enabled: !root.noSelection
+                onTriggered: root.copy()
+            }
+            StatusAction {
+                text: qsTr("Paste")
+                // On iOS, never read the clipboard for UI enablement: reading
+                // canPaste touches UIPasteboard and triggers the system
+                // "paste from..." prompt. Keep Paste always enabled there and let
+                // the actual paste() be the only (user-initiated) clipboard read.
+                // On desktop, reading canPaste is free and keeps the disabled state.
+                enabled: Utils.isIOS || root.canPaste
+                onTriggered: root.paste()
+            }
+            StatusMenuSeparator {}
+            StatusAction {
+                text: qsTr("Select All")
+                enabled: !root.noSelection
+                onTriggered: root.selectAll()
+            }
         }
     }
 
-    ContextMenu.menu: Utils.isAndroid ? null : contextMenu
+    ContextMenu.menu: contextMenuLoader.item
 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -34,7 +34,7 @@ TextField {
         id: hoverHandler
         enabled: root.enabled
         // Build the edit context menu on first hover (see contextMenuLoader).
-        onHoveredChanged: if (hovered && !Utils.isAndroid) contextMenuLoader.active = true
+        onHoveredChanged: if (hovered && !Utils.isMobile) contextMenuLoader.active = true
     }
 
     background: Rectangle {
@@ -71,11 +71,12 @@ TextField {
     // right-click or long-press, both always preceded by the pointer entering the
     // field or the field gaining focus. Building it eagerly per field is a
     // dominant instantiation cost (a full StatusMenu with materialised items),
-    // paid even when the field is never interacted with — and on Android it is not
-    // even attached (see below). So build it lazily on first interaction, never on
-    // Android. The menu is null until then; a right-click cannot happen before the
-    // triggering hover/focus, so the menu is always present by the time it opens.
-    onActiveFocusChanged: if (activeFocus && !Utils.isAndroid) contextMenuLoader.active = true
+    // paid even when the field is never interacted with — and on mobile it is not
+    // even attached (mobile uses the OS-native text menu). So build it lazily on
+    // first interaction, never on mobile. The menu is null until then; a right-click
+    // cannot happen before the triggering hover/focus, so the menu is always present
+    // by the time it opens.
+    onActiveFocusChanged: if (activeFocus && !Utils.isMobile) contextMenuLoader.active = true
 
     Loader {
         id: contextMenuLoader

--- a/ui/StatusQ/src/StatusQ/Controls/StatusToolTip.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusToolTip.qml
@@ -18,7 +18,7 @@ ToolTip {
     property int maxWidth: 800
     property int orientation: StatusToolTip.Orientation.Top
     property int offset: 0
-    property alias arrow: arrow
+    readonly property Item arrow: arrowLoader.item ? arrowLoader.item.arrowRect : null
     property color color: StatusColors.black
 
     implicitWidth: Math.ceil(Math.min(maxWidth,
@@ -32,6 +32,17 @@ ToolTip {
                           : 200
     timeout: Utils.isMobile ? 2500 : -1
 
+    // The tooltip's visual subtree (positioned arrow + text) is expensive to build
+    // and to keep bound while invisible. Controls declare a StatusToolTip eagerly
+    // (e.g. every StatusBaseButton), so defer that subtree until the tooltip is
+    // first about to show; keep it alive afterwards to avoid rebuild churn on hover.
+    QtObject {
+        id: d
+        property bool everShown: false
+    }
+    onAboutToShow: d.everShown = true
+    onVisibleChanged: if (visible) d.everShown = true
+
     background: Item {
         id: statusToolTipBackground
         Rectangle {
@@ -41,47 +52,67 @@ ToolTip {
             anchors.fill: parent
             anchors.bottomMargin: Theme.halfPadding
         }
-        Rectangle {
-            id: arrow
-            color: statusToolTipContentBackground.color
-            height: Theme.padding
-            width: Theme.padding
-            rotation: 45
-            radius: 1
-            x: {
-                if (orientation === StatusToolTip.Orientation.Top || orientation === StatusToolTip.Orientation.Bottom) {
-                    return statusToolTipBackground.width / 2 - width / 2 + offset
-                }
-                if (orientation === StatusToolTip.Orientation.Left) {
-                    return statusToolTipContentBackground.width - statusToolTipContentBackground.radius - radius*2 + offset
-                }
-                if (orientation === StatusToolTip.Orientation.Right) {
-                    return -width/2 + radius*2 + offset
-                }
-            }
-            y: {
-                if (orientation === StatusToolTip.Orientation.Bottom) {
-                    return -height / 2 + 5
-                }
-                if (orientation === StatusToolTip.Orientation.Top) {
-                    return statusToolTipBackground.height - height - 5
-                }
-                if (orientation === StatusToolTip.Orientation.Left || orientation === StatusToolTip.Orientation.Right) {
-                    return statusToolTipContentBackground.height / 2 - (height / 2)
+        Loader {
+            id: arrowLoader
+            anchors.fill: parent
+            active: d.everShown
+            sourceComponent: Item {
+                property alias arrowRect: arrow
+                Rectangle {
+                    id: arrow
+                    objectName: "statusToolTipArrow"
+                    color: statusToolTipContentBackground.color
+                    height: Theme.padding
+                    width: Theme.padding
+                    rotation: 45
+                    radius: 1
+                    x: {
+                        if (orientation === StatusToolTip.Orientation.Top || orientation === StatusToolTip.Orientation.Bottom) {
+                            return statusToolTipBackground.width / 2 - width / 2 + offset
+                        }
+                        if (orientation === StatusToolTip.Orientation.Left) {
+                            return statusToolTipContentBackground.width - statusToolTipContentBackground.radius - radius*2 + offset
+                        }
+                        if (orientation === StatusToolTip.Orientation.Right) {
+                            return -width/2 + radius*2 + offset
+                        }
+                    }
+                    y: {
+                        if (orientation === StatusToolTip.Orientation.Bottom) {
+                            return -height / 2 + 5
+                        }
+                        if (orientation === StatusToolTip.Orientation.Top) {
+                            return statusToolTipBackground.height - height - 5
+                        }
+                        if (orientation === StatusToolTip.Orientation.Left || orientation === StatusToolTip.Orientation.Right) {
+                            return statusToolTipContentBackground.height / 2 - (height / 2)
+                        }
+                    }
                 }
             }
         }
     }
-    contentItem: StatusBaseText {
-        text: root.text
-        color: StatusColors.white
-        linkColor: StatusColors.white
-        wrapMode: Text.Wrap
-        font.pixelSize: Theme.additionalTextSize
-        font.weight: Font.Medium
-        horizontalAlignment: Text.AlignHCenter
-        bottomPadding: Theme.halfPadding
-        textFormat: Text.RichText
-        elide: Text.ElideRight
+    contentItem: Item {
+        id: contentContainer
+        implicitWidth: contentLoader.implicitWidth
+        implicitHeight: contentLoader.implicitHeight
+        Loader {
+            id: contentLoader
+            anchors.fill: parent
+            active: d.everShown
+            sourceComponent: StatusBaseText {
+                objectName: "statusToolTipText"
+                text: root.text
+                color: StatusColors.white
+                linkColor: StatusColors.white
+                wrapMode: Text.Wrap
+                font.pixelSize: Theme.additionalTextSize
+                font.weight: Font.Medium
+                horizontalAlignment: Text.AlignHCenter
+                bottomPadding: Theme.halfPadding
+                textFormat: Text.RichText
+                elide: Text.ElideRight
+            }
+        }
     }
 }


### PR DESCRIPTION
Low-end-device render/creation fixes in StatusQ, driven by on-device profiling (Lenovo TB520FU, QML profiler + simpleperf). Each component keeps its public API and UX; the change is *when* work happens, not *what* the user sees. TDD'd: every fix landed with failing-first behavior tests at the component's public API.

- **StatusTextField**: the Cut/Copy/Paste context menu was built inline at construction for every text field (~66% of a modal's cold create in profiling; never even attached on Android). Now built on first hover/focus.
- **StatusScrollBar**: the thumb is created only once the bar first becomes active (hover/scroll/AlwaysOn); AsNeeded-idle bars create nothing. Fade-out and policy semantics preserved (flick/wheel verified).
- **LoadingComponent / LoadingDotItem / StatusLoadingIndicator**: loading placeholders no longer keep the render loop alive — the animated sweep only exists while visible (hidden placeholders = zero animation objects → render thread can park), and the shimmer dropped a full ShaderEffectSource pass (Qt5Compat LinearGradient → native gradient; rounded mask kept for avatars). Also fixes a real bug: dots born invisible animated forever (`Component.onCompleted: start()` overrode `running: visible`).
- **StatusToolTip**: arrow + text materialize on first show (both hover and imperative `visible = true` paths, synchronously before first paint); ~100 consumer sites inherit it with no changes.

Device context: these were the top named offenders in a 284ms swap-modal-open GUI freeze and a continuous 60fps idle render loop (7 infinite placeholder animations). The idle loop fix is also a battery/thermal win — any single running animation forces whole-scene re-rasterization every vsync.

Tests: new tst_StatusScrollBar (7), shimmer/dots/spinner lifecycle (9), tst_StatusToolTip (6); full storybook suite at baseline.
