### PR TITLE
perf(wallet): swap picker deferral, swap instantiation bench, static send blur

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1081,6 +1081,11 @@ nim-test-run/test/nim/swap_key_harvest_bench.nim: | statusq
 nim-test-run/test/nim/send_modal_instantiation_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
 nim-test-run/test/nim/send_modal_instantiation_bench.nim: | statusq
 
+# swap_modal_instantiation_bench loads the real SwapModal QML tree + SwapModalAdaptor
+# (inline real-store subclasses, no storybook engine) -- links StatusQ.
+nim-test-run/test/nim/swap_modal_instantiation_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
+nim-test-run/test/nim/swap_modal_instantiation_bench.nim: | statusq
+
 nim-test-run/test/nim/send_handler_lookup_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
 nim-test-run/test/nim/send_handler_lookup_bench.nim: | statusq
 

--- a/storybook/pages/SimpleSendModalPage.qml
+++ b/storybook/pages/SimpleSendModalPage.qml
@@ -21,6 +21,12 @@ import Storybook
 import Models
 import Mocks
 
+// Visual parity note: the sticky header and the footer keep their frosted-glass
+// backdrop (FastBlur over a ShaderEffectSource of the scrollable form). The blur
+// is now captured statically (live:false) and re-captured only when the content
+// behind it moves or changes, so the frosted look is unchanged while scrolling
+// the form (drag the list, or scroll to reveal the sticky header) but no longer
+// re-blurs every frame during unrelated animations.
 SplitView {
     id: root
 

--- a/storybook/pages/SimpleSendModalPage.qml
+++ b/storybook/pages/SimpleSendModalPage.qml
@@ -21,12 +21,6 @@ import Storybook
 import Models
 import Mocks
 
-// Visual parity note: the sticky header and the footer keep their frosted-glass
-// backdrop (FastBlur over a ShaderEffectSource of the scrollable form). The blur
-// is now captured statically (live:false) and re-captured only when the content
-// behind it moves or changes, so the frosted look is unchanged while scrolling
-// the form (drag the list, or scroll to reveal the sticky header) but no longer
-// re-blurs every frame during unrelated animations.
 SplitView {
     id: root
 

--- a/storybook/qmlTests/tests/tst_SendModalFooter.qml
+++ b/storybook/qmlTests/tests/tst_SendModalFooter.qml
@@ -235,6 +235,59 @@ Item {
             compare(blurRefreshSpy.count, before + 1, "content width change re-captures the backdrop")
         }
 
+        // The captured region is bound to the scroll view's geometry by the owner
+        // (SimpleSendModal), which only settles after the first layout pass. A
+        // static capture taken against the stale rect squeezes the whole scroll
+        // content into the footer strip.
+        function test_blur_refreshesOnSourceRectChange() {
+            controlUnderTest.blurSource = fakeContent
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src)
+
+            blurRefreshSpy.target = src
+            const before = blurRefreshSpy.count
+
+            controlUnderTest.blurSourceRect = Qt.rect(0, 120, 500, 90)
+            verify(blurRefreshSpy.count > before,
+                   "captured region change re-captures the backdrop")
+        }
+
+        // The footer itself resizes (error tags appearing, window resize); the
+        // static capture would otherwise be stretched over the new size.
+        function test_blur_refreshesOnFooterResize() {
+            controlUnderTest.blurSource = fakeContent
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src)
+
+            blurRefreshSpy.target = src
+
+            let before = blurRefreshSpy.count
+            controlUnderTest.width = controlUnderTest.width + 40
+            verify(blurRefreshSpy.count > before, "width change re-captures the backdrop")
+
+            before = blurRefreshSpy.count
+            controlUnderTest.height = controlUnderTest.height + 30
+            verify(blurRefreshSpy.count > before, "height change re-captures the backdrop")
+        }
+
+        // The content behind the footer can be resized without scrolling (window
+        // resize); what falls inside the captured region changes with it.
+        function test_blur_refreshesOnSourceItemResize() {
+            controlUnderTest.blurSource = fakeContent
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src)
+
+            blurRefreshSpy.target = src
+
+            let before = blurRefreshSpy.count
+            fakeContent.width += 25
+            verify(blurRefreshSpy.count > before, "source width change re-captures the backdrop")
+
+            before = blurRefreshSpy.count
+            fakeContent.height += 25
+            verify(blurRefreshSpy.count > before, "source height change re-captures the backdrop")
+        }
+
         // A theme switch recolors the content behind the footer without moving it;
         // the static backdrop must re-capture so it does not show stale colors.
         function test_blur_refreshesOnThemeChange() {

--- a/storybook/qmlTests/tests/tst_SendModalFooter.qml
+++ b/storybook/qmlTests/tests/tst_SendModalFooter.qml
@@ -32,6 +32,22 @@ Item {
         }
     }
 
+    // Stand-in for the scrollable form content the footer blurs. Mirrors the
+    // Flickable roles the real blurSource (scrollView.contentItem) exposes:
+    // contentY (scrolling), contentHeight/contentWidth (content growth).
+    Flickable {
+        id: fakeContent
+        width: 500
+        height: 300
+        contentWidth: 500
+        contentHeight: 2000
+    }
+
+    SignalSpy {
+        id: blurRefreshSpy
+        signalName: "refreshRequested"
+    }
+
     TestCase {
         name: "SendModalFooter"
         when: windowShown
@@ -169,6 +185,70 @@ Item {
 
             controlUnderTest.errorTags = errorTagsModel
             compare(controlUnderTest.errorTags, errorTagsModel)
+        }
+
+        // The frosted backdrop must exist and be blurred, but captured
+        // statically (live == false) so it is not re-blurred every frame.
+        function test_blur_isStaticNotLive() {
+            controlUnderTest.blurSource = fakeContent
+
+            const backdrop = findChild(controlUnderTest, "blurBackdropRect")
+            verify(!!backdrop, "frosted backdrop rectangle exists")
+            verify(backdrop.visible, "backdrop is visible when content is behind the footer")
+            verify(backdrop.layer.enabled, "FastBlur layer effect is enabled")
+
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src, "backdrop shader effect source exists")
+            compare(src.live, false, "backdrop is static, not re-captured every frame")
+            verify(src.sourceItem === fakeContent, "source is wired to the content behind the footer")
+        }
+
+        // Scrolling the content behind the footer (contentY change, e.g. user
+        // drag or programmatic sticky-header reveal) must re-capture the backdrop.
+        function test_blur_refreshesOnScroll() {
+            controlUnderTest.blurSource = fakeContent
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src)
+
+            blurRefreshSpy.target = src
+            const before = blurRefreshSpy.count
+
+            fakeContent.contentY += 50
+            compare(blurRefreshSpy.count, before + 1, "scroll re-captures the frosted backdrop")
+        }
+
+        // Content growing/shrinking behind the footer (async data arriving, rows
+        // appearing) changes the captured region and must re-capture the backdrop.
+        function test_blur_refreshesOnContentGrowth() {
+            controlUnderTest.blurSource = fakeContent
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src)
+
+            blurRefreshSpy.target = src
+
+            let before = blurRefreshSpy.count
+            fakeContent.contentHeight += 120
+            compare(blurRefreshSpy.count, before + 1, "content height growth re-captures the backdrop")
+
+            before = blurRefreshSpy.count
+            fakeContent.contentWidth += 40
+            compare(blurRefreshSpy.count, before + 1, "content width change re-captures the backdrop")
+        }
+
+        // A theme switch recolors the content behind the footer without moving it;
+        // the static backdrop must re-capture so it does not show stale colors.
+        function test_blur_refreshesOnThemeChange() {
+            controlUnderTest.blurSource = fakeContent
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src)
+
+            blurRefreshSpy.target = src
+            const before = blurRefreshSpy.count
+
+            // root.color tracks Theme.palette.baseColor3, so a palette/theme swap
+            // changes it; drive it directly to exercise the theme trigger.
+            controlUnderTest.color = "#123456"
+            compare(blurRefreshSpy.count, before + 1, "theme/color change re-captures the backdrop")
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_StickySendModalHeader.qml
+++ b/storybook/qmlTests/tests/tst_StickySendModalHeader.qml
@@ -98,6 +98,43 @@ Item {
             compare(blurRefreshSpy.count, before + 1, "content width change re-captures the backdrop")
         }
 
+        // The header animates its height 0 -> N when it is revealed, so the
+        // captured region (bound to the header size) grows over 350ms; a capture
+        // taken at the old size is stretched over the new one.
+        function test_blur_refreshesOnHeaderResize() {
+            controlUnderTest.blurSource = fakeContent
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src)
+
+            blurRefreshSpy.target = src
+
+            let before = blurRefreshSpy.count
+            controlUnderTest.height = controlUnderTest.height + 30
+            verify(blurRefreshSpy.count > before, "height change re-captures the backdrop")
+
+            before = blurRefreshSpy.count
+            controlUnderTest.width = controlUnderTest.width + 40
+            verify(blurRefreshSpy.count > before, "width change re-captures the backdrop")
+        }
+
+        // The content behind the header can be resized without scrolling (window
+        // resize); what falls inside the captured region changes with it.
+        function test_blur_refreshesOnSourceItemResize() {
+            controlUnderTest.blurSource = fakeContent
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src)
+
+            blurRefreshSpy.target = src
+
+            let before = blurRefreshSpy.count
+            fakeContent.width += 25
+            verify(blurRefreshSpy.count > before, "source width change re-captures the backdrop")
+
+            before = blurRefreshSpy.count
+            fakeContent.height += 25
+            verify(blurRefreshSpy.count > before, "source height change re-captures the backdrop")
+        }
+
         // A theme switch recolors the content behind the header without moving it;
         // the static backdrop must re-capture so it does not show stale colors.
         function test_blur_refreshesOnThemeChange() {

--- a/storybook/qmlTests/tests/tst_StickySendModalHeader.qml
+++ b/storybook/qmlTests/tests/tst_StickySendModalHeader.qml
@@ -1,0 +1,120 @@
+import QtQuick
+import QtTest
+import QtQml.Models
+
+import StatusQ.Core.Theme
+
+import AppLayouts.Wallet.panels
+
+Item {
+    id: root
+    width: 600
+    height: 400
+
+    Component {
+        id: componentUnderTest
+
+        StickySendModalHeader {
+            stickyHeaderVisible: true
+
+            assetsModel: ListModel {}
+            collectiblesModel: ListModel {}
+            networksModel: ListModel {}
+        }
+    }
+
+    // Stand-in for the scrollable form content the header blurs. Mirrors the
+    // Flickable roles the real blurSource (scrollView.contentItem) exposes:
+    // contentY (scrolling), contentHeight/contentWidth (content growth).
+    Flickable {
+        id: fakeContent
+        width: 500
+        height: 300
+        contentWidth: 500
+        contentHeight: 2000
+    }
+
+    SignalSpy {
+        id: blurRefreshSpy
+        signalName: "refreshRequested"
+    }
+
+    TestCase {
+        name: "StickySendModalHeader"
+        when: windowShown
+
+        property StickySendModalHeader controlUnderTest: null
+
+        function init() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+            verify(!!controlUnderTest)
+        }
+
+        // The frosted backdrop must exist and be blurred, but captured
+        // statically (live == false) so it is not re-blurred every frame.
+        function test_blur_isStaticNotLive() {
+            controlUnderTest.blurSource = fakeContent
+
+            const backdrop = findChild(controlUnderTest, "blurBackdropRect")
+            verify(!!backdrop, "frosted backdrop rectangle exists")
+            verify(backdrop.visible, "backdrop is visible when content is behind the header")
+            verify(backdrop.layer.enabled, "FastBlur layer effect is enabled")
+
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src, "backdrop shader effect source exists")
+            compare(src.live, false, "backdrop is static, not re-captured every frame")
+            verify(src.sourceItem === fakeContent, "source is wired to the content behind the header")
+        }
+
+        // Scrolling the content behind the header (contentY change, e.g. user
+        // drag or programmatic sticky-header reveal) must re-capture the backdrop.
+        function test_blur_refreshesOnScroll() {
+            controlUnderTest.blurSource = fakeContent
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src)
+
+            blurRefreshSpy.target = src
+            const before = blurRefreshSpy.count
+
+            fakeContent.contentY += 50
+            compare(blurRefreshSpy.count, before + 1, "scroll re-captures the frosted backdrop")
+        }
+
+        // Content growing/shrinking behind the header (async data arriving, rows
+        // appearing) changes the captured region and must re-capture the backdrop.
+        function test_blur_refreshesOnContentGrowth() {
+            controlUnderTest.blurSource = fakeContent
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src)
+
+            blurRefreshSpy.target = src
+
+            let before = blurRefreshSpy.count
+            fakeContent.contentHeight += 120
+            compare(blurRefreshSpy.count, before + 1, "content height growth re-captures the backdrop")
+
+            before = blurRefreshSpy.count
+            fakeContent.contentWidth += 40
+            compare(blurRefreshSpy.count, before + 1, "content width change re-captures the backdrop")
+        }
+
+        // A theme switch recolors the content behind the header without moving it;
+        // the static backdrop must re-capture so it does not show stale colors.
+        function test_blur_refreshesOnThemeChange() {
+            controlUnderTest.blurSource = fakeContent
+            const src = findChild(controlUnderTest, "blurBackdropSource")
+            verify(!!src)
+
+            const fg = findChild(controlUnderTest, "sendHeaderForegroundRect")
+            verify(!!fg, "foreground rectangle exists")
+
+            blurRefreshSpy.target = src
+            const before = blurRefreshSpy.count
+
+            // The backdrop color tracks Theme.palette.baseColor3, so a palette/theme
+            // swap changes it; drive it directly to exercise the theme trigger.
+            fg.color = "#123456"
+            compare(blurRefreshSpy.count, before + 1, "theme/color change re-captures the backdrop")
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_SwapInputPanel.qml
+++ b/storybook/qmlTests/tests/tst_SwapInputPanel.qml
@@ -158,6 +158,25 @@ Item {
             compare(fresh.popularSectionName, qsTr("Popular assets"))
         }
 
+        // The picker model is created lazily after the modal opens, so the panel
+        // lives with a null model for a while — and both of these paths can still
+        // fire in that window (the keyword arrives through a debounce, and the
+        // selector clears its search when the popup closes).
+        function test_searchAndLoadMoreAreSafeWithoutAModel() {
+            failOnWarning(/TypeError/)
+
+            controlUnderTest = createTemporaryObject(componentUnderTest, root,
+                                                     {tokenSelectorModel: null})
+            verify(!!controlUnderTest)
+
+            const holdingSelector = findChild(controlUnderTest, "holdingSelector")
+            verify(!!holdingSelector)
+
+            holdingSelector.search("eth")
+            holdingSelector.search("")
+            holdingSelector.loadMoreRequested()
+        }
+
         function test_selectedHoldingWithoutLogoFallsBackToTheSymbolIcon() {
             controlUnderTest = createTemporaryObject(componentUnderTest, root,
                                                      {groupKey: noLogoGroupKey})

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -2037,5 +2037,50 @@ Item {
             tryCompare(sellItem, "text", "1 ETH ≈ ")
             tryCompare(quoteItem, "text", "1 STT ")
         }
+
+        // The handler destroys the modal and then resets the form, and the reset
+        // clears the source chain before the destination one — a transient bridge
+        // state. Building the destination picker for it (an expensive terminal
+        // model) only to throw it away is pure waste on every plain-swap close.
+        function test_noBridgePickerIsBuiltWhileClosing() {
+            const store = root.swapAdaptor.walletAssetsStore.walletTokensStore
+
+            launchAndVerfyModal()
+            compare(root.swapFormData.selectedNetworkChainId,
+                    root.swapFormData.toNetworkChainId, "plain same-chain swap")
+
+            store.createdKinds = []
+
+            controlUnderTest.close()
+            verify(!controlUnderTest.opened)
+            // same order as SwapModalHandler.onClosed
+            root.swapFormData.resetFormData()
+
+            compare(store.createdKinds.indexOf(3), -1,
+                    "no destination picker built during teardown, got kinds: "
+                    + JSON.stringify(store.createdKinds))
+        }
+
+        // A destination picker built lazily (the user switches the receive chain
+        // after the modal is open) must be seeded like the ones createPickers
+        // builds, otherwise it starts on whatever the producer's last search was.
+        function test_lazyBridgePickerIsSeeded() {
+            const store = root.swapAdaptor.walletAssetsStore.walletTokensStore
+
+            launchAndVerfyModal()
+
+            const receivePanel = findChild(controlUnderTest, "receivePanel")
+            verify(!!receivePanel)
+
+            store.createdKinds = []
+            root.swapFormData.toNetworkChainId = 10 // != source chain => bridge
+
+            compare(store.createdKinds.indexOf(3), 0, "destination picker built")
+            const bridgeModel = receivePanel.tokenSelectorModel
+            verify(!!bridgeModel, "the receive panel is switched to it")
+            compare(bridgeModel.searchCallCount, 1, "and it is seeded")
+
+            closeAndVerfyModal()
+        }
     }
 }

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -132,6 +132,11 @@ Item {
             controlUnderTest.open()
             tryVerify(() => controlUnderTest.opened)
             tryVerify(() => controlUnderTest.enabled)
+            // The token picker models are created lazily just after the modal opens
+            // (kept off the open critical path); wait for them so the tests below can
+            // read payPanel/receivePanel.tokenSelectorModel.
+            const payPanel = findChild(controlUnderTest, "payPanel")
+            tryVerify(() => !!payPanel && !!payPanel.tokenSelectorModel)
         }
 
         function closeAndVerfyModal() {

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -1959,8 +1959,10 @@ Item {
             const invertQuoteApproximation = findChild(controlUnderTest, "invertQuoteApproximation")
             verify(!!invertQuoteApproximation)
 
-            verify(sellItem.visible) // left item is visible once the from token is set
-            verify(quoteItem.visible)
+            // The post-open form setup runs via Qt.callLater (SwapModal onOpened),
+            // so the row's visibility lands asynchronously — poll, don't assert.
+            tryVerify(() => sellItem.visible) // left item is visible once the from token is set
+            tryVerify(() => quoteItem.visible)
             verify(quoteItem.loading) // right item is loading until routes are fetched
             verify(!priceItem.visible)
             verify(!invertQuoteApproximation.visible)

--- a/storybook/src/Mocks/TokenSelectorModelMock.qml
+++ b/storybook/src/Mocks/TokenSelectorModelMock.qml
@@ -43,7 +43,14 @@ ListModel {
     property string ownedSectionName: ""
     property string popularSectionName: ""
 
-    function search(keyword) { root.searchString = keyword }
+    // Counted because the real model's search() also re-seeds the backend list,
+    // so "was it called" is observable behaviour even for the empty keyword.
+    property int searchCallCount: 0
+
+    function search(keyword) {
+        root.searchCallCount++
+        root.searchString = keyword
+    }
     function fetchMore() {}
     function setSectionNames(owned, popular) {
         root.ownedSectionName = owned

--- a/storybook/src/Mocks/TokensStoreMock.qml
+++ b/storybook/src/Mocks/TokensStoreMock.qml
@@ -26,7 +26,12 @@ TokensStore {
     property int _tokenSelectorIdCounter: 0
     readonly property Component _tokenSelectorModelMockComponent: Component { TokenSelectorModelMock {} }
 
+    // The kind of every picker handed out, in order, so tests can assert which
+    // pickers a consumer builds and when. Tests reset it to [] to scope a window.
+    property var createdKinds: []
+
     function createTokenSelectorModel(kind) {
+        root.createdKinds = root.createdKinds.concat([kind])
         // Mirror the producer's per-kind source: swap (1) uses the source-chain
         // groups, bridge receive (3) uses the destination-chain groups, send (0) /
         // buy (2) use the full groups. If a caller pre-seeded tokenSelectorStubData,

--- a/test/nim/benchmarks/swap_modal_instantiation_scene.qml
+++ b/test/nim/benchmarks/swap_modal_instantiation_scene.qml
@@ -1,7 +1,8 @@
 // Real-instantiation scene for the SWAP modal. Loads the ACTUAL SwapModal QML
 // tree + its real SwapModalAdaptor under an offscreen engine, and times:
-//   - createObject of the whole modal (the structural instantiation cost, which
-//     includes creating the 3 terminal token-selector picker models in `d`),
+//   - createObject of the whole modal (the structural instantiation cost; the
+//     terminal token-selector picker models in `d` are NOT part of it — SwapModal
+//     builds them lazily just after onOpened),
 //   - open() -> `opened` (or a documented drain proxy when the offscreen enter
 //     transition can't complete),
 //   - the deferred handler setup() block (the "configure" cost), and
@@ -210,7 +211,7 @@ Window {
         const obj = modalComp.createObject(root)
         const t1 = bench.nowMs()
         if (!obj) {
-            bench.reportCreate(-1, 0, modalComp.errorString())
+            bench.reportCreate(-1, 0, 0, modalComp.errorString())
             return
         }
         root._modal = obj

--- a/test/nim/benchmarks/swap_modal_instantiation_scene.qml
+++ b/test/nim/benchmarks/swap_modal_instantiation_scene.qml
@@ -113,16 +113,16 @@ Window {
         networksStore: theNetworksStore
 
         // The linchpin override: hand out a size-N seeded terminal picker model
-        // instead of delegating to the (absent) Nim producer. Suppress kind 3
-        // when the scene asks, to attribute the eager 3rd picker on plain swaps.
+        // instead of delegating to the (absent) Nim producer, and notify the bench
+        // (onPickerBuilt) on each real build so the driver can detect readiness.
+        // Suppress kind 3 when the scene asks (retained for attribution).
         //
-        // Production SwapModal creates exactly 3 pickers (2x kind 1: pay + same-
-        // chain receive; 1x kind 3: KIND_SWAP_TO). But the picker properties are
-        // `readonly property var ... createTokenSelectorModel(k)` whose binding
-        // re-fires as `swapAdaptor` settles from null during construction, so this
-        // override is CALLED many times. We cache per slot (2 kind1 slots +
-        // 1 kind3 slot) so the size-N seed is paid exactly 3x IN the create window
-        // (matching production), while re-eval calls reuse the cached model.
+        // Production SwapModal now builds the pickers LAZILY in createPickers,
+        // driven from onOpened (off the createObject path): 2x kind 1 (pay + same-
+        // chain receive) on any open, plus 1x kind 3 (KIND_SWAP_TO) only when a
+        // bridge is selected. So during `create` this override is NOT called; it is
+        // called post-open. We still cache per slot (2 kind1 slots + 1 kind3 slot)
+        // so the size-N seed is paid once per distinct picker.
         function createTokenSelectorModel(kind) {
             if (kind === 3) {
                 if (root.suppressSwapTo)
@@ -131,6 +131,7 @@ Window {
                     root._preC = root.buildSelectorModel(root.catalogSize)
                     root._held.push(root._preC)
                     root.kind3Count += 1
+                    bench.onPickerBuilt(3)
                 }
                 return { model: root._preC, id: 3 }
             }
@@ -141,6 +142,7 @@ Window {
                     root._preA = root.buildSelectorModel(root.catalogSize)
                     root._held.push(root._preA)
                     root.kind1Count += 1
+                    bench.onPickerBuilt(1)
                 }
                 return { model: root._preA, id: 1 }
             }
@@ -148,6 +150,7 @@ Window {
                 root._preB = root.buildSelectorModel(root.catalogSize)
                 root._held.push(root._preB)
                 root.kind1Count += 1
+                bench.onPickerBuilt(1)
             }
             return { model: root._preB, id: 2 }
         }
@@ -188,13 +191,20 @@ Window {
     function doCreate(size, suppress) {
         root.catalogSize = size
         root.suppressSwapTo = suppress
+        root.swapFormData.resetFormData()
+        if (root.swapFormData.selectedNetworkChainId === -1)
+            root.swapFormData.selectedNetworkChainId = 1
+
+        // Reset the picker counters + per-slot cache AFTER the form writes above:
+        // a not-yet-destroyed modal from the previous scenario (opened, so its
+        // pickers are initialized) can still react to those writes and build a
+        // picker. Resetting here attributes `create` to the NEW modal only. (The
+        // driver's inter-scenario teardown destroys that old modal before the
+        // monitored window, so it does not affect the create stall either.)
         root.lastModelCount = 0
         root.kind1Count = 0
         root.kind3Count = 0
         root._preA = null; root._preB = null; root._preC = null; root._k1idx = 0
-        root.swapFormData.resetFormData()
-        if (root.swapFormData.selectedNetworkChainId === -1)
-            root.swapFormData.selectedNetworkChainId = 1
 
         const t0 = bench.nowMs()
         const obj = modalComp.createObject(root)
@@ -236,7 +246,14 @@ Window {
     }
 
     function doDestroy() {
-        if (!!root._modal) { root._modal.destroy(); root._modal = null }
+        if (!!root._modal) {
+            // close() first so an opened modal isn't kept alive by the Overlay past
+            // destroy(); otherwise it lingers and reacts to the next scenario's
+            // shared-form writes (building a picker attributed to the next create).
+            root._modal.close()
+            root._modal.destroy()
+            root._modal = null
+        }
         for (let i = 0; i < root._held.length; i++) {
             if (!!root._held[i] && !!root._held[i].destroy) root._held[i].destroy()
         }

--- a/test/nim/benchmarks/swap_modal_instantiation_scene.qml
+++ b/test/nim/benchmarks/swap_modal_instantiation_scene.qml
@@ -1,0 +1,268 @@
+// Real-instantiation scene for the SWAP modal. Loads the ACTUAL SwapModal QML
+// tree + its real SwapModalAdaptor under an offscreen engine, and times:
+//   - createObject of the whole modal (the structural instantiation cost, which
+//     includes creating the 3 terminal token-selector picker models in `d`),
+//   - open() -> `opened` (or a documented drain proxy when the offscreen enter
+//     transition can't complete),
+//   - the deferred handler setup() block (the "configure" cost), and
+//   - a close + reopen (handler reuse).
+//
+// Unlike tst_SwapModal (which uses the storybook stub+mock module tree), this
+// scene is SELF-CONTAINED: it subclasses the REAL store types inline and
+// overrides only the members SwapModal reads, so it runs under the plain app
+// import paths (ui/StatusQ/src, ui/imports, ui/app) with StatusQ linked, no
+// storybook engine. The picker models are seeded to a synthetic catalog size N so
+// the size-dependent create cost (and the KIND_SWAP_TO 3rd-picker share) is
+// measured.
+//
+// OFFSCREEN CAVEAT: the terminal picker model here is a JS ListModel proxy for
+// the real Nim producer (walletSectionTokenSelector is a context property absent
+// offscreen); its per-row seed is a faithful shape/size proxy, not the Nim
+// producer's exact cost. The SwapModal QML-tree structural cost is real.
+
+import QtQuick
+import QtQuick.Window
+import QtQml.Models
+
+import StatusQ.Core.Theme
+
+import shared.stores
+import AppLayouts.Wallet.stores as WalletStores
+import AppLayouts.Wallet.popups.swap
+
+Window {
+    id: root
+    width: 600
+    height: 1000
+    visible: true
+
+    // Synthetic catalog: N terminal token-selector rows per picker. Set by the
+    // Nim driver before each createObject.
+    property int catalogSize: 0
+    // Suppress the KIND_SWAP_TO (kind 3) 3rd picker to attribute its share.
+    property bool suppressSwapTo: false
+
+    // Picker-model creation counters for the last run (attribution). kind1 = the
+    // two source-chain pickers (pay + same-chain receive); kind3 = the eager
+    // KIND_SWAP_TO destination picker.
+    property int kind1Count: 0
+    property int kind3Count: 0
+    property int lastModelCount: 0
+
+    // Per-create cached picker seeds (2 kind1 slots + 1 kind3 slot) so the
+    // construction re-eval storm doesn't multiply the size-N seed.
+    property var _preA: null
+    property var _preB: null
+    property var _preC: null
+    property int _k1idx: 0
+
+    property var _held: []
+
+    // Build one terminal-selector-shaped ListModel with `n` rows. Mirrors the
+    // roles the swap pickers/panels bind. Uses the BATCH append(array) form (one
+    // call, not n calls) so the seed cost reflects a bulk build, not QML
+    // ListModel's per-row append overhead.
+    function buildSelectorRows(n) {
+        const rows = new Array(n)
+        for (let i = 0; i < n; i++) {
+            rows[i] = {
+                key: "grp_" + i,
+                name: "Token Number " + i + " Wrapped Staked Governance Asset",
+                symbol: "TKN" + i,
+                logoUri: "https://raw.githubusercontent.com/status-im/assets/master/tokens/ethereum/0x" + i + "/logo.png",
+                decimals: 18,
+                cryptoPrice: 1.5,
+                currentBalance: 5000000000.0,
+                currencyBalance: 7500000000.0,
+                sectionName: "",
+                communityId: ""
+            }
+        }
+        return rows
+    }
+
+    function buildSelectorModel(n) {
+        const m = Qt.createQmlObject('import QtQuick; ListModel {}', root)
+        if (n > 0)
+            m.append(root.buildSelectorRows(n))
+        return m
+    }
+
+    // ---- inline real-store subclasses -------------------------------------
+
+    // Ids deliberately differ from the adaptor's property names (currencyStore,
+    // networksStore, ...) so `currencyStore: theCurrencyStore` binds the Window's
+    // store, not the adaptor's own same-named (null) property.
+    CurrenciesStore { id: theCurrencyStore }   // real; safe offscreen (USD fallback)
+
+    NetworksStore { id: theNetworksStore }     // real; activeNetworks empty offscreen
+
+    WalletStores.SwapStore {
+        id: theSwapStore
+        // accounts is a readonly context binding in the base (undefined offscreen);
+        // an empty account list is fine for instantiation. resetData/fetch are
+        // no-ops here (no backend).
+        function fetchSuggestedRoutes() {}
+        function resetData() {}
+        function authenticateAndTransfer() {}
+        function reevaluateSwap() {}
+    }
+
+    WalletStores.TokensStore {
+        id: theTokensStore
+        networksStore: theNetworksStore
+
+        // The linchpin override: hand out a size-N seeded terminal picker model
+        // instead of delegating to the (absent) Nim producer. Suppress kind 3
+        // when the scene asks, to attribute the eager 3rd picker on plain swaps.
+        //
+        // Production SwapModal creates exactly 3 pickers (2x kind 1: pay + same-
+        // chain receive; 1x kind 3: KIND_SWAP_TO). But the picker properties are
+        // `readonly property var ... createTokenSelectorModel(k)` whose binding
+        // re-fires as `swapAdaptor` settles from null during construction, so this
+        // override is CALLED many times. We cache per slot (2 kind1 slots +
+        // 1 kind3 slot) so the size-N seed is paid exactly 3x IN the create window
+        // (matching production), while re-eval calls reuse the cached model.
+        function createTokenSelectorModel(kind) {
+            if (kind === 3) {
+                if (root.suppressSwapTo)
+                    return { model: null, id: -1 }
+                if (!root._preC) {
+                    root._preC = root.buildSelectorModel(root.catalogSize)
+                    root._held.push(root._preC)
+                    root.kind3Count += 1
+                }
+                return { model: root._preC, id: 3 }
+            }
+            const slot = root._k1idx % 2
+            root._k1idx += 1
+            if (slot === 0) {
+                if (!root._preA) {
+                    root._preA = root.buildSelectorModel(root.catalogSize)
+                    root._held.push(root._preA)
+                    root.kind1Count += 1
+                }
+                return { model: root._preA, id: 1 }
+            }
+            if (!root._preB) {
+                root._preB = root.buildSelectorModel(root.catalogSize)
+                root._held.push(root._preB)
+                root.kind1Count += 1
+            }
+            return { model: root._preB, id: 2 }
+        }
+        function releaseTokenSelectorModel(id) {}
+        function isChainSupportedForSwapViaParaswap(chainId) { return true }
+        function isChainSupportedForSwapViaLiFi(chainId) { return true }
+        function buildGroupsForChain(chainId, keys) {}
+        function buildGroupsForChainTo(chainId, keys) {}
+    }
+
+    WalletStores.WalletAssetsStore {
+        id: theWalletAssetsStore
+        walletTokensStore: theTokensStore
+    }
+
+    property SwapInputParamsForm swapFormData: SwapInputParamsForm {}
+
+    Component {
+        id: modalComp
+        SwapModal {
+            swapAdaptor: SwapModalAdaptor {
+                currencyStore: theCurrencyStore
+                walletAssetsStore: theWalletAssetsStore
+                swapStore: theSwapStore
+                networksStore: theNetworksStore
+                swapFormData: root.swapFormData
+                swapOutputData: SwapOutputData {}
+            }
+            swapInputParamsForm: root.swapFormData
+            buyEnabled: true
+        }
+    }
+
+    property var _modal: null
+
+    // ---- scenario steps, driven one signal at a time by the Nim bench ------
+
+    function doCreate(size, suppress) {
+        root.catalogSize = size
+        root.suppressSwapTo = suppress
+        root.lastModelCount = 0
+        root.kind1Count = 0
+        root.kind3Count = 0
+        root._preA = null; root._preB = null; root._preC = null; root._k1idx = 0
+        root.swapFormData.resetFormData()
+        if (root.swapFormData.selectedNetworkChainId === -1)
+            root.swapFormData.selectedNetworkChainId = 1
+
+        const t0 = bench.nowMs()
+        const obj = modalComp.createObject(root)
+        const t1 = bench.nowMs()
+        if (!obj) {
+            bench.reportCreate(-1, 0, modalComp.errorString())
+            return
+        }
+        root._modal = obj
+        obj.onOpened.connect(function() { bench.onModalOpened() })
+        obj.onClosed.connect(function() { bench.onModalClosed() })
+        bench.reportCreate(t1 - t0, root.kind1Count, root.kind3Count, "")
+    }
+
+    function doOpen() {
+        if (!root._modal) { bench.onModalOpened(); return }
+        root._modal.open()
+    }
+
+    function doClose() {
+        if (!!root._modal) root._modal.close()
+    }
+
+    // The deferred handler setup(): the form-property assignments run via
+    // Qt.callLater after onOpened in SwapModalHandler. Timed here.
+    function doConfigure() {
+        const f = root.swapFormData
+        const t0 = bench.nowMs()
+        f.fromGroupKey = Qt.binding(() => f.defaultFromGroupKey)
+        f.toGroupKey = Qt.binding(() => f.defaultToGroupKey)
+        f.selectedNetworkChainId = 1
+        f.toNetworkChainId = 1
+        f.defaultToGroupKey = f.getDefaultToGroupKey(f.selectedNetworkChainId)
+        f.selectedSlippage = 0.5
+        f.selectedAccountAddress = "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+        f.fromTokenAmount = "0.001"
+        const t1 = bench.nowMs()
+        bench.reportConfigure(t1 - t0)
+    }
+
+    function doDestroy() {
+        if (!!root._modal) { root._modal.destroy(); root._modal = null }
+        for (let i = 0; i < root._held.length; i++) {
+            if (!!root._held[i] && !!root._held[i].destroy) root._held[i].destroy()
+        }
+        root._held = []
+    }
+
+    Connections {
+        target: bench
+        function onRequestCreate(size, suppress) { root.doCreate(size, suppress) }
+        function onRequestOpen() { root.doOpen() }
+        function onRequestClose() { root.doClose() }
+        function onRequestConfigure() { root.doConfigure() }
+        function onRequestDestroy() { root.doDestroy() }
+    }
+
+    Timer {
+        interval: 16
+        running: true
+        repeat: true
+        onTriggered: bench.onStallTick()
+    }
+
+    Timer {
+        interval: 50
+        running: true
+        repeat: false
+        onTriggered: bench.onSceneReady()
+    }
+}

--- a/test/nim/swap_modal_instantiation_bench.nim
+++ b/test/nim/swap_modal_instantiation_bench.nim
@@ -36,6 +36,16 @@ import os, times, strformat
 import nimqml
 from seaqt/qcoreapplication import QCoreApplication, processEvents
 import std/monotimes
+import std/strutils
+
+# Optional QML profiling: build with `-d:qmldebug` (port via -d:qmlDebugPort:NNNNN)
+# to start the TCP debug/profiler server and BLOCK until `qmlprofiler --attach`
+# connects, so a trace of the create window can be captured. Mirrors the desktop
+# app's enabler in nim_status_client.nim. Test-only; off by default.
+when defined(qmldebug):
+  # `from ... import nil` keeps every symbol qualified so its transitive QVariant
+  # doesn't clash with nimqml.QVariant in the QtObject macro below.
+  from seaqt/qqmldebuggingenabler import nil
 
 {.compile: "bench_statusq_register.cpp".}
 proc bench_registerStatusQTypes() {.importc.}
@@ -136,6 +146,17 @@ proc formatTable(rows: seq[Row]): string =
 when isMainModule:
   putEnv("QT_QPA_PLATFORM", "offscreen")
   let app = newQApplication()
+
+  when defined(qmldebug):
+    const qmlDebugPort {.intdefine: "qmlDebugPort".} = 49155
+    # WaitForClient: block here until qmlprofiler attaches, so the create window
+    # is inside the recorded window. Must run before the QML engine is created.
+    # mode 1 = WaitForClient (block until qmlprofiler attaches)
+    discard qqmldebuggingenabler.startTcpDebugServer(
+      qqmldebuggingenabler.QQmlDebuggingEnabler, qmlDebugPort.cint, 1.cint)
+    stderr.writeLine("[bench] qml debug/profiler server waiting on port " & $qmlDebugPort)
+    stderr.flushFile()
+
   bench_registerStatusQTypes()
 
   let bench = newBench()
@@ -157,7 +178,14 @@ when isMainModule:
     quit(0)
 
   var rows: seq[Row] = @[]
-  const sizes = [100, 1000, 5000, 10000]
+  # Default sweep; override with SWAP_BENCH_SIZES=10000 (comma-separated) to pin a
+  # single size for a profiled run. Not a committed hardcode — env-driven.
+  var sizes = @[100, 1000, 5000, 10000]
+  let sizesEnv = getEnv("SWAP_BENCH_SIZES", "")
+  if sizesEnv.len > 0:
+    sizes = @[]
+    for s in sizesEnv.split(','):
+      if s.strip().len > 0: sizes.add(parseInt(s.strip()))
   const openTimeoutMs = 2500.0
 
   # Opens the modal and waits for `opened` (or drains to timeout), returning the
@@ -298,4 +326,12 @@ when isMainModule:
   # static destructors (Nim's `quit`/`exit` would run them and crash). Using
   # _exit avoids that unrelated shutdown-ordering bug.
   proc c_exit(code: cint) {.importc: "_exit", header: "<unistd.h>".}
+  when defined(qmldebug):
+    # Under profiling, hold the app + debug connection open so qmlprofiler can
+    # flush a CLEAN trace: an immediate _exit drops the TCP socket mid-stream and
+    # the profiler reports "connection dropped ... damaged". Spin processing events
+    # (keeps the debug thread serviced); the harness stops the profiler + kills us.
+    stderr.writeLine("[bench] measurement done; holding open 300s for qmlprofiler flush")
+    stderr.flushFile()
+    bench.spinFor(300000.0)
   c_exit(0)

--- a/test/nim/swap_modal_instantiation_bench.nim
+++ b/test/nim/swap_modal_instantiation_bench.nim
@@ -3,23 +3,26 @@
 ## linked + the app import paths, and times, per synthetic catalog size
 ## (100 / 1k / 5k / 10k terminal token-selector rows per picker):
 ##
-##   create           createObject(SwapModal) wall ms + max 16ms-tick stall.
-##                    Includes creating the 3 terminal picker models in `d`
-##                    (2x kind 1 + 1x kind 3 KIND_SWAP_TO).
-##   create_no_swapto same, but the KIND_SWAP_TO (kind 3) picker is suppressed
-##                    (scene-level toggle) -> attribution for the eager 3rd
-##                    picker on plain swaps.
-##   open             create then open() -> time to reach `opened` (or a drained
-##                    proxy if the offscreen enter transition can't complete),
-##                    wall ms + max stall + frames>32ms.
-##   configure        the deferred handler setup() block (form-property writes
-##                    run via Qt.callLater after onOpened) execution cost.
-##   second_open      close + reopen cost (handler reuse, no rebuild).
+##   create                 createObject(SwapModal) wall ms + max 16ms-tick stall.
+##                          The picker models are NO LONGER built here: SwapModal
+##                          defers createPickers to just after onOpened, so this
+##                          is the picker-free structural tree cost (models=0).
+##   time_to_pickers_ready  create then open()->opened (unmonitored), then measure
+##                          ONLY the deferred picker build+seed stall — the cost
+##                          that used to sit inside `create`. A plain same-chain
+##                          swap builds the 2 source-chain pickers, no kind-3.
+##   open                   create then open() -> time to reach `opened`; monitor
+##                          ENDS at `opened`, before the deferred seed, so open
+##                          stays clean. wall ms + max stall + frames>32ms.
+##   configure              the deferred handler setup() block (form-property writes
+##                          run via Qt.callLater after onOpened) execution cost.
+##   second_open            close + reopen cost (handler + pickers reused, no rebuild).
 ##
 ## Why the size sweep matters here: the SwapModal QML tree itself is
-## size-independent (delegates realize lazily), so the only size-dependent term
-## in `create` is the per-row seed of the picker models. The bench isolates that
-## and the KIND_SWAP_TO share.
+## size-independent (delegates realize lazily), so the only size-dependent term is
+## the per-row seed of the picker models. This bench isolates it and shows the
+## deferral moves it OUT of `create` (create flat, cost lands in
+## time_to_pickers_ready).
 ##
 ## OFFSCREEN CAVEAT (see scene header): the terminal picker model is a JS
 ## ListModel proxy for the real Nim producer; its per-row seed is a faithful
@@ -67,6 +70,11 @@ QtObject:
     # configure handshake
     gotConfigure: bool
     lastConfigureMs: float
+    # deferred picker-build handshake: the scene bumps these each time SwapModal's
+    # post-open createPickers actually builds a picker model (kind 1 = the two
+    # source-chain pickers, kind 3 = the bridge destination picker).
+    builtKind1: int
+    builtKind3: int
 
   proc newBench(): Bench =
     new(result)
@@ -96,6 +104,9 @@ QtObject:
   proc reportConfigure(self: Bench, ms: float) {.slot.} =
     self.lastConfigureMs = ms
     self.gotConfigure = true
+
+  proc onPickerBuilt(self: Bench, kind: int) {.slot.} =
+    if kind == 3: inc self.builtKind3 else: inc self.builtKind1
 
   proc onStallTick(self: Bench) {.slot.} =
     if not self.monitoring: return
@@ -149,16 +160,27 @@ when isMainModule:
   const sizes = [100, 1000, 5000, 10000]
   const openTimeoutMs = 2500.0
 
+  # Opens the modal and waits for `opened` (or drains to timeout), returning the
+  # elapsed ms. The 16ms-tick monitor must be running around this call.
+  proc openAndWait(): float =
+    let t0 = bench.nowMs()
+    bench.requestOpen()
+    while (not bench.modalOpen) and (bench.nowMs() - t0) < openTimeoutMs:
+      QCoreApplication.processEvents()
+    return bench.nowMs() - t0
+
   # A scenario runs create (+optional open/configure/reopen), returning one Row.
   proc runScenario(size: int, scenario: string): Row =
-    let suppress = scenario == "create_no_swapto"
-
     # ---- create ----
+    # The pickers are no longer built here (SwapModal defers createPickers to just
+    # after onOpened), so `create` now measures the picker-free structural tree
+    # cost only; models=0. The moved seed cost is measured by the
+    # `time_to_pickers_ready` scenario below.
     bench.gotCreate = false
     bench.modalOpen = false
     bench.beginMonitor()
     bench.spinFor(32)
-    bench.requestCreate(size, suppress)
+    bench.requestCreate(size, false)
     var s = 0
     while not bench.gotCreate and s < 500000:
       QCoreApplication.processEvents(); inc s
@@ -170,20 +192,38 @@ when isMainModule:
       kind3: bench.lastKind3,
       maxStallMs: bench.maxStallMs, over32: bench.over32, error: bench.lastError)
 
-    if bench.lastError.len == 0 and scenario in ["open", "configure", "second_open"]:
-      # ---- open: measure create->opened (drain to timeout if never opened) ----
-      bench.beginMonitor()
-      let t0 = bench.nowMs()
-      bench.requestOpen()
-      while (not bench.modalOpen) and (bench.nowMs() - t0) < openTimeoutMs:
-        QCoreApplication.processEvents()
-      let openMs = bench.nowMs() - t0
-      bench.spinFor(80)
-      bench.endMonitor()
-      result.openMs = openMs
-      result.opened = if bench.modalOpen: 1 else: 0
-      result.maxStallMs = bench.maxStallMs
-      result.over32 = bench.over32
+    if bench.lastError.len == 0 and
+        scenario in ["time_to_pickers_ready", "open", "configure", "second_open"]:
+
+      if scenario == "time_to_pickers_ready":
+        # Reach `opened` UNMONITORED, then monitor only the deferred picker
+        # build+seed (the cost that used to live in `create`). Success = the two
+        # source-chain pickers built; a plain same-chain swap builds no kind-3.
+        bench.builtKind1 = 0
+        bench.builtKind3 = 0
+        result.openMs = openAndWait()
+        result.opened = if bench.modalOpen: 1 else: 0
+        bench.beginMonitor()
+        let tp = bench.nowMs()
+        while bench.builtKind1 < 2 and (bench.nowMs() - tp) < openTimeoutMs:
+          QCoreApplication.processEvents()
+        bench.spinFor(80)  # let the seed's post-build tick delta register
+        bench.endMonitor()
+        result.models = bench.builtKind1 + bench.builtKind3
+        result.kind3 = bench.builtKind3
+        result.maxStallMs = bench.maxStallMs
+        result.over32 = bench.over32
+      else:
+        # ---- open: measure create->opened only. endMonitor AT `opened`, before
+        # the deferred createPickers seed runs, so the seed does not pollute the
+        # open stall (its cost is the `time_to_pickers_ready` scenario). ----
+        bench.beginMonitor()
+        result.openMs = openAndWait()
+        bench.endMonitor()
+        result.opened = if bench.modalOpen: 1 else: 0
+        result.maxStallMs = bench.maxStallMs
+        result.over32 = bench.over32
+        bench.spinFor(120)  # unmonitored: let the deferred pickers build before next step
 
       if scenario == "configure":
         bench.gotConfigure = false
@@ -197,22 +237,20 @@ when isMainModule:
         bench.requestClose()
         bench.spinFor(120)
         bench.beginMonitor()
-        let t1 = bench.nowMs()
-        bench.requestOpen()
-        while (not bench.modalOpen) and (bench.nowMs() - t1) < openTimeoutMs:
-          QCoreApplication.processEvents()
-        result.openMs = bench.nowMs() - t1
+        result.openMs = openAndWait()
+        bench.endMonitor()
         result.opened = if bench.modalOpen: 1 else: 0
         bench.spinFor(80)
-        bench.endMonitor()
         result.maxStallMs = bench.maxStallMs
         result.over32 = bench.over32
 
     bench.requestDestroy()
-    bench.spinFor(60)
+    bench.spinFor(150)  # let the (possibly opened) modal fully destroy before the
+                        # next scenario's monitored create window, so a lingering
+                        # modal can't seed a picker into it
 
   for size in sizes:
-    for scenario in ["create", "create_no_swapto", "open", "configure", "second_open"]:
+    for scenario in ["create", "time_to_pickers_ready", "open", "configure", "second_open"]:
       # Warm the QML caches once at the first (size, scenario), then measure.
       if size == sizes[0] and scenario == "create":
         discard runScenario(size, scenario)
@@ -241,13 +279,15 @@ when isMainModule:
     &"SwapModal failed to instantiate offscreen: {full.error}"
   doAssert full.wallMs > 0.0,
     &"SwapModal createMs was not measured: {full.wallMs}"
-  # The full create must make all 3 pickers (2 kind1 + 1 kind3); suppressing
-  # kind 3 makes 2 (0 kind3). This is the KIND_SWAP_TO attribution.
-  doAssert full.models == 3 and full.kind3 == 1,
-    &"expected 3 pickers incl 1 kind3, got models={full.models} kind3={full.kind3}"
-  let noSwapTo = rowFor(10000, "create_no_swapto")
-  doAssert noSwapTo.models == 2 and noSwapTo.kind3 == 0,
-    &"expected 2 pickers with swapto suppressed, got models={noSwapTo.models} kind3={noSwapTo.kind3}"
+  # createObject no longer builds any picker: they are deferred to post-open
+  # createPickers. This is the whole point of the optimization.
+  doAssert full.models == 0,
+    &"expected 0 pickers built during create (deferred), got models={full.models}"
+  # A plain (same-chain) swap open builds exactly the two source-chain pickers and
+  # NO bridge (kind 3) picker — the eager 3rd picker on plain swaps is gone.
+  let ready = rowFor(10000, "time_to_pickers_ready")
+  doAssert ready.models == 2 and ready.kind3 == 0,
+    &"expected 2 pickers built post-open incl 0 kind3, got models={ready.models} kind3={ready.kind3}"
 
   echo "assertions passed"
   stdout.flushFile()

--- a/test/nim/swap_modal_instantiation_bench.nim
+++ b/test/nim/swap_modal_instantiation_bench.nim
@@ -1,0 +1,261 @@
+## Real-instantiation benchmark for the SWAP modal: loads the ACTUAL SwapModal
+## QML tree + its real SwapModalAdaptor under an offscreen engine with StatusQ
+## linked + the app import paths, and times, per synthetic catalog size
+## (100 / 1k / 5k / 10k terminal token-selector rows per picker):
+##
+##   create           createObject(SwapModal) wall ms + max 16ms-tick stall.
+##                    Includes creating the 3 terminal picker models in `d`
+##                    (2x kind 1 + 1x kind 3 KIND_SWAP_TO).
+##   create_no_swapto same, but the KIND_SWAP_TO (kind 3) picker is suppressed
+##                    (scene-level toggle) -> attribution for the eager 3rd
+##                    picker on plain swaps.
+##   open             create then open() -> time to reach `opened` (or a drained
+##                    proxy if the offscreen enter transition can't complete),
+##                    wall ms + max stall + frames>32ms.
+##   configure        the deferred handler setup() block (form-property writes
+##                    run via Qt.callLater after onOpened) execution cost.
+##   second_open      close + reopen cost (handler reuse, no rebuild).
+##
+## Why the size sweep matters here: the SwapModal QML tree itself is
+## size-independent (delegates realize lazily), so the only size-dependent term
+## in `create` is the per-row seed of the picker models. The bench isolates that
+## and the KIND_SWAP_TO share.
+##
+## OFFSCREEN CAVEAT (see scene header): the terminal picker model is a JS
+## ListModel proxy for the real Nim producer; its per-row seed is a faithful
+## shape/size proxy, not the Nim producer's exact cost. The QML-tree structural
+## cost is real. Absolute host numbers are far below a device's; the ATTRIBUTION
+## RANKING (create vs open vs configure vs KIND_SWAP_TO share) is what transfers.
+##
+## Links StatusQ (registerStatusQTypes) like send_modal_instantiation_bench.
+
+import os, times, strformat
+import nimqml
+from seaqt/qcoreapplication import QCoreApplication, processEvents
+import std/monotimes
+
+{.compile: "bench_statusq_register.cpp".}
+proc bench_registerStatusQTypes() {.importc.}
+
+type Row = object
+  size: int
+  scenario: string
+  wallMs: float       # createObject wall time, or open/configure wall time
+  openMs: float       # time create->opened (open scenarios only), -1 if n/a
+  opened: int         # 1 if the modal reached `opened`, else 0
+  models: int         # distinct picker models created (kind1 + kind3)
+  kind3: int          # of those, the eager KIND_SWAP_TO (kind 3) picker(s)
+  maxStallMs: float
+  over32: int
+  error: string
+
+QtObject:
+  type Bench = ref object of QObject
+    ready: bool
+    monitoring: bool
+    lastTickNs: float
+    maxStallMs: float
+    over32: int
+    # create handshake
+    gotCreate: bool
+    lastCreateMs: float
+    lastKind1: int
+    lastKind3: int
+    lastError: string
+    # open handshake
+    modalOpen: bool
+    # configure handshake
+    gotConfigure: bool
+    lastConfigureMs: float
+
+  proc newBench(): Bench =
+    new(result)
+    result.QObject.setup
+
+  proc requestCreate(self: Bench, size: int, suppress: bool) {.signal.}
+  proc requestOpen(self: Bench) {.signal.}
+  proc requestClose(self: Bench) {.signal.}
+  proc requestConfigure(self: Bench) {.signal.}
+  proc requestDestroy(self: Bench) {.signal.}
+
+  proc onSceneReady(self: Bench) {.slot.} = self.ready = true
+
+  proc nowMs(self: Bench): float {.slot.} =
+    (getMonoTime() - MonoTime()).inNanoseconds.float / 1_000_000.0
+
+  proc reportCreate(self: Bench, createMs: float, kind1: int, kind3: int, error: string) {.slot.} =
+    self.lastCreateMs = createMs
+    self.lastKind1 = kind1
+    self.lastKind3 = kind3
+    self.lastError = error
+    self.gotCreate = true
+
+  proc onModalOpened(self: Bench) {.slot.} = self.modalOpen = true
+  proc onModalClosed(self: Bench) {.slot.} = self.modalOpen = false
+
+  proc reportConfigure(self: Bench, ms: float) {.slot.} =
+    self.lastConfigureMs = ms
+    self.gotConfigure = true
+
+  proc onStallTick(self: Bench) {.slot.} =
+    if not self.monitoring: return
+    let n = self.nowMs()
+    let delta = n - self.lastTickNs
+    if delta > self.maxStallMs: self.maxStallMs = delta
+    if delta > 32.0: inc self.over32
+    self.lastTickNs = n
+
+  proc beginMonitor(self: Bench) =
+    self.maxStallMs = 0.0
+    self.over32 = 0
+    self.lastTickNs = self.nowMs()
+    self.monitoring = true
+  proc endMonitor(self: Bench) = self.monitoring = false
+
+  proc spinFor(self: Bench, ms: float) =
+    let deadline = self.nowMs() + ms
+    while self.nowMs() < deadline:
+      QCoreApplication.processEvents()
+
+proc formatTable(rows: seq[Row]): string =
+  result = "size\tscenario\twall_ms\topen_ms\topened\tmodels\tkind3\tmax_stall_ms\tover32\terror\n"
+  for r in rows:
+    result.add(&"{r.size}\t{r.scenario}\t{r.wallMs:.4f}\t{r.openMs:.4f}\t{r.opened}\t{r.models}\t{r.kind3}\t{r.maxStallMs:.4f}\t{r.over32}\t{r.error}\n")
+
+when isMainModule:
+  putEnv("QT_QPA_PLATFORM", "offscreen")
+  let app = newQApplication()
+  bench_registerStatusQTypes()
+
+  let bench = newBench()
+  let engine = newQQmlApplicationEngine()
+  let cwd = getCurrentDir()
+  engine.addImportPath(cwd / "ui" / "StatusQ" / "src")
+  engine.addImportPath(cwd / "ui" / "imports")
+  engine.addImportPath(cwd / "ui" / "app")
+  engine.setRootContextProperty("bench", newQVariant(bench))
+
+  let sceneFile = cwd / "test" / "nim" / "benchmarks" / "swap_modal_instantiation_scene.qml"
+  engine.loadData(readFile(sceneFile))
+
+  var spins = 0
+  while not bench.ready and spins < 500000:
+    QCoreApplication.processEvents(); inc spins
+  if not bench.ready:
+    echo "SKIP: swap-modal instantiation scene did not load"
+    quit(0)
+
+  var rows: seq[Row] = @[]
+  const sizes = [100, 1000, 5000, 10000]
+  const openTimeoutMs = 2500.0
+
+  # A scenario runs create (+optional open/configure/reopen), returning one Row.
+  proc runScenario(size: int, scenario: string): Row =
+    let suppress = scenario == "create_no_swapto"
+
+    # ---- create ----
+    bench.gotCreate = false
+    bench.modalOpen = false
+    bench.beginMonitor()
+    bench.spinFor(32)
+    bench.requestCreate(size, suppress)
+    var s = 0
+    while not bench.gotCreate and s < 500000:
+      QCoreApplication.processEvents(); inc s
+    bench.spinFor(120)  # let the post-create tick delta register
+    bench.endMonitor()
+
+    result = Row(size: size, scenario: scenario, wallMs: bench.lastCreateMs,
+      openMs: -1.0, opened: 0, models: bench.lastKind1 + bench.lastKind3,
+      kind3: bench.lastKind3,
+      maxStallMs: bench.maxStallMs, over32: bench.over32, error: bench.lastError)
+
+    if bench.lastError.len == 0 and scenario in ["open", "configure", "second_open"]:
+      # ---- open: measure create->opened (drain to timeout if never opened) ----
+      bench.beginMonitor()
+      let t0 = bench.nowMs()
+      bench.requestOpen()
+      while (not bench.modalOpen) and (bench.nowMs() - t0) < openTimeoutMs:
+        QCoreApplication.processEvents()
+      let openMs = bench.nowMs() - t0
+      bench.spinFor(80)
+      bench.endMonitor()
+      result.openMs = openMs
+      result.opened = if bench.modalOpen: 1 else: 0
+      result.maxStallMs = bench.maxStallMs
+      result.over32 = bench.over32
+
+      if scenario == "configure":
+        bench.gotConfigure = false
+        bench.requestConfigure()
+        var c = 0
+        while not bench.gotConfigure and c < 500000:
+          QCoreApplication.processEvents(); inc c
+        result.wallMs = bench.lastConfigureMs   # report the configure block time
+
+      if scenario == "second_open":
+        bench.requestClose()
+        bench.spinFor(120)
+        bench.beginMonitor()
+        let t1 = bench.nowMs()
+        bench.requestOpen()
+        while (not bench.modalOpen) and (bench.nowMs() - t1) < openTimeoutMs:
+          QCoreApplication.processEvents()
+        result.openMs = bench.nowMs() - t1
+        result.opened = if bench.modalOpen: 1 else: 0
+        bench.spinFor(80)
+        bench.endMonitor()
+        result.maxStallMs = bench.maxStallMs
+        result.over32 = bench.over32
+
+    bench.requestDestroy()
+    bench.spinFor(60)
+
+  for size in sizes:
+    for scenario in ["create", "create_no_swapto", "open", "configure", "second_open"]:
+      # Warm the QML caches once at the first (size, scenario), then measure.
+      if size == sizes[0] and scenario == "create":
+        discard runScenario(size, scenario)
+      let r = runScenario(size, scenario)
+      rows.add(r)
+      stderr.writeLine(&"[bench] size={size} {scenario} wall={r.wallMs:.2f}ms open={r.openMs:.2f}ms opened={r.opened} models={r.models} kind3={r.kind3} maxStall={r.maxStallMs:.2f}ms over32={r.over32} err={r.error}")
+      stderr.flushFile()
+
+  let table = formatTable(rows)
+  echo "\n===== SwapModal real instantiation cost (host, offscreen) ====="
+  echo table
+
+  let resultsDir = cwd / "test" / "nim" / "benchmarks" / "results"
+  createDir(resultsDir)
+  let stamp = now().format("yyyyMMdd'T'HHmmss")
+  writeFile(resultsDir / ("swap_modal_instantiation_" & stamp & ".tsv"), table)
+
+  proc rowFor(size: int, scenario: string): Row =
+    for r in rows:
+      if r.size == size and r.scenario == scenario: return r
+    doAssert false, &"missing row {scenario} @{size}"
+
+  # The full modal must actually instantiate (the whole point of this bench).
+  let full = rowFor(10000, "create")
+  doAssert full.error.len == 0,
+    &"SwapModal failed to instantiate offscreen: {full.error}"
+  doAssert full.wallMs > 0.0,
+    &"SwapModal createMs was not measured: {full.wallMs}"
+  # The full create must make all 3 pickers (2 kind1 + 1 kind3); suppressing
+  # kind 3 makes 2 (0 kind3). This is the KIND_SWAP_TO attribution.
+  doAssert full.models == 3 and full.kind3 == 1,
+    &"expected 3 pickers incl 1 kind3, got models={full.models} kind3={full.kind3}"
+  let noSwapTo = rowFor(10000, "create_no_swapto")
+  doAssert noSwapTo.models == 2 and noSwapTo.kind3 == 0,
+    &"expected 2 pickers with swapto suppressed, got models={noSwapTo.models} kind3={noSwapTo.kind3}"
+
+  echo "assertions passed"
+  stdout.flushFile()
+  stderr.flushFile()
+  # SwapModal instantiates QQuickTextField context menus (QQuickMenu/QQuickAction)
+  # whose static teardown at QApplication destruction SIGSEGVs offscreen. The
+  # measurement + TSV are already done, so hard-exit via _exit(2) BYPASSING C++
+  # static destructors (Nim's `quit`/`exit` would run them and crash). Using
+  # _exit avoids that unrelated shutdown-ordering bug.
+  proc c_exit(code: cint) {.importc: "_exit", header: "<unistd.h>".}
+  c_exit(0)

--- a/test/nim/swap_modal_instantiation_bench.nim
+++ b/test/nim/swap_modal_instantiation_bench.nim
@@ -185,7 +185,16 @@ when isMainModule:
   if sizesEnv.len > 0:
     sizes = @[]
     for s in sizesEnv.split(','):
-      if s.strip().len > 0: sizes.add(parseInt(s.strip()))
+      let entry = s.strip()
+      if entry.len == 0: continue
+      try:
+        sizes.add(parseInt(entry))
+      except ValueError:
+        echo &"ERROR: SWAP_BENCH_SIZES entry is not an integer: '{entry}'"
+        quit(1)
+    if sizes.len == 0:
+      echo "ERROR: SWAP_BENCH_SIZES is set but contains no size"
+      quit(1)
   const openTimeoutMs = 2500.0
 
   # Opens the modal and waits for `opened` (or drains to timeout), returning the
@@ -301,8 +310,11 @@ when isMainModule:
       if r.size == size and r.scenario == scenario: return r
     doAssert false, &"missing row {scenario} @{size}"
 
+  # Assert on the largest size actually swept (the sweep is env-overridable).
+  let biggest = sizes[^1]
+
   # The full modal must actually instantiate (the whole point of this bench).
-  let full = rowFor(10000, "create")
+  let full = rowFor(biggest, "create")
   doAssert full.error.len == 0,
     &"SwapModal failed to instantiate offscreen: {full.error}"
   doAssert full.wallMs > 0.0,
@@ -313,7 +325,7 @@ when isMainModule:
     &"expected 0 pickers built during create (deferred), got models={full.models}"
   # A plain (same-chain) swap open builds exactly the two source-chain pickers and
   # NO bridge (kind 3) picker — the eager 3rd picker on plain swaps is gone.
-  let ready = rowFor(10000, "time_to_pickers_ready")
+  let ready = rowFor(biggest, "time_to_pickers_ready")
   doAssert ready.models == 2 and ready.kind3 == 0,
     &"expected 2 pickers built post-open incl 0 kind3, got models={ready.models} kind3={ready.kind3}"
 

--- a/ui/app/AppLayouts/Wallet/panels/StickySendModalHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/StickySendModalHeader.qml
@@ -129,10 +129,6 @@ Control {
                 anchors.rightMargin: -Theme.xlPadding - parent.radius
                 sourceRect: Qt.rect(0, 0, width, height)
 
-                // Capture the frosted backdrop statically instead of every frame.
-                // With live:true the whole scene is re-blurred at 60fps whenever any
-                // animation runs; here we re-capture only when the content behind the
-                // header actually moves or changes (see refreshRequested wiring below).
                 live: false
 
                 // Emitted whenever the backdrop is re-captured; exposes the
@@ -143,9 +139,6 @@ Control {
                     scheduleUpdate()
                 }
 
-                // The content behind the header is the scrollable form (a Flickable);
-                // re-capture when it scrolls (user drag or programmatic reveal) or
-                // when it grows/shrinks as async data arrives.
                 Connections {
                     target: root.blurSource
                     ignoreUnknownSignals: true

--- a/ui/app/AppLayouts/Wallet/panels/StickySendModalHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/StickySendModalHeader.qml
@@ -106,6 +106,7 @@ Control {
     background: Item {
 
         Rectangle {
+            objectName: "blurBackdropRect"
             anchors.fill: parent
             anchors.leftMargin: radius
             anchors.rightMargin: radius
@@ -119,12 +120,46 @@ Control {
             }
 
             ShaderEffectSource {
+                id: blurBackdropSource
+                objectName: "blurBackdropSource"
+
                 sourceItem: root.blurSource
                 anchors.fill: parent
                 anchors.leftMargin: Theme.xlPadding - parent.radius
                 anchors.rightMargin: -Theme.xlPadding - parent.radius
                 sourceRect: Qt.rect(0, 0, width, height)
-                live: true
+
+                // Capture the frosted backdrop statically instead of every frame.
+                // With live:true the whole scene is re-blurred at 60fps whenever any
+                // animation runs; here we re-capture only when the content behind the
+                // header actually moves or changes (see refreshRequested wiring below).
+                live: false
+
+                // Emitted whenever the backdrop is re-captured; exposes the
+                // refresh-on-movement contract for testing.
+                signal refreshRequested()
+                function refreshBlur() {
+                    refreshRequested()
+                    scheduleUpdate()
+                }
+
+                // The content behind the header is the scrollable form (a Flickable);
+                // re-capture when it scrolls (user drag or programmatic reveal) or
+                // when it grows/shrinks as async data arrives.
+                Connections {
+                    target: root.blurSource
+                    ignoreUnknownSignals: true
+                    function onContentYChanged() { blurBackdropSource.refreshBlur() }
+                    function onContentHeightChanged() { blurBackdropSource.refreshBlur() }
+                    function onContentWidthChanged() { blurBackdropSource.refreshBlur() }
+                }
+
+                // A theme switch recolors the content behind the header without
+                // moving it; re-capture so the static backdrop is not left stale.
+                readonly property color themeProbe: foregroundRect.color
+                onThemeProbeChanged: refreshBlur()
+
+                Component.onCompleted: scheduleUpdate()
             }
         }
 
@@ -132,6 +167,7 @@ Control {
             anchors.fill: parent
             Rectangle {
                 id: foregroundRect
+                objectName: "sendHeaderForegroundRect"
                 anchors.fill: parent
                 color: root.implicitHeight > d.bottomMargin ? StatusColors.alphaColor(Theme.palette.baseColor3, 0.85) : StatusColors.transparent
                 radius: 8

--- a/ui/app/AppLayouts/Wallet/panels/StickySendModalHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/StickySendModalHeader.qml
@@ -145,14 +145,21 @@ Control {
                     function onContentYChanged() { blurBackdropSource.refreshBlur() }
                     function onContentHeightChanged() { blurBackdropSource.refreshBlur() }
                     function onContentWidthChanged() { blurBackdropSource.refreshBlur() }
+                    function onWidthChanged() { blurBackdropSource.refreshBlur() }
+                    function onHeightChanged() { blurBackdropSource.refreshBlur() }
                 }
+
+                // With live == false Qt marks a sourceRect/size change dirty but
+                // never re-renders it, so the capture taken while the header
+                // animates 0 -> N gets stretched; ask for a fresh one explicitly.
+                onSourceRectChanged: refreshBlur()
+                onWidthChanged: refreshBlur()
+                onHeightChanged: refreshBlur()
 
                 // A theme switch recolors the content behind the header without
                 // moving it; re-capture so the static backdrop is not left stale.
                 readonly property color themeProbe: foregroundRect.color
                 onThemeProbeChanged: refreshBlur()
-
-                Component.onCompleted: scheduleUpdate()
             }
         }
 

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -370,10 +370,14 @@ Control {
                 formatCurrencyBalance: (amount) => root.currencyStore.formatCurrencyAmount(amount, root.currencyStore.currentCurrency)
 
                 onSearch: function(keyword) {
-                    root.tokenSelectorModel.search(keyword)
+                    if (root.tokenSelectorModel)
+                        root.tokenSelectorModel.search(keyword)
                 }
 
-                onLoadMoreRequested: root.tokenSelectorModel.fetchMore()
+                onLoadMoreRequested: {
+                    if (root.tokenSelectorModel)
+                        root.tokenSelectorModel.fetchMore()
+                }
 
                 onSelected: function(key) {
                     // Token existance checked with plainTokensBySymbolModel

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -31,12 +31,19 @@ Control {
 
     // Terminal picker model (swap/all-tokens), created by the caller from the
     // token-selector producer. Its per-modal params are driven by the bindings
-    // below; owned/popular/search rows are fed by the producer.
+    // below; owned/popular/search rows are fed by the producer. May be null while
+    // the owning modal defers picker creation until it has opened; the bindings
+    // below tolerate that, and this re-initialises once a model arrives.
     required property var tokenSelectorModel
     // SwapModal rebinds this between the swap and swap-to models when the
     // same-chain check flips, so the titles must follow the instance, not just
     // this panel's chain.
-    onTokenSelectorModelChanged: root.updateSectionNames()
+    onTokenSelectorModelChanged: {
+        if (root.tokenSelectorModel) {
+            root.updateSectionNames()
+            root.reevaluateSelectedId()
+        }
+    }
 
     property int selectedNetworkChainId: -1
     onSelectedNetworkChainIdChanged: {
@@ -102,7 +109,8 @@ Control {
     }
 
     function reset() {
-        root.tokenSelectorModel.search("")
+        if (root.tokenSelectorModel)
+            root.tokenSelectorModel.search("")
     }
 
     // Drive the picker model's per-panel params (swap = all-tokens; -1 chain = no
@@ -147,6 +155,8 @@ Control {
         property string selectedHoldingTokenKey: ""
 
         function reevaluateSelectedId() {
+            if (!root.tokenSelectorModel)
+                return
             const entry = SQUtils.ModelUtils.getByKey(root.tokenSelectorModel, "key", d.selectedHoldingId)
             if (!entry) {
                 // Token doesn't exist in destination chain
@@ -164,6 +174,8 @@ Control {
         }
 
         function setHoldingToSelector() {
+            if (!root.tokenSelectorModel)
+                return
             if (selectedHolding.available && !!selectedHolding.item) {
                 if (!selectedHolding.item.tokens || selectedHolding.item.tokens.ModelCount.count !== 1) {
                     console.error("token for the selected group cannot be resolved", "group-key", d.selectedHoldingId, "chain", root.selectedNetworkChainId)
@@ -352,8 +364,8 @@ Control {
                 Layout.alignment: Qt.AlignRight
 
                 model: root.tokenSelectorModel
-                hasMoreItems: root.tokenSelectorModel.hasMoreItems
-                isLoadingMore: root.tokenSelectorLoading || root.tokenSelectorModel.isLoadingMore
+                hasMoreItems: !!root.tokenSelectorModel && root.tokenSelectorModel.hasMoreItems
+                isLoadingMore: root.tokenSelectorLoading || (!!root.tokenSelectorModel && root.tokenSelectorModel.isLoadingMore)
                 nonInteractiveKey: root.nonInteractiveGroupKey
                 formatCurrencyBalance: (amount) => root.currencyStore.formatCurrencyAmount(amount, root.currencyStore.currentCurrency)
 

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -40,9 +40,15 @@ StatusDialog {
 
     Component.onDestruction: {
         const store = root.swapAdaptor.walletAssetsStore.walletTokensStore
-        store.releaseTokenSelectorModel(d.payTokenSelector.id)
-        store.releaseTokenSelectorModel(d.receiveTokenSelector.id)
-        store.releaseTokenSelectorModel(d.receiveTokenSelectorTo.id)
+        // Only release the pickers that were actually created (they are built
+        // lazily post-open; a modal opened and destroyed before the deferred
+        // setup runs may have none, and a plain swap never builds the bridge one).
+        if (d.payTokenSelector)
+            store.releaseTokenSelectorModel(d.payTokenSelector.id)
+        if (d.receiveTokenSelector)
+            store.releaseTokenSelectorModel(d.receiveTokenSelector.id)
+        if (d.receiveTokenSelectorTo)
+            store.releaseTokenSelectorModel(d.receiveTokenSelectorTo.id)
     }
 
     implicitWidth: 556
@@ -66,9 +72,45 @@ StatusDialog {
         // destruction so the producer stops tracking them (avoids a per-open leak).
         // The receive side has two: the source-chain picker (plain swap) and the
         // destination-chain picker (bridge), switched by isSameChainSwap below.
-        readonly property var payTokenSelector: root.swapAdaptor.walletAssetsStore.walletTokensStore.createTokenSelectorModel(1)
-        readonly property var receiveTokenSelector: root.swapAdaptor.walletAssetsStore.walletTokensStore.createTokenSelectorModel(1)
-        readonly property var receiveTokenSelectorTo: root.swapAdaptor.walletAssetsStore.walletTokensStore.createTokenSelectorModel(3)
+        //
+        // Created LAZILY, off the synchronous createObject path: creating + seeding
+        // these blocks the GUI thread proportionally to the catalog size, so it is
+        // deferred to just after the modal has opened (createPickers, driven from
+        // onOpened). The destination-chain (bridge) picker is created only when a
+        // bridge is actually selected. The panel bindings tolerate a null model
+        // until then; the picker popup can only be tapped once the modal is open.
+        property var payTokenSelector: null
+        property var receiveTokenSelector: null
+        property var receiveTokenSelectorTo: null
+
+        // Guards lazy bridge-picker creation: stays false until createPickers has
+        // run (post-open) so the isBridge binding settling during construction
+        // (a transient true→false toggle as its dependencies resolve) does not
+        // eagerly build the bridge picker back onto the create path.
+        property bool pickersInitialized: false
+
+        // Builds the pay + same-chain-receive pickers (once) and, for a bridge, the
+        // destination picker. Idempotent, so a close+reopen reuses the models.
+        function createPickers() {
+            const store = root.swapAdaptor.walletAssetsStore.walletTokensStore
+            if (!d.payTokenSelector) {
+                d.payTokenSelector = store.createTokenSelectorModel(1)
+                d.receiveTokenSelector = store.createTokenSelectorModel(1)
+            }
+            d.pickersInitialized = true
+            if (d.isBridge)
+                d.ensureBridgePicker()
+            payPanel.reset()
+            receivePanel.reset()
+        }
+
+        // The bridge (destination-chain) picker is only needed when bridging; build
+        // it the first time bridge mode is entered (incl. a pre-filled bridge open,
+        // whose toNetworkChainId is set by the deferred handler setup after onOpened).
+        function ensureBridgePicker() {
+            if (!d.receiveTokenSelectorTo)
+                d.receiveTokenSelectorTo = root.swapAdaptor.walletAssetsStore.walletTokensStore.createTokenSelectorModel(3)
+        }
 
         property var debounceFetchSuggestedRoutes: Backpressure.debounce(root, 1000, function() {
             root.swapAdaptor.fetchSuggestedRoutes(payPanel.rawValue)
@@ -115,6 +157,13 @@ StatusDialog {
         // same chain => plain swap (from/to token must differ); different chains => bridge (same token ok)
         readonly property bool isSameChainSwap: root.swapInputParamsForm.selectedNetworkChainId === root.swapInputParamsForm.toNetworkChainId
         readonly property bool isBridge: root.swapInputParamsForm.toNetworkChainId !== -1 && !isSameChainSwap
+        onIsBridgeChanged: {
+            // Lazily build the destination-chain picker the first time a bridge is
+            // entered — but only after the pickers have been initialized post-open,
+            // so the binding settling during construction can't build it eagerly.
+            if (isBridge && d.pickersInitialized)
+                d.ensureBridgePicker()
+        }
 
         readonly property bool swapViaLiFi: root.swapAdaptor.swapOutputData.txProviderName === Constants.swap.lifiProcessorName
         readonly property string serviceProviderName: d.swapViaLiFi ? Constants.swap.lifiName : Constants.swap.paraswapName
@@ -220,15 +269,18 @@ StatusDialog {
     }
 
     Component.onCompleted: {
-        payPanel.reset()
-        receivePanel.reset()
-
+        // The pickers are created post-open (see d.createPickers); the panel resets
+        // that clear their search move there too. The catalog harvest below is
+        // independent of the picker models and stays on the create path.
         d.rebuildGroupsForChain(root.swapInputParamsForm.selectedNetworkChainId)
         if (d.isBridge)
             d.rebuildGroupsForChain(root.swapInputParamsForm.toNetworkChainId, true)
     }
 
     onOpened: {
+        // Defer the terminal picker model creation + seed off the open critical
+        // path; callLater lets the opened frame render before the seed runs.
+        Qt.callLater(d.createPickers)
         payPanel.forceActiveFocus()
     }
     onClosed: {
@@ -287,7 +339,8 @@ StatusDialog {
 
                     currencyStore: root.swapAdaptor.currencyStore
                     flatNetworksModel: root.swapAdaptor.networksStore.activeNetworks
-                    tokenSelectorModel: d.payTokenSelector.model
+                    // null until the deferred createPickers runs post-open
+                    tokenSelectorModel: d.payTokenSelector ? d.payTokenSelector.model : null
 
                     groupKey: root.swapInputParamsForm.fromGroupKey
                     defaultGroupKey: root.swapInputParamsForm.defaultFromGroupKey
@@ -339,8 +392,12 @@ StatusDialog {
                     currencyStore: root.swapAdaptor.currencyStore
                     flatNetworksModel: root.swapAdaptor.networksStore.activeNetworks
                     // plain swap reuses the source-chain picker; only a bridge uses the destination one
-                    tokenSelectorModel: d.isSameChainSwap ? d.receiveTokenSelector.model
-                                                          : d.receiveTokenSelectorTo.model
+                    // (both null until the deferred createPickers/ensureBridgePicker run post-open)
+                    tokenSelectorModel: {
+                        if (d.isSameChainSwap)
+                            return d.receiveTokenSelector ? d.receiveTokenSelector.model : null
+                        return d.receiveTokenSelectorTo ? d.receiveTokenSelectorTo.model : null
+                    }
 
                     groupKey: root.swapInputParamsForm.toGroupKey
                     defaultGroupKey: root.swapInputParamsForm.defaultToGroupKey

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -40,9 +40,6 @@ StatusDialog {
 
     Component.onDestruction: {
         const store = root.swapAdaptor.walletAssetsStore.walletTokensStore
-        // Only release the pickers that were actually created (they are built
-        // lazily post-open; a modal opened and destroyed before the deferred
-        // setup runs may have none, and a plain swap never builds the bridge one).
         if (d.payTokenSelector)
             store.releaseTokenSelectorModel(d.payTokenSelector.id)
         if (d.receiveTokenSelector)
@@ -61,36 +58,15 @@ StatusDialog {
 
         readonly property string mandatoryKeysSeparator: "$$"
 
-        // Guards the double rebuildGroupsForChain per open (Component.onCompleted +
-        // the chain-changed handler both fire for the same chain): skip the redundant
-        // harvest + async fetch when the chain hasn't changed. One guard per side
-        // (source pay chain / destination bridge chain).
         property int lastRequestedChainId: -1
         property int lastRequestedChainIdTo: -1
 
-        // One terminal picker model per side ({ model, id }); released on modal
-        // destruction so the producer stops tracking them (avoids a per-open leak).
-        // The receive side has two: the source-chain picker (plain swap) and the
-        // destination-chain picker (bridge), switched by isSameChainSwap below.
-        //
-        // Created LAZILY, off the synchronous createObject path: creating + seeding
-        // these blocks the GUI thread proportionally to the catalog size, so it is
-        // deferred to just after the modal has opened (createPickers, driven from
-        // onOpened). The destination-chain (bridge) picker is created only when a
-        // bridge is actually selected. The panel bindings tolerate a null model
-        // until then; the picker popup can only be tapped once the modal is open.
         property var payTokenSelector: null
         property var receiveTokenSelector: null
         property var receiveTokenSelectorTo: null
 
-        // Guards lazy bridge-picker creation: stays false until createPickers has
-        // run (post-open) so the isBridge binding settling during construction
-        // (a transient true→false toggle as its dependencies resolve) does not
-        // eagerly build the bridge picker back onto the create path.
         property bool pickersInitialized: false
 
-        // Builds the pay + same-chain-receive pickers (once) and, for a bridge, the
-        // destination picker. Idempotent, so a close+reopen reuses the models.
         function createPickers() {
             const store = root.swapAdaptor.walletAssetsStore.walletTokensStore
             if (!d.payTokenSelector) {
@@ -104,9 +80,6 @@ StatusDialog {
             receivePanel.reset()
         }
 
-        // The bridge (destination-chain) picker is only needed when bridging; build
-        // it the first time bridge mode is entered (incl. a pre-filled bridge open,
-        // whose toNetworkChainId is set by the deferred handler setup after onOpened).
         function ensureBridgePicker() {
             if (!d.receiveTokenSelectorTo)
                 d.receiveTokenSelectorTo = root.swapAdaptor.walletAssetsStore.walletTokensStore.createTokenSelectorModel(3)
@@ -158,9 +131,6 @@ StatusDialog {
         readonly property bool isSameChainSwap: root.swapInputParamsForm.selectedNetworkChainId === root.swapInputParamsForm.toNetworkChainId
         readonly property bool isBridge: root.swapInputParamsForm.toNetworkChainId !== -1 && !isSameChainSwap
         onIsBridgeChanged: {
-            // Lazily build the destination-chain picker the first time a bridge is
-            // entered — but only after the pickers have been initialized post-open,
-            // so the binding settling during construction can't build it eagerly.
             if (isBridge && d.pickersInitialized)
                 d.ensureBridgePicker()
         }
@@ -269,9 +239,6 @@ StatusDialog {
     }
 
     Component.onCompleted: {
-        // The pickers are created post-open (see d.createPickers); the panel resets
-        // that clear their search move there too. The catalog harvest below is
-        // independent of the picker models and stays on the create path.
         d.rebuildGroupsForChain(root.swapInputParamsForm.selectedNetworkChainId)
         if (d.isBridge)
             d.rebuildGroupsForChain(root.swapInputParamsForm.toNetworkChainId, true)

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -81,8 +81,11 @@ StatusDialog {
         }
 
         function ensureBridgePicker() {
-            if (!d.receiveTokenSelectorTo)
-                d.receiveTokenSelectorTo = root.swapAdaptor.walletAssetsStore.walletTokensStore.createTokenSelectorModel(3)
+            if (d.receiveTokenSelectorTo)
+                return
+            d.receiveTokenSelectorTo = root.swapAdaptor.walletAssetsStore.walletTokensStore.createTokenSelectorModel(3)
+            // seed it like createPickers seeds the source-chain ones
+            receivePanel.reset()
         }
 
         property var debounceFetchSuggestedRoutes: Backpressure.debounce(root, 1000, function() {
@@ -131,7 +134,10 @@ StatusDialog {
         readonly property bool isSameChainSwap: root.swapInputParamsForm.selectedNetworkChainId === root.swapInputParamsForm.toNetworkChainId
         readonly property bool isBridge: root.swapInputParamsForm.toNetworkChainId !== -1 && !isSameChainSwap
         onIsBridgeChanged: {
-            if (isBridge && d.pickersInitialized)
+            // `opened` also excludes teardown: the handler resets the form one
+            // field at a time, which flickers through a bridge state that would
+            // otherwise build a picker for the modal being destroyed.
+            if (isBridge && d.pickersInitialized && root.opened)
                 d.ensureBridgePicker()
         }
 

--- a/ui/app/AppLayouts/Wallet/views/SendModalFooter.qml
+++ b/ui/app/AppLayouts/Wallet/views/SendModalFooter.qml
@@ -42,6 +42,7 @@ StatusDialogFooter {
 
     background: Item {
         Rectangle {
+            objectName: "blurBackdropRect"
             anchors.fill: parent
             anchors.leftMargin: radius
             anchors.rightMargin: radius
@@ -55,12 +56,46 @@ StatusDialogFooter {
             }
 
             ShaderEffectSource {
+                id: blurBackdropSource
+                objectName: "blurBackdropSource"
+
                 sourceItem: root.blurSource
                 anchors.fill: parent
                 anchors.leftMargin: Theme.xlPadding - parent.radius
                 anchors.rightMargin: -Theme.xlPadding - parent.radius
                 sourceRect: root.blurSourceRect
-                live: true
+
+                // Capture the frosted backdrop statically instead of every frame.
+                // With live:true the whole scene is re-blurred at 60fps whenever any
+                // animation runs; here we re-capture only when the content behind the
+                // footer actually moves or changes (see refreshRequested wiring below).
+                live: false
+
+                // Emitted whenever the backdrop is re-captured; exposes the
+                // refresh-on-movement contract for testing.
+                signal refreshRequested()
+                function refreshBlur() {
+                    refreshRequested()
+                    scheduleUpdate()
+                }
+
+                // The content behind the footer is the scrollable form (a Flickable);
+                // re-capture when it scrolls (user drag or programmatic reveal) or
+                // when it grows/shrinks as async data arrives.
+                Connections {
+                    target: root.blurSource
+                    ignoreUnknownSignals: true
+                    function onContentYChanged() { blurBackdropSource.refreshBlur() }
+                    function onContentHeightChanged() { blurBackdropSource.refreshBlur() }
+                    function onContentWidthChanged() { blurBackdropSource.refreshBlur() }
+                }
+
+                // A theme switch recolors the content behind the footer without
+                // moving it; re-capture so the static backdrop is not left stale.
+                readonly property color themeProbe: root.color
+                onThemeProbeChanged: refreshBlur()
+
+                Component.onCompleted: scheduleUpdate()
             }
         }
 

--- a/ui/app/AppLayouts/Wallet/views/SendModalFooter.qml
+++ b/ui/app/AppLayouts/Wallet/views/SendModalFooter.qml
@@ -65,23 +65,14 @@ StatusDialogFooter {
                 anchors.rightMargin: -Theme.xlPadding - parent.radius
                 sourceRect: root.blurSourceRect
 
-                // Capture the frosted backdrop statically instead of every frame.
-                // With live:true the whole scene is re-blurred at 60fps whenever any
-                // animation runs; here we re-capture only when the content behind the
-                // footer actually moves or changes (see refreshRequested wiring below).
                 live: false
 
-                // Emitted whenever the backdrop is re-captured; exposes the
-                // refresh-on-movement contract for testing.
                 signal refreshRequested()
                 function refreshBlur() {
                     refreshRequested()
                     scheduleUpdate()
                 }
 
-                // The content behind the footer is the scrollable form (a Flickable);
-                // re-capture when it scrolls (user drag or programmatic reveal) or
-                // when it grows/shrinks as async data arrives.
                 Connections {
                     target: root.blurSource
                     ignoreUnknownSignals: true
@@ -90,8 +81,6 @@ StatusDialogFooter {
                     function onContentWidthChanged() { blurBackdropSource.refreshBlur() }
                 }
 
-                // A theme switch recolors the content behind the footer without
-                // moving it; re-capture so the static backdrop is not left stale.
                 readonly property color themeProbe: root.color
                 onThemeProbeChanged: refreshBlur()
 

--- a/ui/app/AppLayouts/Wallet/views/SendModalFooter.qml
+++ b/ui/app/AppLayouts/Wallet/views/SendModalFooter.qml
@@ -79,12 +79,19 @@ StatusDialogFooter {
                     function onContentYChanged() { blurBackdropSource.refreshBlur() }
                     function onContentHeightChanged() { blurBackdropSource.refreshBlur() }
                     function onContentWidthChanged() { blurBackdropSource.refreshBlur() }
+                    function onWidthChanged() { blurBackdropSource.refreshBlur() }
+                    function onHeightChanged() { blurBackdropSource.refreshBlur() }
                 }
+
+                // With live == false Qt marks a sourceRect/size change dirty but
+                // never re-renders it, so the stale capture gets stretched over the
+                // new geometry; ask for a fresh one explicitly.
+                onSourceRectChanged: refreshBlur()
+                onWidthChanged: refreshBlur()
+                onHeightChanged: refreshBlur()
 
                 readonly property color themeProbe: root.color
                 onThemeProbeChanged: refreshBlur()
-
-                Component.onCompleted: scheduleUpdate()
             }
         }
 


### PR DESCRIPTION
Swap/send modal-open follow-ups on top of the perf chain (#21500–#21504), driven by device profiling. Stacks on `chore/wallet-perf-benches`.

- **Swap instantiation bench** (`swap_modal_instantiation_bench`): measures SwapModal create / open→opened / configure / second-open / picker-readiness against a synthetic dataset, with an optional QML-profiler enabler (`-d:qmldebug`, compile-gated) for trace captures.
- **Defer token-picker creation off the open path**: the 3 terminal picker models were created+seeded during `createObject`; now created post-`opened` via `Qt.callLater`, and the bridge (KIND_SWAP_TO) picker only when bridge mode is entered — never on plain swaps. Panels tolerate the null-until-opened window; deep-link preselection re-resolves on model arrival. Host: create max-stall 435→120ms @10k catalog (wall flat ~54ms); on-device the seed left the create window entirely (verified by trace).
- **Send frosted-glass blur goes static**: `live: false` + `scheduleUpdate()` on real movement (scroll incl. programmatic sticky reveal, content growth, theme change). Was re-capturing + re-blurring every frame — the heaviest single GPU effect on low-end Adreno; now costs only while content actually moves. Visuals unchanged (same radius/alpha).
- Test hardening: the exchange-rate test polls for SwapModal's deferred post-open setup instead of racing it.

Numbers in the bench TSVs + the device trace analysis; the umbrella PR carries the full stack for end-to-end benchmarking.
