### PR TITLE
perf(wallet): defer NetworkSelectPopup content until first open

### DIFF
--- a/storybook/qmlTests/tests/tst_ConnectDAppModal.qml
+++ b/storybook/qmlTests/tests/tst_ConnectDAppModal.qml
@@ -185,11 +185,11 @@ Item {
             verify(chainSelector, "Chain selector should be present")
             compare(chainSelector.selection.length, NetworksModel.flatNetworks.count)
 
-            // User should not be able to open the popup
+            // User should not be able to open the popup; its content stays
+            // unloaded since it is only created on first open
             mouseClick(chainSelector)
             waitForItemPolished(chainSelector)
-            const networkSelectorList = findChild(chainSelector, "networkSelectorList")
-            verify(networkSelectorList, "Network selector list should be present")
+            verify(!findChild(chainSelector, "networkSelectorList"))
             compare(chainSelector.selection.length, NetworksModel.flatNetworks.count)
             compare(dappModal.selectedChains.length, NetworksModel.flatNetworks.count)
             verify(!chainSelector.control.popup.opened)
@@ -242,11 +242,11 @@ Item {
             verify(chainSelector, "Chain selector should be present")
             compare(chainSelector.selection.length, NetworksModel.flatNetworks.count)
 
-            // User should not be able to open the popup
+            // User should not be able to open the popup; its content stays
+            // unloaded since it is only created on first open
             mouseClick(chainSelector)
             waitForItemPolished(chainSelector)
-            const networkSelectorList = findChild(chainSelector, "networkSelectorList")
-            verify(networkSelectorList, "Network selector list should be present")
+            verify(!findChild(chainSelector, "networkSelectorList"))
             compare(chainSelector.selection.length, NetworksModel.flatNetworks.count)
             compare(dappModal.selectedChains.length, NetworksModel.flatNetworks.count)
             verify(!chainSelector.control.popup.opened)

--- a/storybook/qmlTests/tests/tst_NetworkFilterRepro.qml
+++ b/storybook/qmlTests/tests/tst_NetworkFilterRepro.qml
@@ -1,0 +1,216 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Wallet.controls
+
+import Models
+
+Item {
+    id: root
+    width: 600
+    height: 600
+
+    // stand-in for RightTabView's chainIdsAggregator
+    property var enabledChainIds: []
+
+    // stand-in for SwapInputPanel-style store round-trip
+    property int storeChainId: 0
+
+    Component {
+        id: singleSelectionComponent
+        NetworkFilter {
+            flatNetworks: NetworksModel.flatNetworks
+            multiSelection: false
+            // literal binding on purpose: internal writes must not detach it
+            selection: [root.storeChainId]
+            onSelectionChanged: {
+                if (selection[0] !== undefined && selection[0] !== root.storeChainId)
+                    root.storeChainId = selection[0]
+            }
+        }
+    }
+
+    Component {
+        id: componentUnderTest
+        NetworkFilter {
+            flatNetworks: NetworksModel.flatNetworks
+            multiSelection: true
+
+            Binding on selection {
+                value: root.enabledChainIds
+            }
+        }
+    }
+
+    property NetworkFilter controlUnderTest: null
+
+    TestCase {
+        name: "NetworkFilterRepro"
+        when: windowShown
+
+        function allChainIds() {
+            const ids = []
+            for (let i = 0; i < NetworksModel.flatNetworks.count; i++)
+                ids.push(NetworksModel.flatNetworks.get(i).chainId)
+            return ids
+        }
+
+        function test_multiSelectionBindingPush() {
+            root.enabledChainIds = allChainIds()
+            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+            verify(!!controlUnderTest)
+
+            // the pushed multi selection must survive creation
+            compare(controlUnderTest.selection.length, root.enabledChainIds.length)
+
+            // store-side change must be reflected (RightTabView flow)
+            root.enabledChainIds = [allChainIds()[1]]
+            compare(controlUnderTest.selection, root.enabledChainIds)
+        }
+
+        function test_multiSelectionLatePush() {
+            root.enabledChainIds = []
+            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+            verify(!!controlUnderTest)
+
+            root.enabledChainIds = allChainIds()
+            compare(controlUnderTest.selection.length, root.enabledChainIds.length)
+        }
+
+        // live app models populate late and reset; selection must survive
+        function test_selectionSurvivesModelReset() {
+            root.enabledChainIds = allChainIds()
+
+            const dynamicModel = createTemporaryQmlObject(
+                "import QtQuick; ListModel {}", root)
+            controlUnderTest = createTemporaryObject(componentUnderTest, root,
+                {flatNetworks: dynamicModel})
+            verify(!!controlUnderTest)
+
+            for (let i = 0; i < NetworksModel.flatNetworks.count; i++)
+                dynamicModel.append({chainId: NetworksModel.flatNetworks.get(i).chainId,
+                                     chainName: NetworksModel.flatNetworks.get(i).chainName,
+                                     iconUrl: "", layer: 1, isTest: false})
+
+            compare(controlUnderTest.selection.length, root.enabledChainIds.length)
+
+            // model reset (count -> 0 -> N)
+            dynamicModel.clear()
+            for (let i = 0; i < NetworksModel.flatNetworks.count; i++)
+                dynamicModel.append({chainId: NetworksModel.flatNetworks.get(i).chainId,
+                                     chainName: NetworksModel.flatNetworks.get(i).chainName,
+                                     iconUrl: "", layer: 1, isTest: false})
+
+            compare(controlUnderTest.selection.length, root.enabledChainIds.length)
+        }
+
+        function test_singleSelectionSurvivesModelReset() {
+            const dynamicModel = createTemporaryQmlObject(
+                "import QtQuick; ListModel {}", root)
+            for (let i = 0; i < NetworksModel.flatNetworks.count; i++)
+                dynamicModel.append({chainId: NetworksModel.flatNetworks.get(i).chainId,
+                                     chainName: NetworksModel.flatNetworks.get(i).chainName,
+                                     iconUrl: "", layer: 1, isTest: false})
+
+            root.enabledChainIds = [allChainIds()[1]]
+            controlUnderTest = createTemporaryObject(componentUnderTest, root,
+                {flatNetworks: dynamicModel, multiSelection: false})
+            verify(!!controlUnderTest)
+            compare(controlUnderTest.selection, [allChainIds()[1]])
+
+            dynamicModel.clear()
+            for (let i = 0; i < NetworksModel.flatNetworks.count; i++)
+                dynamicModel.append({chainId: NetworksModel.flatNetworks.get(i).chainId,
+                                     chainName: NetworksModel.flatNetworks.get(i).chainName,
+                                     iconUrl: "", layer: 1, isTest: false})
+
+            // must NOT snap back to the first chain
+            compare(controlUnderTest.selection, [allChainIds()[1]])
+        }
+
+        // once the popup content was instantiated it stays alive (latched
+        // loader); its internal view must not clobber selection on reset either
+        function test_selectionSurvivesModelResetAfterPopupShown() {
+            root.enabledChainIds = allChainIds()
+
+            const dynamicModel = createTemporaryQmlObject(
+                "import QtQuick; ListModel {}", root)
+            for (let i = 0; i < NetworksModel.flatNetworks.count; i++)
+                dynamicModel.append({chainId: NetworksModel.flatNetworks.get(i).chainId,
+                                     chainName: NetworksModel.flatNetworks.get(i).chainName,
+                                     iconUrl: "", layer: 1, isTest: false})
+
+            controlUnderTest = createTemporaryObject(componentUnderTest, root,
+                {flatNetworks: dynamicModel})
+            verify(!!controlUnderTest)
+
+            controlUnderTest.control.popup.open()
+            tryCompare(controlUnderTest.control.popup, "opened", true)
+            controlUnderTest.control.popup.close()
+            tryCompare(controlUnderTest.control.popup, "opened", false)
+
+            compare(controlUnderTest.selection.length, root.enabledChainIds.length)
+
+            dynamicModel.clear()
+            for (let i = 0; i < NetworksModel.flatNetworks.count; i++)
+                dynamicModel.append({chainId: NetworksModel.flatNetworks.get(i).chainId,
+                                     chainName: NetworksModel.flatNetworks.get(i).chainName,
+                                     iconUrl: "", layer: 1, isTest: false})
+
+            compare(controlUnderTest.selection.length, root.enabledChainIds.length)
+        }
+
+        // SwapInputPanel-style store round trip: store changes must keep
+        // flowing into the filter even after the user picked in the popup
+        function test_singleSelectionSurvivesPopupInteraction() {
+            root.storeChainId = allChainIds()[0]
+            controlUnderTest = createTemporaryObject(singleSelectionComponent, root)
+            verify(!!controlUnderTest)
+            compare(controlUnderTest.selection, [allChainIds()[0]])
+
+            // store-side change before any interaction
+            root.storeChainId = allChainIds()[1]
+            compare(controlUnderTest.selection, [allChainIds()[1]])
+
+            // user picks a network via the popup view
+            controlUnderTest.control.popup.open()
+            tryCompare(controlUnderTest.control.popup, "opened", true)
+            const thirdName = NetworksModel.flatNetworks.get(2).chainName
+            const delegate = findChild(controlUnderTest.control.popup.contentItem,
+                                       "networkSelectorDelegate_" + thirdName)
+            verify(!!delegate)
+            mouseClick(delegate)
+            tryCompare(controlUnderTest.control.popup, "opened", false)
+            compare(controlUnderTest.selection, [allChainIds()[2]])
+            compare(root.storeChainId, allChainIds()[2])
+
+            // store-side change after the interaction must still propagate
+            root.storeChainId = allChainIds()[3]
+            compare(controlUnderTest.selection, [allChainIds()[3]])
+        }
+
+        // wallet-header-style Binding element: same round-trip via popup toggle
+        function test_bindingElementSurvivesPopupInteraction() {
+            root.enabledChainIds = allChainIds()
+            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+            verify(!!controlUnderTest)
+            compare(controlUnderTest.selection.length, root.enabledChainIds.length)
+
+            controlUnderTest.control.popup.open()
+            tryCompare(controlUnderTest.control.popup, "opened", true)
+            const firstName = NetworksModel.flatNetworks.get(0).chainName
+            const delegate = findChild(controlUnderTest.control.popup.contentItem,
+                                       "networkSelectorDelegate_" + firstName)
+            verify(!!delegate)
+            mouseClick(delegate)
+
+            // store reacts to the toggle (RightTabView flow)
+            root.enabledChainIds = allChainIds().slice(1)
+            compare(controlUnderTest.selection, root.enabledChainIds)
+
+            // and keeps propagating on later store changes
+            root.enabledChainIds = allChainIds()
+            compare(controlUnderTest.selection, root.enabledChainIds)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_NetworkSelectorView.qml
+++ b/storybook/qmlTests/tests/tst_NetworkSelectorView.qml
@@ -341,7 +341,9 @@ Item {
 
                 mouseClick(delegate)
                 compare(toggleNetworkSpy.count, i + 1)
-                compare(selectionChangedSpy.count, i + 1)
+                // i == 0 re-clicks the auto-selected first chain: toggleNetwork
+                // fires but the selection content does not change
+                compare(selectionChangedSpy.count, i)
             }
         }
     }

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -410,8 +410,13 @@ Item {
             compare(root.swapAdaptor.filteredFlatNetworksModel.get(0).chainId, 560048 /*Hoodi*/)
 
             // lets ensure that the selected one is correctly set
+            // popup content is created lazily on first open
+            mouseClick(networkComboBox)
+            verify(networkComboBox.control.popup.opened)
             const networkSelectorView = findChild(networkComboBox.control.popup.contentItem, "networkSelectorList")
             verify(!!networkSelectorView)
+            mouseClick(networkComboBox)
+            verify(!networkComboBox.control.popup.opened)
 
             for (let i=0; i<networkSelectorView.count; i++) {
                 // launch network selection popup

--- a/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
@@ -162,18 +162,4 @@ QC.Popup {
         enabled: root.opened
         onActivated: root.close()
     }
-
-    // workaround for https://bugreports.qt.io/browse/QTBUG-87804
-    Binding on margins {
-        id: workaroundBinding
-
-        when: false
-        restoreMode: Binding.RestoreBindingOrValue
-    }
-
-    onImplicitContentHeightChanged: {
-        workaroundBinding.value = root.margins + 1
-        workaroundBinding.when = true
-        workaroundBinding.when = false
-    }
 }

--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -35,7 +35,7 @@ StatusComboBox {
     property bool showTitle: true
     property bool selectionAllowed: true
     property bool showManageNetworksButton: false
-    property alias selection: networkSelectorView.selection
+    property var selection: []
 
     property bool showNewChainIcon: false
     property bool showNotificationIcon: false
@@ -179,6 +179,11 @@ StatusComboBox {
         showNewChainIcon: root.showNewChainIcon
         showManageNetworksNotificationIcon: root.showManageNetworksNotificationIcon
 
+        // copy: the popup mutates its selection array in place, so it must
+        // own a distinct instance; this binding survives those mutations
+        selection: [...root.selection]
+        onSelectionChanged: d.commitSelection(selection)
+
         onToggleNetwork: (chainId, index) => root.toggleNetwork(chainId, index)
 
         onManageNetworksClicked: {
@@ -202,6 +207,15 @@ StatusComboBox {
         readonly property bool noneSelected: root.selection.length === 0
         readonly property bool oneSelected: root.selection.length === 1
         readonly property bool selectionUnavailable: d.networksCount <= 1 && d.oneSelected
+
+        // in-place commit: swapping the array pointer would detach literal
+        // bindings consumers install on `selection`
+        function commitSelection(newSelection) {
+            if (JSON.stringify(root.selection) === JSON.stringify(newSelection))
+                return
+            root.selection.splice(0, root.selection.length, ...newSelection)
+            root.selectionChanged()
+        }
 
         readonly property ModelEntry singleSelectionItem: ModelEntry {
             sourceModel: d.oneSelected ? root.flatNetworks : null

--- a/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
@@ -26,7 +26,7 @@ StatusDropdown {
     property bool selectionAllowed: true
     property bool multiSelection: false
     property bool showManageNetworksButton: false
-    property alias selection: scrollView.selection
+    property var selection: []
 
     property bool showNewChainIcon: false
     property bool showManageNetworksNotificationIcon: false
@@ -55,56 +55,73 @@ StatusDropdown {
         }
     }
 
-    contentItem: ColumnLayout {
+    contentItem: Loader {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.margins: 4
+        active: root.visible
+        sourceComponent: ColumnLayout {
+            NetworkSelectorView {
+                id: scrollView
+                Layout.fillWidth: true
 
-        NetworkSelectorView {
-            id: scrollView
-            Layout.fillWidth: true
+                model: root.flatNetworks
+                selection: root.selection
+                disableChainsWithNoCommunitiesSupport: root.disableChainsWithNoCommunitiesSupport
+                interactive: root.selectionAllowed
+                multiSelection: root.multiSelection
+                showIndicator: root.showSelectionIndicator
+                showNewChainIcon: root.showNewChainIcon
 
-            model: root.flatNetworks
-            disableChainsWithNoCommunitiesSupport: root.disableChainsWithNoCommunitiesSupport
-            interactive: root.selectionAllowed
-            multiSelection: root.multiSelection
-            showIndicator: root.showSelectionIndicator
-            showNewChainIcon: root.showNewChainIcon
-
-            onToggleNetwork: (chainId, index) => {
-                if (!root.multiSelection && root.closePolicy !== Popup.NoAutoClose)
-                    root.close()
-                root.toggleNetwork(chainId, index)
+                onToggleNetwork: (chainId, index) => {
+                    if (!root.multiSelection && root.closePolicy !== Popup.NoAutoClose)
+                        root.close()
+                    root.toggleNetwork(chainId, index)
+                }
+                onSelectionChanged: {
+                    if (root.selection !== selection) {
+                        root.selection = selection
+                    }
+                }
             }
-        }
 
-        StatusButton {
-            id: manageNetworksButton
-            visible: root.showManageNetworksButton
-            Layout.fillWidth: true
-            Layout.margins: 4
+            // down-sync for external writes while the popup is open
+            Connections {
+                target: root
+                function onSelectionChanged() {
+                    if (scrollView.selection !== root.selection)
+                        scrollView.selection = root.selection
+                }
+            }
 
-            icon.name: "settings"
-            text: qsTr("Manage networks")
-            isOutline: true
-            onClicked: root.manageNetworksClicked()
+            StatusButton {
+                id: manageNetworksButton
+                visible: root.showManageNetworksButton
+                Layout.fillWidth: true
+                Layout.margins: 4
 
-            Loader {
-                active: root.showManageNetworksNotificationIcon
-                anchors.verticalCenter: parent.top
-                anchors.verticalCenterOffset: 2
-                anchors.horizontalCenterOffset: -2
-                anchors.horizontalCenter: parent.right
-                sourceComponent: StatusRoundIcon {
-                    objectName: "manageNetworksNotificationIcon"
-                    asset.width: 10
-                    asset.height: 10
-                    asset.bgWidth: 15
-                    asset.bgColor: Theme.palette.background
-                    asset.bgHeight: 15
-                    asset.isImage: true
-                    asset.name: Assets.png("status-gradient-dot")
-                    asset.color: StatusColors.transparent
+                icon.name: "settings"
+                text: qsTr("Manage networks")
+                isOutline: true
+                onClicked: root.manageNetworksClicked()
+
+                Loader {
+                    active: root.showManageNetworksNotificationIcon
+                    anchors.verticalCenter: parent.top
+                    anchors.verticalCenterOffset: 2
+                    anchors.horizontalCenterOffset: -2
+                    anchors.horizontalCenter: parent.right
+                    sourceComponent: StatusRoundIcon {
+                        objectName: "manageNetworksNotificationIcon"
+                        asset.width: 10
+                        asset.height: 10
+                        asset.bgWidth: 15
+                        asset.bgColor: Theme.palette.background
+                        asset.bgHeight: 15
+                        asset.isImage: true
+                        asset.name: Assets.png("status-gradient-dot")
+                        asset.color: StatusColors.transparent
+                    }
                 }
             }
         }

--- a/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
@@ -5,10 +5,12 @@ import Qt5Compat.GraphicalEffects
 
 import StatusQ
 import StatusQ.Core.Theme
+import StatusQ.Core.Utils
 import StatusQ.Components
 import StatusQ.Controls
 import StatusQ.Popups.Dialog
 
+import QtModelsToolkit
 import SortFilterProxyModel
 
 import utils
@@ -55,18 +57,73 @@ StatusDropdown {
         }
     }
 
+    // Keeps the single-selection invariant (exactly one selected network,
+    // defaulting to the first one) while the view below is not instantiated.
+    QtObject {
+        id: d
+
+        readonly property int networksCount: root.flatNetworks.ModelCount.count
+        onNetworksCountChanged: d.scheduleNormalize()
+
+        // always deferred (callLater dedupes) so in-progress consumer writes —
+        // e.g. a Binding element applying its initial selection — land first;
+        // normalizing synchronously would auto-default over them
+        function scheduleNormalize() {
+            Qt.callLater(d.normalizeSelection)
+        }
+
+        function normalizeSelection() {
+            let selection = root.selection
+
+            // an empty model (still loading or resetting) cannot validate the
+            // selection; keep it untouched until rows are available again
+            if (d.networksCount === 0)
+                return
+
+            if (!root.multiSelection) {
+                if (selection.length === 0)
+                    selection = [ModelUtils.get(root.flatNetworks, 0, "chainId")]
+                else if (selection.length > 1)
+                    selection = [selection[0]]
+            }
+
+            d.commitSelection(selection)
+        }
+
+        // in-place commit: swapping the array pointer would detach literal
+        // bindings installed on `selection` by the owner of this popup
+        function commitSelection(newSelection) {
+            if (JSON.stringify(root.selection) === JSON.stringify(newSelection))
+                return
+            root.selection.splice(0, root.selection.length, ...newSelection)
+            root.selectionChanged()
+        }
+    }
+
+    Connections {
+        target: root
+        function onSelectionChanged() { d.scheduleNormalize() }
+        function onMultiSelectionChanged() { d.scheduleNormalize() }
+    }
+
+    Component.onCompleted: d.scheduleNormalize()
+
     contentItem: Loader {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.margins: 4
         active: root.visible
+        onLoaded: active = true // latch: keep content alive across close/reopen
         sourceComponent: ColumnLayout {
             NetworkSelectorView {
                 id: scrollView
                 Layout.fillWidth: true
 
                 model: root.flatNetworks
-                selection: root.selection
+                // copy: the view mutates its selection array in place, so it
+                // must own a distinct instance; this binding survives those
+                // mutations and keeps the popup -> view direction live
+                selection: [...root.selection]
                 disableChainsWithNoCommunitiesSupport: root.disableChainsWithNoCommunitiesSupport
                 interactive: root.selectionAllowed
                 multiSelection: root.multiSelection
@@ -78,20 +135,7 @@ StatusDropdown {
                         root.close()
                     root.toggleNetwork(chainId, index)
                 }
-                onSelectionChanged: {
-                    if (root.selection !== selection) {
-                        root.selection = selection
-                    }
-                }
-            }
-
-            // down-sync for external writes while the popup is open
-            Connections {
-                target: root
-                function onSelectionChanged() {
-                    if (scrollView.selection !== root.selection)
-                        scrollView.selection = root.selection
-                }
+                onSelectionChanged: d.commitSelection(selection)
             }
 
             StatusButton {

--- a/ui/app/AppLayouts/Wallet/views/NetworkSelectorView.qml
+++ b/ui/app/AppLayouts/Wallet/views/NetworkSelectorView.qml
@@ -95,7 +95,7 @@ StatusListView {
         readonly property bool allSelected: root.selection.length === d.networksCount
 
         function onToggled(initialState, chainId) {
-            let selection = root.selection
+            let selection = [...root.selection]
             if (initialState === Qt.Unchecked && initialState !== Qt.PartiallyChecked) {
                 if (!root.multiSelection)
                     selection = []
@@ -105,29 +105,37 @@ StatusListView {
                 selection = selection.filter((id) => id !== chainId)
             }
 
-            root.selection = [...selection]
+            d.commitSelection(selection)
         }
 
         function reprocessSelection() {
             let selection = root.selection
 
-            if (d.networksCount === 0) {
-                selection = []
-            } else {
-                if (!root.multiSelection) {
-                    // One and only one chain must be selected
-                    if (selection.length === 0) {
-                        selection = [ModelUtils.get(root.model, 0, "chainId")]
-                    } else if (selection.length > 1) {
-                        console.warn("Warning: Multi-selection is disabled, but multiple items are selected. Automatically selecting the first inserted item.")
-                        selection = [selection[0]]
-                    }
+            // an empty model (still loading or resetting) cannot validate the
+            // selection; keep it untouched until rows are available again
+            if (d.networksCount === 0)
+                return
+
+            if (!root.multiSelection) {
+                // One and only one chain must be selected
+                if (selection.length === 0) {
+                    selection = [ModelUtils.get(root.model, 0, "chainId")]
+                } else if (selection.length > 1) {
+                    console.warn("Warning: Multi-selection is disabled, but multiple items are selected. Automatically selecting the first inserted item.")
+                    selection = [selection[0]]
                 }
             }
 
-            if (root.selection !== selection) {
-                root.selection = selection
-            }
+            d.commitSelection(selection)
+        }
+
+        // in-place commit: swapping the array pointer would detach literal
+        // bindings installed on `selection` by the owner of this view
+        function commitSelection(newSelection) {
+            if (JSON.stringify(root.selection) === JSON.stringify(newSelection))
+                return
+            root.selection.splice(0, root.selection.length, ...newSelection)
+            root.selectionChanged()
         }
     }
 }


### PR DESCRIPTION
Defers NetworkSelectPopup content creation off the component-creation path:

- **Content under a visibility-latched Loader** — the network list + manage-networks button are only instantiated when the dropdown actually opens. Every `NetworkFilter` (send/swap/bridge headers, activity filters) previously built the full popup subtree eagerly at creation time.
- **`selection` alias → explicit two-way sync** — the popup owns `selection`; the loaded view gets it at (re)creation and on external writes (`Connections` down-sync), user toggles publish back up.
- **Drops StatusDropdown's QTBUG-87804 margins workaround** — its imperative nudge re-fires on every `implicitContentHeight` change, which now happens on each deferred load. Doesn't reproduce on qt 6.11
<img width="643" height="503" alt="Screenshot 2026-07-17 at 12 53 17" src="https://github.com/user-attachments/assets/14946f7d-5632-4b04-9f56-26fc5899b684" />



Part of the wallet perf effort — umbrella #21505
