### PR TITLE
fix: ios app run

### DIFF
--- a/mobile/scripts/buildNimStatusClient.sh
+++ b/mobile/scripts/buildNimStatusClient.sh
@@ -32,7 +32,7 @@ fi
 if [[ "$OS" == "ios" ]]; then
     PLATFORM_SPECIFIC=(--app:staticlib -d:ios --os:ios)
 else
-    PLATFORM_SPECIFIC=(--app:lib --os:android -d:android -d:androidNDK -d:chronicles_sinks=textlines[logcat],textlines[file,nocolors] \
+    PLATFORM_SPECIFIC=(--app:lib --os:android -d:android -d:androidNDK -d:lto -d:chronicles_sinks=textlines[logcat],textlines[file,nocolors] \
         --passL="-L$LIB_DIR" --passL="-lstatus_stub" --passL="-lStatusQ$LIB_SUFFIX" --passL="-lqrcodegen" --passL="-lssl_3" --passL="-lcrypto_3" --passL="-lstatus-keycard-qt" -d:taskpool)
 fi
 
@@ -71,7 +71,10 @@ APP_CONFIG_DEFINES=(
 NIM_FLAGS=(
     --mm:orc
     -d:useMalloc
-    -d:lto
+    # NOTE: -d:lto is intentionally NOT here. On the iOS --app:staticlib target,
+    # LTO bitcode in the .a is mis-optimized at Xcode's final link, miscompiling
+    # std/json %* JObject construction (CreateAccountRequest.toJson() -> empty {},
+    # breaking account creation). LTO is re-added for Android below, where it works.
     --opt:size
     --cc:clang
     --cpu:"$CARCH"

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -233,6 +233,12 @@ proc mainProc() =
 
   ensureDirectories(DATADIR, TMPDIR, LOGDIR)
 
+  # Open the log file and set the log level before any subsystem starts logging.
+  # On iOS the stdout sink is disabled (no valid stdout FILE*), so logs go to the
+  # file sink only; opening it here guarantees every startup log has a valid sink
+  # instead of lazily opening a default path mid-init.
+  prepareLogging()
+
   let isExperimental = isExperimental()
   let resourcesPath = determineResourcePath()
   let openUri = determineOpenUri()
@@ -294,7 +300,6 @@ proc mainProc() =
   if not main_constants.IS_MACOS:
     app.icon(app.applicationDirPath & statusAppIconPath)
 
-  prepareLogging()
   statusq_installMessageHandler(logHandlerCallback)
 
   when defined(USE_QML_SERVER):


### PR DESCRIPTION
The first commit fixes the issue of running the app after deploying it to the iOS device. Seems that, after moving the code to the async approach, the app writes to the log file before it is created/set. Setting the file earlier fixed the issue.

The second issue was an inability to create a profile even for a just-installed app, because serializing a CreateAccountRequest request was an empty JsonNode. That was because of the lto (Link-Time Optimization) flag that was enabled for all platforms in this PR https://github.com/status-im/status-app/pull/21356 

On iOS, Nim builds --app:staticlib, so the .a ships bitcode, and the actual LTO + codegen happens at Xcode's final link.
ThinLTO is aggressive about cross-module optimization, and it occasionally miscompiles code with subtle semantics.
The exact pattern that's failing — Nim's ORC move/destructor handling around std/json's ref-based JsonNode built
via %* (a newJObject() followed by a run of OrderedTable inserts) — is a classic place for an over-eager optimizer to
wrongly drop the populated temporary or elide the inserts, yielding an empty {}.