### PR TITLE
fix(StatusEmojiPopup): fix recent emojis

### DIFF
--- a/storybook/pages/StatusEmojiPopupPage.qml
+++ b/storybook/pages/StatusEmojiPopupPage.qml
@@ -41,13 +41,6 @@ SplitView {
             onClicked: emojiPopup.open()
         }
 
-        Settings {
-            id: settings
-            category: "EmojiPopup"
-            property var recentEmojis: []
-            property string skinColor
-        }
-
         StatusEmojiPopup {
             id: emojiPopup
 
@@ -58,17 +51,12 @@ SplitView {
             height: 440
             visible: true
             modal: false
-            recentEmojis: settings.recentEmojis
-            skinColor: settings.skinColor
+            userUID: "0xdeadbeef"
             emojiModel: StatusQUtils.Emoji.emojiModel
             onEmojiSelected: function(emoji, atCu, hexcode) {
                 logs.logEvent("onEmojiSelected", ["emoji", "atCu", "hexcode"], arguments)
                 d.lastSelectedEmoji = emoji
                 d.lastSelectedEmojiHexcode = hexcode
-            }
-            onSetSkinColorRequested: function(skinColor) {
-                logs.logEvent("onSetSkinColorRequested", ["skinColor"], arguments)
-                settings.skinColor = skinColor
             }
         }
     }
@@ -83,13 +71,11 @@ SplitView {
             anchors.fill: parent
 
             Button {
-                text: "Clear settings (reload to take effect)"
+                text: "Clear settings"
                 onClicked: {
                     d.lastSelectedEmoji = ""
                     d.lastSelectedEmojiHexcode = ""
-                    settings.recentEmojis = []
-                    settings.skinColor = ""
-                    settings.sync()
+                    emojiPopup.clearSettings()
                 }
             }
 

--- a/ui/StatusQ/include/StatusQ/statusemojimodel.h
+++ b/ui/StatusQ/include/StatusQ/statusemojimodel.h
@@ -6,6 +6,8 @@
 class StatusEmojiModel : public QAbstractListModel
 {
     Q_OBJECT
+
+    Q_PROPERTY(QString userUID READ userUID WRITE setUserUID NOTIFY userUIDChanged FINAL)
     Q_PROPERTY(QJsonArray emojiJson READ emojiJson WRITE setEmojiJson NOTIFY emojiJsonChanged
                    REQUIRED FINAL)
     Q_PROPERTY(QStringList categories READ categories CONSTANT FINAL)
@@ -43,6 +45,7 @@ public:
 signals:
     void emojiJsonChanged();
     void recentEmojisChanged();
+    void userUIDChanged();
 
 private:
     QJsonArray emojiJson() const;
@@ -62,4 +65,12 @@ private:
 
     QString recentCategoryName() const;
     QString baseSkinColorName() const;
+
+    QString userUID() const;
+    void setUserUID(const QString &newUserUID);
+    QString m_userUID;
+
+    QString settingsGroup() const;
+    void saveRecentEmojis();
+    void loadRecentEmojis();
 };

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageQuickActions.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageQuickActions.qml
@@ -8,7 +8,7 @@ import StatusQ.Core.Theme
 Rectangle {
     id: root
 
-    property list<Item> items
+    default property alias items: buttonRow.children
 
     QtObject {
         id: _internal
@@ -17,7 +17,7 @@ Rectangle {
 
     implicitWidth: buttonRow.width > 0 ? buttonRow.width + (_internal.containerMargin * 2) : 0
     implicitHeight: 36
-    radius: 8
+    radius: Theme.radius
     color: Theme.palette.statusSelect.menuItemBackgroundColor
 
     layer.enabled: true
@@ -41,11 +41,5 @@ Rectangle {
         anchors.leftMargin: _internal.containerMargin
         anchors.verticalCenter: root.verticalCenter
         height: parent.height - 2 * _internal.containerMargin
-    }
-
-    onItemsChanged: {
-        for (let idx in items) {
-            items[idx].parent = buttonRow
-        }
     }
 }

--- a/ui/StatusQ/src/statusemojimodel.cpp
+++ b/ui/StatusQ/src/statusemojimodel.cpp
@@ -2,6 +2,7 @@
 
 #include <QDebug>
 #include <QJsonObject>
+#include <QSettings>
 
 #include <array>
 #include <algorithm>
@@ -27,6 +28,8 @@ const auto skinColors = std::array<const char*, 5>{"1f3fb", "1f3fc", "1f3fd", "1
 constexpr auto MAX_EMOJI_NUMBER = 36;
 
 constexpr auto kRecentCategoryName = "recent"_L1;
+
+constexpr auto kRecentEmojisSettingsEntry = "recentEmojis"_L1;
 }
 
 StatusEmojiModel::StatusEmojiModel(QObject *parent)
@@ -206,6 +209,8 @@ void StatusEmojiModel::addRecentEmoji(const QString &hexcode)
 
 void StatusEmojiModel::cleanAndResizeRecentEmojis()
 {
+    if (m_recentEmojis.isEmpty())
+        return;
     m_recentEmojis.removeDuplicates();
     if (m_recentEmojis.size() > MAX_EMOJI_NUMBER) {
         while (m_recentEmojis.size() > MAX_EMOJI_NUMBER)
@@ -252,4 +257,41 @@ QString StatusEmojiModel::recentCategoryName() const
 QString StatusEmojiModel::baseSkinColorName() const
 {
     return kBaseColor;
+}
+
+QString StatusEmojiModel::userUID() const
+{
+    return m_userUID;
+}
+
+void StatusEmojiModel::setUserUID(const QString &newUserUID)
+{
+    if (m_userUID == newUserUID)
+        return;
+    m_userUID = newUserUID;
+    emit userUIDChanged();
+
+    loadRecentEmojis();
+    connect(this, &StatusEmojiModel::recentEmojisChanged, this, &StatusEmojiModel::saveRecentEmojis);
+}
+
+QString StatusEmojiModel::settingsGroup() const
+{
+    return QStringLiteral("AppMainLocalSettings_%1").arg(m_userUID);
+}
+
+void StatusEmojiModel::saveRecentEmojis()
+{
+    QSettings settings;
+    settings.beginGroup(settingsGroup());
+    settings.setValue(kRecentEmojisSettingsEntry, m_recentEmojis);
+    settings.endGroup();
+}
+
+void StatusEmojiModel::loadRecentEmojis()
+{
+    QSettings settings;
+    settings.beginGroup(settingsGroup());
+    setRecentEmojis(settings.value(kRecentEmojisSettingsEntry).toStringList());
+    settings.endGroup();
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1029,8 +1029,6 @@ Item {
         property bool enablePushNotificationsFreshInstallSeen
         property bool enablePushNotificationsDontAskAgain
         property string enablePushNotificationsLastShownVersion
-        property var recentEmojis: []
-        property string skinColor // NB: must be a string for the twemoji lib to work; we don't want the `#` in the name
         property int theme: ThemeUtils.Style.System
         property int fontSize: {
             if (appMain.isPortraitMode) {
@@ -1457,11 +1455,8 @@ Item {
         sourceComponent: StatusEmojiPopup {
             directParent: appMain.Window.window.contentItem
             height: 440
-            recentEmojis: appMainLocalSettings.recentEmojis
-            skinColor: appMainLocalSettings.skinColor
+            userUID: allContacsAdaptor.selfContactDetails.publicKey
             emojiModel: SQUtils.Emoji.emojiModel
-            onSetSkinColorRequested: color => appMainLocalSettings.skinColor = color
-            onSetRecentEmojisRequested: recentEmojis => appMainLocalSettings.recentEmojis = recentEmojis
         }
     }
 

--- a/ui/imports/shared/status/StatusEmojiPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiPopup.qml
@@ -1,3 +1,4 @@
+import QtCore
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -18,9 +19,8 @@ import SortFilterProxyModel
 StatusDropdown {
     id: root
 
+    required property string userUID
     required property StatusEmojiModel emojiModel
-    required property var recentEmojis
-    required property string skinColor
 
     readonly property var fullModel: SortFilterProxyModel {
         sourceModel: root.emojiModel
@@ -54,7 +54,7 @@ StatusDropdown {
                     roleName: "skinColor"
                     value: root.emojiModel.baseSkinColorName
                 }
-                enabled: root.skinColor === ""
+                enabled: settings.skinColor === ""
             },
             AnyOf {
                 ValueFilter {
@@ -63,9 +63,9 @@ StatusDropdown {
                 }
                 ValueFilter {
                     roleName: "skinColor"
-                    value: root.skinColor
+                    value: settings.skinColor
                 }
-                enabled: root.skinColor !== ""
+                enabled: settings.skinColor !== ""
             }
         ]
 
@@ -78,8 +78,6 @@ StatusDropdown {
     property string emojiSize: ""
 
     signal emojiSelected(string emoji, bool atCursor, string hexcode)
-    signal setSkinColorRequested(string skinColor)
-    signal setRecentEmojisRequested(var recentEmojis)
 
     width: 370
     padding: 0
@@ -100,7 +98,11 @@ StatusDropdown {
         root.close()
     }
 
-    onRecentEmojisChanged: root.emojiModel.recentEmojis = root.recentEmojis || []
+    function clearSettings() {
+        root.emojiModel.recentEmojis = []
+        settings.skinColor = ""
+        settings.sync()
+    }
 
     onOpened: {
         if (!StatusQUtils.Utils.isMobile)
@@ -110,9 +112,6 @@ StatusDropdown {
     }
 
     onClosed: {
-        const recent = root.emojiModel.recentEmojis
-        if (recent.length)
-            root.setRecentEmojisRequested(recent)
         searchBox.clear()
         root.emojiSize = ""
         skinToneEmoji.expandSkinColorOptions = false
@@ -125,6 +124,18 @@ StatusDropdown {
         readonly property int headerMargin: 8
         readonly property int imageWidth: 32
         readonly property int imageMargin: 6
+    }
+
+    Settings {
+        id: settings
+        category: "AppMainLocalSettings_%1".arg(root.userUID)
+        property string skinColor  // NB: must be a string for the twemoji lib to work; we don't want the `#` in the name
+    }
+
+    Binding {
+        target: root.emojiModel
+        property: "userUID"
+        value: root.userUID
     }
 
     contentItem: ColumnLayout {
@@ -173,7 +184,7 @@ StatusDropdown {
                             cursorShape: Qt.PointingHandCursor
                             anchors.fill: parent
                             onClicked: {
-                                root.setSkinColorRequested((index === 5) ? "" : modelData.split("-")[1]);
+                                settings.skinColor = index === 5 ? "" : modelData.split("-")[1]
                                 skinToneEmoji.expandSkinColorOptions = false;
                             }
                         }
@@ -189,7 +200,7 @@ StatusDropdown {
                 anchors.rightMargin: d.headerMargin
                 visible: !skinToneEmoji.expandSkinColorOptions
                 // Hand emoji 🖐️ to which we append the skin color selected by the user
-                emojiId: "1f590" + ((root.skinColor !== "" && visible) ? ("-" + root.skinColor) : "")
+                emojiId: "1f590" + ((settings.skinColor !== "" && visible) ? ("-" + settings.skinColor) : "")
                 StatusMouseArea {
                     cursorShape: Qt.PointingHandCursor
                     anchors.fill: parent
@@ -209,7 +220,7 @@ StatusDropdown {
             color: Theme.palette.secondaryText
             font.pixelSize: Theme.additionalTextSize
             text: d.searchString ? (root.fullModel.count ? qsTr("Search Results") : qsTr("No results found"))
-                                          : emojiGrid.currentCategory
+                                 : emojiGrid.currentCategory
             font.capitalization: Font.AllUppercase
         }
 

--- a/ui/imports/shared/status/StatusEmojiPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiPopup.qml
@@ -26,15 +26,23 @@ StatusDropdown {
         sourceModel: root.emojiModel
 
         filters: [
-            AnyOf {
+            AllOf {
                 enabled: d.searchString !== ""
-                StatusQUtils.SearchFilter {
-                    roleName: "name"
-                    searchPhrase: d.searchString
+                AnyOf {
+                    StatusQUtils.SearchFilter {
+                        roleName: "name"
+                        searchPhrase: d.searchString
+                    }
+                    StatusQUtils.SearchFilter {
+                        roleName: "shortname"
+                        searchPhrase: d.searchString
+                    }
                 }
-                StatusQUtils.SearchFilter {
-                    roleName: "shortname"
-                    searchPhrase: d.searchString
+                // don't duplicate recents in the search results
+                ValueFilter {
+                    roleName: "category"
+                    value: root.emojiModel.recentCategoryName
+                    inverted: true
                 }
             },
             AnyOf {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -1156,15 +1156,15 @@ Loader {
                 }
 
                 quickActions: [
-                    MessageReactionsRow {
-                        visible: {
-                            root.emojiReactionLimitReached
-                            return !root.emojiReactionLimitReached && !root.isViewMemberMessagesePopup
-                        }
-                        emojiModel: emojiPopup.fullModel
-                        onToggleReaction: hexcode => root.emojiReactionToggled(root.messageId, hexcode)
-                        onOpenEmojiPopup: (parent, mouse) => {
-                            d.addReactionClicked(parent, mouse)
+                    Loader {
+                        active: delegate.hovered && d.addReactionAllowed && !root.emojiReactionLimitReached
+                        visible: active
+                        sourceComponent: MessageReactionsRow {
+                            emojiModel: emojiPopup.fullModel
+                            onToggleReaction: hexcode => root.emojiReactionToggled(root.messageId, hexcode)
+                            onOpenEmojiPopup: (parent, mouse) => {
+                                                  d.addReactionClicked(parent, mouse)
+                                              }
                         }
                     },
                     Loader {


### PR DESCRIPTION
### What does the PR do

Fixes 2 issues with the recent emojis; see the 2 commits for details

- filter out duplicates when searching: 
  - augment the search filter with an additional `ValueFilter` to ignore the recent emojis when performing a search (Fixes https://github.com/status-im/status-app/issues/21489)

- fix incorrect/duplicate recent emojis
  - move the settings to the popup/model, simplifying and centralizing the responsibilities when saving/loading the recent emojis
  - wrap the `MessageReactionsRow` quick actions bar into a `Loader`, delaying its construction for after the model and recent emojis have been fully loaded; there was a race condition between the 2 sides because the StatusEmojiModel lives inside a QML singleton, and hence being constructed at startup before anything else
  - adapt the Storybook page (Fixes https://github.com/status-im/status-app/issues/21490)

### Affected areas

StatusEmojiPopup,StatusEmojiPopup,AppMain

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality


https://github.com/user-attachments/assets/dd598efe-bca6-4edb-a984-7063e515f392



### Impact on end user

Correct use of recent emojis

### How to test

- try inserting some emojis, reacting to messages with emojis
- the recents should stays in sync across the whole app, and not be duplicated

### Risk 

low
