### PR TITLE
fix(AppMain): revert to distinct padding values for portrait/landscape

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1044,30 +1044,24 @@ Item {
             }
             return ThemeUtils.PaddingFactor.PaddingM
         }
-        readonly property int defaultFontSize: ThemeUtils.FontSize.FontSizeM
-        readonly property int defaultPaddingFactor: ThemeUtils.PaddingFactor.PaddingM
 
         Component.onCompleted: {
             ThemeUtils.setTheme(appMain.Window.window, appMainLocalSettings.theme)
-            // NB: always returning default font/padding as part of the global scaling epic: https://github.com/status-im/status-app/issues/20169
-            // ThemeUtils.setFontSize(appMain.Window.window, appMainLocalSettings.defaultFontSize)
-            // ThemeUtils.setPaddingFactor(appMain.Window.window, appMainLocalSettings.defaultPaddingFactor)
-            ThemeUtils.setFontSize(appMain.Window.window, appMainLocalSettings.defaultFontSize)
-            ThemeUtils.setPaddingFactor(appMain.Window.window, appMainLocalSettings.defaultPaddingFactor)
+            ThemeUtils.setFontSize(appMain.Window.window, appMainLocalSettings.fontSize)
+            ThemeUtils.setPaddingFactor(appMain.Window.window, appMainLocalSettings.paddingFactor)
 
             // Show the navigation education dialog the first time the app
             // is opened after the new menu is introduce, if the nav bar is in collapsed mode
             d.tryOpenNavigationEducationPopup()
         }
 
-        // NB: disabled as part of the global scaling epic: https://github.com/status-im/status-app/issues/20169
-        // readonly property var _conn: Connections {
-        //     target: appMain
-        //     function onIsPortraitModeChanged() {
-        //         ThemeUtils.setFontSize(appMain.Window.window, appMainLocalSettings.fontSize)
-        //         ThemeUtils.setPaddingFactor(appMain.Window.window, appMainLocalSettings.paddingFactor)
-        //     }
-        // }
+        readonly property var _conn: Connections {
+            target: appMain
+            function onIsPortraitModeChanged() {
+                ThemeUtils.setFontSize(appMain.Window.window, appMainLocalSettings.fontSize)
+                ThemeUtils.setPaddingFactor(appMain.Window.window, appMainLocalSettings.paddingFactor)
+            }
+        }
     }
 
     PopupsLoader {


### PR DESCRIPTION
### What does the PR do

Reverts a portion of https://github.com/status-im/status-app/pull/21391/changes/b4db4891a5d524c9c5519717a5fb05e874a5b04a

Fixes #21449

### Affected areas

App

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Desktop (in portrait):
<img width="976" height="2184" alt="image" src="https://github.com/user-attachments/assets/33ecaef7-9b9f-4185-a47a-d011feec6814" />

Mobile:
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/15bbcece-6131-4643-9433-62572d78869c" />


### Impact on end user

No excessive horizontal paddings on portrait/mobile
