### PR TITLE
feat(archive): adds a selector that supports Logos Storage

### DIFF
--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -106,11 +106,12 @@ proc toggleBrowserSection*(self: Controller) =
 proc toggleCommunitySection*(self: Controller) =
   self.events.emit(TOGGLE_SECTION, ToggleSectionArgs(sectionType: SectionType.Community))
 
-proc isCommunityHistoryArchiveSupportEnabled*(self: Controller): bool =
-  self.nodeConfigurationService.isCommunityHistoryArchiveSupportEnabled()
+proc getCommunityHistoryArchiveProtocolMode*(self: Controller): int =
+  self.nodeConfigurationService.getCommunityHistoryArchiveProtocolMode().int
 
-proc enableCommunityHistoryArchiveSupport*(self: Controller): bool =
-  self.nodeConfigurationService.enableCommunityHistoryArchiveSupport()
-
-proc disableCommunityHistoryArchiveSupport*(self: Controller): bool =
-  self.nodeConfigurationService.disableCommunityHistoryArchiveSupport()
+proc setCommunityHistoryArchiveProtocolMode*(self: Controller, mode: int): bool =
+  if mode < node_configuration_service.ArchiveProtocolMode.low.int or mode > node_configuration_service.ArchiveProtocolMode.high.int:
+     error "invalid archive protocol mode", mode = mode
+     return false
+  let archiveProtocolMode = node_configuration_service.ArchiveProtocolMode(mode)
+  self.nodeConfigurationService.setCommunityHistoryArchiveProtocolMode(archiveProtocolMode)

--- a/src/app/modules/main/profile_section/advanced/io_interface.nim
+++ b/src/app/modules/main/profile_section/advanced/io_interface.nim
@@ -51,13 +51,10 @@ method isDebugEnabled*(self: AccessInterface): bool {.base.} =
 method isRuntimeLogLevelSet*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method isCommunityHistoryArchiveSupportEnabled*(self: AccessInterface): bool {.base.} =
+method getCommunityHistoryArchiveProtocolMode*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method enableCommunityHistoryArchiveSupport*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method disableCommunityHistoryArchiveSupport*(self: AccessInterface) {.base.} =
+method setCommunityHistoryArchiveProtocolMode*(self: AccessInterface, mode: int): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method toggleDebug*(self: AccessInterface) {.base.} =

--- a/src/app/modules/main/profile_section/advanced/module.nim
+++ b/src/app/modules/main/profile_section/advanced/module.nim
@@ -97,16 +97,14 @@ method onNimbusProxyToggled*(self: Module) =
 method isRuntimeLogLevelSet*(self: Module): bool =
   return constants.runtimeLogLevelSet()
 
-method isCommunityHistoryArchiveSupportEnabled*(self: Module): bool =
-  return self.controller.isCommunityHistoryArchiveSupportEnabled()
+method getCommunityHistoryArchiveProtocolMode*(self: Module): int =
+  return self.controller.getCommunityHistoryArchiveProtocolMode()
 
-method enableCommunityHistoryArchiveSupport*(self: Module) =
-  if self.controller.enableCommunityHistoryArchiveSupport():
-    self.view.archiveProtocolEnabledChanged()
-
-method disableCommunityHistoryArchiveSupport*(self: Module) =
-  if self.controller.disableCommunityHistoryArchiveSupport():
-    self.view.archiveProtocolEnabledChanged()
+method setCommunityHistoryArchiveProtocolMode*(self: Module, mode: int): bool =
+  let updated = self.controller.setCommunityHistoryArchiveProtocolMode(mode)
+  if updated:
+    self.view.archiveProtocolModeChanged()
+  return updated
 
 method toggleWalletSection*(self: Module) =
   self.controller.toggleWalletSection()

--- a/src/app/modules/main/profile_section/advanced/view.nim
+++ b/src/app/modules/main/profile_section/advanced/view.nim
@@ -67,18 +67,15 @@ QtObject:
   QtProperty[bool] isRuntimeLogLevelSet:
     read = getIsRuntimeLogLevelSet
 
-  proc archiveProtocolEnabledChanged*(self: View) {.signal.}
-  proc getArchiveProtocolEnabled*(self: View): bool {.slot.} =
-    return self.delegate.isCommunityHistoryArchiveSupportEnabled()
-  QtProperty[bool] archiveProtocolEnabled:
-    read = getArchiveProtocolEnabled
-    notify = archiveProtocolEnabledChanged
+  proc archiveProtocolModeChanged*(self: View) {.signal.}
+  proc getArchiveProtocolMode*(self: View): int {.slot.} =
+    return self.delegate.getCommunityHistoryArchiveProtocolMode()
+  QtProperty[int] archiveProtocolMode:
+    read = getArchiveProtocolMode
+    notify = archiveProtocolModeChanged
 
-  proc enableCommunityHistoryArchiveSupport*(self: View) {.slot.} =
-    self.delegate.enableCommunityHistoryArchiveSupport()
-
-  proc disableCommunityHistoryArchiveSupport*(self: View) {.slot.} =
-    self.delegate.disableCommunityHistoryArchiveSupport()
+  proc setCommunityHistoryArchiveProtocolMode*(self: View, mode: int): bool {.slot.} =
+    return self.delegate.setCommunityHistoryArchiveProtocolMode(mode)
 
   proc toggleWalletSection*(self: View) {.slot.} =
     self.delegate.toggleWalletSection()

--- a/src/app_service/service/node_configuration/dto/node_config.nim
+++ b/src/app_service/service/node_configuration/dto/node_config.nim
@@ -165,6 +165,9 @@ type
   TorrentConfig* = object
     Enabled*: bool
 
+  LogosStorageConfig* = object
+    Enabled*: bool
+
   Whisper* = object
     Min*: int
     Max*: int
@@ -219,6 +222,7 @@ type
     WakuConfig*: WakuConfig
     WakuV2Config*: Waku2Config
     TorrentConfig*: TorrentConfig
+    LogosStorageConfig*: LogosStorageConfig
     BridgeConfig*: BridgeConfig
     ShhextConfig*: ShhextConfig
     WalletConfig*: WalletConfig
@@ -317,6 +321,9 @@ proc toDatabaseConfig*(jsonObj: JsonNode): DatabaseConfig =
     result.PGConfig = toPGConfig(pgConfigObj)
 
 proc toTorrentConfig*(jsonObj: JsonNode): TorrentConfig =
+  discard jsonObj.getProp("Enabled", result.Enabled)
+
+proc toLogosStorageConfig*(jsonObj: JsonNode): LogosStorageConfig =
   discard jsonObj.getProp("Enabled", result.Enabled)
 
 proc toWaku2Config*(jsonObj: JsonNode): Waku2Config =
@@ -520,6 +527,10 @@ proc toNodeConfigDto*(jsonObj: JsonNode): NodeConfigDto =
   var torrentConfigObj: JsonNode
   if(jsonObj.getProp("TorrentConfig", torrentConfigObj)):
     result.TorrentConfig = toTorrentConfig(torrentConfigObj)
+
+  var logosStorageConfigObj: JsonNode
+  if(jsonObj.getProp("LogosStorageConfig", logosStorageConfigObj)):
+    result.LogosStorageConfig = toLogosStorageConfig(logosStorageConfigObj)
 
   var wakuV2ConfigObj: JsonNode
   if(jsonObj.getProp("WakuV2Config", wakuV2ConfigObj)):

--- a/src/app_service/service/node_configuration/service.nim
+++ b/src/app_service/service/node_configuration/service.nim
@@ -23,6 +23,12 @@ type
     logLevel*: LogLevel
 
 type
+  ArchiveProtocolMode* {.pure.} = enum
+    Disabled = 0
+    LogosStorage = 1
+    Torrent = 2
+
+type
   ErrorArgs* = ref object of Args
     msg*: string
 
@@ -32,8 +38,8 @@ type
     events: EventEmitter
 
 # Forward declarations
-proc isCommunityHistoryArchiveSupportEnabled*(self: Service): bool
-proc enableCommunityHistoryArchiveSupport*(self: Service): bool
+proc getCommunityHistoryArchiveProtocolMode*(self: Service): ArchiveProtocolMode
+proc setCommunityHistoryArchiveProtocolMode*(self: Service, mode: ArchiveProtocolMode): bool
 
 
 proc delete*(self: Service) =
@@ -68,20 +74,41 @@ proc getWakuVersion*(self: Service): int =
   error "unsupported waku version"
   return 0
 
-proc isCommunityHistoryArchiveSupportEnabled*(self: Service): bool =
-  return self.configuration.TorrentConfig.Enabled
+proc getCommunityHistoryArchiveProtocolMode*(self: Service): ArchiveProtocolMode =
+  if self.configuration.LogosStorageConfig.Enabled:
+    return ArchiveProtocolMode.LogosStorage
 
-proc enableCommunityHistoryArchiveSupport*(self: Service): bool =
+  if self.configuration.TorrentConfig.Enabled:
+    return ArchiveProtocolMode.Torrent
+
+  return ArchiveProtocolMode.Disabled
+
+proc enableTorrentCommunityHistoryArchiveSupport*(self: Service): bool =
   try:
-    let response = status_node_config.enableCommunityHistoryArchiveSupport()
+    let response = status_node_config.enableTorrentCommunityHistoryArchiveSupport()
     if response.error != nil:
       let error = Json.decode($response.error, RpcError)
       raise newException(RpcException, error.message)
 
     self.configuration.TorrentConfig.Enabled = true
+    self.configuration.LogosStorageConfig.Enabled = false
     return true
   except Exception as e:
-    error "error enabling community history archive support: ", errDescription = e.msg
+    error "error enabling Torrent community history archive support:", errDescription = e.msg
+    return false
+
+proc enableLogosStorageCommunityHistoryArchiveSupport*(self: Service): bool =
+  try:
+    let response = status_node_config.enableLogosStorageCommunityHistoryArchiveSupport()
+    if response.error != nil:
+      let error = Json.decode($response.error, RpcError)
+      raise newException(RpcException, error.message)
+
+    self.configuration.LogosStorageConfig.Enabled = true
+    self.configuration.TorrentConfig.Enabled = false
+    return true
+  except Exception as e:
+    error "error enabling Logos Storage community history archive support:", errDescription = e.msg
     return false
 
 proc disableCommunityHistoryArchiveSupport*(self: Service): bool =
@@ -92,10 +119,29 @@ proc disableCommunityHistoryArchiveSupport*(self: Service): bool =
       raise newException(RpcException, error.message)
 
     self.configuration.TorrentConfig.Enabled = false
+    self.configuration.LogosStorageConfig.Enabled = false
     return true
   except Exception as e:
     error "error disabling community history archive support: ", errDescription = e.msg
     return false
+
+proc setCommunityHistoryArchiveProtocolMode*(self: Service, mode: ArchiveProtocolMode): bool =
+  if self.getCommunityHistoryArchiveProtocolMode() == mode:
+    return true
+
+  case mode:
+    of ArchiveProtocolMode.Disabled:
+      return self.disableCommunityHistoryArchiveSupport()
+    of ArchiveProtocolMode.LogosStorage:
+      if self.getCommunityHistoryArchiveProtocolMode() == ArchiveProtocolMode.Torrent:
+        if not self.disableCommunityHistoryArchiveSupport():
+          return false
+      return self.enableLogosStorageCommunityHistoryArchiveSupport()
+    of ArchiveProtocolMode.Torrent:
+      if self.getCommunityHistoryArchiveProtocolMode() == ArchiveProtocolMode.LogosStorage:
+        if not self.disableCommunityHistoryArchiveSupport():
+          return false
+      return self.enableTorrentCommunityHistoryArchiveSupport()
 
 proc setLightClient*(self: Service, enabled: bool): bool =
   try:

--- a/src/backend/node_config.nim
+++ b/src/backend/node_config.nim
@@ -20,8 +20,11 @@ proc getNodeConfig*(): RpcResponse[JsonNode] =
     raise newException(RpcException, e.msg)
 
 
-proc enableCommunityHistoryArchiveSupport*(): RpcResponse[JsonNode] =
+proc enableTorrentCommunityHistoryArchiveSupport*(): RpcResponse[JsonNode] =
   return core.callPrivateRPC("enableCommunityHistoryArchiveProtocol".prefix, %* [])
+
+proc enableLogosStorageCommunityHistoryArchiveSupport*(): RpcResponse[JsonNode] =
+  return core.callPrivateRPC("enableLogosStorageCommunityHistoryArchiveProtocol".prefix, %* [{}])
 
 proc disableCommunityHistoryArchiveSupport*(): RpcResponse[JsonNode] =
   return core.callPrivateRPC("disableCommunityHistoryArchiveProtocol".prefix, %* [])

--- a/ui/app/AppLayouts/Communities/popups/EnableFullMessageHistoryPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/EnableFullMessageHistoryPopup.qml
@@ -33,7 +33,7 @@ StatusDialog {
             Layout.fillWidth: true
             wrapMode: Text.Wrap
             color: Theme.palette.directColor5
-            text: qsTr("This service operates using the Archive Protocol, which will be automatically enabled.")
+            text: qsTr("This service operates using the Archive Protocol, which will be automatically enabled using Logos Storage by default.")
         }
     }
 

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -4,6 +4,12 @@ import utils
 QtObject {
     id: root
 
+    enum ArchiveProtocolMode {
+        Disabled,
+        LogosStorage,
+        Torrent
+    }
+
     property var advancedModule
     property var walletModule
     property var networksModuleInst: networksModule
@@ -15,12 +21,23 @@ QtObject {
     property bool isDebugEnabled: advancedModule? advancedModule.isDebugEnabled : false
     property int logMaxBackups: advancedModule ? advancedModule.logMaxBackups : 1
     property bool isRuntimeLogLevelSet: advancedModule ? advancedModule.isRuntimeLogLevelSet: false
-    readonly property bool archiveProtocolEnabled: advancedModule ? advancedModule.archiveProtocolEnabled : false
+    readonly property int archiveProtocolMode: advancedModule ? advancedModule.archiveProtocolMode : AdvancedStore.ArchiveProtocolMode.Disabled
+    readonly property string archiveProtocolModeLabel: {
+        switch (root.archiveProtocolMode) {
+        case AdvancedStore.ArchiveProtocolMode.LogosStorage:
+            return qsTr("Logos Storage")
+        case AdvancedStore.ArchiveProtocolMode.Torrent:
+            return qsTr("Torrent")
+        default:
+            return qsTr("Disabled")
+        }
+    }
     readonly property bool ensCommunityPermissionsEnabled: localAccountSensitiveSettings.ensCommunityPermissionsEnabled
 
     property var customNetworksModel: advancedModule? advancedModule.customNetworksModel : []
 
     property bool isManageCommunityOnTestModeEnabled: false
+
     readonly property QtObject experimentalFeatures: QtObject {
         readonly property string browser: "browser"
         readonly property string communities: "communities"
@@ -104,23 +121,19 @@ QtObject {
         }
     }
 
-    function toggleArchiveProtocolEnabled() {
+    function setArchiveProtocolMode(mode) {
         if(!advancedModule)
             return
 
-        if (root.archiveProtocolEnabled) {
-            advancedModule.disableCommunityHistoryArchiveSupport()
-        } else {
-            advancedModule.enableCommunityHistoryArchiveSupport()
-        }
+        advancedModule.setCommunityHistoryArchiveProtocolMode(mode)
     }
 
     function enableArchiveProtocolProperty() {
         if(!advancedModule)
             return
 
-        if (!root.archiveProtocolEnabled) {
-            advancedModule.enableCommunityHistoryArchiveSupport()
+        if (root.archiveProtocolMode === AdvancedStore.ArchiveProtocolMode.Disabled) {
+            advancedModule.setCommunityHistoryArchiveProtocolMode(AdvancedStore.ArchiveProtocolMode.LogosStorage)
         }
     }
 

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -182,12 +182,11 @@ SettingsContentBase {
 
             StatusSettingsLineButton {
                 width: parent.width
-                text: qsTr("Archive Protocol Enabled")
+                text: qsTr("Archive Protocol")
                 visible: !SQUtils.Utils.isMobile
-                isSwitch: true
-                checked: root.advancedStore.archiveProtocolEnabled
+                currentValue: root.advancedStore.archiveProtocolModeLabel
                 onClicked: {
-                    root.advancedStore.toggleArchiveProtocolEnabled()
+                    archiveProtocolModeModal.open()
                 }
             }
 
@@ -481,6 +480,61 @@ SettingsContentBase {
             onVelocityChanged: value => root.advancedStore.setScrollVelocity(value)
             onDecelerationChanged: value => root.advancedStore.setScrollDeceleration(value)
             onCustomScrollingChanged: enabled => root.advancedStore.setCustomScrollingEnabled(enabled)
+        }
+
+        StatusDialog {
+            id: archiveProtocolModeModal
+
+            width: 400
+            modal: true
+            title: qsTr("Archive Protocol")
+
+            contentItem: ColumnLayout {
+                spacing: 2 * Constants.settingsSection.itemSpacing
+
+                ButtonGroup {
+                    id: archiveProtocolModeGroup
+                }
+
+                SettingsRadioButton {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Theme.padding
+                    Layout.rightMargin: Theme.padding
+                    label: qsTr("Disabled")
+                    group: archiveProtocolModeGroup
+                    checked: root.advancedStore.archiveProtocolMode === AdvancedStore.ArchiveProtocolMode.Disabled
+                    onClicked: {
+                        root.advancedStore.setArchiveProtocolMode(AdvancedStore.ArchiveProtocolMode.Disabled)
+                        archiveProtocolModeModal.close()
+                    }
+                }
+
+                SettingsRadioButton {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Theme.padding
+                    Layout.rightMargin: Theme.padding
+                    label: qsTr("Logos Storage")
+                    group: archiveProtocolModeGroup
+                    checked: root.advancedStore.archiveProtocolMode === AdvancedStore.ArchiveProtocolMode.LogosStorage
+                    onClicked: {
+                        root.advancedStore.setArchiveProtocolMode(AdvancedStore.ArchiveProtocolMode.LogosStorage)
+                        archiveProtocolModeModal.close()
+                    }
+                }
+
+                SettingsRadioButton {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Theme.padding
+                    Layout.rightMargin: Theme.padding
+                    label: qsTr("Torrent")
+                    group: archiveProtocolModeGroup
+                    checked: root.advancedStore.archiveProtocolMode === AdvancedStore.ArchiveProtocolMode.Torrent
+                    onClicked: {
+                        root.advancedStore.setArchiveProtocolMode(AdvancedStore.ArchiveProtocolMode.Torrent)
+                        archiveProtocolModeModal.close()
+                    }
+                }
+            }
         }
 
         RPCStatsModal {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1021,6 +1021,21 @@
     </message>
 </context>
 <context>
+    <name>AdvancedStore</name>
+    <message>
+        <source>Logos Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Torrent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AdvancedView</name>
     <message>
         <source>This feature is experimental and is meant for testing purposes by core contributors and the community. It&apos;s not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.</source>
@@ -1059,10 +1074,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Archive Protocol Enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>ENS Community Permissions Enabled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1096,6 +1107,10 @@
     </message>
     <message>
         <source>Debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Archive Protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1160,6 +1175,18 @@
     </message>
     <message>
         <source>Change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logos Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Torrent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6751,7 +6778,7 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This service operates using the Archive Protocol, which will be automatically enabled.</source>
+        <source>This service operates using the Archive Protocol, which will be automatically enabled using Logos Storage by default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1024,6 +1024,21 @@
     </message>
 </context>
 <context>
+    <name>AdvancedStore</name>
+    <message>
+        <source>Logos Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Torrent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AdvancedView</name>
     <message>
         <source>This feature is experimental and is meant for testing purposes by core contributors and the community. It&apos;s not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.</source>
@@ -1062,10 +1077,6 @@
         <translation>Web/dApp prohlížeč</translation>
     </message>
     <message>
-        <source>Archive Protocol Enabled</source>
-        <translation>Archivní protokol povolen</translation>
-    </message>
-    <message>
         <source>ENS Community Permissions Enabled</source>
         <translation>Oprávnění ENS komunity povolena</translation>
     </message>
@@ -1100,6 +1111,10 @@
     <message>
         <source>Debug</source>
         <translation>Ladění</translation>
+    </message>
+    <message>
+        <source>Archive Protocol</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Logos Messaging options</source>
@@ -1164,6 +1179,18 @@
     <message>
         <source>Change</source>
         <translation>Změnit</translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logos Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Torrent</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Refetch transaction history</source>
@@ -6785,8 +6812,8 @@ key pair. Keycard will be required for signing</source>
         <translation>Povolení služby historie komunity zajišťuje, že každý člen může zobrazit kompletní historii zpráv pro všechny kanály, ke kterým má oprávnění. Bez této funkce bude historie zpráv omezena na posledních 30 dní. Váš počítač, který je řídicím uzlem pro komunitu, musí zůstat online, aby to fungovalo.</translation>
     </message>
     <message>
-        <source>This service operates using the Archive Protocol, which will be automatically enabled.</source>
-        <translation>Tato služba funguje pomocí protokolu Archive, který bude automaticky povolen.</translation>
+        <source>This service operates using the Archive Protocol, which will be automatically enabled using Logos Storage by default.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Read more</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1021,6 +1021,21 @@
     </message>
 </context>
 <context>
+    <name>AdvancedStore</name>
+    <message>
+        <source>Logos Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Torrent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AdvancedView</name>
     <message>
         <source>This feature is experimental and is meant for testing purposes by core contributors and the community. It&apos;s not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.</source>
@@ -1059,10 +1074,6 @@
         <translation>Navegador Web/dApp</translation>
     </message>
     <message>
-        <source>Archive Protocol Enabled</source>
-        <translation>Protocolo de archivo habilitado</translation>
-    </message>
-    <message>
         <source>ENS Community Permissions Enabled</source>
         <translation>Permisos de comunidad ENS habilitados</translation>
     </message>
@@ -1097,6 +1108,10 @@
     <message>
         <source>Debug</source>
         <translation>Depuración</translation>
+    </message>
+    <message>
+        <source>Archive Protocol</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Logos Messaging options</source>
@@ -1161,6 +1176,18 @@
     <message>
         <source>Change</source>
         <translation>Cambiar</translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logos Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Torrent</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Refetch transaction history</source>
@@ -6762,8 +6789,8 @@ key pair. Keycard will be required for signing</source>
         <translation>Habilitar el Servicio de Historial de Comunidad garantiza que cada miembro pueda ver el historial completo de mensajes de todos los canales que tiene permiso para ver. Sin esta función, el historial de mensajes se limitará a los últimos 30 días. Tu computadora, que es el nodo de control de la comunidad, debe permanecer en línea para que esto funcione.</translation>
     </message>
     <message>
-        <source>This service operates using the Archive Protocol, which will be automatically enabled.</source>
-        <translation>Este servicio opera usando el Protocolo de Archivo, que se habilitará automáticamente.</translation>
+        <source>This service operates using the Archive Protocol, which will be automatically enabled using Logos Storage by default.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Read more</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1018,6 +1018,21 @@
     </message>
 </context>
 <context>
+    <name>AdvancedStore</name>
+    <message>
+        <source>Logos Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Torrent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AdvancedView</name>
     <message>
         <source>This feature is experimental and is meant for testing purposes by core contributors and the community. It&apos;s not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.</source>
@@ -1056,10 +1071,6 @@
         <translation>웹/dApp 브라우저</translation>
     </message>
     <message>
-        <source>Archive Protocol Enabled</source>
-        <translation>아카이브 프로토콜 활성화됨</translation>
-    </message>
-    <message>
         <source>ENS Community Permissions Enabled</source>
         <translation>ENS 커뮤니티 권한 활성화됨</translation>
     </message>
@@ -1094,6 +1105,10 @@
     <message>
         <source>Debug</source>
         <translation>디버그</translation>
+    </message>
+    <message>
+        <source>Archive Protocol</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Logos Messaging options</source>
@@ -1158,6 +1173,18 @@
     <message>
         <source>Change</source>
         <translation>변경</translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logos Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Torrent</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Refetch transaction history</source>
@@ -6738,8 +6765,8 @@ key pair. Keycard will be required for signing</source>
         <translation>커뮤니티 히스토리 서비스 활성화 시, 권한이 있는 모든 채널의 전체 메시지 기록을 모든 구성원이 볼 수 있습니다. 이 기능을 켜지 않으면 메시지 기록은 최근 30일로 제한됩니다. 커뮤니티의 제어 Node 역할을 하는 사용자의 컴퓨터는 이 기능이 동작하도록 계속 온라인 상태여야 합니다.</translation>
     </message>
     <message>
-        <source>This service operates using the Archive Protocol, which will be automatically enabled.</source>
-        <translation>이 서비스는 Archive Protocol을 사용하여 운영되며, 자동으로 활성화됩니다.</translation>
+        <source>This service operates using the Archive Protocol, which will be automatically enabled using Logos Storage by default.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Read more</source>


### PR DESCRIPTION
### What does the PR do

Fixes #21576

Replaces the global Community Archive Protocol control in Advanced settings from a boolean switch with a mode selector offering three options: Disabled, Logos Storage, and Torrent. In the UI, the previous “Archive Protocol Enabled” toggle is replaced by an “Archive Protocol” settings row that displays the active mode and opens a selection modal. The Profile store maps internal mode values to user-facing labels and applies mode changes directly, while preserving the existing behavior that when a community flow requires archive support and the global mode is disabled, the app auto-enables the default mode.

Also extends the node configuration and settings-service pipeline to support protocol modes instead of a single enabled flag. Logos Storage state parsing is added in the node config DTO, explicit mode handling is introduced in the node configuration service (including direct switching logic between protocols), and the mode is exposed through the Advanced module/controller/view bridge so QML can read and set it consistently. Per-community archive support remains unchanged (still boolean), while global protocol selection becomes explicit and aligned with the currently supported archive backends.

### Affected areas

- AdvancedView.qml: Replaced the Archive Protocol boolean toggle with a mode selector entry and selection modal (Disabled, Logos Storage, Torrent).
- AdvancedStore.qml: Switched from boolean archive state to mode-based state, added mode label mapping, and updated auto-enable behavior to default to Logos Storage when disabled.
- view.nim: Exposed archive protocol as a mode property/slot instead of a boolean property/slots.
- module.nim: Routed mode get/set through module methods and emitted mode-change notifications.
- controller.nim: Converted controller API from enable/disable boolean operations to mode-based get/set operations.
- io_interface.nim: Updated interface contract to expose archive protocol mode methods instead of boolean archive support methods.
- service.nim: Added archive protocol mode enum and mode switching logic; supports direct transitions between Disabled, Logos Storage, and Torrent.
- node_config.nim: Added Logos Storage config parsing/storage so both protocol states are represented in node config DTO.
- node_config.nim: Added/renamed RPC wrappers for protocol-specific enable calls, including torrent-specific naming and Logos Storage enable call.
- EnableFullMessageHistoryPopup.qml: Updated user-facing copy to reflect automatic enable behavior with Logos Storage as default.
- CreateCommunityPopup.qml: Continues to trigger global archive protocol auto-enable through AdvancedStore helper.
- CommunitySettingsView.qml: Continues to trigger global archive protocol auto-enable through AdvancedStore helper.

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[logos-storage-support.webm](https://github.com/user-attachments/assets/fbc1c3f8-e7a0-42e2-a2a9-fdcae7c51286)

### Impact on end user

Enables the user to useLogos Storage instead of Torrent for their community

### How to test

Go in Advanced settings and click Archive Protocol
Enable community setting

To test the whole flow, you'll need to have two accounts, one a control node, the other a member. Both need to enable Logos Storage archive.

### Risk 

Low since it's off by default
