### PR TITLE
chore: bump status-go (Go 1.26 upgrade)

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -9,7 +9,7 @@ def isPRBuild = utils.isPRBuild()
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
   agent {
-    label "${getAgentLabels().join(' && ')} && qt-${QT_VERSION} && go-1.24 && xcode-26.4"
+    label "${getAgentLabels().join(' && ')} && qt-${QT_VERSION} && go-1.26 && xcode-26.4"
   }
 
   parameters {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -7,7 +7,7 @@ QT_VERSION = "6.11.0"
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label "windows && x86_64 && qt-${QT_VERSION} && go-1.24" }
+  agent { label "windows && x86_64 && qt-${QT_VERSION} && go-1.26" }
 
   parameters {
     booleanParam(


### PR DESCRIPTION
Companion PR for status-im/status-go#7651 (upgrade to Go 1.26, merged).

Bumps `vendor/status-go` to the merged commit on develop and requires `go-1.26` Jenkins agents (labels bumped in ci/Jenkinsfile.macos and ci/Jenkinsfile.windows).
