### PR TITLE
fix(ScreenZoom): unbreak baseline DPR on Android 

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -196,7 +196,7 @@ proc enableHDPI(uiScaleFilePath: string) =
 
     try:
       var scale = parseFloat(scaleStr)
-      scale = clamp(scale, 0.5, 2.0)
+      scale = clamp(scale, 0.75, 1.5)
       echo "[Debug] Setting custom UI scale to ", scale
       putEnv(scaleEnvVar, formatFloat(scale, ffDecimal, precision = 2))
 

--- a/storybook/pages/AppearanceViewPage.qml
+++ b/storybook/pages/AppearanceViewPage.qml
@@ -18,7 +18,7 @@ Item {
     AppearanceView {
         anchors.fill: parent
         anchors.topMargin: 80
-        contentWidth: Math.min(650, root.width)
+        contentWidth: root.width * 4 / 5
 
         theme: ThemeUtils.Style.System
         onThemeChangeRequested: function(theme) {

--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -91,5 +91,7 @@ private:
     bool m_androidKeyboardVisible = false;
     int m_iosKeyboardHeight = 0;
     bool m_iosKeyboardVisible = false;
+#ifdef Q_OS_IOS
     QTimer* m_iosKeyboardPollTimer = nullptr;
+#endif
 };

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -676,19 +676,40 @@ void SystemUtilsInternal::startShakeDetection()
 
 qreal SystemUtilsInternal::nativeDpr(QQuickWindow *window) const
 {
-    if (!window)
+#ifdef Q_OS_ANDROID
+    Q_UNUSED(window);
+    // Access standard Android context and get display metrics density
+    QJniObject activity = QNativeInterface::QAndroidApplication::context();
+    if (activity.isValid()) {
+        QJniObject resources = activity.callObjectMethod("getResources", "()Landroid/content/res/Resources;");
+        if (resources.isValid()) {
+            QJniObject metrics = resources.callObjectMethod("getDisplayMetrics", "()Landroid/util/DisplayMetrics;");
+            if (metrics.isValid()) {
+                return metrics.getField<float>("density");
+            }
+        }
+    }
+    return 1.0f;
+#else
+    if (!window) {
+        qWarning() << Q_FUNC_INFO << "invalid window, returning scaling of 1.0";
         return 1.0;
+    }
 
     auto screen = window->screen();
-    if (!screen)
+    if (!screen) {
+        qWarning() << Q_FUNC_INFO << "invalid window's screen, returning scaling of 1.0";
         return 1.0;
+    }
 
     if (auto platformScreen = screen->handle()) {
         return platformScreen->devicePixelRatio();
     }
 
     // Fallback to standard API if platform handle isn't available
+    qWarning() << Q_FUNC_INFO << "invalid native platform screen";
     return screen->devicePixelRatio();
+#endif
 }
 
 #ifdef Q_OS_IOS

--- a/ui/app/AppLayouts/HomePage/HomePageGrid.qml
+++ b/ui/app/AppLayouts/HomePage/HomePageGrid.qml
@@ -73,7 +73,7 @@ Control {
             objectName: "homePageGridView"
 
             readonly property int delegateCountPerRow: Math.min(Math.trunc(parent.width / (root.delegateWidth + root.spacing)),
-                                                                root.model.ModelCount.count) // for small models where count < delegateCountPerRow
+                                                                root.model?.ModelCount.count ?? 0) // for small models where count < delegateCountPerRow
 
             height: parent.height
             width: delegateCountPerRow * cellWidth

--- a/ui/app/AppLayouts/HomePage/delegates/HomePageGridWalletItem.qml
+++ b/ui/app/AppLayouts/HomePage/delegates/HomePageGridWalletItem.qml
@@ -21,7 +21,7 @@ HomePageGridItem {
     background: Rectangle {
         color: hovered ? Qt.lighter(Theme.palette.baseColor4, 1.5) : Theme.palette.baseColor4
         Behavior on color { ColorAnimation { duration: ThemeUtils.AnimationDuration.Fast } }
-        radius: Theme.padding
+        radius: Theme.defaultPadding
 
         opacity: pressed || down ? ThemeUtils.pressedOpacity : enabled ? 1 : ThemeUtils.disabledOpacity
         Behavior on opacity { NumberAnimation { duration: ThemeUtils.AnimationDuration.Fast } }

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -87,8 +87,6 @@ StatusSectionLayout {
     property var dismissedReceivedRequestContactsModel
 
     required property int theme // ThemeUtils.Style.xxx
-    required property int fontSize // ThemeUtils.FontSize.xxx
-    required property int paddingFactor // ThemeUtils.PaddingFactor.xxx
 
     required property var whitelistedDomainsModel
  
@@ -98,8 +96,6 @@ StatusSectionLayout {
     signal releaseUsernameRequested(string ensName, string senderAddress, int chainId)
 
     signal themeChangeRequested(int theme)
-    signal fontSizeChangeRequested(int fontSize)
-    signal paddingFactorChangeRequested(int paddingFactor)
     signal leaveCommunityRequest(string communityId)
     signal setCommunityMutedRequest(string communityId, int mutedType)
     signal inviteFriends(var communityData)

--- a/ui/app/AppLayouts/Profile/views/AppearanceView.qml
+++ b/ui/app/AppLayouts/Profile/views/AppearanceView.qml
@@ -118,13 +118,13 @@ SettingsContentBase {
 
         Rectangle {
             Layout.fillWidth: true
-            Layout.preferredHeight: 480
+            Layout.preferredHeight: 380
             radius: Theme.radius
             color: Theme.palette.baseColor5
 
             StatusCommunityCard {
                 id: preview
-                width: (parent.width / 2) - Theme.padding
+                width: (parent.width / 1.5) - Theme.padding
                 anchors.centerIn: parent
 
                 scale: slider.value/d.nativeWindowDpr
@@ -181,8 +181,8 @@ SettingsContentBase {
             StatusSlider {
                 Layout.fillWidth: true
                 id: slider
-                from: d.nativeWindowDpr/2 // half of the baseline
-                to: d.nativeWindowDpr*2 // twice the baseline
+                from: d.nativeWindowDpr*.75 // 3/4 of the baseline
+                to: d.nativeWindowDpr*1.5 // 1.5x the baseline
                 value: d.windowDpr
                 stepSize: 0.05 // steps of 5%
                 snapMode: Slider.SnapAlways

--- a/ui/app/AppLayouts/Profile/views/AppearanceView.qml
+++ b/ui/app/AppLayouts/Profile/views/AppearanceView.qml
@@ -43,17 +43,16 @@ SettingsContentBase {
             }
         }
 
-        readonly property string resultFactor: slider.value !== d.nativeWindowDpr ? Number(slider.value/d.nativeWindowDpr)
-                                                                                  : ""
+        readonly property string resultFactor: slider.value !== 1 ? slider.value : ""
+
+        property real prevValue
 
         function resetToDefaults() {
-            slider.value = d.nativeWindowDpr
+            slider.value = 1
         }
 
         function reset() {
-            slider.value = d.windowDpr
-            if (slider.value === d.nativeWindowDpr)
-                defaultsToggle.checked = Qt.binding(() => slider.value === d.nativeWindowDpr)
+            slider.value = d.prevValue
             d.dirty = false
         }
     }
@@ -69,6 +68,7 @@ SettingsContentBase {
     onResetChangesClicked: d.reset()
     onSaveChangesClicked: {
         if (SQUtils.StringUtils.writeTextFile(root.uiScaleFile, d.resultFactor)) {
+            d.prevValue = slider.value
             d.dirty = false
             root.restartRequested()
         } else {
@@ -76,6 +76,8 @@ SettingsContentBase {
             d.reset()
         }
     }
+
+    Component.onCompleted: d.prevValue = slider.value
 
     content: ColumnLayout {
         width: root.contentWidth - 2 * Theme.padding
@@ -127,7 +129,7 @@ SettingsContentBase {
                 width: (parent.width / 1.5) - Theme.padding
                 anchors.centerIn: parent
 
-                scale: slider.value/d.nativeWindowDpr
+                scale: slider.value
                 transformOrigin: Item.Center
 
                 communityId: "community_id"
@@ -161,7 +163,7 @@ SettingsContentBase {
             id: defaultsToggle
             text: qsTr("Follow display zoom")
             leftSide: false
-            checked: slider.value === d.nativeWindowDpr
+            checked: slider.value === 1
             onToggled: {
                 if(checked)
                     d.resetToDefaults()
@@ -181,9 +183,9 @@ SettingsContentBase {
             StatusSlider {
                 Layout.fillWidth: true
                 id: slider
-                from: d.nativeWindowDpr*.75 // 3/4 of the baseline
-                to: d.nativeWindowDpr*1.5 // 1.5x the baseline
-                value: d.windowDpr
+                from: 0.75 // 3/4 of the baseline
+                to: 1.5 // 1.5x the baseline
+                value: d.windowDpr/d.nativeWindowDpr
                 stepSize: 0.05 // steps of 5%
                 snapMode: Slider.SnapAlways
                 onMoved: d.dirty = true

--- a/ui/app/AppLayouts/Profile/views/AppearanceView.qml
+++ b/ui/app/AppLayouts/Profile/views/AppearanceView.qml
@@ -25,7 +25,7 @@ SettingsContentBase {
 
     QtObject {
         id: d
-        readonly property bool portraitMode: root.width <= root.contentWidth
+        readonly property bool portraitMode: root.width <= ThemeUtils.portraitBreakpoint.width
 
         property bool dirty
 
@@ -86,40 +86,22 @@ SettingsContentBase {
         RowLayout {
             Layout.fillWidth: true
 
-            StatusImageRadioButton {
-                Layout.fillWidth: true
-                image.source: d.portraitMode ? Assets.svgImg("appearance-light-small") : Assets.svgImg("appearance-light")
+            ModeRadioButton {
+                mode: ThemeUtils.Style.Light
+                imageSource: d.portraitMode ? Assets.svgImg("appearance-light-small") : Assets.svgImg("appearance-light")
                 text: qsTr("Light")
-                checked: root.theme === ThemeUtils.Style.Light
-                onToggled: {
-                    if (checked) {
-                        root.themeChangeRequested(ThemeUtils.Style.Light)
-                    }
-                }
             }
 
-            StatusImageRadioButton {
-                Layout.fillWidth: true
-                image.source: d.portraitMode ? Assets.svgImg("appearance-system-small") : Assets.svgImg("appearance-system")
+            ModeRadioButton {
+                mode: ThemeUtils.Style.System
+                imageSource: d.portraitMode ? Assets.svgImg("appearance-system-small") : Assets.svgImg("appearance-system")
                 text: qsTr("System")
-                checked: root.theme === ThemeUtils.Style.System
-                onToggled: {
-                    if (checked) {
-                        root.themeChangeRequested(ThemeUtils.Style.System)
-                    }
-                }
             }
 
-            StatusImageRadioButton {
-                Layout.fillWidth: true
-                image.source: d.portraitMode ? Assets.svgImg("appearance-dark-small") : Assets.svgImg("appearance-dark")
+            ModeRadioButton {
+                mode: ThemeUtils.Style.Dark
+                imageSource: d.portraitMode ? Assets.svgImg("appearance-dark-small") : Assets.svgImg("appearance-dark")
                 text: qsTr("Dark")
-                checked: root.theme === ThemeUtils.Style.Dark
-                onToggled: {
-                    if (checked) {
-                        root.themeChangeRequested(ThemeUtils.Style.Dark)
-                    }
-                }
             }
         }
 
@@ -194,6 +176,7 @@ SettingsContentBase {
 
         RowLayout {
             Layout.fillWidth: true
+            Layout.leftMargin: Theme.bigPadding // in order not to collide with the sidebar
             spacing: Theme.bigPadding
             StatusSlider {
                 Layout.fillWidth: true
@@ -215,6 +198,18 @@ SettingsContentBase {
                     id: textMetrics
                     text: "999%"
                 }
+            }
+        }
+    }
+
+    component ModeRadioButton: StatusImageRadioButton {
+        property int mode
+        checked: root.theme === mode
+        Layout.fillWidth: true
+        imageSize: d.portraitMode ? Qt.size(99, 48) : Qt.size(176, 48)
+        onToggled: {
+            if (checked) {
+                root.themeChangeRequested(mode)
             }
         }
     }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2229,22 +2229,12 @@ Item {
                         isProduction: appMain.rootStore.isProduction
                         systemTrayIconAvailable: appMain.systemTrayIconAvailable
                         theme: appMainLocalSettings.theme
-                        fontSize: appMainLocalSettings.fontSize
-                        paddingFactor: appMainLocalSettings.paddingFactor
                         whitelistedDomainsModel: appMainLocalSettings.whitelistedUnfurledDomains
                         leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
 
                         onThemeChangeRequested: (theme) => {
                             appMainLocalSettings.theme = theme
                             ThemeUtils.setTheme(appMain.Window.window, theme)
-                        }
-                        onFontSizeChangeRequested: (fontSize) => {
-                            appMainLocalSettings.fontSize = fontSize
-                            ThemeUtils.setFontSize(appMain.Window.window, fontSize)
-                        }
-                        onPaddingFactorChangeRequested: (paddingFactor) => {
-                            appMainLocalSettings.paddingFactor = paddingFactor
-                            ThemeUtils.setPaddingFactor(appMain.Window.window, paddingFactor)
                         }
                         onRemoveWhitelistedDomainRequested: (index) => {
                             // in order to notify changes in this model, we need to re assign to this model

--- a/ui/app/mainui/sectionLoaders/ChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ChatLoader.qml
@@ -119,8 +119,8 @@ Loader {
             emojiPopup:                     Qt.binding(() => root.emojiPopupLoader.item),
             stickersPopup:                  Qt.binding(() => root.stickersPopupLoader.item),
             sendViaPersonalChatEnabled:     Qt.binding(() => root.featureFlagsStore.sendViaPersonalChatEnabled),
-            disabledTooltipText:            Qt.binding(() => !root.networkConnectionStore.sendBuyBridgeEnabled
-                                                   ? root.networkConnectionStore.sendBuyBridgeToolTipText : ""),
+            disabledTooltipText:            Qt.binding(() => !root.networkConnectionStore.walletReadyForTransactionsEnabled
+                                                   ? root.networkConnectionStore.walletReadyForTransactionsToolTipText : ""),
             messageLinkSharingEnabled:      Qt.binding(() => root.featureFlagsStore.messageLinkSharingEnabled),
             paymentRequestFeatureEnabled:   Qt.binding(() => root.featureFlagsStore.paymentRequestEnabled),
             extraLeftPadding:               Qt.binding(() => root.isPortraitMode ? SQUtils.Utils.swipeIndicatorWidth : 0),

--- a/ui/app/mainui/sectionLoaders/HandlersManagerLoader.qml
+++ b/ui/app/mainui/sectionLoaders/HandlersManagerLoader.qml
@@ -100,7 +100,7 @@ Loader {
             callable()
             return
         }
-        if (root.active == false) {
+        if (!root.active) {
             root.active = true
         }
         d.pending.push(callable)

--- a/ui/app/mainui/sectionLoaders/ProfileLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ProfileLoader.qml
@@ -56,8 +56,6 @@ Loader {
     required property bool isProduction
     required property bool systemTrayIconAvailable
     required property int theme
-    required property int fontSize
-    required property int paddingFactor
     required property var whitelistedDomainsModel
 
     property int settingsSubsection: -1
@@ -90,8 +88,6 @@ Loader {
 
     // Signals re-emitted so AppMain can mutate appMainLocalSettings / Theme outside the loader
     signal themeChangeRequested(int theme)
-    signal fontSizeChangeRequested(int fontSize)
-    signal paddingFactorChangeRequested(int paddingFactor)
     signal removeWhitelistedDomainRequested(int index)
 
     asynchronous: false
@@ -146,8 +142,6 @@ Loader {
             privacyModeFeatureEnabled:              Qt.binding(() => root.featureFlagsStore.privacyModeFeatureEnabled),
             minimizeOnCloseOptionVisible:           Qt.binding(() => root.systemTrayIconAvailable),
             theme:                                  Qt.binding(() => root.theme),
-            fontSize:                               Qt.binding(() => root.fontSize),
-            paddingFactor:                          Qt.binding(() => root.paddingFactor),
             whitelistedDomainsModel:                Qt.binding(() => root.whitelistedDomainsModel),
             leftPanelWidthOverride:                 Qt.binding(() => root.leftPanelWidthOverride),
             settingsSubsection:                     Qt.binding(() => root.settingsSubsection),
@@ -180,8 +174,6 @@ Loader {
             root.popupHandler.releaseUsername(ensName, senderAddress, chainId)
         }
         function onThemeChangeRequested(theme) { root.themeChangeRequested(theme) }
-        function onFontSizeChangeRequested(fontSize) { root.fontSizeChangeRequested(fontSize) }
-        function onPaddingFactorChangeRequested(paddingFactor) { root.paddingFactorChangeRequested(paddingFactor) }
         function onLeaveCommunityRequest(communityId) {
             root.communitiesStore.leaveCommunity(communityId)
         }

--- a/ui/imports/shared/status/StatusImageRadioButton.qml
+++ b/ui/imports/shared/status/StatusImageRadioButton.qml
@@ -10,7 +10,8 @@ import utils
 RadioButton {
     id: root
 
-    property alias image: img
+    property url imageSource
+    property size imageSize
 
     padding: Theme.halfPadding
     spacing: Theme.halfPadding
@@ -20,25 +21,32 @@ RadioButton {
     font.pixelSize: Theme.fontSize(13)
     font.weight: checked ? Font.DemiBold : Font.Medium
 
-    background: Rectangle {
-        radius: Theme.radius
-        color: checked ? Theme.palette.secondaryBackground :
-                         (hovered ? Theme.palette.backgroundHover : StatusColors.transparent)
-        border.width: 2
-        border.color: checked ? Theme.palette.primaryColor1 : StatusColors.transparent
-    }
+    background: null
 
     contentItem: ColumnLayout {
         id: layout
         spacing: root.spacing
 
-        Image {
-            id: img
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            fillMode: Image.PreserveAspectFit
-            mipmap: true
-            antialiasing: true
+        Rectangle {
+            Layout.preferredWidth: img.implicitWidth
+            Layout.preferredHeight: img.implicitHeight
+            Layout.alignment: Qt.AlignHCenter
+
+            radius: 8
+            color: StatusColors.transparent
+            border.width: 2
+            border.color: checked ? Theme.palette.primaryColor1 : hovered ? Theme.palette.primaryColor2
+                                                                          : StatusColors.transparent
+
+            Image {
+                id: img
+                anchors.fill: parent
+                anchors.margins: 4
+                mipmap: true
+                antialiasing: true
+                source: root.imageSource
+                sourceSize: root.imageSize
+            }
         }
 
         StatusBaseText {


### PR DESCRIPTION
### What does the PR do

(commit by commit)

- use a native JNI call to get the base (native) DPR of the underlying window/screen, as the Android QPA doesn't implement/overrride the `QPlatformScreen::devicePixelRatio()` and always returns `1.0f`
- reduce the min/max range to `[0.75,1.5]` of the baseline
- fix(AppearanceView): align the mode switch button to latest Figma
- chore(Screen Zoom): drop `fontSize` & `paddingFactor` remnants from the previous PR

Fixes https://github.com/status-im/status-app/issues/21543

### Affected areas

App global zoom,Settings/Appearance

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Android UI (defaults):
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/856df2c1-203f-4e90-8ab1-fd30c3d4a066" />

Android, scaled up:
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/dd974825-1887-4b59-ba3b-4201a40a2d20" />

Android, scaled down:
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/9658965b-ffe8-4bb8-a1a6-672067be1140" />

### Impact on end user

Working screen zoom feature on Android

### How to test

- change the zoom slider, restart
- check the defaults switch, restart
- observe the correct zoom factor applied

### Risk 

low
