### PR TITLE
feat: make a key pair signing method alignment for paired devices optional

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -461,8 +461,7 @@ proc finishAppLoading*(self: AppController) =
     self.onboardingModule.onAppLoaded(account.keyUid)
     self.onboardingModule = nil
 
-  if not self.resumeLogin:
-    self.mainModule.checkAndPerformProfileMigrationIfNeeded()
+  self.mainModule.checkAndPerformProfileMigrationIfNeeded()
 
   self.notificationsManager.onAppReady()
 

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -327,6 +327,12 @@ method getKeycardManagementModule*(self: AccessInterface): QVariant {.base.} =
 method checkAndPerformProfileMigrationIfNeeded*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onProfileMigrationFlowOpened*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onProfileMigrationFlowClosed*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onMyRequestAdded*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -145,6 +145,8 @@ type
     contactsLoaded: bool
     pendingSpectateRequest: SpectateRequest
     statusDeepLinkToActivate: string
+    pendingProfileMigrationCheck: bool
+    profileMigrationFlowInProgress: bool
 
 {.push warning[Deprecated]: off.}
 
@@ -1008,6 +1010,10 @@ method onChatsLoaded*[T](
 
   if self.statusDeepLinkToActivate != "":
     self.activateStatusDeepLink(self.statusDeepLinkToActivate)
+
+  if self.pendingProfileMigrationCheck:
+    self.pendingProfileMigrationCheck = false
+    self.checkAndPerformProfileMigrationIfNeeded()
 
 method onCommunityDataLoaded*[T](
   self: Module[T],
@@ -2048,12 +2054,24 @@ method checkAndPerformProfileMigrationIfNeeded*[T](self: Module[T]) =
     return
   if not migrationNeeded:
     return
+  if not self.chatsLoaded:
+    # delay the check for after the chats are loaded
+    self.pendingProfileMigrationCheck = true
+    return
+  if self.profileMigrationFlowInProgress:
+    return
   if profileKeypair.migratedToColdWallet():
     info "run stop using keycard flow for the profile, cause profile was migrated on paired device"
-    # TODO: send signal to qml to `runStopUsingKeycardForProfilePopup()`
+    self.view.profileMigrationFlowRequested(migrateToKeycard = false)
     return
   info "run migrate to a Keycard flow for the profile, cause profile was migrated on paired device"
-  # TODO: send signal to qml to `runStartUsingKeycardForProfilePopup()`
+  self.view.profileMigrationFlowRequested(migrateToKeycard = true)
+
+method onProfileMigrationFlowOpened*[T](self: Module[T]) =
+  self.profileMigrationFlowInProgress = true
+
+method onProfileMigrationFlowClosed*[T](self: Module[T]) =
+  self.profileMigrationFlowInProgress = false
 
 
 method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =

--- a/src/app/modules/main/profile_section/wallet/controller.nim
+++ b/src/app/modules/main/profile_section/wallet/controller.nim
@@ -3,6 +3,7 @@ import app/core/eventemitter
 import app_service/service/wallet_account/service as wallet_account_service
 import app_service/service/devices/service as devices_service
 import app_service/service/node/service as node_service
+import app_service/service/settings/service as settings_service
 
 type
   Controller* = ref object of RootObj
@@ -10,18 +11,21 @@ type
     events: EventEmitter
     walletAccountService: wallet_account_service.Service
     nodeService: node_service.Service
+    settingsService: settings_service.Service
 
 proc newController*(
   delegate: io_interface.AccessInterface,
   events: EventEmitter,
   walletAccountService: wallet_account_service.Service,
-  nodeService: node_service.Service
+  nodeService: node_service.Service,
+  settingsService: settings_service.Service
 ): Controller =
   result = Controller()
   result.delegate = delegate
   result.events = events
   result.walletAccountService = walletAccountService
   result.nodeService = nodeService
+  result.settingsService = settingsService
 
 proc delete*(self: Controller) =
   discard
@@ -30,6 +34,9 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_LOCAL_PAIRING_STATUS_UPDATE) do(e:Args):
     let data = LocalPairingStatus(e)
     self.delegate.onLocalPairingStatusUpdate(data)
+
+  self.events.on(SIGNAL_AUTO_APPLY_KEYPAIR_MIGRATIONS_UPDATED) do(e: Args):
+    self.delegate.onAutoApplyKeypairMigrationsUpdated()
 
 proc hasPairedDevices*(self: Controller): bool =
   return self.walletAccountService.hasPairedDevices()
@@ -42,3 +49,9 @@ proc resetRpcStats*(self: Controller) =
 
 proc refetchTxHistory*(self: Controller) =
   self.walletAccountService.refetchTxHistory()
+
+proc getAutoApplyKeypairMigrations*(self: Controller): bool =
+  return self.settingsService.getAutoApplyKeypairMigrations()
+
+proc setAutoApplyKeypairMigrations*(self: Controller, value: bool) =
+  discard self.settingsService.saveAutoApplyKeypairMigrations(value)

--- a/src/app/modules/main/profile_section/wallet/io_interface.nim
+++ b/src/app/modules/main/profile_section/wallet/io_interface.nim
@@ -60,3 +60,12 @@ method resetRpcStats*(self: AccessInterface) {.base.} =
 
 method refetchTxHistory*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getAutoApplyKeypairMigrations*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setAutoApplyKeypairMigrations*(self: AccessInterface, value: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onAutoApplyKeypairMigrationsUpdated*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/wallet/module.nim
+++ b/src/app/modules/main/profile_section/wallet/module.nim
@@ -49,7 +49,7 @@ proc newModule*(
 ): Module =
   result = Module()
   result.delegate = delegate
-  result.controller = controller.newController(result, events, walletAccountService, nodeService)
+  result.controller = controller.newController(result, events, walletAccountService, nodeService, settingsService)
   result.view = newView(result)
   result.viewVariant = newQVariant(result.view)
   result.events = events
@@ -133,3 +133,12 @@ method resetRpcStats*(self: Module) =
 
 method refetchTxHistory*(self: Module) =
   self.controller.refetchTxHistory()
+
+method getAutoApplyKeypairMigrations*(self: Module): bool =
+  return self.controller.getAutoApplyKeypairMigrations()
+
+method setAutoApplyKeypairMigrations*(self: Module, value: bool) =
+  self.controller.setAutoApplyKeypairMigrations(value)
+
+method onAutoApplyKeypairMigrationsUpdated*(self: Module) =
+  self.view.emitAutoApplyKeypairMigrationsChangedSignal()

--- a/src/app/modules/main/profile_section/wallet/view.nim
+++ b/src/app/modules/main/profile_section/wallet/view.nim
@@ -53,6 +53,17 @@ QtObject:
     read = getHasPairedDevices
     notify = hasPairedDevicesChanged
 
+  proc autoApplyKeypairMigrationsChanged*(self: View) {.signal.}
+  proc emitAutoApplyKeypairMigrationsChangedSignal*(self: View) =
+    self.autoApplyKeypairMigrationsChanged()
+  proc getAutoApplyKeypairMigrations(self: View): bool {.slot.} =
+    return self.delegate.getAutoApplyKeypairMigrations()
+  proc setAutoApplyKeypairMigrations*(self: View, value: bool) {.slot.} =
+    self.delegate.setAutoApplyKeypairMigrations(value)
+  QtProperty[bool] autoApplyKeypairMigrations:
+    read = getAutoApplyKeypairMigrations
+    notify = autoApplyKeypairMigrationsChanged
+
   proc getRpcStats(self: View): string {.slot.} =
     return self.delegate.getRpcStats()
   proc resetRpcStats(self: View) {.slot.} =

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -439,6 +439,17 @@ QtObject:
 
   proc wcLinkActivated*(self: View, url: string) {.signal.}
 
+  proc profileMigrationFlowRequested*(self: View, migrateToKeycard: bool) {.signal.}
+
+  proc profileMigrationFlowOpened*(self: View) {.slot.} =
+    self.delegate.onProfileMigrationFlowOpened()
+
+  proc profileMigrationFlowClosed*(self: View) {.slot.} =
+    self.delegate.onProfileMigrationFlowClosed()
+
+  proc checkProfileMigrationNeeded*(self: View) {.slot.} =
+    self.delegate.checkAndPerformProfileMigrationIfNeeded()
+
   proc loadMembersForSectionId*(self: View, communityId: string) {.slot.} =
     self.delegate.loadMembersForSectionId(communityId)
 

--- a/src/app/modules/shared_modules/authentication/controller.nim
+++ b/src/app/modules/shared_modules/authentication/controller.nim
@@ -43,6 +43,9 @@ proc init*(self: Controller) =
     let args = KeycardExportedPublicKeysArgs(e)
     self.delegate.onKeycardExportPublicKeysFinished(args.exportedPublicKeys, args.error)
 
+proc passwordProvided*(self: Controller, keyUid: string, password: string) =
+  self.events.emit(SIGNAL_PASSWORD_PROVIDED, AuthenticationArgs(keyUid: keyUid, password: password))
+
 proc verifyPassword*(self: Controller, password: string): bool =
   return self.accountsService.verifyPassword(password)
 

--- a/src/app/modules/shared_modules/authentication/controller.nim
+++ b/src/app/modules/shared_modules/authentication/controller.nim
@@ -1,5 +1,6 @@
 import chronicles
 import io_interface
+import uuids
 
 import app/core/eventemitter
 import app_service/service/accounts/service as accounts_service
@@ -14,6 +15,7 @@ type
   Controller* = ref object of RootObj
     delegate: io_interface.AccessInterface
     events: EventEmitter
+    connectionIds: seq[UUID]
     accountsService: accounts_service.Service
     walletAccountService: wallet_account_service.Service
     keycardServiceV2: keycard_serviceV2.Service
@@ -27,21 +29,28 @@ proc newController*(delegate: io_interface.AccessInterface,
   result = Controller()
   result.delegate = delegate
   result.events = events
+  result.connectionIds = @[]
   result.accountsService = accountsService
   result.walletAccountService = walletAccountService
   result.keycardServiceV2 = keycardServiceV2
 
+proc disconnectAll(self: Controller) =
+  for id in self.connectionIds:
+    self.events.disconnect(id)
+
 proc delete*(self: Controller) =
-  discard
+  self.disconnectAll()
 
 proc init*(self: Controller) =
-  self.events.on(SIGNAL_KEYCARD_STATE_UPDATED) do(e: Args):
+  var handlerId = self.events.onWithUUID(SIGNAL_KEYCARD_STATE_UPDATED) do(e: Args):
     let args = KeycardEventArg(e)
     self.delegate.onKeycardStateUpdated(args.keycardEvent)
+  self.connectionIds.add(handlerId)
 
-  self.events.on(SIGNAL_KEYCARD_EXPORT_PUBLIC_KEYS_FINISHED) do(e: Args):
+  handlerId = self.events.onWithUUID(SIGNAL_KEYCARD_EXPORT_PUBLIC_KEYS_FINISHED) do(e: Args):
     let args = KeycardExportedPublicKeysArgs(e)
     self.delegate.onKeycardExportPublicKeysFinished(args.exportedPublicKeys, args.error)
+  self.connectionIds.add(handlerId)
 
 proc passwordProvided*(self: Controller, keyUid: string, password: string) =
   self.events.emit(SIGNAL_PASSWORD_PROVIDED, AuthenticationArgs(keyUid: keyUid, password: password))

--- a/src/app/modules/shared_modules/authentication/io_interface.nim
+++ b/src/app/modules/shared_modules/authentication/io_interface.nim
@@ -12,6 +12,9 @@ method delete*(self: AccessInterface) {.base.} =
 method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method passwordProvided*(self: AccessInterface, keyUid: string, password: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method verifyPassword*(self: AccessInterface, password: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/shared_modules/authentication/module.nim
+++ b/src/app/modules/shared_modules/authentication/module.nim
@@ -46,6 +46,9 @@ method delete*[T](self: Module[T]) =
 method getModuleAsVariant*[T](self: Module[T]): QVariant =
   return self.viewVariant
 
+method passwordProvided*[T](self: Module[T], keyUid: string, password: string) =
+  self.controller.passwordProvided(keyUid, password)
+
 method verifyPassword*[T](self: Module[T], password: string): bool =
   return self.controller.verifyPassword(password)
 

--- a/src/app/modules/shared_modules/authentication/view.nim
+++ b/src/app/modules/shared_modules/authentication/view.nim
@@ -21,6 +21,9 @@ QtObject:
     result.keycardState = ""
     result.remainingPinAttempts = 0
 
+  proc passwordProvided*(self: View, keyUid: string, password: string) {.slot.} =
+    self.delegate.passwordProvided(keyUid, password)
+
   proc verifyPassword*(self: View, password: string): bool {.slot.} =
     return self.delegate.verifyPassword(password)
 

--- a/src/app/modules/shared_modules/keycard_management/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_management/io_interface.nim
@@ -79,6 +79,10 @@ method startMigratingProfileKeypairToKeycard*(self: AccessInterface, password: s
     seedPhrase: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method startMigratingProfileKeypairUsingExistingKeycard*(self: AccessInterface, password: string, pin: string,
+    seedPhrase: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onConvertingProfileKeypairFinished*(self: AccessInterface, success: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/shared_modules/keycard_management/module.nim
+++ b/src/app/modules/shared_modules/keycard_management/module.nim
@@ -30,6 +30,8 @@ type FlowType {.pure.} = enum
                                         # if the key pair is not already addded to the app, the flow adds it
   MigratingNonProfileKeypairToKeycard = "MigratingNonProfileKeypairToKeycard" # migrates a non-profile keypair to the keycard (only if the keypair is not already migrated)
   MigratingProfileKeypairToKeycard = "MigratingProfileKeypairToKeycard" # migrates a profile keypair to the keycard (only if the keypair is not already migrated)
+  MigratingProfileKeypairUsingExistingKeycard = "MigratingProfileKeypairUsingExistingKeycard" # aligns with a paired device which already migrated the profile keypair to a keycard,
+                                                                                              # migrates the profile keypair by using the existing keycard instead of loading the seed onto an empty one
   AddingKeyPairFromKeycard = "AddingKeyPairFromKeycard" # adds a new key pair from the keycard to the app (only if the key pair is not already added)
   StoppingKeycardForKeyPair = "StoppingKeycardForKeyPair" # stops using a Keycard for a non-profile key pair by moving it back into the app
   StoppingKeycardForProfileKeyPair = "StoppingKeycardForProfileKeyPair" # stops using a Keycard for the profile key pair by moving it back into the app
@@ -209,6 +211,8 @@ proc emitError[T](self: Module[T], err: string) =
     self.view.keycardMoveKeyPairError(err)
   elif self.tmpFlowType == FlowType.MigratingProfileKeypairToKeycard:
     self.view.keycardMoveProfileKeyPairError(err)
+  elif self.tmpFlowType == FlowType.MigratingProfileKeypairUsingExistingKeycard:
+    self.view.keycardMoveProfileKeyPairError(err)
   elif self.tmpFlowType == FlowType.AddingKeyPairFromKeycard:
     self.view.keycardAddKeyPairError(err)
   elif self.tmpFlowType == FlowType.StoppingKeycardForKeyPair:
@@ -276,8 +280,20 @@ method startMigratingProfileKeypairToKeycard*[T](self: Module[T], password: stri
   let metadataAccounts = self.getKeyPairAccountPathsJsonForKeyUid(keyUid)
   self.startLoadSeedPhrase(pin, seedPhrase, metadataName, metadataAccounts)
 
+method startMigratingProfileKeypairUsingExistingKeycard*[T](self: Module[T], password: string, pin: string, seedPhrase: string) =
+  self.tmpFlowType = FlowType.MigratingProfileKeypairUsingExistingKeycard
+  self.tmpPassword = password
+  self.tmpSeedPhrase = seedPhrase
+  let keyUid = self.controller.getKeyUidForSeedPhrase(seedPhrase)
+  if keyUid != singletonInstance.userProfile.getKeyUid():
+    self.emitError("provided seed phrase doesn't match the profile key pair")
+    return
+  self.tmpKeyUid = keyUid
+  self.controller.startAsyncLogin(keyUid, pin, xPubPath = "")
+
 method onConvertingProfileKeypairFinished*[T](self: Module[T], success: bool) =
-  if self.tmpFlowType == FlowType.MigratingProfileKeypairToKeycard:
+  if self.tmpFlowType == FlowType.MigratingProfileKeypairToKeycard or
+      self.tmpFlowType == FlowType.MigratingProfileKeypairUsingExistingKeycard:
     if not success:
       self.emitError("failed to convert profile keypair to keycard")
       return
@@ -438,6 +454,25 @@ method startAsyncLogin*[T](self: Module[T], keyUid, pin: string, generateXPub: b
   self.controller.startAsyncLogin(keyUid, pin, xPubPath, extendedResponse = true) # extendedResponse is true to get the full recover keys set (master address, walletRootAddress, eip1581Address...)
 
 method onKeycardAsyncLoginFinished*[T](self: Module[T], exportedKeys: KeycardExportedKeysDto, error: string) =
+  if self.tmpFlowType == FlowType.MigratingProfileKeypairUsingExistingKeycard:
+    if error.len > 0:
+      self.emitError("keycard login error: " & error)
+      return
+    if self.view.getKeyUid() != self.tmpKeyUid:
+      self.emitError("the keycard doesn't hold the profile key pair")
+      return
+    self.view.keycardInteractionSuccessfullyCompleted()
+    # from here on this is the same as the MigratingProfileKeypairToKeycard handeld in `onKeycardLoadSeedPhraseFinished`,
+    # just without loading the seed onto the card
+    let acc = self.controller.createAccountFromMnemonic(self.tmpSeedPhrase, includeEncryption = true)
+    let newPassword = acc.derivedAccounts.encryption.publicKey
+    if newPassword.len == 0:
+      self.emitError("failed to derive encryption public key from seed phrase")
+      return
+    self.controller.setStoreToKeychainValueNotNow()
+    let keycardUid = self.view.getKeycardUid()
+    self.controller.convertRegularProfileKeypairToKeycard(keycardUid, self.tmpPassword, newPassword)
+    return
   if self.tmpFlowType != FlowType.AsyncLogin:
     return
   if error.len > 0:

--- a/src/app/modules/shared_modules/keycard_management/view.nim
+++ b/src/app/modules/shared_modules/keycard_management/view.nim
@@ -162,6 +162,9 @@ QtObject:
   proc startMigratingProfileKeypairToKeycard*(self: View, password: string, pin: string, seedPhrase: string) {.slot.} =
     self.delegate.startMigratingProfileKeypairToKeycard(password, pin, seedPhrase)
 
+  proc startMigratingProfileKeypairUsingExistingKeycard*(self: View, password: string, pin: string, seedPhrase: string) {.slot.} =
+    self.delegate.startMigratingProfileKeypairUsingExistingKeycard(password, pin, seedPhrase)
+
   proc startAddingKeyPairToStatusFromKeycard*(self: View, pin: string, keyUid: string, metadataName: string,
       metadataAccounts: string) {.slot.} =
     self.delegate.startAddingKeyPairToStatusFromKeycard(pin, keyUid, metadataName, metadataAccounts)

--- a/src/app/modules/shared_modules/keypair_import/internal/export_keypair_state.nim
+++ b/src/app/modules/shared_modules/keypair_import/internal/export_keypair_state.nim
@@ -10,3 +10,6 @@ proc delete*(self: ExportKeypairState) =
 
 method executePrePrimaryStateCommand*(self: ExportKeypairState, controller: Controller) =
   controller.closeKeypairImportPopup()
+
+method executePreSecondaryStateCommand*(self: ExportKeypairState, controller: Controller) =
+  controller.authenticateLoggedInUser()

--- a/src/app/modules/shared_modules/keypair_import/module.nim
+++ b/src/app/modules/shared_modules/keypair_import/module.nim
@@ -65,7 +65,7 @@ method load*[T](self: Module[T], keyUid: string, mode: ImportKeypairModuleMode) 
       self.view.getSelectedKeypair().setName(keypair.name)
     if mode == ImportKeypairModuleMode.ExportKeypairQr:
       self.view.setCurrentState(newExportKeypairState(nil))
-      self.controller.authenticateLoggedInUser()
+      self.delegate.onKeypairImportModuleLoaded()
       return
     elif mode == ImportKeypairModuleMode.ImportViaQr:
       self.view.setCurrentState(newImportQrState(nil))

--- a/src/app/modules/shared_modules/signing/controller.nim
+++ b/src/app/modules/shared_modules/signing/controller.nim
@@ -1,5 +1,6 @@
 import chronicles
 import io_interface
+import uuids
 
 import app/core/eventemitter
 import app_service/service/accounts/service as accounts_service
@@ -16,6 +17,7 @@ type
   Controller* = ref object of RootObj
     delegate: io_interface.AccessInterface
     events: EventEmitter
+    connectionIds: seq[UUID]
     accountsService: accounts_service.Service
     walletAccountService: wallet_account_service.Service
     transactionService: transaction_service.Service
@@ -31,22 +33,29 @@ proc newController*(delegate: io_interface.AccessInterface,
   result = Controller()
   result.delegate = delegate
   result.events = events
+  result.connectionIds = @[]
   result.accountsService = accountsService
   result.walletAccountService = walletAccountService
   result.transactionService = transactionService
   result.keycardServiceV2 = keycardServiceV2
 
+proc disconnectAll(self: Controller) =
+  for id in self.connectionIds:
+    self.events.disconnect(id)
+
 proc delete*(self: Controller) =
-  discard
+  self.disconnectAll()
 
 proc init*(self: Controller) =
-  self.events.on(SIGNAL_KEYCARD_STATE_UPDATED) do(e: Args):
+  var handlerId = self.events.onWithUUID(SIGNAL_KEYCARD_STATE_UPDATED) do(e: Args):
     let args = KeycardEventArg(e)
     self.delegate.onKeycardStateUpdated(args.keycardEvent)
+  self.connectionIds.add(handlerId)
 
-  self.events.on(SIGNAL_KEYCARD_SIGN_FINISHED) do(e: Args):
+  handlerId = self.events.onWithUUID(SIGNAL_KEYCARD_SIGN_FINISHED) do(e: Args):
     let args = KeycardSignArgs(e)
     self.delegate.onKeycardSignFinished(args.signature, args.error)
+  self.connectionIds.add(handlerId)
 
 proc passwordProvided*(self: Controller, keyUid: string, password: string) =
   self.events.emit(SIGNAL_PASSWORD_PROVIDED, AuthenticationArgs(keyUid: keyUid, password: password))

--- a/src/app/modules/shared_modules/signing/controller.nim
+++ b/src/app/modules/shared_modules/signing/controller.nim
@@ -48,6 +48,9 @@ proc init*(self: Controller) =
     let args = KeycardSignArgs(e)
     self.delegate.onKeycardSignFinished(args.signature, args.error)
 
+proc passwordProvided*(self: Controller, keyUid: string, password: string) =
+  self.events.emit(SIGNAL_PASSWORD_PROVIDED, AuthenticationArgs(keyUid: keyUid, password: password))
+
 proc verifyPassword*(self: Controller, password: string): bool =
   return self.accountsService.verifyPassword(password)
 

--- a/src/app/modules/shared_modules/signing/io_interface.nim
+++ b/src/app/modules/shared_modules/signing/io_interface.nim
@@ -12,6 +12,9 @@ method delete*(self: AccessInterface) {.base.} =
 method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method passwordProvided*(self: AccessInterface, keyUid: string, password: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method verifyPassword*(self: AccessInterface, password: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/shared_modules/signing/module.nim
+++ b/src/app/modules/shared_modules/signing/module.nim
@@ -48,6 +48,9 @@ method delete*[T](self: Module[T]) =
 method getModuleAsVariant*[T](self: Module[T]): QVariant =
   return self.viewVariant
 
+method passwordProvided*[T](self: Module[T], keyUid: string, password: string) =
+  self.controller.passwordProvided(keyUid, password)
+
 method verifyPassword*[T](self: Module[T], password: string): bool =
   return self.controller.verifyPassword(password)
 

--- a/src/app/modules/shared_modules/signing/view.nim
+++ b/src/app/modules/shared_modules/signing/view.nim
@@ -21,6 +21,9 @@ QtObject:
     result.keycardState = ""
     result.remainingPinAttempts = 0
 
+  proc passwordProvided*(self: View, keyUid: string, password: string) {.slot.} =
+    self.delegate.passwordProvided(keyUid, password)
+
   proc verifyPassword*(self: View, password: string): bool {.slot.} =
     return self.delegate.verifyPassword(password)
 

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -56,6 +56,7 @@ const KEY_DISPLAY_ASSETS_BELOW_BALANCE_THRESHOLD* = "display-assets-below-balanc
 const KEY_COLLECTIBLE_GROUP_BY_COMMUNITY* = "collectible-group-by-community?"
 const KEY_COLLECTIBLE_GROUP_BY_COLLECTION* = "collectible-group-by-collection?"
 const PROFILE_MIGRATION_NEEDED* = "profile-migration-needed"
+const KEY_AUTO_APPLY_KEYPAIR_MIGRATIONS* = "auto-apply-keypair-migrations"
 const KEY_URL_UNFURLING_MODE* = "url-unfurling-mode"
 const KEY_AUTO_REFRESH_TOKENS* = "auto-refresh-tokens-enabled"
 const KEY_LAST_TOKENS_UPDATE* = "last-tokens-update"
@@ -174,6 +175,7 @@ type
     notificationsVolume*: int
     notificationsMessagePreview*: int
     profileMigrationNeeded*: bool
+    autoApplyKeypairMigrations*: bool
     tokenGroupByCommunity*: bool
     showCommunityAssetWhenSendingTokens*: bool
     displayAssetsBelowBalance*: bool
@@ -245,6 +247,7 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
   discard jsonObj.getProp(KEY_COLLECTIBLE_GROUP_BY_COMMUNITY, result.collectibleGroupByCommunity)
   discard jsonObj.getProp(KEY_COLLECTIBLE_GROUP_BY_COLLECTION, result.collectibleGroupByCollection)
   discard jsonObj.getProp(PROFILE_MIGRATION_NEEDED, result.profileMigrationNeeded)
+  discard jsonObj.getProp(KEY_AUTO_APPLY_KEYPAIR_MIGRATIONS, result.autoApplyKeypairMigrations)
   discard jsonObj.getProp(KEY_AUTO_REFRESH_TOKENS, result.autoRefreshTokens)
   discard jsonObj.getProp(KEY_BACKUP_PATH, result.backupPath)
   discard jsonObj.getProp(KEY_MESSAGES_BACKUP_ENABLED, result.messagesBackupEnabled)

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -31,6 +31,7 @@ const SIGNAL_BIO_UPDATED* = "bioUpdated"
 const SIGNAL_MNEMONIC_REMOVED* = "mnemonicRemoved"
 const SIGNAL_CURRENT_USER_STATUS_UPDATED* = "currentUserStatusUpdated"
 const SIGNAL_PROFILE_MIGRATION_NEEDED_UPDATED* = "profileMigrationNeededUpdated"
+const SIGNAL_AUTO_APPLY_KEYPAIR_MIGRATIONS_UPDATED* = "autoApplyKeypairMigrationsUpdated"
 const SIGNAL_URL_UNFURLING_MODE_UPDATED* = "urlUnfurlingModeUpdated"
 const SIGNAL_PINNED_MAILSERVER_CHANGED* = "pinnedMailserverChanged"
 const SIGNAL_AUTO_REFRESH_TOKENS_UPDATED* = "autoRefreshTokensUpdated"
@@ -107,6 +108,9 @@ QtObject:
     of PROFILE_MIGRATION_NEEDED:
       self.settings.profileMigrationNeeded = settingsField.value.getBool
       self.events.emit(SIGNAL_PROFILE_MIGRATION_NEEDED_UPDATED, SettingsBoolValueArgs(value: self.settings.profileMigrationNeeded))
+    of KEY_AUTO_APPLY_KEYPAIR_MIGRATIONS:
+      self.settings.autoApplyKeypairMigrations = settingsField.value.getBool
+      self.events.emit(SIGNAL_AUTO_APPLY_KEYPAIR_MIGRATIONS_UPDATED, SettingsBoolValueArgs(value: self.settings.autoApplyKeypairMigrations))
     of KEY_URL_UNFURLING_MODE:
       self.settings.urlUnfurlingMode = toUrlUnfurlingMode(settingsField.value.getInt)
       self.events.emit(SIGNAL_URL_UNFURLING_MODE_UPDATED, UrlUnfurlingModeArgs(value: self.settings.urlUnfurlingMode))
@@ -1099,6 +1103,16 @@ QtObject:
 
   proc getProfileMigrationNeeded*(self: Service): bool =
     self.settings.profileMigrationNeeded
+
+  proc getAutoApplyKeypairMigrations*(self: Service): bool =
+    self.settings.autoApplyKeypairMigrations
+
+  proc saveAutoApplyKeypairMigrations*(self: Service, value: bool): bool =
+    if(self.saveSetting(KEY_AUTO_APPLY_KEYPAIR_MIGRATIONS, value)):
+      self.settings.autoApplyKeypairMigrations = value
+      self.events.emit(SIGNAL_AUTO_APPLY_KEYPAIR_MIGRATIONS_UPDATED, SettingsBoolValueArgs(value: value))
+      return true
+    return false
 
   proc mnemonicWasShown*(self: Service) =
     let response = status_settings.mnemonicWasShown()

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -59,8 +59,7 @@ QtObject:
   proc handleWalletAccount(self: Service, account: WalletAccountDto, notify: bool = true)
   proc handleKeypair(self: Service, keypair: KeypairDto)
   proc updateAccountsPositions(self: Service)
-  proc importPartiallyOperableAccounts(self: Service, keyUid: string, password: string)
-  proc cleanKeystoreFiles(self: Service, password: string)
+  proc onPasswordProvided(self: Service, keyUid: string, password: string)
   proc getCurrencyValueForToken*(self: Service, tokenKey: string, amountInt: UInt256): float64
   proc fetchENSNamesForAddressesAsync(self: Service, addresses: seq[string], chainId: int)
   # All slots defined in included files have to be forward declared

--- a/src/app_service/service/wallet_account/service_account.nim
+++ b/src/app_service/service/wallet_account/service_account.nim
@@ -204,8 +204,7 @@ proc init*(self: Service) =
 
   self.events.on(SIGNAL_PASSWORD_PROVIDED) do(e: Args):
     let args = AuthenticationArgs(e)
-    self.cleanKeystoreFiles(args.password)
-    self.importPartiallyOperableAccounts(args.keyUid, args.password)
+    self.onPasswordProvided(args.keyUid, args.password)
 
   let addresses = self.getWalletAddresses()
   self.buildAllTokens(addresses, forceRefresh = true)
@@ -485,6 +484,20 @@ proc cleanKeystoreFiles(self: Service, password: string) =
       error "status-go error", procName="cleanKeystoreFiles", errCode=response.error.code, errDesription=response.error.message
   except Exception as e:
     error "error: ", procName="makeSeedPhraseKeypairFullyOperable", errName=e.name, errDesription=e.msg
+
+proc onPasswordProvided(self: Service, keyUid: string, password: string) =
+  ## Whenever user provides a password/pin we need to make all partially operable accounts (if any exists) a fully operable.
+  if password.isEmptyOrWhitespace:
+    return
+  let kp = self.getKeypairByKeyUid(keyUid)
+  if kp.isNil:
+    return
+  if kp.keyUid != singletonInstance.userProfile.getKeyUid() and kp.migratedToColdWallet:
+    return
+  # if provided keyUid matches the profile key pair or if doesn't match it's not migrated to cold wallet, then we can use
+  # password (or pub enc key) for updating the keystore files
+  self.cleanKeystoreFiles(password)
+  self.makePartiallyOperableAccoutsFullyOperable(password, not singletonInstance.userProfile.getMigratedToColdWallet())
 
 proc onNonProfileColdWalletKeypairMigratedToApp*(self: Service, response: string) {.slot.} =
   var data = KeycardArgs(
@@ -853,12 +866,6 @@ proc areTestNetworksEnabled*(self: Service): bool =
 
 proc hasPairedDevices*(self: Service): bool =
   return hasPairedDevices()
-
-proc importPartiallyOperableAccounts(self: Service, keyUid: string, password: string) =
-  ## Whenever user provides a password/pin we need to make all partially operable accounts (if any exists) a fully operable.
-  if  keyUid != singletonInstance.userProfile.getKeyUid():
-    return
-  self.makePartiallyOperableAccoutsFullyOperable(password, not singletonInstance.userProfile.getMigratedToColdWallet())
 
 proc addressWasShown*(self: Service, address: string) =
   try:

--- a/src/app_service/service/wallet_account/service_account.nim
+++ b/src/app_service/service/wallet_account/service_account.nim
@@ -824,6 +824,7 @@ proc handleKeypair(self: Service, keypair: KeypairDto) =
     localKp.name = keypair.name
     localKp.lastUsedDerivationIndex = keypair.lastUsedDerivationIndex
     localKp.syncedFrom = keypair.syncedFrom
+    localKp.coldWalletType = keypair.coldWalletType
     # - first remove removed accounts from the UI
     let addresses = localKp.accounts.map(a => a.address)
     for address in addresses:

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -14,6 +14,7 @@ QtObject {
 
     property var walletModule
     property var accountsModule: root.walletModule.accountsModule
+    readonly property bool autoApplyKeypairMigrations: root.walletModule ? root.walletModule.autoApplyKeypairMigrations : true
     property var collectibles: _jointCollectiblesBySymbolModel
 
     property var accountSensitiveSettings: Global.appIsReady? localAccountSensitiveSettings : null
@@ -158,5 +159,9 @@ QtObject {
 
     function resetRpcStats() {
         root.walletModule.resetRpcStats()
+    }
+
+    function setAutoApplyKeypairMigrations(enabled) {
+        root.walletModule.setAutoApplyKeypairMigrations(enabled)
     }
 }

--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -208,36 +208,35 @@ Column {
         width: parent.width
     }
 
-    // TODO uncomment when mobile has implemented the QR code import
-    // Rectangle {
-    //     visible: root.walletStore.walletModule.hasPairedDevices &&
-    //              !d.allNonProfileKeypairsMigratedToAColdWallet
-    //     height: 102
-    //     width: parent.width
-    //     color: StatusColors.transparent
-    //     radius: 8
-    //     border.width: 1
-    //     border.color: Theme.palette.baseColor5
+    Rectangle {
+        visible: root.walletStore.walletModule.hasPairedDevices &&
+                 !d.allNonProfileKeypairsMigratedToAColdWallet
+        height: 102
+        width: parent.width
+        color: StatusColors.transparent
+        radius: 8
+        border.width: 1
+        border.color: Theme.palette.baseColor5
 
-    //     Column {
-    //         anchors.fill: parent
-    //         padding: 16
-    //         spacing: 8
+        Column {
+            anchors.fill: parent
+            padding: 16
+            spacing: 8
 
-    //         StatusBaseText {
-    //             text: qsTr("Import key pairs from this device to your other synced devices")
-    //             font.pixelSize: Theme.primaryTextFontSize
-    //         }
+            StatusBaseText {
+                text: qsTr("Import key pairs from this device to your other synced devices")
+                font.pixelSize: Theme.primaryTextFontSize
+            }
 
-    //         StatusButton {
-    //             text: qsTr("Show encrypted QR of key pairs on device")
-    //             icon.name: "qr"
-    //             onClicked: {
-    //                 root.walletStore.runKeypairImportPopup("", Constants.keypairImportPopup.mode.exportKeypairQr)
-    //             }
-    //         }
-    //     }
-    // }
+            StatusButton {
+                text: qsTr("Show encrypted QR of key pairs on device")
+                icon.name: "qr"
+                onClicked: {
+                    root.walletStore.runKeypairImportPopup("", Constants.keypairImportPopup.mode.exportKeypairQr)
+                }
+            }
+        }
+    }
 
     Rectangle {
         visible: root.walletStore.walletModule.hasPairedDevices &&

--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -180,6 +180,29 @@ Column {
 
     Separator {}
 
+    StatusListItem {
+        objectName: "autoApplyKeypairMigrationsItem"
+        title: qsTr("Automatically apply key pair migrations from paired devices")
+        subTitle: qsTr("When off, moving a key pair to or from a Keycard on a paired device won't change how this device logs in or signs. Turning it back on doesn't apply past changes.")
+        visible: root.walletStore.walletModule.hasPairedDevices
+        width: parent.width
+        bgColor: StatusColors.transparent
+        components: [
+            StatusSwitch {
+                objectName: "autoApplyKeypairMigrationsSwitch"
+                checked: root.walletStore.autoApplyKeypairMigrations
+                onToggled: {
+                    checked = Qt.binding(() => root.walletStore.autoApplyKeypairMigrations)
+                    root.walletStore.setAutoApplyKeypairMigrations(!root.walletStore.autoApplyKeypairMigrations)
+                }
+            }
+        ]
+    }
+
+    Separator {
+        visible: root.walletStore.walletModule.hasPairedDevices
+    }
+
     Spacer {
         visible: root.walletStore.walletModule.hasPairedDevices
         width: parent.width

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -241,6 +241,10 @@ QtObject {
                 root.wcLinkActivated(url)
             }
 
+            function onProfileMigrationFlowRequested(migrateToKeycard) {
+                root.profileMigrationFlowRequested(migrateToKeycard)
+            }
+
             function onDisplayUserProfile(publicKey: string) {
                 root.displayUserProfile(publicKey)
             }
@@ -261,10 +265,23 @@ QtObject {
         internal.mainModuleInst.resolveENS(value, uuid)
     }
 
+    function profileMigrationFlowOpened() {
+        internal.mainModuleInst.profileMigrationFlowOpened()
+    }
+
+    function profileMigrationFlowClosed() {
+        internal.mainModuleInst.profileMigrationFlowClosed()
+    }
+
+    function checkProfileMigrationNeeded() {
+        internal.mainModuleInst.checkProfileMigrationNeeded()
+    }
+
     signal ensNameResolved(string resolvedPubKey, string resolvedAddress, string uuid)
     signal openUrl(string link)
     signal openActivityCenter()
     signal wcLinkActivated(string link)
+    signal profileMigrationFlowRequested(bool migrateToKeycard)
     signal displayUserProfile(string publicKey)
     signal showToastPairingFallbackCompleted()
     // End of Settings related stuff

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -68,6 +68,8 @@ Item {
         appMain.forceActiveFocus()
         // record only the initial value - no binding
         d.lastRecordedSectionId = appMain.rootStore.activeSectionId
+        // if a profile migration request emitted before AppMain existed, re-run the check now
+        appMain.rootStore.checkProfileMigrationNeeded()
     }
 
     // Primary store container — all additional stores should be initialized under this root
@@ -86,6 +88,10 @@ Item {
                 d.pairWalletConnectUri(wcUri)
             }
         }
+        onProfileMigrationFlowRequested: (migrateToKeycard) => {
+                                             appMain.rootStore.profileMigrationFlowOpened()
+                                             popups.openAlignWithPairedDevicePopup(migrateToKeycard)
+                                         }
         keychain: appMain.keychain
         palette: appMain.Theme.palette
     }
@@ -1166,6 +1172,13 @@ Item {
 
         function onActivateDeepLink(link: string) {
             appMain.rootStore.activateStatusDeepLink(link)
+        }
+
+        function onKeycardFlowDone(flow: string, keyUid: string, keycardUid: string, success: bool) {
+            if (flow === Constants.keycard.flow.moveProfileKeyPair ||
+                    flow === Constants.keycard.flow.stopUsingKeycardForProfile) {
+                appMain.rootStore.profileMigrationFlowClosed()
+            }
         }
 
         function onPlaySendMessageSound() {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -727,6 +727,7 @@ QtObject {
                 store: root.authenticationStore
                 keychain: root.keychain
                 onAuthenticationSuccess: function(reason, password, pin, keyUid, chatPrivateKey) {
+                    root.authenticationStore.passwordProvided(keyUid, password)
                     Global.authenticationResult(reason, password, pin, keyUid, chatPrivateKey)
                 }
 
@@ -744,6 +745,11 @@ QtObject {
 
                 store: root.signingStore
                 keychain: root.keychain
+
+                onPasswordProvided: function(password) {
+                    // in case of signing tx via keycard no password (enc pub key)
+                    root.signingStore.passwordProvided(signPopup.keyUid, password)
+                }
 
                 onSigningSuccess: function(signature) {
                     signPopup.resultSignature = signature

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -235,11 +235,11 @@ QtObject {
         openPopup(signingPopupComponent, { reason: reason, keyUid: finalKeyUid, txHash: txHash, path: path, address: address })
     }
 
-    function openKeycardManagementPopup(flow, keyUid, keycardUid, cardMetadataName, cardMetadataWalletAccountsJson) {
+    function openKeycardManagementPopup(flow, keyUid, keycardUid, cardMetadataName, cardMetadataWalletAccountsJson, useExistingKeycardWhenMigratingProfileToKeycard = false) {
         let finalFlow = flow
         let finalKeyUid = keyUid
 
-        // if no keyUid is set, follow the flow, otherwise, validate and adjust params
+        // if keyUid is set validate and adjust the flow, or if not set try to set it based on flow, or if cannot be determined just follow the flow
         if (!!finalKeyUid) {
             switch(flow) {
             case Constants.keycard.flow.moveKeyPair:
@@ -263,6 +263,10 @@ QtObject {
                 }
                 break
             }
+        } else if (flow === Constants.keycard.flow.moveProfileKeyPair ||
+                   flow === Constants.keycard.flow.stopUsingKeycardForProfile) {
+            finalKeyUid = root.keycardManagementStore.userProfileKeyUid
+
         }
 
         if (finalFlow !== flow) {
@@ -276,7 +280,8 @@ QtObject {
             keyUid: finalKeyUid,
             keycardUid: keycardUid,
             cardMetadataName: cardMetadataName,
-            cardMetadataWalletAccountsJson: cardMetadataWalletAccountsJson
+            cardMetadataWalletAccountsJson: cardMetadataWalletAccountsJson,
+            useExistingKeycardWhenMigratingProfileToKeycard: useExistingKeycardWhenMigratingProfileToKeycard
         })
     }
 

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -285,6 +285,10 @@ QtObject {
         })
     }
 
+    function openAlignWithPairedDevicePopup(migrateToKeycard) {
+        openPopup(alignWithPairedDevicePopupComponent, { migrateToKeycard })
+    }
+
     function openCommunityProfilePopup(store, community, communitySectionModule) {
         openPopup(communityProfilePopup, { store: store, community: community, communitySectionModule: communitySectionModule})
     }
@@ -1333,6 +1337,48 @@ QtObject {
                 destroyOnClose: true
                 onOpenExternalLink: (link) => root.openExternalLink(link)
                 onSaveDomainToUnfurledWhitelist: (domain) => root.saveDomainToUnfurledWhitelist(domain)
+            }
+        },
+
+        Component {
+            id: alignWithPairedDevicePopupComponent
+            ConfirmationDialog {
+                property bool migrateToKeycard
+                property bool continueToMigrationFlow: false
+
+                destroyOnClose: true
+                headerSettings.title: qsTr("Align with paired device")
+                showCancelButton: true
+                btnType: ""
+                cancelBtnType: ""
+                confirmButtonLabel: qsTr("Continue")
+                cancelButtonLabel: qsTr("Cancel")
+                confirmationText: "<b>%1</b><br/><br/>%2<br/><br/>%3"
+                    .arg(migrateToKeycard
+                         ? qsTr("Your profile has been migrated to Keycard on paired device")
+                         : qsTr("Your profile has been migrated from Keycard to Status"))
+                    .arg(qsTr("In order to align on the login/signing method on this device, you need to complete the migration flow, clicking the \"Continue\" button below, or cancel this popup if you want to keep the current login/signing method."))
+                    .arg(qsTr("If you don't want to see this message again, go to Settings/Wallet and toggle off \"Automatically apply key pair migrations from paired device\"."))
+
+                onConfirmButtonClicked: {
+                    continueToMigrationFlow = true
+                    close()
+                    root.openKeycardManagementPopup(
+                                migrateToKeycard
+                                ? Constants.keycard.flow.moveProfileKeyPair
+                                : Constants.keycard.flow.stopUsingKeycardForProfile,
+                                "",
+                                "",
+                                "",
+                                "[]",
+                                true /* useExistingKeycardWhenMigratingProfileToKeycard */)
+                }
+                onCancelButtonClicked: close()
+                onClosed: {
+                    if (!continueToMigrationFlow) {
+                        root.rootStore.profileMigrationFlowClosed()
+                    }
+                }
             }
         },
 

--- a/ui/app/mainui/sectionLoaders/PopupsLoader.qml
+++ b/ui/app/mainui/sectionLoaders/PopupsLoader.qml
@@ -139,6 +139,9 @@ Loader {
     function openConfirmExternalLinkPopup(link, domain) {
         invoke(() => root.item.openConfirmExternalLinkPopup(link, domain))
     }
+    function openAlignWithPairedDevicePopup(migrateToKeycard) {
+        invoke(() => root.item.openAlignWithPairedDevicePopup(migrateToKeycard))
+    }
     function openBackUpSeedPopup() {
         invoke(() => root.item.openBackUpSeedPopup())
     }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -10350,6 +10350,14 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Automatically apply key pair migrations from paired devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When off, moving a key pair to or from a Keycard on a paired device won&apos;t change how this device logs in or signs. Turning it back on doesn&apos;t apply past changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Get Keycard</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -12915,10 +12915,6 @@ to load</source>
 <context>
     <name>Popups</name>
     <message>
-        <source>Image saved to system gallery</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Share addresses with %1&apos;s owner</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12928,6 +12924,10 @@ to load</source>
     </message>
     <message>
         <source>Image saved to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image saved to system gallery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -13032,6 +13032,30 @@ to load</source>
     </message>
     <message>
         <source>Testnet mode turned off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Align with paired device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your profile has been migrated to Keycard on paired device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your profile has been migrated from Keycard to Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In order to align on the login/signing method on this device, you need to complete the migration flow, clicking the &quot;Continue&quot; button below, or cancel this popup if you want to keep the current login/signing method.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you don&apos;t want to see this message again, go to Settings/Wallet and toggle off &quot;Automatically apply key pair migrations from paired device&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -7658,6 +7658,14 @@ Please add it and try again.</source>
 <context>
     <name>ExportKeypair</name>
     <message>
+        <source>Authenticate to create a QR code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authenticate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Encrypted key pairs code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10336,6 +10344,14 @@ to load</source>
     </message>
     <message>
         <source>Saved Addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import key pairs from this device to your other synced devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show encrypted QR of key pairs on device</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -14690,6 +14690,10 @@ to load</source>
         <source>Any ETH address</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>key pair requires import to use on this device</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SelectParamsForBuyCryptoPanel</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -10412,6 +10412,14 @@ selhalo</translation>
         <translation>Importovat chybějící páry klíčů</translation>
     </message>
     <message>
+        <source>Automatically apply key pair migrations from paired devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When off, moving a key pair to or from a Keycard on a paired device won&apos;t change how this device logs in or signs. Turning it back on doesn&apos;t apply past changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Get Keycard</source>
         <translation type="unfinished">Získat Keycard</translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -7698,6 +7698,14 @@ Prosím přidejte jej a zkuste to znovu.</translation>
 <context>
     <name>ExportKeypair</name>
     <message>
+        <source>Authenticate to create a QR code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authenticate</source>
+        <translation type="unfinished">Ověřit</translation>
+    </message>
+    <message>
         <source>Encrypted key pairs code</source>
         <translation>Kód šifrovaných párů klíčů</translation>
     </message>
@@ -10398,6 +10406,14 @@ selhalo</translation>
     <message>
         <source>Saved Addresses</source>
         <translation>Uložené adresy</translation>
+    </message>
+    <message>
+        <source>Import key pairs from this device to your other synced devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show encrypted QR of key pairs on device</source>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <source>%n key pair(s) require import to use on this device</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -14769,6 +14769,10 @@ selhalo</translation>
         <source>Any ETH address</source>
         <translation>Jakákoli ETH adresa</translation>
     </message>
+    <message>
+        <source>key pair requires import to use on this device</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SelectParamsForBuyCryptoPanel</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -12991,19 +12991,19 @@ selhalo</translation>
 <context>
     <name>Popups</name>
     <message>
-        <source>Image saved to system gallery</source>
+        <source>Share addresses with %1&apos;s owner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Share addresses with %1&apos;s owner</source>
-        <translation>Sdílet adresy s vlastníkem %1</translation>
-    </message>
-    <message>
         <source>Share addresses to rejoin %1</source>
-        <translation>Sdílet adresy pro opětovné připojení k %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Image saved to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image saved to system gallery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -13012,152 +13012,176 @@ selhalo</translation>
     </message>
     <message>
         <source>%1 removed from contacts and marked as untrusted</source>
-        <translation>%1 odstraněn z kontaktů a označen jako nedůvěryhodný</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 marked as trusted</source>
-        <translation>%1 označen jako důvěryhodný</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 trust mark removed, removed from contacts and marked as untrusted</source>
-        <translation>%1 značka důvěry odstraněna, odstraněn z kontaktů a označen jako nedůvěryhodný</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 trust mark removed and marked as untrusted</source>
-        <translation>%1 značka důvěry odstraněna a označen jako nedůvěryhodný</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 trust mark removed and removed from contacts</source>
-        <translation>%1 značka důvěry odstraněna a odstraněn z kontaktů</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Contact request accepted</source>
-        <translation>Žádost o kontakt přijata</translation>
+        <translation type="unfinished">Žádost o kontakt přijata</translation>
     </message>
     <message>
         <source>Contact request ignored</source>
-        <translation>Žádost o kontakt ignorována</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Recovery phrase permanently removed from Status application storage</source>
-        <translation>Obnovovací fráze trvale odstraněna z úložiště aplikace Status</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>You backed up your recovery phrase. Access it in Settings</source>
-        <translation>Zálohovali jste svou obnovovací frázi. Přístup k ní máte v Nastavení</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Profile Picture</source>
-        <translation>Profilový obrázek</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Make this my Profile Pic</source>
-        <translation>Nastavit jako můj profilový obrázek</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 marked as untrusted</source>
-        <translation>%1 označen jako nedůvěryhodný</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 unblocked</source>
-        <translation>%1 odblokován</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 blocked</source>
-        <translation>%1 zablokován</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please choose a directory</source>
-        <translation>Vyberte prosím adresář</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure want to leave &apos;%1&apos;?</source>
-        <translation>Opravdu chcete opustit &apos;%1&apos;?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>You will need to request to join if you want to become a member again in the future. If you joined the Community via public key ensure you have a copy of it before you go.</source>
-        <translation>Pokud se budete chtít v budoucnu znovu stát členem, budete muset požádat o připojení. Pokud jste se ke komunitě připojili pomocí veřejného klíče, ujistěte se, že máte jeho kopii, než odejdete.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation>Zrušit</translation>
+        <translation type="unfinished">Zrušit</translation>
     </message>
     <message>
         <source>Leave %1</source>
-        <translation>Opustit %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off testnet mode</source>
-        <translation>Vypnout režim testnet</translation>
+        <translation type="unfinished">Vypnout režim testnet</translation>
     </message>
     <message>
         <source>Turn on testnet mode</source>
-        <translation>Zapnout režim testnet</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to turn off %1? All future transactions will be performed on live networks with real funds</source>
-        <translation>Opravdu chcete vypnout %1? Všechny budoucí transakce budou prováděny na živých sítích se skutečnými prostředky</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to turn on %1? In this mode, all blockchain data displayed will come from testnets and all blockchain interactions will be with testnets. Testnet mode switches the entire app to using testnets only. Please switch this mode on only if you know exactly why you need to use it.</source>
-        <translation>Opravdu chcete zapnout %1? V tomto režimu budou všechna zobrazená blockchainová data pocházet z testnetů a všechny interakce s blockchainem budou probíhat s testnety. Režim testnet přepne celou aplikaci pouze na používání testnetů. Zapněte tento režim pouze v případě, že přesně víte, proč jej potřebujete použít.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Testnet mode turned on</source>
-        <translation>Režim testnet zapnut</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Testnet mode turned off</source>
-        <translation>Režim testnet vypnut</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Align with paired device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Pokračovat</translation>
+    </message>
+    <message>
+        <source>Your profile has been migrated to Keycard on paired device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your profile has been migrated from Keycard to Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In order to align on the login/signing method on this device, you need to complete the migration flow, clicking the &quot;Continue&quot; button below, or cancel this popup if you want to keep the current login/signing method.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you don&apos;t want to see this message again, go to Settings/Wallet and toggle off &quot;Automatically apply key pair migrations from paired device&quot;.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign transaction - update %1 smart contract</source>
-        <translation>Podepsat transakci - aktualizovat chytrý kontrakt %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 (%2) successfully hidden. You can toggle asset visibility via %3.</source>
-        <translation>%1 (%2) úspěšně skryto. Viditelnost aktiv můžete přepínat přes %3.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings</source>
         <comment>Go to Settings</comment>
-        <translation>Nastavení</translation>
+        <translation type="unfinished">Nastavení</translation>
     </message>
     <message>
         <source>Hide collectible</source>
-        <translation>Skrýt sběratelský předmět</translation>
+        <translation type="unfinished">Skrýt sběratelský předmět</translation>
     </message>
     <message>
         <source>Hide %1</source>
-        <translation>Skrýt %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to hide %1? You will no longer see or be able to interact with this collectible anywhere inside Status.</source>
-        <translation>Opravdu chcete skrýt %1? Tento sběratelský předmět již nikde ve Statusu neuvidíte ani s ním nebudete moci interagovat.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 successfully hidden. You can toggle collectible visibility via %2.</source>
-        <translation>%1 úspěšně skryto. Viditelnost sběratelských předmětů můžete přepínat přes %2.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Status Software Privacy Policy</source>
-        <translation>Zásady ochrany osobních údajů softwaru Status</translation>
+        <translation type="unfinished">Zásady ochrany osobních údajů softwaru Status</translation>
     </message>
     <message>
         <source>Status Software Terms of Use</source>
-        <translation>Podmínky použití softwaru Status</translation>
+        <translation type="unfinished">Podmínky použití softwaru Status</translation>
     </message>
     <message>
         <source>Sign out</source>
-        <translation>Odhlásit se</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Make sure you have your account password and recovery phrase stored. Without them you can lock yourself out of your account and lose funds.</source>
-        <translation>Ujistěte se, že máte uložené heslo k účtu a obnovovací frázi. Bez nich se můžete uzamknout ze svého účtu a přijít o prostředky.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign out &amp; Quit</source>
-        <translation>Odhlásit se a ukončit</translation>
+        <translation type="unfinished">Odhlásit se a ukončit</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -8083,7 +8083,7 @@ Opravdu to chcete udělat?</translation>
     <name>GetSyncCodeDesktopInstructions</name>
     <message>
         <source>Ensure both devices are on the same network</source>
-        <translation>Ujistěte se, že jsou obě zařízení ve stejné síti</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open Status on the device you want to import from</source>
@@ -8181,7 +8181,7 @@ Opravdu to chcete udělat?</translation>
     <name>GetSyncCodeMobileInstructions</name>
     <message>
         <source>Ensure both devices are on the same network</source>
-        <translation>Ujistěte se, že jsou obě zařízení ve stejné síti</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open Status on the device you want to import from</source>
@@ -17002,7 +17002,7 @@ selhalo</translation>
     </message>
     <message>
         <source>Ensure both devices are on the same local network</source>
-        <translation>Ujistěte se, že jsou obě zařízení ve stejné místní síti</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Continue</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -8054,7 +8054,7 @@ Are you sure you want to do this?</source>
     <name>GetSyncCodeDesktopInstructions</name>
     <message>
         <source>Ensure both devices are on the same network</source>
-        <translation>Asegúrate de que ambos dispositivos estén en la misma red</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open Status on the device you want to import from</source>
@@ -8152,7 +8152,7 @@ Are you sure you want to do this?</source>
     <name>GetSyncCodeMobileInstructions</name>
     <message>
         <source>Ensure both devices are on the same network</source>
-        <translation>Asegúrate de que ambos dispositivos estén en la misma red</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open Status on the device you want to import from</source>
@@ -16926,7 +16926,7 @@ al cargar</translation>
     </message>
     <message>
         <source>Ensure both devices are on the same local network</source>
-        <translation>Asegúrate de que ambos dispositivos estén en la misma red local</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Continue</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -12930,13 +12930,12 @@ al cargar</translation>
 <context>
     <name>Popups</name>
     <message>
-        <source>Settings</source>
-        <comment>Go to Settings</comment>
-        <translation>Ajustes</translation>
+        <source>Share addresses with %1&apos;s owner</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Share addresses with %1&apos;s owner</source>
-        <translation>Compartir direcciones con el propietario de %1</translation>
+        <source>Share addresses to rejoin %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Image saved to %1</source>
@@ -12947,156 +12946,181 @@ al cargar</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Share addresses to rejoin %1</source>
-        <translation>Compartir direcciones para volver a unirse a %1</translation>
-    </message>
-    <message>
         <source>Failed to save image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 removed from contacts and marked as untrusted</source>
-        <translation>%1 eliminado de contactos y marcado como no confiable</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 marked as trusted</source>
-        <translation>%1 marcado como confiable</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 trust mark removed, removed from contacts and marked as untrusted</source>
-        <translation>Marca de confianza de %1 eliminada, eliminado de contactos y marcado como no confiable</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 trust mark removed and marked as untrusted</source>
-        <translation>Marca de confianza de %1 eliminada y marcado como no confiable</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 trust mark removed and removed from contacts</source>
-        <translation>Marca de confianza de %1 eliminada y eliminado de contactos</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Contact request accepted</source>
-        <translation>Solicitud de contacto aceptada</translation>
+        <translation type="unfinished">Solicitud de contacto aceptada</translation>
     </message>
     <message>
         <source>Contact request ignored</source>
-        <translation>Solicitud de contacto ignorada</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Recovery phrase permanently removed from Status application storage</source>
-        <translation>Frase de recuperación eliminada permanentemente del almacenamiento de la aplicación Status</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>You backed up your recovery phrase. Access it in Settings</source>
-        <translation>Hiciste una copia de seguridad de tu frase de recuperación. Accede a ella en Ajustes</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Profile Picture</source>
-        <translation>Foto de perfil</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Make this my Profile Pic</source>
-        <translation>Hacer esta mi foto de perfil</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 marked as untrusted</source>
-        <translation>%1 marcado como no confiable</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 unblocked</source>
-        <translation>%1 desbloqueado</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 blocked</source>
-        <translation>%1 bloqueado</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please choose a directory</source>
-        <translation>Por favor elige un directorio</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure want to leave &apos;%1&apos;?</source>
-        <translation>¿Estás seguro de que quieres dejar &apos;%1&apos;?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>You will need to request to join if you want to become a member again in the future. If you joined the Community via public key ensure you have a copy of it before you go.</source>
-        <translation>Necesitarás solicitar unirte si quieres volver a ser miembro en el futuro. Si te uniste a la Comunidad mediante clave pública, asegúrate de tener una copia antes de irte.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation>Cancelar</translation>
+        <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
         <source>Leave %1</source>
-        <translation>Dejar %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off testnet mode</source>
-        <translation>Desactivar modo testnet</translation>
+        <translation type="unfinished">Desactivar modo testnet</translation>
     </message>
     <message>
         <source>Turn on testnet mode</source>
-        <translation>Activar modo testnet</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to turn off %1? All future transactions will be performed on live networks with real funds</source>
-        <translation>¿Estás seguro de que quieres desactivar %1? Todas las transacciones futuras se realizarán en redes en vivo con fondos reales</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to turn on %1? In this mode, all blockchain data displayed will come from testnets and all blockchain interactions will be with testnets. Testnet mode switches the entire app to using testnets only. Please switch this mode on only if you know exactly why you need to use it.</source>
-        <translation>¿Estás seguro de que quieres activar %1? En este modo, todos los datos de blockchain mostrados provendrán de testnets y todas las interacciones de blockchain serán con testnets. El modo testnet cambia toda la aplicación para usar solo testnets. Por favor activa este modo solo si sabes exactamente por qué necesitas usarlo.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Testnet mode turned on</source>
-        <translation>Modo testnet activado</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Testnet mode turned off</source>
-        <translation>Modo testnet desactivado</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Align with paired device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Continuar</translation>
+    </message>
+    <message>
+        <source>Your profile has been migrated to Keycard on paired device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your profile has been migrated from Keycard to Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In order to align on the login/signing method on this device, you need to complete the migration flow, clicking the &quot;Continue&quot; button below, or cancel this popup if you want to keep the current login/signing method.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you don&apos;t want to see this message again, go to Settings/Wallet and toggle off &quot;Automatically apply key pair migrations from paired device&quot;.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign transaction - update %1 smart contract</source>
-        <translation>Firmar transacción - actualizar contrato inteligente %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 (%2) successfully hidden. You can toggle asset visibility via %3.</source>
-        <translation>%1 (%2) ocultado exitosamente. Puedes alternar la visibilidad del activo mediante %3.</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <comment>Go to Settings</comment>
+        <translation type="unfinished">Ajustes</translation>
     </message>
     <message>
         <source>Hide collectible</source>
-        <translation>Ocultar coleccionable</translation>
+        <translation type="unfinished">Ocultar coleccionable</translation>
     </message>
     <message>
         <source>Hide %1</source>
-        <translation>Ocultar %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to hide %1? You will no longer see or be able to interact with this collectible anywhere inside Status.</source>
-        <translation>¿Estás seguro de que quieres ocultar %1? Ya no verás ni podrás interactuar con este coleccionable en ningún lugar dentro de Status.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 successfully hidden. You can toggle collectible visibility via %2.</source>
-        <translation>%1 ocultado exitosamente. Puedes alternar la visibilidad del coleccionable mediante %2.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Status Software Privacy Policy</source>
-        <translation>Política de Privacidad del Software Status</translation>
+        <translation type="unfinished">Política de Privacidad del Software Status</translation>
     </message>
     <message>
         <source>Status Software Terms of Use</source>
-        <translation>Términos de Uso del Software Status</translation>
+        <translation type="unfinished">Términos de Uso del Software Status</translation>
     </message>
     <message>
         <source>Sign out</source>
-        <translation>Cerrar sesión</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Make sure you have your account password and recovery phrase stored. Without them you can lock yourself out of your account and lose funds.</source>
-        <translation>Asegúrate de tener almacenada tu contraseña de cuenta y frase de recuperación. Sin ellas puedes quedar bloqueado de tu cuenta y perder fondos.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign out &amp; Quit</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -10363,6 +10363,14 @@ al cargar</translation>
         <translation>Importar pares de claves faltantes</translation>
     </message>
     <message>
+        <source>Automatically apply key pair migrations from paired devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When off, moving a key pair to or from a Keycard on a paired device won&apos;t change how this device logs in or signs. Turning it back on doesn&apos;t apply past changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Get Keycard</source>
         <translation type="unfinished">Obtener Keycard</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -7670,6 +7670,14 @@ Por favor, agrégala e intenta de nuevo.</translation>
 <context>
     <name>ExportKeypair</name>
     <message>
+        <source>Authenticate to create a QR code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authenticate</source>
+        <translation type="unfinished">Autenticar</translation>
+    </message>
+    <message>
         <source>Encrypted key pairs code</source>
         <translation>Código cifrado de pares de claves</translation>
     </message>
@@ -10350,6 +10358,14 @@ al cargar</translation>
     <message>
         <source>Saved Addresses</source>
         <translation>Direcciones guardadas</translation>
+    </message>
+    <message>
+        <source>Import key pairs from this device to your other synced devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show encrypted QR of key pairs on device</source>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <source>%n key pair(s) require import to use on this device</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -14705,6 +14705,10 @@ al cargar</translation>
         <source>Any ETH address</source>
         <translation>Cualquier dirección ETH</translation>
     </message>
+    <message>
+        <source>key pair requires import to use on this device</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SelectParamsForBuyCryptoPanel</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -14642,6 +14642,10 @@ to load</source>
         <source>Any ETH address</source>
         <translation>모든 ETH 주소</translation>
     </message>
+    <message>
+        <source>key pair requires import to use on this device</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SelectParamsForBuyCryptoPanel</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -10315,6 +10315,14 @@ to load</source>
         <translation>누락된 키 쌍 가져오기</translation>
     </message>
     <message>
+        <source>Automatically apply key pair migrations from paired devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When off, moving a key pair to or from a Keycard on a paired device won&apos;t change how this device logs in or signs. Turning it back on doesn&apos;t apply past changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Get Keycard</source>
         <translation type="unfinished">Keycard 받기</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -8026,7 +8026,7 @@ Are you sure you want to do this?</source>
     <name>GetSyncCodeDesktopInstructions</name>
     <message>
         <source>Ensure both devices are on the same network</source>
-        <translation>두 기기가 같은 네트워크에 있는지 확인하세요</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open Status on the device you want to import from</source>
@@ -8124,7 +8124,7 @@ Are you sure you want to do this?</source>
     <name>GetSyncCodeMobileInstructions</name>
     <message>
         <source>Ensure both devices are on the same network</source>
-        <translation>두 기기가 같은 네트워크에 연결되어 있는지 확인하세요</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open Status on the device you want to import from</source>
@@ -16851,7 +16851,7 @@ to load</source>
     </message>
     <message>
         <source>Ensure both devices are on the same local network</source>
-        <translation>두 기기가 동일한 로컬 네트워크에 있는지 확인하세요</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Continue</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -12870,19 +12870,19 @@ to load</source>
 <context>
     <name>Popups</name>
     <message>
-        <source>Image saved to system gallery</source>
+        <source>Share addresses with %1&apos;s owner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Share addresses with %1&apos;s owner</source>
-        <translation>%1의 소유자와 주소 공유</translation>
-    </message>
-    <message>
         <source>Share addresses to rejoin %1</source>
-        <translation>%1에 다시 참여하려면 주소를 공유하세요</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Image saved to %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Image saved to system gallery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12891,152 +12891,176 @@ to load</source>
     </message>
     <message>
         <source>%1 removed from contacts and marked as untrusted</source>
-        <translation>%1 연락처에서 제거되고 신뢰하지 않는 대상으로 표시됨</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 marked as trusted</source>
-        <translation>%1 신뢰함으로 표시됨</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 trust mark removed, removed from contacts and marked as untrusted</source>
-        <translation>%1 신뢰 마크 제거, 연락처에서 삭제되고 신뢰하지 않음으로 표시됨</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 trust mark removed and marked as untrusted</source>
-        <translation>%1 신뢰 표시가 제거되어, 신뢰하지 않음으로 표시됨</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 trust mark removed and removed from contacts</source>
-        <translation>%1 신뢰 마크가 제거되고 연락처에서 삭제됨</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Contact request accepted</source>
-        <translation>연락 요청이 승인됨</translation>
+        <translation type="unfinished">연락 요청이 승인됨</translation>
     </message>
     <message>
         <source>Contact request ignored</source>
-        <translation>연락 요청 무시됨</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Recovery phrase permanently removed from Status application storage</source>
-        <translation>복구 구문이 Status 애플리케이션 저장소에서 영구적으로 삭제되었습니다</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>You backed up your recovery phrase. Access it in Settings</source>
-        <translation>복구 구문을 백업했어요. 설정에서 확인하세요</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Profile Picture</source>
-        <translation>프로필 사진</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Make this my Profile Pic</source>
-        <translation>이걸 내 프로필 사진으로 설정</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 marked as untrusted</source>
-        <translation>%1 신뢰할 수 없음으로 표시됨</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 unblocked</source>
-        <translation>%1 차단 해제됨</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 blocked</source>
-        <translation>%1명이 차단됨</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please choose a directory</source>
-        <translation>디렉터리를 선택하세요</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure want to leave &apos;%1&apos;?</source>
-        <translation>정말로 &apos;%1&apos;에서 나가시겠어요?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>You will need to request to join if you want to become a member again in the future. If you joined the Community via public key ensure you have a copy of it before you go.</source>
-        <translation>앞으로 다시 멤버가 되고 싶다면 가입 요청을 해야 합니다. 퍼블릭 키로 커뮤니티에 합류했다면, 떠나기 전에 해당 키를 꼭 백업해 두세요.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation>취소</translation>
+        <translation type="unfinished">취소</translation>
     </message>
     <message>
         <source>Leave %1</source>
-        <translation>%1 나가기</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off testnet mode</source>
-        <translation>테스트넷 모드 끄기</translation>
+        <translation type="unfinished">Testnet 모드 끄기</translation>
     </message>
     <message>
         <source>Turn on testnet mode</source>
-        <translation>Testnet 모드 켜기</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to turn off %1? All future transactions will be performed on live networks with real funds</source>
-        <translation>정말로 %1을(를) 끄시겠습니까? 앞으로의 모든 거래는 실제 자금이 오가는 라이브 네트워크에서 수행됩니다</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to turn on %1? In this mode, all blockchain data displayed will come from testnets and all blockchain interactions will be with testnets. Testnet mode switches the entire app to using testnets only. Please switch this mode on only if you know exactly why you need to use it.</source>
-        <translation>정말로 %1을(를) 켜시겠습니까? 이 모드에서는 표시되는 모든 블록체인 데이터가 Testnet에서 오며, 모든 블록체인 상호작용도 Testnet과만 이루어집니다. Testnet 모드는 앱 전체를 Testnet만 사용하도록 전환합니다. 정확한 사용 이유를 알고 있을 때에만 이 모드를 켜세요.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Testnet mode turned on</source>
-        <translation>Testnet 모드가 켜졌습니다</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Testnet mode turned off</source>
-        <translation>Testnet 모드가 꺼졌습니다</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Align with paired device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">계속</translation>
+    </message>
+    <message>
+        <source>Your profile has been migrated to Keycard on paired device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your profile has been migrated from Keycard to Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In order to align on the login/signing method on this device, you need to complete the migration flow, clicking the &quot;Continue&quot; button below, or cancel this popup if you want to keep the current login/signing method.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you don&apos;t want to see this message again, go to Settings/Wallet and toggle off &quot;Automatically apply key pair migrations from paired device&quot;.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign transaction - update %1 smart contract</source>
-        <translation>트랜잭션 서명 - %1 스마트 컨트랙트 업데이트</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 (%2) successfully hidden. You can toggle asset visibility via %3.</source>
-        <translation>%1(%2)가 성공적으로 숨겨졌습니다. 자산 표시 여부는 %3에서 전환할 수 있습니다.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings</source>
         <comment>Go to Settings</comment>
-        <translation>설정</translation>
+        <translation type="unfinished">설정</translation>
     </message>
     <message>
         <source>Hide collectible</source>
-        <translation>수집품 숨기기</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hide %1</source>
-        <translation>%1 숨기기</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to hide %1? You will no longer see or be able to interact with this collectible anywhere inside Status.</source>
-        <translation>정말 %1을(를) 숨길까요? 숨기면 Status 내 어디에서도 이 컬렉터블을 보거나 상호작용할 수 없습니다.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 successfully hidden. You can toggle collectible visibility via %2.</source>
-        <translation>%1이(가) 성공적으로 숨겨졌습니다. %2에서 수집품 표시/숨기기를 전환할 수 있습니다.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Status Software Privacy Policy</source>
-        <translation>Status 소프트웨어 개인정보 처리방침</translation>
+        <translation type="unfinished">Status 소프트웨어 개인정보 처리방침</translation>
     </message>
     <message>
         <source>Status Software Terms of Use</source>
-        <translation>Status 소프트웨어 이용 약관</translation>
+        <translation type="unfinished">Status 소프트웨어 이용약관</translation>
     </message>
     <message>
         <source>Sign out</source>
-        <translation>로그아웃</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Make sure you have your account password and recovery phrase stored. Without them you can lock yourself out of your account and lose funds.</source>
-        <translation>계정 비밀번호와 복구 구문을 안전하게 보관하세요. 둘 중 하나라도 없으면 계정에 접근하지 못하고 자금을 잃을 수 있습니다.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign out &amp; Quit</source>
-        <translation>로그아웃 및 종료</translation>
+        <translation type="unfinished">로그아웃 및 종료</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -7641,6 +7641,14 @@ Please add it and try again.</source>
 <context>
     <name>ExportKeypair</name>
     <message>
+        <source>Authenticate to create a QR code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authenticate</source>
+        <translation type="unfinished">인증</translation>
+    </message>
+    <message>
         <source>Encrypted key pairs code</source>
         <translation>암호화된 키 페어 코드</translation>
     </message>
@@ -10303,6 +10311,14 @@ to load</source>
     <message>
         <source>Saved Addresses</source>
         <translation>저장된 주소</translation>
+    </message>
+    <message>
+        <source>Import key pairs from this device to your other synced devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show encrypted QR of key pairs on device</source>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <source>%n key pair(s) require import to use on this device</source>

--- a/ui/imports/shared/popups/addaccount/panels/SelectOrigin.qml
+++ b/ui/imports/shared/popups/addaccount/panels/SelectOrigin.qml
@@ -77,10 +77,11 @@ StatusSelect {
 
         width: root.width
 
-        property bool isProfileKeypair: model.keyPair.pairType === Constants.addAccountPopup.keyPairType.profile
-        property bool isOption: model.keyPair.keyUid === Constants.appTranslatableConstants.addAccountLabelOptionAddNewMasterKey ||
-                                model.keyPair.keyUid === Constants.appTranslatableConstants.addAccountLabelOptionAddWatchOnlyAcc
-        property bool isHeader: model.keyPair.pairType === Constants.addAccountPopup.keyPairType.unknown && !menu.isOption
+        readonly property bool isProfileKeypair: model.keyPair.pairType === Constants.addAccountPopup.keyPairType.profile
+        readonly property bool isOption: model.keyPair.keyUid === Constants.appTranslatableConstants.addAccountLabelOptionAddNewMasterKey
+                                         || model.keyPair.keyUid === Constants.appTranslatableConstants.addAccountLabelOptionAddWatchOnlyAcc
+        readonly property bool isHeader: model.keyPair.pairType === Constants.addAccountPopup.keyPairType.unknown && !menu.isOption
+        readonly property bool nonOperableKeypair: model.keyPair.operability === Constants.keypair.operability.nonOperable
 
         title: model.keyPair.pairType === Constants.addAccountPopup.keyPairType.unknown?
                    Utils.appTranslation(model.keyPair.keyUid) :
@@ -94,7 +95,12 @@ StatusSelect {
             }
             return ""
         }
-        enabled: !menu.isHeader && model.keyPair.pairType !== Constants.addAccountPopup.keyPairType.privateKeyImport
+        enabled: !menu.isHeader
+                 && model.keyPair.pairType !== Constants.addAccountPopup.keyPairType.privateKeyImport
+                 && !menu.nonOperableKeypair
+
+        tertiaryTitle: menu.nonOperableKeypair? qsTr("key pair requires import to use on this device") : ""
+        statusListItemTertiaryTitle.color: Theme.palette.warningColor1
 
         asset {
             width: model.keyPair.icon? 24 : 40

--- a/ui/imports/shared/popups/authentication/stores/AuthenticationStore.qml
+++ b/ui/imports/shared/popups/authentication/stores/AuthenticationStore.qml
@@ -73,6 +73,14 @@ QtObject {
         return d.mainModuleInst.authenticationModule.isKeypairMigratedToColdWallet(keyUid)
     }
 
+    function passwordProvided(keyUid, password) {
+        if (!d.mainModuleInst.authenticationModule) {
+            console.error("authentication module was not created")
+            return
+        }
+        d.mainModuleInst.authenticationModule.passwordProvided(keyUid, password)
+    }
+
     function verifyPassword(password) {
         if (!d.mainModuleInst.authenticationModule) {
             console.error("authentication module was not created")

--- a/ui/imports/shared/popups/keycard_new/KeycardManagementPopup.qml
+++ b/ui/imports/shared/popups/keycard_new/KeycardManagementPopup.qml
@@ -27,6 +27,8 @@ StatusDialog {
 
     required property QtObject store // shared between onboarding and the main app parts
 
+    property bool useExistingKeycardWhenMigratingProfileToKeycard: false
+
     property var emojiPopup: null
 
     property var passwordStrengthScoreFunction: (password) => { console.error("passwordStrengthScoreFunction: IMPLEMENT ME") }
@@ -278,6 +280,12 @@ StatusDialog {
             d.currentStep = KeycardManagementPopup.FlowStep.Migrating
             d.processing = true
             Backpressure.setTimeout(this, 500, () => {
+                                        if (root.useExistingKeycardWhenMigratingProfileToKeycard) {
+                                            root.store.startMigratingProfileKeypairUsingExistingKeycard(d.authenticationPassword,
+                                                                                                     d.newPin,
+                                                                                                     d.seedPhrase)
+                                            return
+                                        }
                                         root.store.startMigratingProfileKeypairToKeycard(d.authenticationPassword,
                                                                                          d.newPin,
                                                                                          d.seedPhrase)
@@ -389,9 +397,11 @@ StatusDialog {
                 return
             }
             if (d.currentStep === KeycardManagementPopup.FlowStep.SelectKeyPair) {
-                d.currentStep = d.keycardHasOnlyPinSet
-                    ? KeycardManagementPopup.FlowStep.EnterPin
-                    : KeycardManagementPopup.FlowStep.EnterNewPin
+                const profileMigrationUsingExistingKeycard = root.flow === Constants.keycard.flow.moveProfileKeyPair
+                                                           && root.useExistingKeycardWhenMigratingProfileToKeycard
+                d.currentStep = (d.keycardHasOnlyPinSet || profileMigrationUsingExistingKeycard)
+                        ? KeycardManagementPopup.FlowStep.EnterPin
+                        : KeycardManagementPopup.FlowStep.EnterNewPin
                 return
             }
             if (d.currentStep === KeycardManagementPopup.FlowStep.ConfirmKeyPair) {

--- a/ui/imports/shared/popups/keycard_new/stores/KeycardManagementStore.qml
+++ b/ui/imports/shared/popups/keycard_new/stores/KeycardManagementStore.qml
@@ -172,6 +172,14 @@ BaseKeycardManagementStore {
         backend.startMigratingProfileKeypairToKeycard(password, pin, seedPhrase)
     }
 
+    function startMigratingProfileKeypairUsingExistingKeycard(password, pin, seedPhrase) {
+        if (!backend) {
+            console.error("keycard management module was not created")
+            return
+        }
+        backend.startMigratingProfileKeypairUsingExistingKeycard(password, pin, seedPhrase)
+    }
+
     function startAddingKeyPairToStatusFromKeycard(pin, keyUid, metadataName, metadataAccounts) {
         if (!backend) {
             console.error("keycard management module was not created")

--- a/ui/imports/shared/popups/keypairimport/states/ExportKeypair.qml
+++ b/ui/imports/shared/popups/keypairimport/states/ExportKeypair.qml
@@ -1,6 +1,11 @@
 import QtQuick
 import QtQuick.Layouts
 
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Controls
+
+import utils
 import shared.views
 
 import "../stores"
@@ -12,10 +17,42 @@ Item {
 
     implicitHeight: layout.implicitHeight
 
+    Component.onCompleted: {
+        Qt.callLater(root.store.currentState.doSecondaryAction)
+    }
+
     ColumnLayout {
         id: layout
         anchors.fill: parent
         anchors.margins: 16
+
+        Column {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+            visible: !root.store.keypairImportModule.connectionString
+                     && !root.store.keypairImportModule.connectionStringError
+            spacing: Theme.padding
+
+            StatusBaseText {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: qsTr("Authenticate to create a QR code")
+                font.pixelSize: Theme.secondaryAdditionalTextSize
+            }
+
+            StatusButton {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: qsTr("Authenticate")
+                visible: !root.store.keypairImportModule.connectionString
+                         && !root.store.keypairImportModule.connectionStringError
+
+                icon.name: Utils.resolveAuthSignIcon(root.store.userProfileKeyUid,
+                                                     root.store.migratedToColdWallet,
+                                                     Constants.AuthSignPurpose.General)
+                onClicked: {
+                    root.store.currentState.doSecondaryAction()
+                }
+            }
+        }
 
         SyncingDisplayCode {
             Layout.fillWidth: true

--- a/ui/imports/shared/popups/keypairimport/states/ScanOrEnterQrCode.qml
+++ b/ui/imports/shared/popups/keypairimport/states/ScanOrEnterQrCode.qml
@@ -28,6 +28,7 @@ Item {
         firstInstructionButtonName: Constants.keypairImportPopup.instructionsLabelForQr
         secondInstructionButtonName: Constants.keypairImportPopup.instructionsLabelForEncryptedKey
         syncCodeLabel: qsTr("Paste encrypted key")
+        proceedWithContineButton: false
 
         validateConnectionString: function(connectionString) {
             const result = root.store.validateConnectionString(connectionString)

--- a/ui/imports/shared/popups/keypairimport/stores/KeypairImportStore.qml
+++ b/ui/imports/shared/popups/keypairimport/stores/KeypairImportStore.qml
@@ -13,6 +13,9 @@ BasePopupStore {
 
     property bool syncViaQr: true
 
+    readonly property string userProfileKeyUid: userProfile.keyUid
+    readonly property bool migratedToColdWallet: userProfile.migratedToColdWallet
+
     // Module Properties
     property var currentState: root.keypairImportModule.currentState
     property var selectedKeypair: root.keypairImportModule.selectedKeypair

--- a/ui/imports/shared/popups/signing/SignPopup.qml
+++ b/ui/imports/shared/popups/signing/SignPopup.qml
@@ -17,6 +17,7 @@ PopupBase {
 
     required property SigningStore store
 
+    signal passwordProvided(string password)
     signal signingSuccess(string signature)
 
     purpose: PopupBase.Purpose.Signing
@@ -46,6 +47,8 @@ PopupBase {
         const success = root.store.verifyPassword(password)
         if (!success)
             return false
+
+        root.passwordProvided(password) // only here, in case of signing tx via keycard no password (enc pub key)
 
         const signature = root.store.signMessage(root.address, password, root.txHash)
         if (signature === "")

--- a/ui/imports/shared/popups/signing/stores/SigningStore.qml
+++ b/ui/imports/shared/popups/signing/stores/SigningStore.qml
@@ -69,6 +69,14 @@ QtObject {
         return d.mainModuleInst.signingModule.isKeypairMigratedToColdWallet(keyUid)
     }
 
+    function passwordProvided(keyUid, password) {
+        if (!d.mainModuleInst.signingModule) {
+            console.error("signing module was not created")
+            return
+        }
+        d.mainModuleInst.signingModule.passwordProvided(keyUid, password)
+    }
+
     function verifyPassword(password) {
         if (!d.mainModuleInst.signingModule) {
             console.error("signing module was not created")

--- a/ui/imports/shared/views/SyncingEnterCode.qml
+++ b/ui/imports/shared/views/SyncingEnterCode.qml
@@ -22,6 +22,7 @@ ColumnLayout {
 
     property var validateConnectionString: function(stringValue) { return false }
 
+    property bool proceedWithContineButton: true
     readonly property bool syncViaQr: !switchTabBar.currentIndex
 
     signal displayInstructions()
@@ -100,6 +101,12 @@ ColumnLayout {
                         validate: root.validateConnectionString
                     }
                 ]
+
+                input.onValidChanged: {
+                    if (root.proceedWithContineButton || !input.valid)
+                        return
+                    root.proceed(syncCode.text)
+                }
             }
             StatusBaseText {
                 Layout.fillWidth: true
@@ -112,6 +119,7 @@ ColumnLayout {
                 objectName: "continue_StatusButton"
                 Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: Theme.padding
+                visible: root.proceedWithContineButton
                 text: qsTr("Continue")
                 enabled: syncCode.input.valid
                 onClicked: root.proceed(syncCode.text)


### PR DESCRIPTION
Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/7652

What's changed:
- device-local toggle for auto-applying key pair login/signing method from paired device added to settings/wallet
- a new keycad flow `MigratingProfileKeypairUsingExistingKeycard` added to handle profile migration to keycard, if the keycard is already set (doesn't require providing an empty keycard) 
- added a flow to handle profile migration on this device if the profile is migrated on the paired device
- flows for export/import key pair/s via QR are fixed
- selecting a non-operable key pair as origin when adding a new account is disabled
- importing keystore files via connection string is fixed
- logic for making partially operable accounts (if they exist) fully operable whenever a password is provided for any reason is fixed
- handling key pair changes when syncing from paired device is fixed, cold wallet type changes are visible on ui immediatelly

Closes #20461