### PR TITLE
Show AppMain as soon as possible and speed up login speed

### DIFF
--- a/src/app/global/app_sections_config.nim
+++ b/src/app/global/app_sections_config.nim
@@ -2,7 +2,7 @@ const CHAT_SECTION_NAME* = "Messages"
 const CHAT_SECTION_ICON* = "chat"
 
 const LOADING_SECTION_ID* = "loadingSection"
-const LOADING_SECTION_NAME* = "Chat section loading..."
+const LOADING_SECTION_NAME* = "Messages are loading..."
 const LOADING_SECTION_ICON* = "loading"
 
 const HOMEPAGE_SECTION_ID* = "homePage"

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -732,6 +732,24 @@ method load*[T](
     if activeSectionId == homePageSectionItem.id:
       activeSection = homePageSectionItem
 
+  # Keep the Messages position visible in the navigation until chat data creates
+  # the real personal chat section.
+  let loadingSectionItem = initSectionItem(
+    LOADING_SECTION_ID,
+    SectionType.LoadingSection,
+    LOADING_SECTION_NAME,
+    memberRole = MemberRole.Owner,
+    description = "",
+    image = "",
+    icon = LOADING_SECTION_ICON,
+    color = "",
+    hasNotification = false,
+    notificationsCount = 0,
+    active = false,
+    enabled = true,
+  )
+  self.view.model().addItem(loadingSectionItem)
+
   # Communities Portal Section
   let communitiesPortalSectionItem = initSectionItem(
     COMMUNITIESPORTAL_SECTION_ID,
@@ -922,6 +940,8 @@ method onChatsLoaded*[T](
   let myPubKey = singletonInstance.userProfile.getPubKey()
   var activeSection: SectionItem
   var activeSectionId = singletonInstance.localAccountSensitiveSettings.getActiveSection()
+
+  self.view.model().removeItem(LOADING_SECTION_ID)
 
   # Create personal chat section
   self.chatSectionModules[myPubKey] = chat_section_module.newModule(

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -43,8 +43,15 @@ QtObject:
     result.activityController = activityController
     result.tmpActivityControllers = tmpActivityControllers
     result.collectibleDetailsController = collectibleDetailsController
-    result.wcController = newQVariant(wcController)
-    result.dappsConnectorController = newQVariant(dappsConnectorController)
+    if wcController.isNil:
+      result.wcController = newQVariant()
+    else:
+      result.wcController = newQVariant(wcController)
+    if dappsConnectorController.isNil:
+      result.dappsConnectorController = newQVariant()
+    else:
+      result.dappsConnectorController = newQVariant(dappsConnectorController)
+    result.totalCurrencyBalance = newCurrencyAmount()
 
     result.setup()
 
@@ -68,6 +75,8 @@ QtObject:
   proc totalCurrencyBalanceChanged*(self: View) {.signal.}
 
   proc getTotalCurrencyBalance(self: View): QVariant {.slot.} =
+    if self.totalCurrencyBalance.isNil:
+      self.totalCurrencyBalance = newCurrencyAmount()
     return newQVariant(self.totalCurrencyBalance)
 
   QtProperty[QVariant] totalCurrencyBalance:
@@ -124,21 +133,29 @@ QtObject:
     self.walletAccountRemoved(address)
 
   proc getActivityController(self: View): QVariant {.slot.} =
+    if self.activityController.isNil:
+      return newQVariant()
     return newQVariant(self.activityController)
   QtProperty[QVariant] activityController:
     read = getActivityController
 
   proc getCollectibleDetailsController(self: View): QVariant {.slot.} =
+    if self.collectibleDetailsController.isNil:
+      return newQVariant()
     return newQVariant(self.collectibleDetailsController)
   QtProperty[QVariant] collectibleDetailsController:
     read = getCollectibleDetailsController
 
   proc getTmpActivityController0(self: View): QVariant {.slot.} =
+    if self.tmpActivityControllers[0].isNil:
+      return newQVariant()
     return newQVariant(self.tmpActivityControllers[0])
   QtProperty[QVariant] tmpActivityController0:
     read = getTmpActivityController0
 
   proc getTmpActivityController1(self: View): QVariant {.slot.} =
+    if self.tmpActivityControllers[1].isNil:
+      return newQVariant()
     return newQVariant(self.tmpActivityControllers[1])
   QtProperty[QVariant] tmpActivityController1:
     read = getTmpActivityController1

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -337,6 +337,7 @@ method loginRequested*[T](self: Module[T], keyUid: string, loginFlow: int, dataJ
 
 proc finishAppLoading2[T](self: Module[T]) =
   self.delegate.finishAppLoading()
+  self.view.appShellReady()
   self.delegate.appReady()
 
 method onAccountLoginError*[T](self: Module[T], error: string) =

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -28,6 +28,7 @@ QtObject:
 
   ### QtSignals ###
 
+  proc appShellReady*(self: View) {.signal.}
   proc appLoaded*(self: View) {.signal.}
   proc accountLoginError*(self: View, error: string, wrongPassword: bool) {.signal.}
   proc saveBiometricsRequested*(self: View, account: string, credential: string) {.signal.}

--- a/ui/app/AppLayouts/ActivityCenter/adaptors/ActivityCenterAdaptor.qml
+++ b/ui/app/AppLayouts/ActivityCenter/adaptors/ActivityCenterAdaptor.qml
@@ -235,7 +235,7 @@ QtObject {
         // heavy delegate processing for entries that will never be shown.
         // Community membership decisions are kept so pending/final states remain visible.
         readonly property SortFilterProxyModel filteredNotifications: SortFilterProxyModel {
-            sourceModel: root.notifications
+            sourceModel: root.notifications ?? null
             filters: AnyOf {
                 ValueFilter {
                     roleName: "dismissed"

--- a/ui/app/AppLayouts/Onboarding/StartupOnboardingWrapper.qml
+++ b/ui/app/AppLayouts/Onboarding/StartupOnboardingWrapper.qml
@@ -62,6 +62,11 @@ Item {
                     root.requestMoveToAppMain()
                 }
             }
+            onAppShellReady: {
+                if (!root.biometricFlowPending) {
+                    Qt.callLater(() => root.requestMoveToAppMain())
+                }
+            }
             onAccountLoginError: function (error, wrongPassword) {
                 onboardingStore.loginRequestSent = false
 

--- a/ui/app/AppLayouts/Onboarding/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding/stores/OnboardingStore.qml
@@ -7,6 +7,7 @@ import AppLayouts.Onboarding.enums
 QtObject {
     id: root
 
+    signal appShellReady()
     signal appLoaded()
     signal saveBiometricsRequested(string keyUid, string credential)
     signal deleteBiometricsRequested(string keyUid)
@@ -16,6 +17,7 @@ QtObject {
         readonly property var onboardingModuleInst: onboardingModule
 
         Component.onCompleted: {
+            d.onboardingModuleInst.appShellReady.connect(root.appShellReady)
             d.onboardingModuleInst.appLoaded.connect(root.appLoaded)
             d.onboardingModuleInst.accountLoginError.connect(root.accountLoginError)
             d.onboardingModuleInst.saveBiometricsRequested.connect(root.saveBiometricsRequested)

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -32,19 +32,19 @@ QtObject {
     readonly property var largeImage: userProfile.largeImage
     readonly property int colorId: Utils.colorIdForPubkey(root.pubKey)
 
-    readonly property string bio: profileModule.bio
-    readonly property string socialLinksJson: profileModule.socialLinksJson
-    readonly property var socialLinksModel: profileModule.socialLinksModel
-    readonly property var temporarySocialLinksModel: profileModule.temporarySocialLinksModel // for editing purposes
-    readonly property var temporarySocialLinksJson: profileModule.temporarySocialLinksJson
-    readonly property bool socialLinksDirty: profileModule.socialLinksDirty
+    readonly property string bio: profileModule?.bio ?? ""
+    readonly property string socialLinksJson: profileModule?.socialLinksJson ?? ""
+    readonly property var socialLinksModel: profileModule?.socialLinksModel ?? null
+    readonly property var temporarySocialLinksModel: profileModule?.temporarySocialLinksModel ?? null // for editing purposes
+    readonly property var temporarySocialLinksJson: profileModule?.temporarySocialLinksJson ?? null
+    readonly property bool socialLinksDirty: profileModule?.socialLinksDirty ?? false
 
 
-    readonly property var showcasePreferencesCommunitiesModel: profileModule.showcasePreferencesCommunitiesModel
-    readonly property var showcasePreferencesAccountsModel: profileModule.showcasePreferencesAccountsModel
-    readonly property var showcasePreferencesCollectiblesModel: profileModule.showcasePreferencesCollectiblesModel
-    readonly property var showcasePreferencesAssetsModel: profileModule.showcasePreferencesAssetsModel
-    readonly property var showcasePreferencesSocialLinksModel: profileModule.showcasePreferencesSocialLinksModel
+    readonly property var showcasePreferencesCommunitiesModel: profileModule?.showcasePreferencesCommunitiesModel ?? null
+    readonly property var showcasePreferencesAccountsModel: profileModule?.showcasePreferencesAccountsModel ?? null
+    readonly property var showcasePreferencesCollectiblesModel: profileModule?.showcasePreferencesCollectiblesModel ?? null
+    readonly property var showcasePreferencesAssetsModel: profileModule?.showcasePreferencesAssetsModel ?? null
+    readonly property var showcasePreferencesSocialLinksModel: profileModule?.showcasePreferencesSocialLinksModel ?? null
 
     readonly property alias ownShowcaseCommunitiesModel: ownShowcaseModels.adaptedCommunitiesSourceModel
     readonly property alias ownShowcaseAccountsModel: ownShowcaseModels.adaptedAccountsSourceModel

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -16,6 +16,7 @@ QtObject {
 
     required property Keychain keychain
     required property ThemePalette palette
+    property bool mainReady: false
 
     // Global properties that have to remain on `RootStore` (the module instances must be private properties and just used to initialize the
     // rest and specific stores
@@ -72,14 +73,29 @@ QtObject {
 
     // Here there should be all the ContextSpecificRootStore objects creation
     readonly property MessagingStores.MessagingRootStore messagingRootStore: MessagingStores.MessagingRootStore {}
-    readonly property ProfileStores.ProfileSectionStore profileSectionStore: ProfileStores.ProfileSectionStore {
-        localBackupEnabled: root.localBackupEnabled
-        palette: root.palette
+    readonly property var profileSectionStore: profileSectionStoreLoader.item
+    readonly property var contactsStore: contactsStoreLoader.item
+    readonly property var activityCenterStore: activityCenterStoreLoader.item
+
+    readonly property var profileSectionStoreLoader: Loader {
+        active: root.mainReady
+        sourceComponent: ProfileStores.ProfileSectionStore {
+            localBackupEnabled: root.localBackupEnabled
+            palette: root.palette
+        }
+    }
+
+    readonly property var contactsStoreLoader: Loader {
+        active: root.mainReady
+        sourceComponent: ContactsStore {}
+    }
+
+    readonly property var activityCenterStoreLoader: Loader {
+        active: root.mainReady
+        sourceComponent: ActivityCenterStore {}
     }
 
     readonly property AccountSettingsStore accountSettingsStore: AccountSettingsStore {}
-    readonly property ContactsStore contactsStore: ContactsStore {}
-    readonly property ActivityCenterStore activityCenterStore: ActivityCenterStore {}
 
     // readonly property ChatStores.RootStore rootChatStore: ChatStores.RootStore { ... }
     // readonly property SharedStores.NetworkConnectionStore networkConnectionStore: SharedStores.NetworkConnectionStore { ... }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2494,6 +2494,7 @@ Item {
                     return false
                 }
                 thirdpartyServicesEnabled: appMain.rootStore.thirdpartyServicesEnabled
+                profileLoading: !appMain.mainReady
 
                 onActivityCenterRequested: function(shouldShow) {
                     d.closeActivityCenterOnNextBack = false

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -75,8 +75,9 @@ Item {
     // Primary store container — all additional stores should be initialized under this root
     readonly property AppStores.RootStore rootStore: AppStores.RootStore {
         localBackupEnabled: appMain.featureFlagsStore.localBackupEnabled
+        mainReady: appMain.mainReady
         thirdpartyServicesEnabled: appMain.featureFlagsStore.privacyModeFeatureEnabled ?
-                                   appMain.privacyStore.thirdpartyServicesEnabled: true
+                                   appMain.privacyStore?.thirdpartyServicesEnabled ?? true : true
         onOpenUrl: (link) => Global.requestOpenLink(link)
         onOpenActivityCenter: () => {
             d.closeActivityCenterOnNextBack = false
@@ -98,20 +99,20 @@ Item {
 
     // Global cross-domain stores (just references from `rootStore`)
     readonly property AppStores.AccountSettingsStore accountSettingsStore: rootStore.accountSettingsStore
-    readonly property AppStores.ContactsStore contactsStore: rootStore.contactsStore
-    readonly property AppStores.ActivityCenterStore activityCenterStore: rootStore.activityCenterStore
+    readonly property var contactsStore: rootStore.contactsStore
+    readonly property var activityCenterStore: rootStore.activityCenterStore
     readonly property AppStores.AppSearchStore appSearchStore: rootStore.appSearchStore
 
     // Settings (just references from `rootStore`)
-    readonly property ProfileStores.AboutStore aboutStore: rootStore.profileSectionStore.aboutStore
-    readonly property ProfileStores.ProfileStore profileStore: rootStore.profileSectionStore.profileStore
-    readonly property ProfileStores.DevicesStore devicesStore: rootStore.profileSectionStore.devicesStore
-    readonly property ProfileStores.AdvancedStore advancedStore: rootStore.profileSectionStore.advancedStore
-    readonly property ProfileStores.PrivacyStore privacyStore: rootStore.profileSectionStore.privacyStore
-    readonly property ProfileStores.NotificationsStore notificationsStore: rootStore.profileSectionStore.notificationsStore
-    readonly property ProfileStores.KeycardNewStore keycardNewStore: rootStore.profileSectionStore.keycardNewStore
-    readonly property ProfileStores.WalletStore walletProfileStore: rootStore.profileSectionStore.walletStore
-    readonly property ProfileStores.EnsUsernamesStore ensUsernamesStore: rootStore.profileSectionStore.ensUsernamesStore
+    readonly property var aboutStore: rootStore.profileSectionStore?.aboutStore ?? null
+    readonly property var profileStore: rootStore.profileSectionStore?.profileStore ?? null
+    readonly property var devicesStore: rootStore.profileSectionStore?.devicesStore ?? null
+    readonly property var advancedStore: rootStore.profileSectionStore?.advancedStore ?? null
+    readonly property var privacyStore: rootStore.profileSectionStore?.privacyStore ?? null
+    readonly property var notificationsStore: rootStore.profileSectionStore?.notificationsStore ?? null
+    readonly property var keycardNewStore: rootStore.profileSectionStore?.keycardNewStore ?? null
+    readonly property var walletProfileStore: rootStore.profileSectionStore?.walletStore ?? null
+    readonly property var ensUsernamesStore: rootStore.profileSectionStore?.ensUsernamesStore ?? null
 
     // Messaging (just references from `rootStore`)
     readonly property MessagingStores.MessagingRootStore messagingRootStore: rootStore.messagingRootStore
@@ -126,13 +127,21 @@ Item {
 
     readonly property SharedStores.NetworksStore networksStore: SharedStores.NetworksStore {}
 
-    property ChatStores.RootStore rootChatStore: ChatStores.RootStore {
-        contactsStore: appMain.contactsStore
-        currencyStore: appMain.currencyStore
-        communityTokensStore: appMain.communityTokensStore
-        openCreateChat: createChatView.opened
-        networkConnectionStore: appMain.networkConnectionStore
+    readonly property var rootChatStore: rootChatStoreLoader.item
+
+    Loader {
+        id: rootChatStoreLoader
+        active: appMain.mainReady
+
+        sourceComponent: ChatStores.RootStore {
+            contactsStore: appMain.contactsStore
+            currencyStore: appMain.currencyStore
+            communityTokensStore: appMain.communityTokensStore
+            openCreateChat: createChatView.opened
+            networkConnectionStore: appMain.networkConnectionStore
+        }
     }
+
     property ChatStores.CreateChatPropertiesStore createChatPropertiesStore: ChatStores.CreateChatPropertiesStore {}
     property SharedStores.NetworkConnectionStore networkConnectionStore: SharedStores.NetworkConnectionStore {
         networksStore: appMain.networksStore
@@ -141,7 +150,13 @@ Item {
     property SharedStores.CommunityTokensStore communityTokensStore: SharedStores.CommunityTokensStore {
         currencyStore: appMain.currencyStore
     }
-    property CommunitiesStore communitiesStore: CommunitiesStore {}
+    readonly property var communitiesStore: communitiesStoreLoader.item
+
+    Loader {
+        id: communitiesStoreLoader
+        active: appMain.mainReady
+        sourceComponent: CommunitiesStore {}
+    }
     // Main wallet root store. It is currently a singleton, but should be refactored to be an instance
     // created only by AppStores.RootStore rootStore. Until then, access it through this single property.
     readonly property WalletStores.RootStore walletRootStore: WalletStores.RootStore
@@ -168,6 +183,7 @@ Item {
     required property Keychain keychain
 
     required property bool systemTrayIconAvailable
+    required property bool mainReady
 
     readonly property bool isPortraitMode: appMain.width < ThemeUtils.portraitBreakpoint.width
 
@@ -203,51 +219,68 @@ Item {
         }
     }
 
-    ContactDetails {
-        id: ownContactDetails
-        isCurrentUser: true
-        publicKey: appMain.profileStore.pubKey
-        compressedPubKey: appMain.profileStore.compressedPubKey
-        displayName: appMain.profileStore.displayName
-        ensName: appMain.profileStore.name
-        ensVerified: !!ensName && Utils.isValidEns(ensName)
-        preferredDisplayName: appMain.profileStore.preferredName
-        alias: appMain.profileStore.username
-        usesDefaultName: appMain.profileStore.usesDefaultName
-        icon: appMain.profileStore.icon
-        colorId: appMain.profileStore.colorId
-        onlineStatus: appMain.profileStore.currentUserStatus
-        thumbnailImage: appMain.profileStore.thumbnailImage
-        largeImage: appMain.profileStore.largeImage
-        bio: appMain.profileStore.bio
+    Loader {
+        id: contactInfrastructureLoader
+        active: appMain.mainReady && !!appMain.profileStore && !!appMain.contactsStore
+
+        sourceComponent: QtObject {
+            property var contactDetails: ContactDetails {
+                isCurrentUser: true
+                publicKey: appMain.profileStore.pubKey
+                compressedPubKey: appMain.profileStore.compressedPubKey
+                displayName: appMain.profileStore.displayName
+                ensName: appMain.profileStore.name
+                ensVerified: !!ensName && Utils.isValidEns(ensName)
+                preferredDisplayName: appMain.profileStore.preferredName
+                alias: appMain.profileStore.username
+                usesDefaultName: appMain.profileStore.usesDefaultName
+                icon: appMain.profileStore.icon
+                colorId: appMain.profileStore.colorId
+                onlineStatus: appMain.profileStore.currentUserStatus
+                thumbnailImage: appMain.profileStore.thumbnailImage
+                largeImage: appMain.profileStore.largeImage
+                bio: appMain.profileStore.bio
+            }
+
+            property var allContactsAdaptor: AllContactsAdaptor {
+                contactsModel: appMain.contactsStore.contactsModel
+                selfContactDetails: contactDetails
+            }
+
+            property var contactsAdaptor: ContactsModelAdaptor {
+                allContacts: appMain.contactsStore.contactsModel
+            }
+        }
     }
 
-    AllContactsAdaptor {
-        id: allContacsAdaptor
+    readonly property var ownContactDetails: contactInfrastructureLoader.item?.contactDetails ?? null
+    readonly property ContactDetails loadingContactDetails: ContactDetails {
+        publicKey: ""
+    }
+    readonly property var allContacsAdaptor: contactInfrastructureLoader.item?.allContactsAdaptor ?? null
+    readonly property var contactsModelAdaptor: contactInfrastructureLoader.item?.contactsAdaptor ?? null
 
-        contactsModel: appMain.contactsStore.contactsModel
-        selfContactDetails: ownContactDetails
+    Loader {
+        id: toastsManagerLoader
+        active: appMain.mainReady
+                && !!appMain.contactsStore
+                && !!appMain.rootChatStore
+                && !!appMain.profileStore
+                && !!appMain.devicesStore
+
+        sourceComponent: ToastsManager {
+            rootStore: appMain.rootStore
+            contactsStore: appMain.contactsStore
+            rootChatStore: appMain.rootChatStore
+            communityTokensStore: appMain.communityTokensStore
+            profileStore: appMain.profileStore
+            devicesStore: appMain.devicesStore
+
+            onSendRequested: popupRequestsHandler.openSend()
+        }
     }
 
-    ContactsModelAdaptor {
-        id: contactsModelAdaptor
-
-        allContacts: appMain.contactsStore.contactsModel
-    }
-
-    // Central UI point for managing app toasts:
-    ToastsManager {
-        id: toastsManager
-
-        rootStore: appMain.rootStore
-        contactsStore: appMain.contactsStore
-        rootChatStore: appMain.rootChatStore
-        communityTokensStore: appMain.communityTokensStore
-        profileStore: appMain.profileStore
-        devicesStore: appMain.devicesStore
-
-        onSendRequested: popupRequestsHandler.openSend()
-    }
+    readonly property var toastsManager: toastsManagerLoader.item
 
     Connections {
         target: rootStore
@@ -470,9 +503,10 @@ Item {
             }
 
             if (txType === Constants.SendType.StickersBuy) {
-                const idx = appMain.rootChatStore.stickersModuleInst.stickerPacks.findIndexById(packId, false)
+                const stickerPacks = appMain.rootChatStore?.stickersModuleInst?.stickerPacks
+                const idx = stickerPacks?.findIndexById(packId, false) ?? -1
                 if(idx >= 0) {
-                    const entry = SQUtils.ModelUtils.get(appMain.rootChatStore.stickersModuleInst.stickerPacks, idx)
+                    const entry = SQUtils.ModelUtils.get(stickerPacks, idx)
                     if (!!entry) {
                         stickersPackName = entry.name
                     }
@@ -961,7 +995,8 @@ Item {
                                                            activeSectionType === Constants.appSection.dApp
         readonly property bool isBrowserEnabled: appMain.featureFlagsStore.browserEnabled &&
                                                  localAccountSensitiveSettings.isBrowserEnabled
-        readonly property int syncingBadgeCount: appMain.devicesStore.totalDevicesCount - appMain.devicesStore.pairedDevicesCount
+        readonly property int syncingBadgeCount: (appMain.devicesStore?.totalDevicesCount ?? 0)
+                              - (appMain.devicesStore?.pairedDevicesCount ?? 0)
 
         function openHomePage() {
             appMain.rootStore.setActiveSectionBySectionType(Constants.appSection.homePage)
@@ -969,7 +1004,8 @@ Item {
         }
 
         function maybeDisplayIntroduceYourselfPopup() {
-            if (!appMainLocalSettings.introduceYourselfPopupSeen && allContacsAdaptor.selfDisplayName === "") {
+            if (!appMainLocalSettings.introduceYourselfPopupSeen
+                    && allContacsAdaptor?.selfDisplayName === "") {
                 introduceYourselfPopupComponent.createObject(appMain).open()
                 return true
             }
@@ -1028,7 +1064,9 @@ Item {
 
     Settings {
         id: appMainLocalSettings
-        category: "AppMainLocalSettings_%1".arg(allContacsAdaptor.selfContactDetails.publicKey)
+        category: "AppMainLocalSettings_%1".arg(allContacsAdaptor?.selfContactDetails?.publicKey
+                                                  ?? appMain.profileStore?.pubKey
+                                                  ?? "")
         property var whitelistedUnfurledDomains: []
         property bool introduceYourselfPopupSeen
         property bool enableMessageBackupPopupSeen
@@ -1094,8 +1132,8 @@ Item {
         privacyStore: appMain.privacyStore
         messagingRootStore: appMain.messagingRootStore
 
-        allContactsModel: allContacsAdaptor.allContactsModel
-        mutualContactsModel: contactsModelAdaptor.mutualContacts
+        allContactsModel: allContacsAdaptor?.allContactsModel ?? null
+        mutualContactsModel: contactsModelAdaptor?.mutualContacts ?? null
 
         isDevBuild: !appMain.rootStore.isProduction
         emojiPopup: statusEmojiPopup.item
@@ -1141,7 +1179,17 @@ Item {
         notificationsStore: appMain.notificationsStore
 
         Component.onCompleted: {
-            Qt.callLater(() => popupRequestsHandler.maybeDisplayEnablePushNotificationsPopup())
+            if (appMain.mainReady)
+                Qt.callLater(() => popupRequestsHandler.maybeDisplayEnablePushNotificationsPopup())
+        }
+
+        Connections {
+            target: appMain
+
+            function onMainReadyChanged() {
+                if (appMain.mainReady)
+                    popupRequestsHandler.maybeDisplayEnablePushNotificationsPopup()
+            }
         }
     }
 
@@ -1217,12 +1265,12 @@ Item {
                 appMain.rootStore.setNavToMsgDetailsFlag(true)
                 appMain.rootStore.setActiveSectionChat(appMain.profileStore.pubKey, subsection)
             } else if (sectionType === Constants.appSection.community && subsection !== "") {
-                appMain.communitiesStore.setActiveCommunity(subsection)
+                appMain.communitiesStore?.setActiveCommunity(subsection)
             }
         }
 
         function onSwitchToCommunity(communityId: string) {
-            appMain.communitiesStore.setActiveCommunity(communityId)
+            appMain.communitiesStore?.setActiveCommunity(communityId)
         }
 
         function onOpenAddEditSavedAddressesPopup(params) {
@@ -1260,7 +1308,8 @@ Item {
             switch (state)
             {
             case Constants.communityImported:
-                const community = appMain.communitiesStore.getCommunityDetailsAsJson(communityId)
+                const community = appMain.communitiesStore?.getCommunityDetailsAsJson(communityId)
+                                  ?? ({})
                 if(community.isControlNode) {
                     title = qsTr("This device is now the control node for the %1 Community").arg(community.name)
                     notificationType = Constants.ephemeralNotificationType.success
@@ -1334,8 +1383,8 @@ Item {
     }
 
     Connections {
-        target: appMain.notificationsStore.notificationsSettings
-        enabled: SQUtils.Utils.isIOS
+        target: appMain.mainReady ? appMain.notificationsStore?.notificationsSettings ?? null : null
+        enabled: SQUtils.Utils.isIOS && appMain.mainReady
 
         function onRemotePushNotificationsEnabledChanged() {
             if (!appMain.notificationsStore.notificationsSettings.remotePushNotificationsEnabled)
@@ -1348,8 +1397,8 @@ Item {
     }
 
     Connections {
-        target: appMain.notificationsStore
-        enabled: SQUtils.Utils.isIOS
+        target: appMain.mainReady ? appMain.notificationsStore ?? null : null
+        enabled: SQUtils.Utils.isIOS && appMain.mainReady
         function onNotificationsSettingsChanged() {
             if (!!appMain.notificationsStore.notificationsSettings)
                 appMain.notificationsStore.notificationsSettings.deviceToken = PushNotifications.token
@@ -1458,7 +1507,7 @@ Item {
 
     Loader {
         id: statusEmojiPopup
-        active: appMain.rootStore.sectionsLoaded
+        active: appMain.mainReady
         sourceComponent: StatusEmojiPopup {
             directParent: appMain.Window.window.contentItem
             height: 440
@@ -1469,12 +1518,12 @@ Item {
 
     Loader {
         id: statusStickersPopupLoader
-        active: appMain.rootStore.sectionsLoaded
+        active: appMain.mainReady
         sourceComponent: StatusStickersPopup {
             directParent: appMain.Window.contentItem
             height: 440
             store: appMain.rootChatStore
-            isWalletEnabled: appMain.walletProfileStore.isWalletEnabled
+            isWalletEnabled: appMain.walletProfileStore?.isWalletEnabled ?? false
             thirdpartyServicesEnabled: appMain.rootStore.thirdpartyServicesEnabled
 
             onBuyClicked: (packId, price) => popupRequestsHandler.buyStickerPack(packId, price)
@@ -1507,7 +1556,8 @@ Item {
 
                 isOnline: d.networkChecker.isOnline
                 testnetEnabled: appMain.networksStore.areTestNetworksEnabled
-                seedphraseBackedUp: appMain.privacyStore.mnemonicBackedUp || appMain.profileStore.userDeclinedBackupBanner
+                seedphraseBackedUp: appMain.privacyStore?.mnemonicBackedUp === true
+                                   || appMain.profileStore?.userDeclinedBackupBanner === true
 
                 onOpenTestnetPopupRequested: Global.openTestnetPopup()
                 onOpenBackUpSeedPopupRequested: popups.openBackUpSeedPopup()
@@ -1516,17 +1566,18 @@ Item {
 
             ModuleWarning {
                 Layout.fillWidth: true
-                readonly property int progress: appMain.communitiesStore.discordImportProgress
-                readonly property bool inProgress: (progress > 0 && progress < 100) || appMain.communitiesStore.discordImportInProgress
+                readonly property int progress: appMain.communitiesStore?.discordImportProgress ?? 0
+                readonly property bool inProgress: (progress > 0 && progress < 100)
+                                                   || (appMain.communitiesStore?.discordImportInProgress ?? false)
                 readonly property bool finished: progress >= 100
-                readonly property bool cancelled: appMain.communitiesStore.discordImportCancelled
-                readonly property bool stopped: appMain.communitiesStore.discordImportProgressStopped
-                readonly property int errors: appMain.communitiesStore.discordImportErrorsCount
-                readonly property int warnings: appMain.communitiesStore.discordImportWarningsCount
-                readonly property string communityId: appMain.communitiesStore.discordImportCommunityId
-                readonly property string communityName: appMain.communitiesStore.discordImportCommunityName
-                readonly property string channelId: appMain.communitiesStore.discordImportChannelId
-                readonly property string channelName: appMain.communitiesStore.discordImportChannelName
+                readonly property bool cancelled: appMain.communitiesStore?.discordImportCancelled ?? false
+                readonly property bool stopped: appMain.communitiesStore?.discordImportProgressStopped ?? false
+                readonly property int errors: appMain.communitiesStore?.discordImportErrorsCount ?? 0
+                readonly property int warnings: appMain.communitiesStore?.discordImportWarningsCount ?? 0
+                readonly property string communityId: appMain.communitiesStore?.discordImportCommunityId ?? ""
+                readonly property string communityName: appMain.communitiesStore?.discordImportCommunityName ?? ""
+                readonly property string channelId: appMain.communitiesStore?.discordImportChannelId ?? ""
+                readonly property string channelName: appMain.communitiesStore?.discordImportChannelName ?? ""
                 readonly property string channelOrCommunityName: channelName || communityName
                 delay: false
                 active: !cancelled && (inProgress || finished || stopped)
@@ -1564,7 +1615,7 @@ Item {
                     if (!!channelId)
                         rootStore.setActiveSectionChat(communityId, channelId)
                     else
-                        appMain.communitiesStore.setActiveCommunity(communityId)
+                        appMain.communitiesStore?.setActiveCommunity(communityId)
                 }
                 onCloseClicked: hide()
             }
@@ -1885,14 +1936,14 @@ Item {
                 Loader {
                     id: acPanelLoader
                     sourceComponent: ActivityCenterAdaptor {
-                        contactsModel: appMain.contactsStore.contactsModel
-                        userProfileName: appMain.profileStore.name
-                        notifications: appMain.activityCenterStore.activityCenterNotifications
+                        contactsModel: appMain.contactsStore?.contactsModel ?? null
+                        userProfileName: appMain.profileStore?.name ?? ""
+                        notifications: appMain.activityCenterStore?.activityCenterNotifications ?? null
                         getCommunityDetails: function(communityId) {
-                            return appMain.rootChatStore.getCommunityDetailsAsJson(communityId)
+                            return appMain.rootChatStore?.getCommunityDetailsAsJson(communityId) ?? ({})
                         }
                         getChatDetails: function(chatId) {
-                            return appMain.rootChatStore.getChatDetails(chatId)
+                            return appMain.rootChatStore?.getChatDetails(chatId) ?? ({})
                         }
                         onPopulateContactDetailsRequested: (contactId) => appMain.contactsStore.populateContactDetails(contactId)
                     }
@@ -1902,20 +1953,20 @@ Item {
 
                 backgroundColor: Theme.palette.statusAppLayout.backgroundColor
 
-                hasAdmin: appMain.activityCenterStore.adminCount > 0
-                hasReplies: appMain.activityCenterStore.repliesCount > 0
-                hasMentions: appMain.activityCenterStore.mentionsCount > 0
-                hasContactRequests: appMain.activityCenterStore.contactRequestsCount > 0
-                hasMembership: appMain.activityCenterStore.membershipCount > 0
-                hasSystem: appMain.activityCenterStore.systemCount > 0
-                hasNews: appMain.activityCenterStore.newsCount > 0
-                activeGroup: appMain.activityCenterStore.activeNotificationGroup
+                hasAdmin: (appMain.activityCenterStore?.adminCount ?? 0) > 0
+                hasReplies: (appMain.activityCenterStore?.repliesCount ?? 0) > 0
+                hasMentions: (appMain.activityCenterStore?.mentionsCount ?? 0) > 0
+                hasContactRequests: (appMain.activityCenterStore?.contactRequestsCount ?? 0) > 0
+                hasMembership: (appMain.activityCenterStore?.membershipCount ?? 0) > 0
+                hasSystem: (appMain.activityCenterStore?.systemCount ?? 0) > 0
+                hasNews: (appMain.activityCenterStore?.newsCount ?? 0) > 0
+                activeGroup: appMain.activityCenterStore?.activeNotificationGroup ?? ""
 
-                hasUnreadNotifications: appMain.activityCenterStore.unreadNotificationsCount > 0
-                readNotificationsStatus: appMain.activityCenterStore.activityCenterReadType
+                hasUnreadNotifications: (appMain.activityCenterStore?.unreadNotificationsCount ?? 0) > 0
+                readNotificationsStatus: appMain.activityCenterStore?.activityCenterReadType ?? 0
                 notificationsModel: adaptor?.model ?? null
-                newsSettingsStatus: appMain.notificationsStore.notificationsSettings.notifSettingStatusNews
-                newsEnabledViaRSS: appMain.privacyStore.isStatusNewsViaRSSEnabled
+                newsSettingsStatus: appMain.notificationsStore?.notificationsSettings?.notifSettingStatusNews ?? 0
+                newsEnabledViaRSS: appMain.privacyStore?.isStatusNewsViaRSSEnabled ?? false
 
                 onCloseRequested: mainLayoutItem.openACCenterPanel = false
                 onMarkAllAsReadRequested: appMain.activityCenterStore.markAllActivityCenterNotificationsRead()
@@ -2016,7 +2067,7 @@ Item {
 
             Shortcut {
                 enabled: mainLayoutItem.openACCenterPanel
-                sequence: StandardKey.Cancel
+                sequences: [StandardKey.Cancel]
                 onActivated: mainLayoutItem.openACCenterPanel = false
             }
 
@@ -2360,7 +2411,7 @@ Item {
                         }
                         createChatPropertiesStore: appMain.createChatPropertiesStore
 
-                        mutualContactsModel: contactsModelAdaptor.mutualContacts
+                        mutualContactsModel: contactsModelAdaptor?.mutualContacts ?? null
                         allContactsModel: appMain.contactsStore.contactsModel
 
                         emojiPopup: statusEmojiPopup.item
@@ -2391,19 +2442,22 @@ Item {
 
 
                 acVisible: mainLayoutItem.openACCenterPanel
-                acHasUnseenNotifications: appMain.activityCenterStore.hasUnseenNotifications
-                acUnreadNotificationsCount: appMain.activityCenterStore.unreadNotificationsCount
+                acHasUnseenNotifications: appMain.activityCenterStore?.hasUnseenNotifications ?? false
+                acUnreadNotificationsCount: appMain.activityCenterStore?.unreadNotificationsCount ?? 0
 
-                selfContactDetails: ownContactDetails
+                selfContactDetails: ownContactDetails ?? loadingContactDetails
                 getEmojiHashFn: appMain.utilsStore.getEmojiHash
-                getLinkToProfileFn: appMain.contactsStore.getLinkToProfile
+                getLinkToProfileFn: appMain.contactsStore?.getLinkToProfile
+                                    ?? function() { return "" }
 
                 communityPopupMenu: communityContextMenuComponent
 
                 profileSectionHasNotification: {
-                    if (contactsModelAdaptor.pendingReceivedRequestContacts.ModelCount.count > 0) // pending contact request
+                    if (contactsModelAdaptor?.pendingReceivedRequestContacts?.ModelCount.count > 0) // pending contact request
                         return true
-                    if (!appMain.privacyStore.mnemonicBackedUp && !appMain.profileStore.userDeclinedBackupBanner) // seedphrase not backed up (removed)
+                    if (appMain.mainReady
+                        && !appMain.privacyStore?.mnemonicBackedUp
+                        && !appMain.profileStore?.userDeclinedBackupBanner) // seedphrase not backed up (removed)
                         return true
                     if (d.syncingBadgeCount > 0) // sync entries
                         return true
@@ -2457,7 +2511,7 @@ Item {
             openHandler: function () {
                 // we cannot return QVariant if we pass another parameter in a function call
                 // that's why we're using it this way
-                communityContextMenu.chatCommunitySectionModule = appMain.rootChatStore.getCommunitySectionModule(model.id)
+                communityContextMenu.chatCommunitySectionModule = appMain.rootChatStore?.getCommunitySectionModule(model.id)
             }
 
             StatusAction {
@@ -2661,7 +2715,8 @@ Item {
             onLinkActivated: {
                 this.open = false
                 if(actionRequired) {
-                    toastsManager.doAction(model.actionType, model.actionData)
+                    if (toastsManager)
+                        toastsManager.doAction(model.actionType, model.actionData)
                     return
                 }
 
@@ -2974,7 +3029,8 @@ Item {
 
         // It seems some of the functionality of the dapp connector depends on the DAppsService
         active: {
-            return (featureFlagsStore.dappsEnabled || featureFlagsStore.connectorEnabled) && appMain.visible
+                return (featureFlagsStore.dappsEnabled || featureFlagsStore.connectorEnabled)
+                    && appMain.visible && appMain.mainReady
         }
 
         sourceComponent: DAppsService {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2174,7 +2174,8 @@ Item {
                         // to reset scroll, not send text input and etc during the
                         // sections switching
                         Binding on active {
-                            when: appView.currentIndex === Constants.appViewStackIndex.chat
+                            when: appMain.mainReady
+                                  && appView.currentIndex === Constants.appViewStackIndex.chat
                             value: true
                             restoreMode: Binding.RestoreNone
                         }
@@ -2206,7 +2207,8 @@ Item {
                     }
 
                     CommunitiesPortalLoader {
-                        active: appView.currentIndex === Constants.appViewStackIndex.communitiesPortal
+                        active: appMain.mainReady
+                                && appView.currentIndex === Constants.appViewStackIndex.communitiesPortal
                         rootStore: appMain.rootStore
                         communitiesStore: appMain.communitiesStore
                         leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
@@ -2345,7 +2347,8 @@ Item {
                             // to reset scroll, not send text input and etc during the
                             // sections switching
                             Binding on active {
-                                when: sectionId === appMain.rootStore.activeSectionId
+                                when: appMain.mainReady
+                                      && sectionId === appMain.rootStore.activeSectionId
                                 value: true
                                 restoreMode: Binding.RestoreNone
                             }
@@ -2381,6 +2384,33 @@ Item {
                             onOpenAppSearchRequested: appSearch.openSearchPopup()
                         }
                     }
+                }
+
+                Loader {
+                    id: sectionStartupLoading
+                    anchors.fill: parent
+                    z: 1
+                    active: !appMain.mainReady
+                            && (d.activeSectionType === Constants.appSection.chat
+                                || d.activeSectionType === Constants.appSection.community
+                                || d.activeSectionType === Constants.appSection.communitiesPortal)
+                    sourceComponent: d.activeSectionType === Constants.appSection.communitiesPortal
+                                     ? communitiesPortalLoading
+                                     : chatLayoutLoading
+                }
+
+                Component {
+                    id: chatLayoutLoading
+
+                    ChatLayoutLoading {
+                        showMembersPanel: appMain.accountSettingsStore.showUsersList
+                    }
+                }
+
+                Component {
+                    id: communitiesPortalLoading
+
+                    CommunitiesPortalLoading {}
                 }
 
                 Loader {

--- a/ui/app/mainui/adaptors/PrimaryNavSidebarAdaptor.qml
+++ b/ui/app/mainui/adaptors/PrimaryNavSidebarAdaptor.qml
@@ -58,6 +58,10 @@ SQUtils.QObject {
             }
             ValueFilter {
                 roleName: "sectionType"
+                value: Constants.appSection.loadingSection
+            }
+            ValueFilter {
+                roleName: "sectionType"
                 value: Constants.appSection.browser
                 enabled: root.browserEnabled
             }
@@ -92,11 +96,6 @@ SQUtils.QObject {
         sourceModel: root.sectionsModel
         filters: [
             ValueFilter {
-                roleName: "sectionType"
-                value: Constants.appSection.loadingSection
-                inverted: true
-            },
-            ValueFilter {
                 roleName: "enabled"
                 value: true
                 enabled: root.showEnabledSectionsOnly
@@ -110,6 +109,7 @@ SQUtils.QObject {
                     Constants.appSection.wallet,
                     Constants.appSection.market,
                     Constants.appSection.swap,
+                    Constants.appSection.loadingSection,
                     Constants.appSection.chat,
                     Constants.appSection.browser,
                     Constants.appSection.communitiesPortal

--- a/ui/app/mainui/panels/PrimaryNavSidebar.qml
+++ b/ui/app/mainui/panels/PrimaryNavSidebar.qml
@@ -54,6 +54,7 @@ Control {
 
     required property bool profileSectionHasNotification
     required property bool thirdpartyServicesEnabled
+    property bool profileLoading: false
 
     // Set from AppMain: used on mobile so native overlay can dismiss the drawer over Browser WebView.
     property bool browserSectionActive: false
@@ -261,6 +262,7 @@ Control {
                     objectName: "statusProfileNavBarTabButton"
                     Layout.alignment: Qt.AlignHCenter
                     Layout.topMargin: root.spacing
+                    loading: root.profileLoading
                     name: root.selfContactDetails.displayName
                     pubKey: root.selfContactDetails.publicKey
                     compressedPubKey: root.selfContactDetails.compressedPubKey

--- a/ui/app/mainui/panels/PrimaryNavSidebar.qml
+++ b/ui/app/mainui/panels/PrimaryNavSidebar.qml
@@ -320,6 +320,7 @@ Control {
 
         tooltipText: Utils.translatedSectionName(model.sectionType)
         checked: model.active
+        enabled: model.sectionType !== Constants.appSection.loadingSection
         icon.name: model.icon
         icon.source: model.image
         text: model.icon.length > 0 ? "" : model.name

--- a/ui/app/mainui/sectionLoaders/AppMainLoader.qml
+++ b/ui/app/mainui/sectionLoaders/AppMainLoader.qml
@@ -17,6 +17,7 @@ Loader {
     required property bool systemTrayIconAvailable
 
     property SharedStores.UtilsStore utilsStore
+    property bool mainReady: false
 
     function loadSection() {
         if (!root.active)
@@ -30,6 +31,7 @@ Loader {
             keychain:               Qt.binding(() => root.keychain),
             utilsStore:             Qt.binding(() => root.utilsStore),
             systemTrayIconAvailable:Qt.binding(() => root.systemTrayIconAvailable),
+            mainReady:              Qt.binding(() => root.mainReady),
         })
     }
 
@@ -39,6 +41,8 @@ Loader {
             return
         }
     }
+
+    onMainReadyChanged: loadSection()
 
     Component.onCompleted: QmlCompiler.precompile(QmlCompiler.appMainUrl, false)
 }

--- a/ui/app/mainui/sectionLoaders/CommunitiesPortalLoading.qml
+++ b/ui/app/mainui/sectionLoaders/CommunitiesPortalLoading.qml
@@ -1,0 +1,107 @@
+import QtQuick
+import QtQuick.Layouts
+
+import StatusQ.Components
+import StatusQ.Core.Theme
+
+Item {
+    id: root
+
+    RowLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        Rectangle {
+            Layout.fillHeight: true
+            Layout.minimumWidth: 250
+            Layout.preferredWidth: 290
+            Layout.maximumWidth: 340
+            color: Theme.palette.secondaryMenuBackground
+
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: Theme.padding
+                spacing: Theme.padding
+
+                LoadingComponent {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 36
+                    radius: 8
+                }
+
+                Repeater {
+                    model: 7
+
+                    delegate: LoadingComponent {
+                        required property int index
+
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: index === 0 ? 84 : 42
+                        radius: 8
+                    }
+                }
+
+                Item { Layout.fillHeight: true }
+            }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            color: Theme.palette.statusAppLayout.backgroundColor
+
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: Theme.padding * 2
+                spacing: Theme.padding
+
+                LoadingComponent {
+                    Layout.preferredWidth: 220
+                    Layout.preferredHeight: 32
+                    radius: 6
+                }
+
+                Repeater {
+                    model: 4
+
+                    delegate: RowLayout {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 92
+                        spacing: Theme.padding
+
+                        LoadingComponent {
+                            Layout.preferredWidth: 64
+                            Layout.preferredHeight: 64
+                            radius: 32
+                        }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: Theme.halfPadding
+
+                            LoadingComponent {
+                                Layout.preferredWidth: 180
+                                Layout.preferredHeight: 18
+                                radius: 4
+                            }
+
+                            LoadingComponent {
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: 14
+                                radius: 4
+                            }
+
+                            LoadingComponent {
+                                Layout.preferredWidth: 120
+                                Layout.preferredHeight: 14
+                                radius: 4
+                            }
+                        }
+                    }
+                }
+
+                Item { Layout.fillHeight: true }
+            }
+        }
+    }
+}

--- a/ui/app/mainui/sectionLoaders/qmldir
+++ b/ui/app/mainui/sectionLoaders/qmldir
@@ -4,6 +4,7 @@ AppMainLoader 1.0 AppMainLoader.qml
 BrowserLoader 1.0 BrowserLoader.qml
 ChatLoader 1.0 ChatLoader.qml
 CommunitiesPortalLoader 1.0 CommunitiesPortalLoader.qml
+CommunitiesPortalLoading 1.0 CommunitiesPortalLoading.qml
 CommunityChatLoader 1.0 CommunityChatLoader.qml
 HandlersManagerLoader 1.0 HandlersManagerLoader.qml
 HomePageLoader 1.0 HomePageLoader.qml

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -18198,10 +18198,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Chat section loading...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Swap</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18332,6 +18328,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     </message>
     <message>
         <source>LineaScan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Messages are loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -18298,10 +18298,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
         <translation>Objevujte komunity</translation>
     </message>
     <message>
-        <source>Chat section loading...</source>
-        <translation>Načítá se sekce chatu...</translation>
-    </message>
-    <message>
         <source>Swap</source>
         <translation>Směnit</translation>
     </message>
@@ -18437,6 +18433,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>LineaScan</source>
         <translation>LineaScan</translation>
+    </message>
+    <message>
+        <source>Messages are loading...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Unichain Explorer</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -18231,10 +18231,6 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
         <translation>Descubrir comunidades</translation>
     </message>
     <message>
-        <source>Chat section loading...</source>
-        <translation>Cargando sección de chat...</translation>
-    </message>
-    <message>
         <source>Swap</source>
         <translation></translation>
     </message>
@@ -18364,6 +18360,10 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
     </message>
     <message>
         <source>LineaScan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Messages are loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -18146,10 +18146,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
         <translation>커뮤니티 탐색</translation>
     </message>
     <message>
-        <source>Chat section loading...</source>
-        <translation>채팅 섹션 불러오는 중...</translation>
-    </message>
-    <message>
         <source>Swap</source>
         <translation>스왑</translation>
     </message>
@@ -18284,6 +18280,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     </message>
     <message>
         <source>LineaScan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Messages are loading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/imports/shared/controls/ProfileButton.qml
+++ b/ui/imports/shared/controls/ProfileButton.qml
@@ -20,6 +20,7 @@ StatusIconTabButton {
     required property int colorId
     required property int currentUserStatus
 
+    property bool loading: false
     property var getLinkToProfileFn: function(pubKey) { console.error("IMPLEMENT ME"); return "" }
     property var getEmojiHashFn: function(pubKey) { console.error("IMPLEMENT ME"); return "" }
 
@@ -28,7 +29,9 @@ StatusIconTabButton {
     signal setCurrentUserStatusRequested(int status)
 
     name: root.name
-    icon.source: root.iconSource
+    enabled: !root.loading
+    icon.name: root.loading ? "loading" : ""
+    icon.source: root.loading ? "" : root.iconSource
     implicitWidth: 32
     implicitHeight: 32
     identicon.asset.width: width
@@ -36,6 +39,9 @@ StatusIconTabButton {
     identicon.asset.useAcronymForLetterIdenticon: true
 
     identicon.asset.name: {
+        if (root.loading) {
+            return "loading"
+        }
         if (identicon.asset.isImage) {
             return icon.source
         }
@@ -50,7 +56,7 @@ StatusIconTabButton {
     identicon.asset.isLetterIdenticon: root.usesDefaultName ? false : icon.name !== "" && !identicon.asset.isImage
     identicon.asset.bgColor: root.usesDefaultName ? Utils.colorForPubkey(Theme.palette, root.pubKey) : "transparent"
 
-    identicon.badge.visible: true
+    identicon.badge.visible: !root.loading
     identicon.badge.border.width: 2
     identicon.badge.border.color: Theme.palette.statusAppNavBar.backgroundColor
     identicon.badge.height: 12
@@ -65,7 +71,10 @@ StatusIconTabButton {
         }
     }
 
-    onClicked: userStatusContextMenu.opened ? userStatusContextMenu.close() : userStatusContextMenu.open()
+    onClicked: {
+        if (!root.loading)
+            userStatusContextMenu.opened ? userStatusContextMenu.close() : userStatusContextMenu.open()
+    }
 
     UserStatusContextMenu {
         id: userStatusContextMenu

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -426,7 +426,7 @@ QtObject {
         case Constants.appSection.communitiesPortal:
             return qsTr("Discover Communities")
         case Constants.appSection.loadingSection:
-            return qsTr("Chat section loading...")
+            return qsTr("Messages are loading...")
         case Constants.appSection.swap:
             return qsTr("Swap")
         case Constants.appSection.market:

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -344,7 +344,7 @@ Window {
             applicationWindow.storeAppState() // noop on mobile
             if (SQUtils.Utils.isMobile) {
                 close.accepted = false
-                if (loader.item && loader.item.tryGoBack())
+                if (loader.item && loader.item.tryGoBack && loader.item.tryGoBack())
                     return
                 if (SQUtils.Utils.isAndroid)
                     MobileUI.backToHomeScreen()
@@ -488,7 +488,8 @@ Window {
                 NumberAnimation { duration: 120 }
             }
 
-            active: d.appMainTriggered && (typeof mainModule !== "undefined") && (mainModule?.mainLoaded ?? false)
+            active: d.appMainTriggered && (typeof mainModule !== "undefined")
+            mainReady: typeof mainModule !== "undefined" && (mainModule?.mainLoaded ?? false)
 
             featureFlagsStore: applicationWindow.featureFlagsStore
             languageStore: applicationWindow.languageStore
@@ -497,7 +498,6 @@ Window {
             utilsStore: applicationWindow.utilsStore
 
             onLoaded: {
-                Global.appIsReady = true
                 appMainFadeIn.running = true
                 startupOnboardingLoader.active = false
                 splashScreenLoader.active = false
@@ -506,7 +506,12 @@ Window {
                         && !!onboardingModule) {
                     Qt.callLater(() => onboardingModule.cleanupAfterMainTransition())
                 }
-                if (d.showSkippedBiometricFlow)
+                if (mainReady) {
+                    Global.appIsReady = true
+                    applicationWindow.appIsReady = true
+                    applicationWindow.storeAppState()
+                }
+                if (mainReady && d.showSkippedBiometricFlow)
                     loader.item.showEnableBiometricsFlow()
             }
 
@@ -515,6 +520,18 @@ Window {
                     console.error("Failed to load AppMain.qml")
                     Qt.exit(-1)
                 }
+            }
+        }
+
+        Connections {
+            target: typeof mainModule !== "undefined" ? mainModule : null
+
+            function onMainLoadedChanged() {
+                if (!mainModule.mainLoaded || startupOnboardingLoader.active)
+                    return
+                Global.appIsReady = true
+                applicationWindow.appIsReady = true
+                applicationWindow.storeAppState()
             }
         }
 


### PR DESCRIPTION
### What does the PR do

Fixes #21462
Status-go PR: https://github.com/status-im/status-go/pull/7653

This batch significantly speeds up login by displaying `AppMain` as soon as the application shell is available, while deferring module-dependent stores and services until initialization completes and showing dedicated loading states for Messages, communities, and the user profile. It also improves backend login performance by opening established databases concurrently, avoiding unnecessary key decryption and profile lookups, and moving token-manager and leaderboard-cache initialization outside the critical login path, reducing measured backend login time from roughly 2.15 seconds to 0.47–0.50 seconds. Additionally, it validates reply targets before sending chat messages to provide a clear error when the referenced message does not exist.

You can review by commit to see the steps.

### Affected areas

- Main
- AppMain
- Main module
- onbaording module
- stores
- status-go

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

BEFORE:

[slow-login.webm](https://github.com/user-attachments/assets/b338ca52-9ab3-4b67-aa3c-9e54f9a28fab)

AFTER:

[fast-login2.webm](https://github.com/user-attachments/assets/2c7a02ba-b424-49db-8d20-be50223861a7)

FAKE LOADING (I added a 5 second sleep in the async task to simulate a slow loading of chats and communities):

[fake-loading.webm](https://github.com/user-attachments/assets/b47606e6-be26-47ab-b20c-23d2df5c620f)

### Impact on end user

Speeds up the login. It will be particularly useful on slow devices like mobiles, where loading the communities could take some time. Now they will have access to most sections before the rest is available.

Also, on Android, during a warm start (backend still alive), AppMain should show immediately (test and demo coming soon)

### How to test

Login on big accounts

### Risk 

Medium/High. 

The initial change was quite dangerous, since I moved to the AppMain before everything is ready. So I had to guard a lot of components and sections behind loaders, so that they would not crash.

We need to test this a bit to make sure I didn't miss one part that my account doesn't trigger.
