### PR TITLE
fix(connection): get connectionStatus on start to avoid race condition

### DIFF
--- a/src/app_service/service/node/service.nim
+++ b/src/app_service/service/node/service.nim
@@ -44,6 +44,10 @@ QtObject:
     self.events.on(SignalType.ConnectionStatusChange.event) do(e: Args):
       self.setConnected(ConnectionStatusChangeSignal(e).isOnline)
 
+    # Seed connectivity from backend state in case first signal was emitted
+    # before this service subscribed.
+    self.setConnected(status_node.getConnectionStatus())
+
   proc isConnected*(self: Service): bool = self.connected
 
   proc getRpcStats*(self: Service): string =

--- a/src/backend/node.nim
+++ b/src/backend/node.nim
@@ -1,7 +1,22 @@
-import core
+import core, chronicles, json
+import ../app_service/common/utils
+
+logScope:
+    topics = "rpc-node"
 
 proc getRpcStats*(): string =
     result = callPrivateRPCNoDecode("rpcstats_getStats")
 
 proc resetRpcStats*() =
     discard callPrivateRPCNoDecode("rpcstats_reset")
+
+proc getConnectionStatus*(): bool =
+    try:
+        let response = callPrivateRPC("connectionStatus".prefix, %*[])
+        let isOnline = response.result{"isOnline"}
+        if isOnline.kind != JNull:
+            return isOnline.getBool()
+    except Exception as e:
+        error "error:", methodName="getConnectionStatus", errName=e.name, errDesription=e.msg
+
+    return false


### PR DESCRIPTION
### What does the PR do

Fixes #21603
status-go PR: https://github.com/status-im/status-go/pull/7656

The problem was that the connected status could be fired by the backend even before the service was ready to listen to it, so it could fall through the cracks.

If it did, then we never got a new signal, because it is only emitted when it changes.

### Affected areas

- status-go
- node service

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/4da2d69b-7e78-46f3-bc5f-6b70ffeb72ca" />

### Impact on end user

No more banner on phones

### How to test

Open the app and go to a messaging section

### Risk 

Low
