### PR TITLE
feat(StatusQ): Make ripple feedback follow pointer

### DIFF
--- a/storybook/pages/StatusButtonPage.qml
+++ b/storybook/pages/StatusButtonPage.qml
@@ -364,12 +364,12 @@ SplitView {
                         id: ctrlRippleFollowPointer
                         ButtonGroup.group: rippleOriginButtonGroup
                         text: "Follow pointer"
+                        checked: true
                     }
                     RadioButton {
                         id: ctrlRippleCentered
                         ButtonGroup.group: rippleOriginButtonGroup
                         text: "Centered"
-                        checked: true
                     }
                 }
                 CheckBox {

--- a/storybook/pages/StatusRipplePage.qml
+++ b/storybook/pages/StatusRipplePage.qml
@@ -8,6 +8,8 @@ import StatusQ.Components
 import StatusQ.Controls
 import StatusQ.Popups
 
+import mainui
+
 import Storybook
 
 SplitView {
@@ -71,6 +73,53 @@ SplitView {
                             rippleOrigin: d.effectiveRippleOrigin
                             scaleOnPressEnabled: false
                             onClicked: logs.logEvent("StatusFlatButton clicked")
+                        }
+                    }
+                }
+            }
+
+            Pane {
+                Layout.fillWidth: true
+
+                ColumnLayout {
+                    width: parent.width
+                    spacing: Theme.padding
+
+                    Label {
+                        text: "Round and navigation buttons"
+                        font.bold: true
+                    }
+
+                    RowLayout {
+                        spacing: Theme.padding
+
+                        StatusRoundButton {
+                            icon.name: "close"
+                            rippleEnabled: ctrlRipple.checked
+                            rippleOrigin: d.effectiveRippleOrigin
+                            highlighted: ctrlHighlighted.checked
+                            onClicked: logs.logEvent("StatusRoundButton clicked")
+                        }
+
+                        StatusRoundButton {
+                            type: StatusRoundButton.Type.Quaternary
+                            icon.name: "delete"
+                            rippleEnabled: ctrlRipple.checked
+                            rippleOrigin: d.effectiveRippleOrigin
+                            highlighted: ctrlHighlighted.checked
+                            onClicked: logs.logEvent("Danger StatusRoundButton clicked")
+                        }
+
+                        PrimaryNavSidebarButton {
+                            tooltipText: "Activity Center"
+                            icon.name: "notification"
+                            checkable: true
+                            checked: ctrlHighlighted.checked
+                            highlighted: ctrlHighlighted.checked
+                            rippleEnabled: ctrlRipple.checked
+                            rippleOrigin: d.effectiveRippleOrigin
+                            thirdpartyServicesEnabled: true
+                            onClicked: logs.logEvent("PrimaryNavSidebarButton clicked")
                         }
                     }
                 }

--- a/storybook/pages/StatusRipplePage.qml
+++ b/storybook/pages/StatusRipplePage.qml
@@ -92,6 +92,7 @@ SplitView {
                         Layout.preferredWidth: 280
                         label: "StatusComboBox"
                         model: ["One", "Two", "Three"]
+                        rippleOrigin: d.effectiveRippleOrigin
                     }
                 }
             }
@@ -114,6 +115,7 @@ SplitView {
                         icon.name: "info"
                         icon.color: Theme.palette.primaryColor1
                         highlighted: ctrlHighlighted.checked
+                        rippleOrigin: d.effectiveRippleOrigin
                         onClicked: logs.logEvent("StatusItemDelegate clicked")
                     }
 
@@ -125,6 +127,7 @@ SplitView {
 
                     StatusMenu {
                         id: menu
+                        rippleOrigin: d.effectiveRippleOrigin
 
                         StatusAction {
                             text: "Menu option"
@@ -159,6 +162,7 @@ SplitView {
                         subTitle: "Primary list option"
                         asset.name: "info"
                         highlighted: ctrlHighlighted.checked
+                        rippleOrigin: d.effectiveRippleOrigin
                         onClicked: logs.logEvent("StatusListItem clicked")
                     }
 
@@ -169,6 +173,7 @@ SplitView {
                         type: StatusListItem.Type.Danger
                         asset.name: "warning"
                         highlighted: ctrlHighlighted.checked
+                        rippleOrigin: d.effectiveRippleOrigin
                         onClicked: logs.logEvent("Danger StatusListItem clicked")
                     }
                 }

--- a/storybook/qmlTests/tests/tst_PrimaryNavSidebar.qml
+++ b/storybook/qmlTests/tests/tst_PrimaryNavSidebar.qml
@@ -147,6 +147,31 @@ Item {
             compare(activityCenterSpy.signalArguments[0][0], true)
         }
 
+        function test_activity_center_button_ripple() {
+            const acButton = findChild(controlUnderTest, "Activity Center-navbar")
+            verify(!!acButton)
+            waitForRendering(acButton)
+
+            const ripple = findChild(acButton, "primaryNavSidebarButtonRipple")
+            verify(!!ripple)
+            verify(ripple.enabled)
+            verify(!ripple.visible)
+
+            const pressX = acButton.width / 2
+            const pressY = acButton.height / 2
+            const ripplePoint = acButton.mapToItem(ripple, pressX, pressY)
+
+            mousePress(acButton, pressX, pressY)
+            tryVerify(() => ripple.visible)
+            verify(ripple.pressed)
+            verify(Math.abs(ripple.pressX - ripplePoint.x) <= 1)
+            verify(Math.abs(ripple.pressY - ripplePoint.y) <= 1)
+
+            mouseRelease(acButton, pressX, pressY)
+            tryCompare(ripple, "visible", false)
+            verify(!ripple.pressed)
+        }
+
         function test_regular_section_buttons_exist() {
             // Check for Messages button
             const messagesBtn = findChild(controlUnderTest, "Messages-navbar")

--- a/storybook/qmlTests/tests/tst_StatusButton.qml
+++ b/storybook/qmlTests/tests/tst_StatusButton.qml
@@ -50,7 +50,7 @@ Item {
             verify(!controlUnderTest.isRoundIcon)
             verify(controlUnderTest.rippleEnabled)
             verify(controlUnderTest.scaleOnPressEnabled)
-            compare(controlUnderTest.rippleOrigin, StatusRipple.RippleOrigin.Center)
+            compare(controlUnderTest.rippleOrigin, StatusRipple.RippleOrigin.Pointer)
         }
 
         function test_text() {
@@ -324,19 +324,21 @@ Item {
             compare(buttonBackground.scale, 1)
             compare(controlUnderTest.contentItem.scale, 1)
 
-            mousePress(controlUnderTest, controlUnderTest.width / 2, controlUnderTest.height / 2)
+            const pressX = controlUnderTest.width / 4
+            const pressY = controlUnderTest.height * 3 / 4
+            mousePress(controlUnderTest, pressX, pressY)
             tryVerify(() => buttonRipple.visible)
             tryCompare(buttonBackground, "scale", controlUnderTest.pressedScale)
             compare(controlUnderTest.contentItem.scale, 1)
             verify(buttonRipple.rippleRadius >= 0)
+            verify(Math.abs(buttonRipple.pressX - pressX) <= coordinateTolerance)
+            verify(Math.abs(buttonRipple.pressY - pressY) <= coordinateTolerance)
 
-            mouseRelease(controlUnderTest, controlUnderTest.width / 2, controlUnderTest.height / 2)
+            mouseRelease(controlUnderTest, pressX, pressY)
             tryCompare(buttonRipple, "visible", false)
             tryCompare(buttonBackground, "scale", 1)
             compare(buttonRipple.rippleRadius, 0)
 
-            const pressX = controlUnderTest.width / 4
-            const pressY = controlUnderTest.height * 3 / 4
             controlUnderTest.rippleOrigin = StatusRipple.RippleOrigin.Pointer
             compare(buttonRipple.origin, StatusRipple.RippleOrigin.Pointer)
             mousePress(controlUnderTest, pressX, pressY)

--- a/storybook/qmlTests/tests/tst_StatusRippleFeedback.qml
+++ b/storybook/qmlTests/tests/tst_StatusRippleFeedback.qml
@@ -58,6 +58,17 @@ Item {
         }
     }
 
+    Component {
+        id: roundButtonComponent
+
+        StatusRoundButton {
+            property int clickCount: 0
+
+            icon.name: "close"
+            onClicked: clickCount++
+        }
+    }
+
     property Item controlUnderTest: null
 
     TestCase {
@@ -181,6 +192,29 @@ Item {
             verify(!!controlUnderTest)
 
             verifyRippleFeedback(controlUnderTest, "statusMenuItemRipple", false, true)
+        }
+
+        function test_roundButtonRipple() {
+            controlUnderTest = createTemporaryObject(roundButtonComponent, root)
+            verify(!!controlUnderTest)
+
+            verifyRippleFeedback(controlUnderTest, "buttonRipple", true, true)
+
+            controlUnderTest.destroy()
+            controlUnderTest = createTemporaryObject(roundButtonComponent, root, {
+                rippleOrigin: StatusRipple.RippleOrigin.Center
+            })
+            verify(!!controlUnderTest)
+
+            verifyRippleFeedback(controlUnderTest, "buttonRipple", false, true)
+
+            const ripple = findChild(controlUnderTest, "buttonRipple")
+            verify(!!ripple)
+            controlUnderTest.rippleEnabled = false
+            verify(!ripple.enabled)
+            mousePress(controlUnderTest, controlUnderTest.width / 2, controlUnderTest.height / 2)
+            verify(!ripple.visible)
+            mouseRelease(controlUnderTest, controlUnderTest.width / 2, controlUnderTest.height / 2)
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_StatusRippleFeedback.qml
+++ b/storybook/qmlTests/tests/tst_StatusRippleFeedback.qml
@@ -96,8 +96,16 @@ Item {
             controlUnderTest = createTemporaryObject(comboBoxComponent, root)
             verify(!!controlUnderTest)
 
-            verifyRippleFeedback(controlUnderTest.control, "statusComboBoxRipple", false, false)
+            verifyRippleFeedback(controlUnderTest.control, "statusComboBoxRipple", true, false)
             compare(controlUnderTest.control.scale, 1)
+
+            controlUnderTest.destroy()
+            controlUnderTest = createTemporaryObject(comboBoxComponent, root, {
+                rippleOrigin: StatusRipple.RippleOrigin.Center
+            })
+            verify(!!controlUnderTest)
+
+            verifyRippleFeedback(controlUnderTest.control, "statusComboBoxRipple", false, false)
         }
 
         function test_itemDelegateRipple() {
@@ -106,6 +114,14 @@ Item {
 
             verifyRippleFeedback(controlUnderTest, "statusItemDelegateRipple", true, true)
             compare(controlUnderTest.scale, 1)
+
+            controlUnderTest.destroy()
+            controlUnderTest = createTemporaryObject(itemDelegateComponent, root, {
+                rippleOrigin: StatusRipple.RippleOrigin.Center
+            })
+            verify(!!controlUnderTest)
+
+            verifyRippleFeedback(controlUnderTest, "statusItemDelegateRipple", false, true)
         }
 
         function test_highlightedItemDelegateDefaultColors() {
@@ -141,6 +157,14 @@ Item {
 
             verifyRippleFeedback(controlUnderTest, "statusListItemRipple", true, true)
             compare(controlUnderTest.scale, 1)
+
+            controlUnderTest.destroy()
+            controlUnderTest = createTemporaryObject(listItemComponent, root, {
+                rippleOrigin: StatusRipple.RippleOrigin.Center
+            })
+            verify(!!controlUnderTest)
+
+            verifyRippleFeedback(controlUnderTest, "statusListItemRipple", false, true)
         }
 
         function test_menuItemRipple() {
@@ -149,6 +173,14 @@ Item {
 
             verifyRippleFeedback(controlUnderTest, "statusMenuItemRipple", true, true)
             compare(controlUnderTest.scale, 1)
+
+            controlUnderTest.destroy()
+            controlUnderTest = createTemporaryObject(menuItemComponent, root, {
+                rippleOrigin: StatusRipple.RippleOrigin.Center
+            })
+            verify(!!controlUnderTest)
+
+            verifyRippleFeedback(controlUnderTest, "statusMenuItemRipple", false, true)
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -43,6 +43,7 @@ Rectangle {
     property bool loading: false
     property bool loadingSubTitle: loading
     property bool errorMode: false
+    property int rippleOrigin: StatusRipple.RippleOrigin.Pointer
 
     property StatusAssetSettings asset: StatusAssetSettings {
         height: isImage ? 40 : 20
@@ -140,7 +141,7 @@ Rectangle {
         color: root.type === StatusListItem.Type.Danger ? Theme.palette.dangerColor1
                                                         : Theme.palette.directColor1
         radius: root.radius
-        origin: StatusRipple.RippleOrigin.Pointer
+        origin: root.rippleOrigin
     }
 
     QtObject {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
@@ -211,23 +211,7 @@ AbstractButton {
             color: root.rippleColor
             radius: root.radius
             origin: root.rippleOrigin
-        }
-    }
-
-    TapHandler {
-        id: pressFeedbackHandler
-        enabled: ripple.enabled
-        acceptedButtons: Qt.LeftButton
-        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchScreen | PointerDevice.TouchPad | PointerDevice.Stylus
-        gesturePolicy: TapHandler.DragThreshold
-
-        onPressedChanged: {
-            if (pressed) {
-                const ripplePoint = root.mapToItem(ripple, point.position.x, point.position.y)
-                ripple.press(ripplePoint.x, ripplePoint.y)
-            } else {
-                ripple.release()
-            }
+            button: root
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
@@ -54,11 +54,11 @@ AbstractButton {
     property bool rippleEnabled: true
 
     /*!
-       Controls where the ripple starts from. Use \c StatusRipple.RippleOrigin.Center
-       for a centered ripple or \c StatusRipple.RippleOrigin.Pointer to start from
-       the press position.
+       Controls where the ripple starts from. Use \c StatusRipple.RippleOrigin.Pointer
+       to start from the press position or \c StatusRipple.RippleOrigin.Center
+       for a centered ripple.
     */
-    property int rippleOrigin: StatusRipple.RippleOrigin.Center
+    property int rippleOrigin: StatusRipple.RippleOrigin.Pointer
 
     /*!
        Color used by the ripple animation.

--- a/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
@@ -34,6 +34,7 @@ Item {
 
     property int size: StatusComboBox.Size.Large
     property int type: StatusComboBox.Type.Primary
+    property int rippleOrigin: StatusRipple.RippleOrigin.Pointer
 
     readonly property Component defaultBackgroundComponent: Rectangle {
         color: root.type === StatusComboBox.Type.Secondary ? "transparent" : Theme.palette.baseColor2
@@ -68,6 +69,7 @@ Item {
             color: root.type === StatusComboBox.Type.Secondary ? Theme.palette.baseColor1
                                                                : Theme.palette.directColor1
             radius: parent.radius
+            origin: root.rippleOrigin
         }
 
         function pressRipple(x, y) {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
@@ -73,21 +73,7 @@ ItemDelegate {
             color: d.contentColor
             radius: parent.radius
             origin: root.rippleOrigin
-        }
-    }
-
-    TapHandler {
-        enabled: itemDelegateRipple.enabled
-        acceptedButtons: Qt.LeftButton
-        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchScreen | PointerDevice.TouchPad | PointerDevice.Stylus
-
-        onPressedChanged: {
-            if (pressed) {
-                const ripplePoint = root.mapToItem(itemDelegateRipple, point.position.x, point.position.y)
-                itemDelegateRipple.press(ripplePoint.x, ripplePoint.y)
-            } else {
-                itemDelegateRipple.release()
-            }
+            button: root
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
@@ -12,6 +12,7 @@ ItemDelegate {
     property int radius: 0
     property int cursorShape: Qt.PointingHandCursor
     property color highlightColor: Theme.palette.statusMenu.hoverBackgroundColor
+    property int rippleOrigin: StatusRipple.RippleOrigin.Pointer
 
     padding: Theme.halfPadding
     spacing: Theme.halfPadding
@@ -71,7 +72,7 @@ ItemDelegate {
             enabled: root.enabled
             color: d.contentColor
             radius: parent.radius
-            origin: StatusRipple.RippleOrigin.Pointer
+            origin: root.rippleOrigin
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusRipple.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusRipple.qml
@@ -35,6 +35,11 @@ Item {
     property int origin: StatusRipple.RippleOrigin.Pointer
 
     /*!
+       Optional button that drives this ripple from its press/release signals.
+    */
+    property var button: null
+
+    /*!
        Duration of the expansion animation.
     */
     property int expandDuration: ThemeUtils.AnimationDuration.Fast
@@ -95,6 +100,26 @@ Item {
         d.pressed = false
         if (!expandAnimation.running)
             collapseAnimation.restart()
+    }
+
+    Connections {
+        target: root.button
+
+        function onPressed() {
+            if (!root.enabled)
+                return
+
+            const ripplePoint = root.button.mapToItem(root, root.button.pressX, root.button.pressY)
+            root.press(ripplePoint.x, ripplePoint.y)
+        }
+
+        function onReleased() {
+            root.release()
+        }
+
+        function onCanceled() {
+            root.release()
+        }
     }
 
     QtObject {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusRipple.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusRipple.qml
@@ -28,11 +28,11 @@ Item {
     property int radius: 0
 
     /*!
-       Controls where the ripple starts from. Use \c RippleOrigin.Center for a
-       centered ripple or \c RippleOrigin.Pointer to start from the coordinates
-       passed to \c press.
+       Controls where the ripple starts from. Use \c RippleOrigin.Pointer to
+       start from the coordinates passed to \c press or \c RippleOrigin.Center
+       for a centered ripple.
     */
-    property int origin: StatusRipple.RippleOrigin.Center
+    property int origin: StatusRipple.RippleOrigin.Pointer
 
     /*!
        Duration of the expansion animation.

--- a/ui/StatusQ/src/StatusQ/Controls/StatusRoundButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusRoundButton.qml
@@ -64,6 +64,9 @@ Rectangle {
     }
 
     property bool loading: false
+    property bool rippleEnabled: true
+    property int rippleOrigin: StatusRipple.RippleOrigin.Pointer
+    property color rippleColor: d.iconColor
 
     property alias hovered: sensor.containsMouse
     property alias hoverEnabled: sensor.hoverEnabled
@@ -153,6 +156,16 @@ Rectangle {
         return backgroundSettings.disabledColor
     }
 
+    StatusRipple {
+        id: ripple
+        objectName: "buttonRipple"
+        anchors.fill: parent
+        enabled: root.rippleEnabled && root.enabled && !root.loading
+        color: root.rippleColor
+        radius: root.radius
+        origin: root.rippleOrigin
+    }
+
     StatusMouseArea {
         id: sensor
 
@@ -185,8 +198,16 @@ Rectangle {
         } // Loader
 
         onClicked: mouse => root.clicked(mouse)
-        onPressed: mouse => root.pressed(mouse)
-        onReleased: mouse => root.released(mouse)
+        onPressed: mouse => {
+            if (ripple.enabled)
+                ripple.press(mouse.x, mouse.y)
+            root.pressed(mouse)
+        }
+        onReleased: mouse => {
+            ripple.release()
+            root.released(mouse)
+        }
+        onCanceled: ripple.release()
         onPressAndHold: mouse => root.pressAndHold(mouse)
     } // Sensor
 } // Rectangle

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
@@ -8,6 +8,7 @@ import Qt5Compat.GraphicalEffects
 import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Components
+import StatusQ.Controls
 import StatusQ.Popups
 
 /*!
@@ -41,6 +42,7 @@ Menu {
     readonly property color defaultIconColor: Theme.palette.primaryColor1
 
     property int type: StatusAction.Type.Normal
+    property int rippleOrigin: StatusRipple.RippleOrigin.Pointer
 
     property StatusAssetSettings assetSettings: StatusAssetSettings {
         width: 18
@@ -99,6 +101,7 @@ Menu {
         visible: root.hideDisabledItems && !visibleOnDisabled ? enabled : true
         height: visible ? implicitHeight : 0
         visualizeShortcuts: root.visualizeShortcuts
+        rippleOrigin: root.rippleOrigin
     }
 
     contentItem: StatusScrollView {

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
@@ -21,6 +21,7 @@ MenuItem {
     property bool visibleOnDisabled: d.isStatusAction ? action.visibleOnDisabled : false
 
     property bool visualizeShortcuts
+    property int rippleOrigin: StatusRipple.RippleOrigin.Pointer
 
     font.pixelSize: d.fontSettings ? d.fontSettings.pixelSize : d.defaultFontSettings.pixelSize
 
@@ -187,7 +188,7 @@ MenuItem {
                   : d.isStatusSuccessAction ? Theme.palette.successColor1
                                             : Theme.palette.directColor1
             radius: parent.radius
-            origin: StatusRipple.RippleOrigin.Pointer
+            origin: root.rippleOrigin
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
@@ -189,21 +189,7 @@ MenuItem {
                                             : Theme.palette.directColor1
             radius: parent.radius
             origin: root.rippleOrigin
-        }
-    }
-
-    TapHandler {
-        enabled: menuItemRipple.enabled
-        acceptedButtons: Qt.LeftButton
-        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchScreen | PointerDevice.TouchPad | PointerDevice.Stylus
-
-        onPressedChanged: {
-            if (pressed) {
-                const ripplePoint = root.mapToItem(menuItemRipple, point.position.x, point.position.y)
-                menuItemRipple.press(ripplePoint.x, ripplePoint.y)
-            } else {
-                menuItemRipple.release()
-            }
+            button: root
         }
     }
 

--- a/ui/app/mainui/controls/PrimaryNavSidebarButton.qml
+++ b/ui/app/mainui/controls/PrimaryNavSidebarButton.qml
@@ -68,9 +68,7 @@ ToolButton {
         }
 
         radius: root.bgRadius
-    }
 
-    contentItem: Item {
         StatusRipple {
             id: ripple
             objectName: "primaryNavSidebarButtonRipple"
@@ -79,41 +77,41 @@ ToolButton {
             color: root.rippleColor
             radius: root.bgRadius
             origin: root.rippleOrigin
+            button: root
         }
+    }
 
-        StatusSmartIdenticon {
-            id: identicon
-            anchors.fill: parent
-            asset.width: root.icon.width
-            asset.height: root.icon.height
-            loading: root.icon.name === "loading"
-            asset.isImage: loading || root.icon.source.toString() !== ""
-            asset.name: asset.isImage ? root.icon.source : root.icon.name
-            name: root.text
-            asset.isLetterIdenticon: name !== "" && !asset.isImage
-            asset.letterSize: Theme.secondaryAdditionalTextSize
-            asset.charactersLen: 1
-            asset.useAcronymForLetterIdenticon: false
-            asset.color: root.icon.color
+    contentItem: StatusSmartIdenticon {
+        id: identicon
+        asset.width: root.icon.width
+        asset.height: root.icon.height
+        loading: root.icon.name === "loading"
+        asset.isImage: loading || root.icon.source.toString() !== ""
+        asset.name: asset.isImage ? root.icon.source : root.icon.name
+        name: root.text
+        asset.isLetterIdenticon: name !== "" && !asset.isImage
+        asset.letterSize: Theme.secondaryAdditionalTextSize
+        asset.charactersLen: 1
+        asset.useAcronymForLetterIdenticon: false
+        asset.color: root.icon.color
 
-            StatusNewItemGradient { id: newGradient }
+        StatusNewItemGradient { id: newGradient }
 
-            badge {
-                width: root.badgeCount ? badge.implicitWidth : 16 - badge.border.width // bigger dot
-                height: root.badgeCount ? badge.implicitHeight : 16 - badge.border.width
-                border.width: 2
-                border.color: Theme.palette.statusAppNavBar.backgroundColor
-                anchors.bottom: undefined // override StatusBadge
-                anchors.bottomMargin: 0 // override StatusBadge
-                anchors.right: identicon.right
-                anchors.rightMargin: badge.value ? -16 : -8
-                anchors.top: identicon.top
-                anchors.topMargin: badge.value ? -10 : -8
+        badge {
+            width: root.badgeCount ? badge.implicitWidth : 16 - badge.border.width // bigger dot
+            height: root.badgeCount ? badge.implicitHeight : 16 - badge.border.width
+            border.width: 2
+            border.color: Theme.palette.statusAppNavBar.backgroundColor
+            anchors.bottom: undefined // override StatusBadge
+            anchors.bottomMargin: 0 // override StatusBadge
+            anchors.right: identicon.right
+            anchors.rightMargin: badge.value ? -16 : -8
+            anchors.top: identicon.top
+            anchors.topMargin: badge.value ? -10 : -8
 
-                visible: root.showBadge
-                value: root.badgeCount
-                gradient: root.showBadgeGradient ? newGradient : undefined // gradient has precedence over a simple color
-            }
+            visible: root.showBadge
+            value: root.badgeCount
+            gradient: root.showBadgeGradient ? newGradient : undefined // gradient has precedence over a simple color
         }
     }
 
@@ -130,27 +128,6 @@ ToolButton {
     HoverHandler {
         id: hoverHandler
         cursorShape: hovered && root.hoverEnabled ? Qt.PointingHandCursor : undefined
-    }
-
-    TapHandler {
-        enabled: ripple.enabled
-        acceptedButtons: Qt.LeftButton
-        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchScreen | PointerDevice.TouchPad | PointerDevice.Stylus
-        gesturePolicy: TapHandler.DragThreshold
-
-        onPressedChanged: {
-            if (pressed) {
-                const ripplePoint = root.mapToItem(ripple, point.position.x, point.position.y)
-                ripple.press(ripplePoint.x, ripplePoint.y)
-            } else {
-                ripple.release()
-            }
-        }
-    }
-
-    onPressedChanged: {
-        if (!pressed)
-            ripple.release()
     }
 
     // open the context menu at "x" where the tooltip opens, and top of the button (0)

--- a/ui/app/mainui/controls/PrimaryNavSidebarButton.qml
+++ b/ui/app/mainui/controls/PrimaryNavSidebarButton.qml
@@ -17,6 +17,9 @@ ToolButton {
     property bool showBadgeGradient
     property bool thirdpartyServicesEnabled
     property real bgRadius: width/2
+    property bool rippleEnabled: true
+    property int rippleOrigin: StatusRipple.RippleOrigin.Pointer
+    property color rippleColor: root.icon.color
 
     // mainly for testing
     readonly property bool badgeVisible: identicon.badge.visible
@@ -67,37 +70,50 @@ ToolButton {
         radius: root.bgRadius
     }
 
-    contentItem: StatusSmartIdenticon {
-        id: identicon
-        asset.width: root.icon.width
-        asset.height: root.icon.height
-        loading: root.icon.name === "loading"
-        asset.isImage: loading || root.icon.source.toString() !== ""
-        asset.name: asset.isImage ? root.icon.source : root.icon.name
-        name: root.text
-        asset.isLetterIdenticon: name !== "" && !asset.isImage
-        asset.letterSize: Theme.secondaryAdditionalTextSize
-        asset.charactersLen: 1
-        asset.useAcronymForLetterIdenticon: false
-        asset.color: root.icon.color
+    contentItem: Item {
+        StatusRipple {
+            id: ripple
+            objectName: "primaryNavSidebarButtonRipple"
+            anchors.fill: parent
+            enabled: root.rippleEnabled && root.enabled
+            color: root.rippleColor
+            radius: root.bgRadius
+            origin: root.rippleOrigin
+        }
 
-        StatusNewItemGradient { id: newGradient }
+        StatusSmartIdenticon {
+            id: identicon
+            anchors.fill: parent
+            asset.width: root.icon.width
+            asset.height: root.icon.height
+            loading: root.icon.name === "loading"
+            asset.isImage: loading || root.icon.source.toString() !== ""
+            asset.name: asset.isImage ? root.icon.source : root.icon.name
+            name: root.text
+            asset.isLetterIdenticon: name !== "" && !asset.isImage
+            asset.letterSize: Theme.secondaryAdditionalTextSize
+            asset.charactersLen: 1
+            asset.useAcronymForLetterIdenticon: false
+            asset.color: root.icon.color
 
-        badge {
-            width: root.badgeCount ? badge.implicitWidth : 16 - badge.border.width // bigger dot
-            height: root.badgeCount ? badge.implicitHeight : 16 - badge.border.width
-            border.width: 2
-            border.color: Theme.palette.statusAppNavBar.backgroundColor
-            anchors.bottom: undefined // override StatusBadge
-            anchors.bottomMargin: 0 // override StatusBadge
-            anchors.right: identicon.right
-            anchors.rightMargin: badge.value ? -16 : -8
-            anchors.top: identicon.top
-            anchors.topMargin: badge.value ? -10 : -8
+            StatusNewItemGradient { id: newGradient }
 
-            visible: root.showBadge
-            value: root.badgeCount
-            gradient: root.showBadgeGradient ? newGradient : undefined // gradient has precedence over a simple color
+            badge {
+                width: root.badgeCount ? badge.implicitWidth : 16 - badge.border.width // bigger dot
+                height: root.badgeCount ? badge.implicitHeight : 16 - badge.border.width
+                border.width: 2
+                border.color: Theme.palette.statusAppNavBar.backgroundColor
+                anchors.bottom: undefined // override StatusBadge
+                anchors.bottomMargin: 0 // override StatusBadge
+                anchors.right: identicon.right
+                anchors.rightMargin: badge.value ? -16 : -8
+                anchors.top: identicon.top
+                anchors.topMargin: badge.value ? -10 : -8
+
+                visible: root.showBadge
+                value: root.badgeCount
+                gradient: root.showBadgeGradient ? newGradient : undefined // gradient has precedence over a simple color
+            }
         }
     }
 
@@ -114,6 +130,27 @@ ToolButton {
     HoverHandler {
         id: hoverHandler
         cursorShape: hovered && root.hoverEnabled ? Qt.PointingHandCursor : undefined
+    }
+
+    TapHandler {
+        enabled: ripple.enabled
+        acceptedButtons: Qt.LeftButton
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchScreen | PointerDevice.TouchPad | PointerDevice.Stylus
+        gesturePolicy: TapHandler.DragThreshold
+
+        onPressedChanged: {
+            if (pressed) {
+                const ripplePoint = root.mapToItem(ripple, point.position.x, point.position.y)
+                ripple.press(ripplePoint.x, ripplePoint.y)
+            } else {
+                ripple.release()
+            }
+        }
+    }
+
+    onPressedChanged: {
+        if (!pressed)
+            ripple.release()
     }
 
     // open the context menu at "x" where the tooltip opens, and top of the button (0)


### PR DESCRIPTION
Closes #21094

### What does the PR do

Set ripple origin to pointer by default across StatusQ ripple-based controls and update related QML tests/storybook defaults.


### Affected areas

Buttons in general

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

Better UX

### Risk 

Low
