### PR TITLE
fix(StatusFlatRoundButton): make the tooltip arrow dynamic

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusFlatRoundButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusFlatRoundButton.qml
@@ -178,5 +178,6 @@ Rectangle {
     StatusToolTip {
         id: statusToolTip
         visible: !!text && root.hovered
+        offset: -(x + width/2 - root.width/2)
     } // Tooltip
 } // Rectangle


### PR DESCRIPTION
### What does the PR do

- center the tooltip arrow horizontally over the button's width

Fixes #20845

### Affected areas

StatusRoundButton

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="1504" height="629" alt="Snímek obrazovky z 2026-07-24 15-19-57" src="https://github.com/user-attachments/assets/b57ccfb7-4e36-4b9c-aa16-02b2dbb6e1c7" />


### Impact on end user

Tooltip UI/UX

### Risk 

low
