### PR TITLE
fix(Communities): correct channel name validation message

### DIFF
--- a/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
@@ -722,7 +722,7 @@ StatusStackModal {
                         },
                         StatusRegularExpressionValidator {
                             regularExpression: Constants.regularExpressions.alphanumericalExpanded
-                            errorMessage: Constants.errorMessages.alphanumericalExpandedRegExp
+                            errorMessage: qsTr("Only letters, numbers, underscores, periods and hyphens allowed")
                         }
                     ]
                 }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -4637,6 +4637,10 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Only letters, numbers, underscores, periods and hyphens allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Channel colour</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -4659,6 +4659,10 @@ Zůstanete přihlášeni a vaše obnovovací fráze bude zcela ve vašich rukou.
         <translation>název kanálu</translation>
     </message>
     <message>
+        <source>Only letters, numbers, underscores, periods and hyphens allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Channel colour</source>
         <translation>Barva kanálu</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -4642,6 +4642,10 @@ Permanecerás conectado y tu frase de recuperación estará completamente en tus
         <translation>nombre del canal</translation>
     </message>
     <message>
+        <source>Only letters, numbers, underscores, periods and hyphens allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Channel colour</source>
         <translation>Color del canal</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -4624,6 +4624,10 @@ You will remain logged in, and your recovery phrase will be entirely in your han
         <translation>채널 이름</translation>
     </message>
     <message>
+        <source>Only letters, numbers, underscores, periods and hyphens allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Channel colour</source>
         <translation>채널 색상</translation>
     </message>


### PR DESCRIPTION
### What does the PR do

Updates the channel-name validation message to match the field's behavior. Spaces are converted to hyphens while typing, so whitespace is no longer listed as an allowed final character.

Fixes #21602

### Affected areas

Communities — create/edit channel popup

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

The before-state screenshot is included in #21602.

### Impact on end user

The validation message now accurately describes the characters allowed after spaces are converted to hyphens.

### How to test

1. Open the create or edit community channel popup.
2. Type a channel name containing a space and confirm it becomes a hyphen.
3. Enter an unsupported character such as `!`.
4. Confirm the error no longer lists whitespace as allowed.

### Risk

Low. The change is limited to one validation message and its translation catalog entries.
<!-- retrigger CI after workflow fix #21677 -->