### PR TITLE
fix: signing a regular key pair's tx while profile key pair is keycard migrated

### DIFF
--- a/src/app/modules/shared_modules/signing/controller.nim
+++ b/src/app/modules/shared_modules/signing/controller.nim
@@ -63,9 +63,12 @@ proc passwordProvided*(self: Controller, keyUid: string, password: string) =
 proc verifyPassword*(self: Controller, password: string): bool =
   return self.accountsService.verifyPassword(password)
 
-proc signMessage*(self: Controller, address: string, password: string, txHash: string): tuple[res: string, err: string] =
-  let hashedPassword = common_utils.hashPassword(password)
-  return self.transactionService.signMessage(address, hashedPassword, txHash)
+proc signMessage*(self: Controller, address: string, password: string, txHash: string,
+  doPasswordHashing: bool = true): tuple[res: string, err: string] =
+  var finalPassword = password
+  if doPasswordHashing:
+    finalPassword = common_utils.hashPassword(password)
+  return self.transactionService.signMessage(address, finalPassword, txHash)
 
 proc startKeycardSigning*(self: Controller, keyUid: string, pin: string, txHash: string, path: string) =
   self.keycardServiceV2.asyncSign(keyUid, pin, txHash, path)

--- a/src/app/modules/shared_modules/signing/module.nim
+++ b/src/app/modules/shared_modules/signing/module.nim
@@ -3,6 +3,7 @@ import nimqml, chronicles, strutils
 import io_interface
 import view, controller
 import app/core/eventemitter
+import app/global/global_singleton
 import app/modules/shared_models/keypair_item
 
 import app_service/common/wallet_constants as wallet_constants
@@ -73,7 +74,8 @@ proc toCanonicalSignature(r, s, v: string): string =
     error "failed to parse v", msg = vClean
 
 method signMessage*[T](self: Module[T], address: string, password: string, txHash: string): string =
-  let (res, err) = self.controller.signMessage(address, password, txHash)
+  let doPasswordHashing = not singletonInstance.userProfile.getMigratedToColdWallet()
+  let (res, err) = self.controller.signMessage(address, password, txHash, doPasswordHashing)
   if err.len > 0:
     error "signMessage failed", error=err
     return ""

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -7285,6 +7285,19 @@ Please add it and try again.</source>
 <context>
     <name>EnterPin</name>
     <message>
+        <source>Authorization required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This key pair is not stored on your Keycard. Authorize with your profile
+to sign using the keys stored on this device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authorize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>PIN incorrect</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15366,6 +15379,10 @@ to load</source>
     </message>
     <message>
         <source>Update PIN &amp; sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to sign with the authorized credentials</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -7321,6 +7321,19 @@ Prosím přidejte jej a zkuste to znovu.</translation>
 <context>
     <name>EnterPin</name>
     <message>
+        <source>Authorization required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This key pair is not stored on your Keycard. Authorize with your profile
+to sign using the keys stored on this device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authorize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>PIN incorrect</source>
         <translation type="unfinished">Nesprávný PIN</translation>
     </message>
@@ -15449,6 +15462,10 @@ selhalo</translation>
     </message>
     <message>
         <source>Update PIN &amp; sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to sign with the authorized credentials</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -7297,6 +7297,19 @@ Por favor, agrégala e intenta de nuevo.</translation>
 <context>
     <name>EnterPin</name>
     <message>
+        <source>Authorization required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This key pair is not stored on your Keycard. Authorize with your profile
+to sign using the keys stored on this device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authorize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>PIN incorrect</source>
         <translation type="unfinished">PIN incorrecto</translation>
     </message>
@@ -15381,6 +15394,10 @@ al cargar</translation>
     </message>
     <message>
         <source>Update PIN &amp; sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to sign with the authorized credentials</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -7272,6 +7272,19 @@ Please add it and try again.</source>
 <context>
     <name>EnterPin</name>
     <message>
+        <source>Authorization required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This key pair is not stored on your Keycard. Authorize with your profile
+to sign using the keys stored on this device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authorize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>PIN incorrect</source>
         <translation type="unfinished">PIN이 올바르지 않습니다</translation>
     </message>
@@ -15314,6 +15327,10 @@ to load</source>
     </message>
     <message>
         <source>Update PIN &amp; sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to sign with the authorized credentials</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/imports/shared/popups/auth_sign_base/PopupBase.qml
+++ b/ui/imports/shared/popups/auth_sign_base/PopupBase.qml
@@ -42,6 +42,10 @@ StatusDialog {
                                             root.keyUid
                                           : root.userProfileKeyUid
 
+    property bool externalAuthorization: false // when set, the credential is not collected here, instead an "Authorize" buutton is shown, emitting authorizeRequested signal
+
+    signal authorizeRequested()
+
     // buttons
     required property string btnActionName
     required property string btnPasswordActionAndUpdateName
@@ -74,6 +78,10 @@ StatusDialog {
 
                 if (!root.useKeycard) {
                     return enterPasswordComponent
+                }
+
+                if (root.externalAuthorization) {
+                    return enterPinComponent
                 }
 
                 if (d.verifying) {
@@ -188,6 +196,7 @@ StatusDialog {
         id: d
 
         readonly property bool usingBiometrics: root.keychain.available
+                                                && !root.externalAuthorization // the authentication popup runs its own biometrics
                                                 && root.useKeyUid === root.userProfileKeyUid
                                                 && keychain.hasCredential(root.useKeyUid) === Keychain.StatusSuccess
 
@@ -403,7 +412,9 @@ StatusDialog {
             remainingAttempts: d.processedRemainingPinAttempts
             submitOnPinComplete: !d.credentialMismatchAfterBiometrics
             keyPairForProcessing: root.keyPairForProcessing
+            authorizeMode: root.externalAuthorization
             onAccepted: d.performKeycardActionInternal(pin)
+            onAuthorizeRequested: root.authorizeRequested()
         }
     }
 }

--- a/ui/imports/shared/popups/auth_sign_base/states/EnterPin.qml
+++ b/ui/imports/shared/popups/auth_sign_base/states/EnterPin.qml
@@ -22,10 +22,13 @@ Control {
     property bool submitOnPinComplete: true
     property var keyPairForProcessing: null
 
+    property bool authorizeMode: false // instead of entering a PIN here, the credential is collected via "Authorize" button
+
     readonly property alias pin: pinInputField.pinInput
     readonly property bool pinValid: pinInputField.pinInput.length === Constants.keycard.general.keycardPinLength && !root.wrongPin
 
     signal accepted()
+    signal authorizeRequested()
 
     leftPadding: Theme.xlPadding
     rightPadding: Theme.xlPadding
@@ -51,13 +54,25 @@ Control {
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
-            text: qsTr("Enter the Keycard PIN")
+            text: root.authorizeMode ? qsTr("Authorization required")
+                                     : qsTr("Enter the Keycard PIN")
             font.weight: Font.Bold
             font.pixelSize: Theme.fontSize(22)
         }
 
+        StatusBaseText {
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            visible: root.authorizeMode
+            text: qsTr("This key pair is not stored on your Keycard. Authorize with your profile\nto sign using the keys stored on this device.")
+            font.pixelSize: Theme.primaryTextFontSize
+            color: Theme.palette.baseColor1
+        }
+
         StatusPinInput {
             id: pinInputField
+            visible: !root.authorizeMode
             Layout.fillWidth: true
             Layout.maximumWidth: implicitWidth
             Layout.alignment: Qt.AlignHCenter
@@ -71,6 +86,14 @@ Control {
                 if (pinInput.length === pinLen && root.submitOnPinComplete)
                     root.accepted()
             }
+        }
+
+        StatusButton {
+            objectName: "authorizeToSignButton"
+            Layout.alignment: Qt.AlignHCenter
+            visible: root.authorizeMode
+            text: qsTr("Authorize")
+            onClicked: root.authorizeRequested()
         }
 
         StatusBaseText {

--- a/ui/imports/shared/popups/signing/SignPopup.qml
+++ b/ui/imports/shared/popups/signing/SignPopup.qml
@@ -43,12 +43,14 @@ PopupBase {
     isKeycardKeyPair: root.store.ready && root.store.isKeypairMigratedToColdWallet(root.keyUid)
     keyPairForProcessing: root.store.keyPairForProcessing
 
+    externalAuthorization: !root.isKeycardKeyPair && root.userProfileMigratedToColdWallet
+
     performPasswordAction: function(password) {
         const success = root.store.verifyPassword(password)
         if (!success)
             return false
 
-        root.passwordProvided(password) // only here, in case of signing tx via keycard no password (enc pub key)
+        root.passwordProvided(password) // in case of signing tx via keycard no password (enc pub key)
 
         const signature = root.store.signMessage(root.address, password, root.txHash)
         if (signature === "")
@@ -61,6 +63,10 @@ PopupBase {
 
     performKeycardAction: function(keyUid, pin) {
         root.store.startKeycardSigning(keyUid, pin, root.txHash, root.path)
+    }
+
+    onAuthorizeRequested: {
+        Global.openAuthenticationPopup(Constants.authenticationReason.signing, root.store.userProfileKeyUid, false)
     }
 
     closePopupAction: function() {
@@ -78,6 +84,29 @@ PopupBase {
 
         function onKeycardSignError(error) {
             root.handleKeycardError(error)
+        }
+    }
+
+    Connections {
+        target: Global
+        enabled: root.externalAuthorization
+
+        function onAuthenticationResult(reason, password, pin, keyUid, chatPrivateKey) {
+            if (reason !== Constants.authenticationReason.signing)
+                return
+            if (!password)
+                return
+
+            root.passwordProvided(password) // in case of signing tx via keycard no password (enc pub key)
+
+            const signature = root.store.signMessage(root.address, password, root.txHash)
+            if (signature === "") {
+                Global.displayToastMessage(qsTr("Failed to sign with the authorized credentials"), "", "warning",
+                                           false, Constants.ephemeralNotificationType.danger, "")
+                return
+            }
+            root.signingSuccess(signature)
+            root.close()
         }
     }
 

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -451,6 +451,7 @@ QtObject {
         readonly property string addAccount: "add-account"
         readonly property string importKeypair: "import-keypair"
         readonly property string syncDevice: "sync-device"
+        readonly property string signing: "signing"
     }
 
     readonly property QtObject signingReason: QtObject {


### PR DESCRIPTION
There was an issue signing tx for a non-profile key pair that is not migrated to the keycard while the profile key pair is migrated to the keycard. It was not explicitly stated which of those 2 key pairs is being used for signing and which one for authentication. Now there is a screen that would require a password for signing a non-profile, non-keycard migrated key pair's transaction with an explicit "Authorize" button that runs an auth flow to get the password from the keycard migrated profile key pair, which will be used for signing.

<img width="659" height="667" alt="NewAuthScreenWehnSigning" src="https://github.com/user-attachments/assets/1ce660d5-7c1b-4002-876b-72da39fe9e99" />
