### PR TITLE
chore: organise nim test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ GIT_ROOT ?= $(shell git rev-parse --show-toplevel 2>/dev/null || echo .)
 	run-linux \
 	run-macos \
 	run-windows \
+	tests-nim \
 	tests-nim-linux \
+	benches-nim \
 	status-go \
 	status-keycard-qt \
 	statusq-sanity-checker \
@@ -1052,87 +1054,7 @@ run-windows: compile_windows_resources nim_status_client
 	echo -e "\033[92mRunning:\033[39m bin/nim_status_client.exe"
 	cd bin && ./nim_status_client.exe $(ARGS)
 
-NIM_TEST_FILES := $(wildcard test/nim/*.nim)
-NIM_TESTS := $(foreach test_file,$(NIM_TEST_FILES),nim-test-run/$(test_file))
-
-nim-test-run/test/nim/signal_handler_test.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
-nim-test-run/test/nim/signal_handler_test.nim: | statusq
-
-nim-test-run/test/nim/url_scheme_event_test.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
-nim-test-run/test/nim/url_scheme_event_test.nim: | statusq
-
-# typed_completion_test drives finishTyped -> signal_handler -> statusq_invoke_method_queued,
-# so it needs the StatusQ library linked (like signal_handler_test above).
-nim-test-run/test/nim/typed_completion_test.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
-nim-test-run/test/nim/typed_completion_test.nim: | statusq
-
-# asset_proxy_chain_bench stands up the real StatusQ/SFPM proxy chain in an
-# offscreen QML engine, so it links StatusQ and needs the installed QML modules.
-nim-test-run/test/nim/asset_proxy_chain_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
-nim-test-run/test/nim/asset_proxy_chain_bench.nim: | statusq
-
-# swap_key_harvest_bench drives the real QtMT.ModelQuery (registerStatusQTypes) in an
-# offscreen QML engine, so it links StatusQ.
-nim-test-run/test/nim/swap_key_harvest_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
-nim-test-run/test/nim/swap_key_harvest_bench.nim: | statusq
-
-# send_modal_instantiation_bench loads the real SimpleSendModal QML tree, and
-# send_handler_lookup_bench drives the real ModelUtils/ModelQuery -- both link StatusQ.
-nim-test-run/test/nim/send_modal_instantiation_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
-nim-test-run/test/nim/send_modal_instantiation_bench.nim: | statusq
-
-# swap_modal_instantiation_bench loads the real SwapModal QML tree + SwapModalAdaptor
-# (inline real-store subclasses, no storybook engine) -- links StatusQ.
-nim-test-run/test/nim/swap_modal_instantiation_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
-nim-test-run/test/nim/swap_modal_instantiation_bench.nim: | statusq
-
-nim-test-run/test/nim/send_handler_lookup_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
-nim-test-run/test/nim/send_handler_lookup_bench.nim: | statusq
-
-# send_handler_adaptors_bench builds the real CollectiblesSelectionAdaptor /
-# WalletAccountsSelectorAdaptor / RecipientViewAdaptor proxy chains offscreen -- links StatusQ.
-nim-test-run/test/nim/send_handler_adaptors_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
-nim-test-run/test/nim/send_handler_adaptors_bench.nim: | statusq
-
-# collectibles_selector_bench drives the real CollectiblesSelectionAdaptor proxy
-# chain through two offscreen ListViews (RED baseline) -- links StatusQ.
-nim-test-run/test/nim/collectibles_selector_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
-nim-test-run/test/nim/collectibles_selector_bench.nim: | statusq
-
-# collectibles_selector_model_bench measures the GREEN terminal model directly
-# (context-injected, no proxies above it) -- links StatusQ for the offscreen engine.
-nim-test-run/test/nim/collectibles_selector_model_bench.nim: NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
-nim-test-run/test/nim/collectibles_selector_model_bench.nim: | statusq
-
-# Model-spy tests call inspection accessors gated behind
-# `when defined(testing) or defined(QT_MODEL_SPY)` or assert on the granular
-# signals model_sync records only under QT_MODEL_SPY. The define is applied
-# per-file, NOT globally, so the timing benches keep measuring uninstrumented
-# models.
-nim-test-run/test/nim/assets_adaptor_model_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
-nim-test-run/test/nim/token_selector_model_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
-nim-test-run/test/nim/collectibles_selector_model_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
-nim-test-run/test/nim/token_selector_producer_view_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
-nim-test-run/test/nim/model_sync_move_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
-nim-test-run/test/nim/model_sync_unified_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
-nim-test-run/test/nim/token_groups_model_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
-nim-test-run/test/nim/grouped_account_assets_model_test.nim: NIM_PARAMS += -d:QT_MODEL_SPY
-# Exception among benches: its GREEN gates assert structural propagation shape
-# (bounded inserts, zero resets) via the spy counters.
-nim-test-run/test/nim/token_selector_model_bench.nim: NIM_PARAMS += -d:QT_MODEL_SPY
-
-ifneq ($(mkspecs),win32)
-nim-test-run/%: NIM_PARAMS += --passL:"$(QT_SEAQT_EXTRA_LIBS)"
-endif
-# --mm:orc matches the production build (Makefile app targets); it also makes a
-# dropped child QObject's free ORDER relative to its parent's remove signal
-# deterministic, so the `when defined(gcOrc)` use-after-free regressions
-# actually execute here instead of compiling to a skip.
-nim-test-run/%: | qt-pkgconfig $(STATUSGO) $(QRCODEGEN)
-	LD_LIBRARY_PATH="$(QT_LIBDIR)":"$(NIMSDS_LIBDIR)":"$(STATUSGO_LIBDIR)":"$(EXTRA_LIBS_PATH)":"$(LD_LIBRARY_PATH)" $(ENV_SCRIPT) \
-	nim c $(NIM_PARAMS) $(NIM_EXTRA_PARAMS) --mm:orc --passL:"-L$(STATUSGO_LIBDIR)" --passL:"-lstatus" --passL:"$(QRCODEGEN)" -r $(subst nim-test-run/,,$@)
-
-tests-nim-linux: $(NIM_TESTS)
+include makefiles/nim-tests.mk
 
 define qmkq
 $(shell $(QMAKE) -query $(1))

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -30,7 +30,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 20, unit: 'MINUTES')
+    timeout(time: 35, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',

--- a/makefiles/nim-tests.mk
+++ b/makefiles/nim-tests.mk
@@ -60,6 +60,9 @@ tests-nim: $(NIM_TESTS)
 benches-nim: $(NIM_BENCHES)
 
 # CI target (ci/Jenkinsfile.tests-nim). Deliberately runs the benchmarks too:
-# their setup code and GREEN-gate assertions only stay honest if CI keeps
-# building and executing them.
+# their setup code and structural GREEN-gate assertions only stay honest if CI
+# keeps building and executing them. Wall-clock perf gates flake on the shared
+# executors, so BENCH_ASSERTS=0 downgrades them to report-only (see
+# test/nim/benchmarks/perf_gate.nim).
+tests-nim-linux: export BENCH_ASSERTS := 0
 tests-nim-linux: tests-nim benches-nim

--- a/makefiles/nim-tests.mk
+++ b/makefiles/nim-tests.mk
@@ -1,0 +1,65 @@
+# Nim host tests and benchmarks (test/nim/). Included from the main Makefile;
+# relies on NIM_PARAMS, STATUSQ_LIB_PATH, STATUSGO*, QRCODEGEN and the Qt
+# variables being defined at the include site.
+#
+# Naming convention: benchmarks end in `_bench.nim`; everything else is a test.
+
+NIM_BENCH_FILES := $(wildcard test/nim/*_bench.nim)
+NIM_TEST_FILES := $(filter-out $(NIM_BENCH_FILES),$(wildcard test/nim/*.nim))
+NIM_TESTS := $(addprefix nim-test-run/,$(NIM_TEST_FILES))
+NIM_BENCHES := $(addprefix nim-test-run/,$(NIM_BENCH_FILES))
+
+# These stand up real StatusQ machinery — signal_handler /
+# statusq_invoke_method_queued, ModelQuery/ModelUtils, SFPM proxy chains, or
+# full modal QML trees in an offscreen engine — so they link libStatusQ and
+# need it built first.
+NIM_TESTS_LINK_STATUSQ := \
+	asset_proxy_chain_bench \
+	collectibles_selector_bench \
+	collectibles_selector_model_bench \
+	send_handler_adaptors_bench \
+	send_handler_lookup_bench \
+	send_modal_instantiation_bench \
+	signal_handler_test \
+	swap_key_harvest_bench \
+	swap_modal_instantiation_bench \
+	typed_completion_test \
+	url_scheme_event_test
+
+NIM_STATUSQ_TARGETS := $(patsubst %,nim-test-run/test/nim/%.nim,$(NIM_TESTS_LINK_STATUSQ))
+$(NIM_STATUSQ_TARGETS): NIM_PARAMS += --passL:"-L$(STATUSQ_LIB_PATH)" --passL:"-lStatusQ"
+$(NIM_STATUSQ_TARGETS): | statusq
+
+# Model-spy tests call inspection accessors gated behind
+# `when defined(testing) or defined(QT_MODEL_SPY)` or assert on the granular
+# signals model_sync records only under QT_MODEL_SPY. The define is applied
+# per-file, NOT globally
+NIM_TESTS_MODEL_SPY := \
+	assets_adaptor_model_test \
+	collectibles_selector_model_test \
+	grouped_account_assets_model_test \
+	model_sync_move_test \
+	model_sync_unified_test \
+	token_groups_model_test \
+	token_selector_model_bench \
+	token_selector_model_test \
+	token_selector_producer_view_test
+
+$(patsubst %,nim-test-run/test/nim/%.nim,$(NIM_TESTS_MODEL_SPY)): NIM_PARAMS += -d:QT_MODEL_SPY
+
+ifneq ($(mkspecs),win32)
+nim-test-run/%: NIM_PARAMS += --passL:"$(QT_SEAQT_EXTRA_LIBS)"
+endif
+
+nim-test-run/%: | qt-pkgconfig $(STATUSGO) $(QRCODEGEN)
+	LD_LIBRARY_PATH="$(QT_LIBDIR)":"$(NIMSDS_LIBDIR)":"$(STATUSGO_LIBDIR)":"$(EXTRA_LIBS_PATH)":"$(LD_LIBRARY_PATH)" $(ENV_SCRIPT) \
+	nim c $(NIM_PARAMS) $(NIM_EXTRA_PARAMS) --mm:orc --passL:"-L$(STATUSGO_LIBDIR)" --passL:"-lstatus" --passL:"$(QRCODEGEN)" -r $(subst nim-test-run/,,$@)
+
+tests-nim: $(NIM_TESTS)
+
+benches-nim: $(NIM_BENCHES)
+
+# CI target (ci/Jenkinsfile.tests-nim). Deliberately runs the benchmarks too:
+# their setup code and GREEN-gate assertions only stay honest if CI keeps
+# building and executing them.
+tests-nim-linux: tests-nim benches-nim

--- a/makefiles/nim-tests.mk
+++ b/makefiles/nim-tests.mk
@@ -62,7 +62,9 @@ benches-nim: $(NIM_BENCHES)
 # CI target (ci/Jenkinsfile.tests-nim). Deliberately runs the benchmarks too:
 # their setup code and structural GREEN-gate assertions only stay honest if CI
 # keeps building and executing them. Wall-clock perf gates flake on the shared
-# executors, so BENCH_ASSERTS=0 downgrades them to report-only (see
+# executors, so BENCH_ASSERTS=0 downgrades them to report-only, and BENCH_QUICK=1
+# trims the size sweeps to the assert-relevant sizes (see
 # test/nim/benchmarks/perf_gate.nim).
 tests-nim-linux: export BENCH_ASSERTS := 0
+tests-nim-linux: export BENCH_QUICK := 1
 tests-nim-linux: tests-nim benches-nim

--- a/test/nim/asset_proxy_chain_bench.nim
+++ b/test/nim/asset_proxy_chain_bench.nim
@@ -34,6 +34,7 @@ import os, times, strformat
 import nimqml
 from seaqt/qcoreapplication import QCoreApplication, processEvents
 import std/monotimes
+import benchmarks/perf_gate
 
 {.compile: "bench_statusq_register.cpp".}
 proc bench_registerStatusQTypes() {.importc.}
@@ -106,6 +107,11 @@ when isMainModule:
   let engine = newQQmlApplicationEngine()
   engine.addImportPath(getCurrentDir() / "ui" / "StatusQ" / "src")
   engine.setRootContextProperty("bench", benchVariant)
+  # The RED-baseline amplification is O(N^2): all_prices_change@1000 alone runs
+  # ~12 minutes on CI, @5000 effectively never finishes. The scene skips the
+  # large sizes in quick mode; the structural asserts hold at any size.
+  let quickVariant = newQVariant(benchQuick())
+  engine.setRootContextProperty("benchQuick", quickVariant)
 
   let sceneFile = getCurrentDir() / "test" / "nim" / "benchmarks" / "asset_proxy_chain_scene.qml"
   engine.loadData(readFile(sceneFile))

--- a/test/nim/asset_terminal_model_bench.nim
+++ b/test/nim/asset_terminal_model_bench.nim
@@ -22,6 +22,7 @@ from seaqt/qcoreapplication import QCoreApplication, processEvents
 import std/monotimes
 
 import app/modules/shared_models/assets_adaptor_model
+import benchmarks/perf_gate
 
 type Row = object
   size: int
@@ -227,9 +228,8 @@ when isMainModule:
     # restore descending sort for the next size
     model.sortBy("marketBalance", 1)
 
-  runSize(100)
-  runSize(1000)
-  runSize(5000)
+  for size in benchSizes([100, 1000, 5000], [100]):
+    runSize(size)
 
   let table = formatTable(bench.rows)
   echo "\n===== terminal-model propagation (GREEN) ====="

--- a/test/nim/benchmarks/asset_proxy_chain_scene.qml
+++ b/test/nim/benchmarks/asset_proxy_chain_scene.qml
@@ -326,9 +326,9 @@ Window {
         repeat: false
         onTriggered: {
             const chains = 5
-            runSize(100, chains)
-            runSize(1000, chains)
-            runSize(5000, chains)
+            const sizes = benchQuick ? [100] : [100, 1000, 5000]
+            for (const size of sizes)
+                runSize(size, chains)
             bench.done()
         }
     }

--- a/test/nim/benchmarks/perf_gate.nim
+++ b/test/nim/benchmarks/perf_gate.nim
@@ -1,0 +1,13 @@
+# Wall-clock perf gates flake on loaded CI executors. BENCH_ASSERTS=0 (set by
+# the CI target in makefiles/nim-tests.mk) downgrades them to report-only;
+# structural gates (resets/row-churn/counts) stay hard doAsserts.
+import std/[os, strutils]
+
+proc perfAssertsEnabled*(): bool =
+  getEnv("BENCH_ASSERTS", "1").toLowerAscii() notin ["0", "false", "off"]
+
+template perfAssert*(cond: untyped, msg: string) =
+  if perfAssertsEnabled():
+    doAssert cond, msg
+  elif not (cond):
+    echo "PERF GATE SKIPPED (BENCH_ASSERTS=0): ", msg

--- a/test/nim/benchmarks/perf_gate.nim
+++ b/test/nim/benchmarks/perf_gate.nim
@@ -11,3 +11,11 @@ template perfAssert*(cond: untyped, msg: string) =
     doAssert cond, msg
   elif not (cond):
     echo "PERF GATE SKIPPED (BENCH_ASSERTS=0): ", msg
+
+# BENCH_QUICK=1 (set by the CI target) trims size sweeps to the assert-relevant
+# sizes: gates that pin a size keep it, structural gates keep the smallest.
+proc benchQuick*(): bool =
+  getEnv("BENCH_QUICK", "0").toLowerAscii() in ["1", "true", "on"]
+
+proc benchSizes*(full, quick: openArray[int]): seq[int] =
+  if benchQuick(): @quick else: @full

--- a/test/nim/collectibles_selector_bench.nim
+++ b/test/nim/collectibles_selector_bench.nim
@@ -33,6 +33,7 @@ import os, times, strformat
 import nimqml
 from seaqt/qcoreapplication import QCoreApplication, processEvents
 import std/monotimes
+import benchmarks/perf_gate
 
 {.compile: "bench_statusq_register.cpp".}
 proc bench_registerStatusQTypes() {.importc.}
@@ -127,7 +128,7 @@ proc formatTable(rows: seq[Row]): string =
     result.add(&"{r.size}\t{r.scenario}\t{r.wallMs:.4f}\t{r.maxStallMs:.4f}\t{r.resetsG}\t{r.resetsF}\t{r.insertsG}\t{r.insertsF}\t{r.dcRowsG}\t{r.dcRowsF}\t{r.delCreatedG}\t{r.delDestroyedG}\t{r.delCreatedF}\t{r.delDestroyedF}\t{r.countFlat}\t{r.countGrouped}\t{r.error}\n")
 
 const scenarioNames = ["build", "account_switch", "chain_filter", "append_50", "balance_update"]
-const sizes = [200, 1000, 3000]
+let sizes = benchSizes([200, 1000, 3000], [3000])
 
 when isMainModule:
   putEnv("QT_QPA_PLATFORM", "offscreen")

--- a/test/nim/collectibles_selector_model_bench.nim
+++ b/test/nim/collectibles_selector_model_bench.nim
@@ -22,6 +22,7 @@ from seaqt/qcoreapplication import QCoreApplication, processEvents
 import std/monotimes
 
 import app/modules/shared_models/collectibles_selector_model
+import benchmarks/perf_gate
 
 type Row = object
   size: int
@@ -148,7 +149,7 @@ proc formatTable(rows: seq[Row]): string =
   for r in rows:
     result.add(&"{r.size}\t{r.scenario}\t{r.wallMs:.4f}\t{r.maxStallMs:.4f}\t{r.resetsG}\t{r.resetsF}\t{r.insertsG}\t{r.insertsF}\t{r.dcRowsG}\t{r.dcRowsF}\t{r.delCreatedG}\t{r.delDestroyedG}\t{r.delCreatedF}\t{r.delDestroyedF}\t{r.countFlat}\t{r.countGrouped}\n")
 
-const sizes = [200, 1000, 3000]
+let sizes = benchSizes([200, 1000, 3000], [200])
 
 when isMainModule:
   putEnv("QT_QPA_PLATFORM", "offscreen")

--- a/test/nim/send_handler_adaptors_bench.nim
+++ b/test/nim/send_handler_adaptors_bench.nim
@@ -25,6 +25,7 @@ import os, times, strformat
 import nimqml
 from seaqt/qcoreapplication import QCoreApplication, processEvents
 import std/monotimes
+import benchmarks/perf_gate
 
 {.compile: "bench_statusq_register.cpp".}
 proc bench_registerStatusQTypes() {.importc.}
@@ -188,7 +189,7 @@ when isMainModule:
   # below the direct build), yet produces the full model once activated.
   doAssert rowFor(5).countA == 3000,
     &"deferred collectibles did not populate on activation: {rowFor(5).countA}"
-  doAssert rowFor(5).createMs < rowFor(2).createMs,
+  perfAssert rowFor(5).createMs < rowFor(2).createMs,
     &"deferred open cost {rowFor(5).createMs} not below direct build {rowFor(2).createMs}"
 
   echo "assertions passed"

--- a/test/nim/send_handler_lookup_bench.nim
+++ b/test/nim/send_handler_lookup_bench.nim
@@ -109,7 +109,7 @@ proc formatTable(rows: seq[Row]): string =
   for r in rows:
     result.add(&"{r.size}\t{r.scenario}\t{r.ms:.4f}\n")
 
-const sizes = [500, 2000, 5000]
+let sizes = benchSizes([500, 2000, 5000], [5000])
 const lookups = ["getByKey_norole", "getByKey_role", "get_loop_allroles",
   "getFirstModelEntryIf", "modelToFlatArray"]
 

--- a/test/nim/send_handler_lookup_bench.nim
+++ b/test/nim/send_handler_lookup_bench.nim
@@ -24,6 +24,7 @@ import os, times, strformat, strutils, tables
 import nimqml
 from seaqt/qcoreapplication import QCoreApplication, processEvents
 import std/monotimes
+import benchmarks/perf_gate
 
 {.compile: "bench_statusq_register.cpp".}
 proc bench_registerStatusQTypes() {.importc.}
@@ -169,7 +170,7 @@ when isMainModule:
   # role-restricted flat scan at the largest size.
   let loopBig = rowFor("get_loop_allroles", 5000)
   let flatBig = rowFor("modelToFlatArray", 5000)
-  doAssert loopBig.ms > flatBig.ms,
+  perfAssert loopBig.ms > flatBig.ms,
     &"expected the all-roles get-loop to exceed the role-restricted scan @5000 " &
     &"(get_loop {loopBig.ms:.2f}ms, modelToFlatArray {flatBig.ms:.2f}ms)"
 

--- a/test/nim/send_modal_open_bench.nim
+++ b/test/nim/send_modal_open_bench.nim
@@ -293,11 +293,8 @@ when isMainModule:
       stderr.writeLine(&"[bench] size={size} dropdown_open maxStall={rows[^1].maxStallMs:.2f}ms over32={rows[^1].over32} delegates={rows[^1].delegatesCreated} chips={rows[^1].chipsCreated}")
       stderr.flushFile()
 
-  runSize(50)
-  runSize(200)
-  runSize(500)
-  runSize(1000)
-  runSize(2000)
+  for size in benchSizes([50, 200, 500, 1000, 2000], [200]):
+    runSize(size)
 
   let table = formatTable(rows)
   echo "\n===== SimpleSendModal open: GUI-thread cost of the send picker seed ====="

--- a/test/nim/send_modal_open_bench.nim
+++ b/test/nim/send_modal_open_bench.nim
@@ -45,6 +45,7 @@ import std/monotimes
 import app/modules/shared_models/token_selector_model
 import app/modules/shared_models/token_selector_builder
 import app/modules/shared_models/assets_aggregator
+import benchmarks/perf_gate
 
 type Row = object
   size: int
@@ -315,7 +316,7 @@ when isMainModule:
   # At a realistic heavy-user owned set (~200) the on-open seed burst must not drop
   # a frame -- the picker seed is NOT the source of the ~1s open at real sizes.
   let seed200 = rowFor("open_seed", 200)
-  doAssert seed200.over32 == 0 and seed200.maxStallMs <= 32.0,
+  perfAssert seed200.over32 == 0 and seed200.maxStallMs <= 32.0,
     &"send picker open_seed dropped a frame @200 owned " &
     &"(compute {seed200.computeMs:.2f}ms, inject {seed200.injectMs:.2f}ms, " &
     &"maxStall {seed200.maxStallMs:.2f}ms, over32 {seed200.over32})"

--- a/test/nim/swap_key_harvest_bench.nim
+++ b/test/nim/swap_key_harvest_bench.nim
@@ -24,6 +24,7 @@ import os, osproc, times, strformat, strutils, tables
 import nimqml
 from seaqt/qcoreapplication import QCoreApplication, processEvents
 import std/monotimes
+import benchmarks/perf_gate
 
 {.compile: "bench_statusq_register.cpp".}
 proc bench_registerStatusQTypes() {.importc.}
@@ -211,7 +212,7 @@ when isMainModule:
   # nothing.
   let redBig = rowFor("all_roles", 5000)
   let greenBig = rowFor("single_role", 5000)
-  doAssert greenBig.ms < redBig.ms * 0.7,
+  perfAssert greenBig.ms < redBig.ms * 0.7,
     &"expected single-role harvest materially faster @5000 (all_roles {redBig.ms:.2f}ms, single_role {greenBig.ms:.2f}ms)"
 
   echo "assertions passed"

--- a/test/nim/swap_key_harvest_bench.nim
+++ b/test/nim/swap_key_harvest_bench.nim
@@ -124,7 +124,7 @@ proc formatTable(rows: seq[Row]): string =
   for r in rows:
     result.add(&"{r.size}\t{r.scenario}\t{r.ms:.4f}\t{r.joinedLen}\n")
 
-const sizes = [500, 2000, 5000]
+let sizes = benchSizes([500, 2000, 5000], [5000])
 
 when isMainModule:
   let modeEnv = getEnv("HARVEST_MODE")

--- a/test/nim/swap_modal_instantiation_bench.nim
+++ b/test/nim/swap_modal_instantiation_bench.nim
@@ -37,6 +37,7 @@ import nimqml
 from seaqt/qcoreapplication import QCoreApplication, processEvents
 import std/monotimes
 import std/strutils
+import benchmarks/perf_gate
 
 # Optional QML profiling: build with `-d:qmldebug` (port via -d:qmlDebugPort:NNNNN)
 # to start the TCP debug/profiler server and BLOCK until `qmlprofiler --attach`
@@ -180,7 +181,7 @@ when isMainModule:
   var rows: seq[Row] = @[]
   # Default sweep; override with SWAP_BENCH_SIZES=10000 (comma-separated) to pin a
   # single size for a profiled run. Not a committed hardcode — env-driven.
-  var sizes = @[100, 1000, 5000, 10000]
+  var sizes = benchSizes([100, 1000, 5000, 10000], [1000])
   let sizesEnv = getEnv("SWAP_BENCH_SIZES", "")
   if sizesEnv.len > 0:
     sizes = @[]

--- a/test/nim/swap_modal_open_bench.nim
+++ b/test/nim/swap_modal_open_bench.nim
@@ -47,6 +47,7 @@ import app/modules/main/wallet_section/all_tokens/io_interface
 import app_service/service/token/items/token_group
 import app_service/service/token/items/token
 import app_service/service/token/dto/token as token_dto
+import benchmarks/perf_gate
 
 # Faithful replica of the string-envelope decode the production slot performed
 # before the typed handoff: same DTO seq, same decode cost.
@@ -322,7 +323,7 @@ when isMainModule:
   # decode + build blocks the GUI thread (inject_ms) mid-open. Gated on the observed
   # frame gap (the brief's tick-to-tick metric); inject_ms is the pure-compute block.
   let redRow = rowFor("open_string_envelope", 10000)
-  doAssert redRow.over32 >= 1 and redRow.maxStallMs > 32.0,
+  perfAssert redRow.over32 >= 1 and redRow.maxStallMs > 32.0,
     &"expected string-envelope open to drop a frame @10k " &
     &"(maxStall {redRow.maxStallMs:.2f}ms, over32 {redRow.over32}, inject {redRow.injectMs:.2f}ms)"
 
@@ -331,7 +332,7 @@ when isMainModule:
   # mandatory-keys expansion) never blocks a frame -- no >32ms tick, and the pure
   # GUI-thread block stays well within one frame.
   let greenRow = rowFor("open_typed_handoff", 10000)
-  doAssert greenRow.over32 == 0 and greenRow.maxStallMs <= 32.0 and greenRow.injectMs <= 32.0,
+  perfAssert greenRow.over32 == 0 and greenRow.maxStallMs <= 32.0 and greenRow.injectMs <= 32.0,
     &"typed-handoff open should not drop a frame @10k " &
     &"(maxStall {greenRow.maxStallMs:.2f}ms, over32 {greenRow.over32}, inject {greenRow.injectMs:.2f}ms) -- " &
     "residual GUI-thread fan-out (modelsUpdated reset / mandatory-keys scan) too heavy"

--- a/test/nim/swap_modal_open_bench.nim
+++ b/test/nim/swap_modal_open_bench.nim
@@ -300,9 +300,8 @@ when isMainModule:
     measure("open_string_envelope", buildOffWindow = false)
     measure("open_typed_handoff", buildOffWindow = true)
 
-  runSize(2000)
-  runSize(5000)
-  runSize(10000)
+  for size in benchSizes([2000, 5000, 10000], [10000]):
+    runSize(size)
 
   let table = formatTable(rows)
   echo "\n===== SwapModal open: GUI-thread stall by completion regime ====="

--- a/test/nim/token_selector_model_bench.nim
+++ b/test/nim/token_selector_model_bench.nim
@@ -39,6 +39,7 @@ import app/modules/shared_models/token_selector_model
 import app/modules/shared_models/token_selector_builder
 import app/modules/shared_models/assets_aggregator
 import app/modules/shared/qt_model_spy
+import benchmarks/perf_gate
 
 type Row = object
   size: int
@@ -194,9 +195,8 @@ when isMainModule:
     # 5) page append: grow the popular list by one page (bounded insert).
     measure("page_append", proc() = m.fetchMore())
 
-  runSize(100)
-  runSize(1000)
-  runSize(5000)
+  for size in benchSizes([100, 1000, 5000], [100]):
+    runSize(size)
 
   let table = formatTable(rows)
   echo "\n===== token-picker terminal-model propagation (GREEN) ====="


### PR DESCRIPTION


### What does the PR do

follow-up for https://github.com/status-im/status-app/pull/21522#discussion_r3659257114


- move the nim test targets to a dedicated nim-tests.mk file
- split tests and benchmarks in two different targets, but keep the benchmarks as part of the nim-tests-run so that it doesn't rot over time
- group tests/benchmarks that will need statusQ or QT_MODEL_SPY



+ disabled benchmark assertions. It's flaky on CI
+ increase timeout to 35 mins
+ shorten the bench size