### PR TITLE
ci: fix status-go submodule check for external-contributor PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,11 @@ jobs:
 
       - name: Fetch relevant status-go branches
         run: |
-          git submodule update --init vendor/status-go
+          # pin the submodule URL so a PR-modified .gitmodules cannot point
+          # the policy check at a non-upstream remote
+          git submodule init vendor/status-go
+          git config submodule.vendor/status-go.url https://github.com/status-im/status-go.git
+          git submodule update vendor/status-go
           cd vendor/status-go
           if ! git fetch origin 'release/*:refs/remotes/origin/release/*' 2>/dev/null; then
             echo "[WARN] No release/* branches found."
@@ -120,7 +124,11 @@ jobs:
         with:
           submodules: false
       - name: Init vendored status-go (the shipped pin)
-        run: git submodule update --init vendor/status-go
+        run: |
+          # same URL pinning as above: never fetch a PR-supplied remote
+          git submodule init vendor/status-go
+          git config submodule.vendor/status-go.url https://github.com/status-im/status-go.git
+          git submodule update vendor/status-go
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          # head SHA, not head_ref: fork branches don't exist in this repo,
+          # but their commits are fetchable by SHA via the PR ref network
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           submodules: false
 


### PR DESCRIPTION
## What
The required `Check status-go submodule branch` check fails on every fork PR (e.g. #21664) before any policy step runs: the checkout uses `ref: ${{ github.head_ref }}`, which names a branch in the contributor's fork that doesn't exist in this repository.

## Fix
Check out `github.event.pull_request.head.sha` instead. Fork commits are fetchable from the base repo by SHA via the PR ref network, and this preserves the check's intended semantics: it validates the PR's actual submodule pin (including the recency rule that forces stale pins to catch up with the base branch), unlike the merge ref which would silently resolve stale pins to the base's pointer.

## Unblocking existing PRs
Once merged, affected PRs re-run via any new trigger event — the workflow triggers on `edited`, so a trivial title/body edit suffices (re-running the old failed run replays the old workflow snapshot and won't help).