### PR TITLE
ci: run windows e2e in release

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -88,11 +88,6 @@ pipeline {
               }
             }
             stage('Windows E2E Tests') {
-              when {
-                expression {
-                  env.JOB_NAME.toLowerCase().contains('nightly')
-                }
-              }
               steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                   script {


### PR DESCRIPTION
## Summary

This job used to only run in nightly, but now it will run in releases too.
