### PR TITLE
feat(intake): external-intake seam, deep-link routing, Android browser candidacy

### DIFF
--- a/mobile/android/qt6/AndroidManifest.xml
+++ b/mobile/android/qt6/AndroidManifest.xml
@@ -114,6 +114,20 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="status-app" />
             </intent-filter>
+            <!--
+              Browser candidacy: handle arbitrary http/https links so Status appears
+              in the OS link-open chooser and in Settings > Default apps > Browser.
+              A scheme-only VIEW+BROWSABLE filter (no host) is what qualifies an app
+              as a browser. Routing happens at the Nim external-intake seam: Status
+              links keep deep-link behavior, anything else opens a new browser tab.
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+            </intent-filter>
         </activity>
 
         <provider

--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -28,9 +28,14 @@ public class StatusQtActivity extends QtActivity {
     private static StatusQtActivity sInstance = null;
 
     private static final AtomicBoolean userLoggedIn = new AtomicBoolean(false);
-    private static String savedDeepLink = null;
+    // Java mirror of the Nim pending intake slot (single, last-wins): holds the
+    // intake URL until mainWindowReady, since on a cold start the native side
+    // isn't up yet to receive it. No routing here — that lives at the Nim
+    // external-intake seam.
+    private static String pendingIntakeUrl = null;
 
-    // JNI hook: implemented in native code to forward deep links to Qt
+    // JNI hook: implemented in native code to forward external intake URLs
+    // (deep links and arbitrary web links) to Qt
     private static native void passDeepLinkToQt(String deepLink);
 
     @Override
@@ -53,7 +58,7 @@ public class StatusQtActivity extends QtActivity {
         // Set up shake detection (used for share-on-shake)
         ShakeDetector.start(this);
 
-        handleDeepLink(getIntent());
+        handleUrlIntake(getIntent());
     }
 
     @Override
@@ -76,7 +81,7 @@ public class StatusQtActivity extends QtActivity {
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         setIntent(intent);
-        handleDeepLink(intent);
+        handleUrlIntake(intent);
     }
 
     @Override
@@ -117,19 +122,21 @@ public class StatusQtActivity extends QtActivity {
     public static void mainWindowReady() {
         splashShouldHide.set(true);
         userLoggedIn.set(true);
-        if (savedDeepLink != null) {
-            passDeepLinkToQt(savedDeepLink);
-            savedDeepLink = null;
+        if (pendingIntakeUrl != null) {
+            passDeepLinkToQt(pendingIntakeUrl);
+            pendingIntakeUrl = null;
         }
     }
 
-    private void handleDeepLink(Intent intent) {
+    // Thin, decision-free platform layer: extract the URL payload from the
+    // VIEW intent and forward it to the external-intake seam.
+    private void handleUrlIntake(Intent intent) {
         if (intent == null) return;
         String action = intent.getAction();
         Uri data = intent.getData();
         if (Intent.ACTION_VIEW.equals(action) && data != null) {
             if (!userLoggedIn.get()) {
-                savedDeepLink = data.toString();
+                pendingIntakeUrl = data.toString();
                 return;
             }
             passDeepLinkToQt(data.toString());

--- a/src/app/core/custom_urls/urls_manager.nim
+++ b/src/app/core/custom_urls/urls_manager.nim
@@ -2,6 +2,7 @@ import nimqml, strutils, chronicles
 import ./url_scheme_event
 import app/global/single_instance
 import ../eventemitter
+import ../intake/external_intake
 
 import ../../global/app_signals
 
@@ -14,8 +15,7 @@ const StatusExternalLink* = "https://status.app/"
 QtObject:
   type UrlsManager* = ref object of QObject
     events: EventEmitter
-    protocolUriOnStart: string
-    appReady: bool
+    intake: ExternalIntake
 
   proc setup(self: UrlsManager, urlSchemeEvent: UrlSchemeEvent,
       singleInstance: SingleInstance) =
@@ -28,14 +28,6 @@ QtObject:
   proc delete*(self: UrlsManager) =
     self.QObject.delete
 
-  proc newUrlsManager*(events: EventEmitter, urlSchemeEvent: UrlSchemeEvent,
-      singleInstance: SingleInstance, protocolUriOnStart: string): UrlsManager =
-    new(result)
-    result.setup(urlSchemeEvent, singleInstance)
-    result.events = events
-    result.protocolUriOnStart = protocolUriOnStart
-    result.appReady = false
-
   proc convertInternalLinkToExternal*(self: UrlsManager, statusDeepLink: string): string =
     let idx = find(statusDeepLink, StatusInternalLink)
     result = statusDeepLink
@@ -44,19 +36,29 @@ QtObject:
       result = StatusExternalLink & result
 
   proc onUrlActivated*(self: UrlsManager, urlRaw: string) {.slot.} =
-    if not self.appReady:
-      self.protocolUriOnStart = urlRaw
-      return
-
     let url = urlRaw.multiReplace((" ", ""))
       .multiReplace(("\r\n", ""))
       .multiReplace(("\n", ""))
-    let data = StatusUrlArgs(url: self.convertInternalLinkToExternal(url))
+    self.intake.submit(ExternalIntakeEvent(kind: ExternalIntakeUrl, url: url))
 
-    self.events.emit(SIGNAL_STATUS_URL_ACTIVATED, data)
+  proc newUrlsManager*(events: EventEmitter, urlSchemeEvent: UrlSchemeEvent,
+      singleInstance: SingleInstance, protocolUriOnStart: string): UrlsManager =
+    new(result)
+    result.setup(urlSchemeEvent, singleInstance)
+    result.events = events
+    result.intake = newExternalIntake()
+
+    let self = result
+    result.intake.onDeepLinkUrl = proc(url: string) =
+      let data = StatusUrlArgs(url: self.convertInternalLinkToExternal(url))
+      self.events.emit(SIGNAL_STATUS_URL_ACTIVATED, data)
+    result.intake.onBrowserTabUrl = proc(url: string) =
+      self.events.emit(SIGNAL_EXTERNAL_URL_INTAKE_BROWSER_TAB,
+        ExternalUrlIntakeArgs(url: url))
+
+    if protocolUriOnStart != "":
+      # Launched via URL: park it in the pending intake slot until appReady.
+      self.onUrlActivated(protocolUriOnStart)
 
   proc appReady*(self: UrlsManager) =
-    self.appReady = true
-    if self.protocolUriOnStart != "":
-      self.onUrlActivated(self.protocolUriOnStart)
-      self.protocolUriOnStart = ""
+    self.intake.setReady()

--- a/src/app/core/intake/external_intake.nim
+++ b/src/app/core/intake/external_intake.nim
@@ -37,7 +37,6 @@ type
     onDeepLinkUrl*: proc(url: string)
     onBrowserTabUrl*: proc(url: string)
 
-const StatusInternalLinkScheme = "status-app"
 const StatusExternalLinkHost = "status.app"
 
 proc routeForUrl*(url: string): UrlIntakeRoute =

--- a/src/app/core/intake/external_intake.nim
+++ b/src/app/core/intake/external_intake.nim
@@ -1,0 +1,88 @@
+## External intake seam (see CONTEXT.md -> "External intake").
+##
+## The single typed entry point where the platform layer (Android JNI deep-link
+## hand-off, macOS QFileOpenEvent, iOS QDesktopServices handler, desktop
+## single-instance forwarding) hands the app an intake event. This slice covers
+## the `url` kind; share payloads extend `ExternalIntakeKind` later.
+##
+## Routing lives at this seam, not in the platform layer:
+## - `status-app:` links and `status.app` web links keep the existing
+##   deep-link behavior,
+## - any other web URL is a browser-tab intake (browser candidacy: it opens as
+##   a new tab in the in-app browser, browser section foregrounded).
+##
+## The seam also owns the pending intake slot: a single, last-wins buffer
+## holding an intake until the app can act on it (main-window-ready, i.e. after
+## login or onboarding). It generalizes the saved-deep-link mechanism that
+## previously lived in UrlsManager.
+
+import std/[options, strutils, uri]
+
+type
+  ExternalIntakeKind* = enum
+    ExternalIntakeUrl
+
+  ExternalIntakeEvent* = object
+    case kind*: ExternalIntakeKind
+    of ExternalIntakeUrl:
+      url*: string
+
+  UrlIntakeRoute* = enum
+    UrlIntakeDeepLink   ## existing Status deep-link routing
+    UrlIntakeBrowserTab ## new tab in the in-app browser
+
+  ExternalIntake* = ref object
+    ready: bool
+    pendingSlot: Option[ExternalIntakeEvent]
+    onDeepLinkUrl*: proc(url: string)
+    onBrowserTabUrl*: proc(url: string)
+
+const StatusInternalLinkScheme = "status-app"
+const StatusExternalLinkHost = "status.app"
+
+proc routeForUrl*(url: string): UrlIntakeRoute =
+  ## Status links keep their deep-link behavior; any other web URL opens in a
+  ## browser tab. Non-web schemes keep the historical deep-link path (the
+  ## deep-link pipeline already falls back for unsupported links).
+  let parsed = parseUri(url)
+  let scheme = parsed.scheme.toLowerAscii()
+  if scheme == "http" or scheme == "https":
+    let host = parsed.hostname.toLowerAscii()
+    if host == StatusExternalLinkHost or host.endsWith("." & StatusExternalLinkHost):
+      return UrlIntakeDeepLink
+    return UrlIntakeBrowserTab
+  return UrlIntakeDeepLink
+
+proc newExternalIntake*(): ExternalIntake =
+  ExternalIntake()
+
+proc hasPending*(self: ExternalIntake): bool =
+  self.pendingSlot.isSome
+
+proc dispatch(self: ExternalIntake, event: ExternalIntakeEvent) =
+  case event.kind
+  of ExternalIntakeUrl:
+    case routeForUrl(event.url)
+    of UrlIntakeDeepLink:
+      if not self.onDeepLinkUrl.isNil:
+        self.onDeepLinkUrl(event.url)
+    of UrlIntakeBrowserTab:
+      if not self.onBrowserTabUrl.isNil:
+        self.onBrowserTabUrl(event.url)
+
+proc submit*(self: ExternalIntake, event: ExternalIntakeEvent) =
+  ## Platform-layer entry point. Until ready, events land in the pending
+  ## intake slot — single, last-wins.
+  if not self.ready:
+    self.pendingSlot = some(event)
+    return
+  self.dispatch(event)
+
+proc setReady*(self: ExternalIntake) =
+  ## Called at main-window-ready (after login or onboarding completes).
+  ## Delivers the pending intake, if any.
+  self.ready = true
+  if self.pendingSlot.isSome:
+    let event = self.pendingSlot.get()
+    self.pendingSlot = none(ExternalIntakeEvent)
+    self.dispatch(event)

--- a/src/app/core/intake/external_intake.nim
+++ b/src/app/core/intake/external_intake.nim
@@ -39,15 +39,26 @@ type
 
 const StatusExternalLinkHost = "status.app"
 
+proc isStatusWebUrl*(url: string): bool =
+  ## True for web URLs on status.app or a subdomain — links Status itself
+  ## handles (and the in-app browser can render). An external hand-off of such
+  ## a URL routes straight back here when Status holds the browser role, so
+  ## the unresolvable-deep-link fallback opens them as an in-app browser tab
+  ## instead of handing off externally.
+  let parsed = parseUri(url)
+  let scheme = parsed.scheme.toLowerAscii()
+  if scheme != "http" and scheme != "https":
+    return false
+  let host = parsed.hostname.toLowerAscii()
+  return host == StatusExternalLinkHost or host.endsWith("." & StatusExternalLinkHost)
+
 proc routeForUrl*(url: string): UrlIntakeRoute =
   ## Status links keep their deep-link behavior; any other web URL opens in a
   ## browser tab. Non-web schemes keep the historical deep-link path (the
   ## deep-link pipeline already falls back for unsupported links).
-  let parsed = parseUri(url)
-  let scheme = parsed.scheme.toLowerAscii()
+  let scheme = parseUri(url).scheme.toLowerAscii()
   if scheme == "http" or scheme == "https":
-    let host = parsed.hostname.toLowerAscii()
-    if host == StatusExternalLinkHost or host.endsWith("." & StatusExternalLinkHost):
+    if isStatusWebUrl(url):
       return UrlIntakeDeepLink
     return UrlIntakeBrowserTab
   return UrlIntakeDeepLink

--- a/src/app/core/intake/external_intake.nim
+++ b/src/app/core/intake/external_intake.nim
@@ -1,5 +1,3 @@
-## External intake seam (see CONTEXT.md -> "External intake").
-##
 ## The single typed entry point where the platform layer (Android JNI deep-link
 ## hand-off, macOS QFileOpenEvent, iOS QDesktopServices handler, desktop
 ## single-instance forwarding) hands the app an intake event. This slice covers
@@ -56,10 +54,10 @@ proc routeForUrl*(url: string): UrlIntakeRoute =
   ## Status links keep their deep-link behavior; any other web URL opens in a
   ## browser tab. Non-web schemes keep the historical deep-link path (the
   ## deep-link pipeline already falls back for unsupported links).
+  if isStatusWebUrl(url):
+    return UrlIntakeDeepLink
   let scheme = parseUri(url).scheme.toLowerAscii()
   if scheme == "http" or scheme == "https":
-    if isStatusWebUrl(url):
-      return UrlIntakeDeepLink
     return UrlIntakeBrowserTab
   return UrlIntakeDeepLink
 

--- a/src/app/global/app_signals.nim
+++ b/src/app/global/app_signals.nim
@@ -41,6 +41,15 @@ type
 
 const SIGNAL_STATUS_URL_ACTIVATED* = "statusUrlActivated"
 
+type
+  ExternalUrlIntakeArgs* = ref object of Args
+    url*: string
+
+const SIGNAL_EXTERNAL_URL_INTAKE_BROWSER_TAB* = "externalUrlIntakeBrowserTab"
+## Emitted for an externally received web URL that is not a Status link
+## (browser candidacy): it must open as a new tab in the in-app browser with
+## the browser section foregrounded.
+
 const SIGNAL_MAIN_LOADED* = "signalMainLoaded"
 
 type

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -296,6 +296,10 @@ proc init*(self: Controller) =
     var args = StatusUrlArgs(e)
     self.delegate.activateStatusDeepLink(args.url)
 
+  self.events.on(SIGNAL_EXTERNAL_URL_INTAKE_BROWSER_TAB) do(e: Args):
+    let args = ExternalUrlIntakeArgs(e)
+    self.delegate.openUrlInNewBrowserTab(args.url)
+
   self.events.on(SIGNAL_OS_NOTIFICATION_CLICKED) do(e: Args):
     var args = ClickedNotificationArgs(e)
     self.delegate.osNotificationClicked(args.details)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -342,6 +342,9 @@ method onMyRequestAdded*(self: AccessInterface) {.base.} =
 method activateStatusDeepLink*(self: AccessInterface, statusDeepLink: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method openUrlInNewBrowserTab*(self: AccessInterface, url: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method setCommunityIdToSpectate*(self: AccessInterface, commnityId: string, channelUuid: string = "") {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -147,12 +147,14 @@ type
     statusDeepLinkToActivate: string
     pendingProfileMigrationCheck: bool
     profileMigrationFlowInProgress: bool
+    urlToOpenInNewBrowserTab: string
 
 {.push warning[Deprecated]: off.}
 
 # Forward declaration
 proc switchToContactOrDisplayUserProfile[T](self: Module[T], publicKey: string)
 method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string)
+method openUrlInNewBrowserTab*[T](self: Module[T], url: string)
 proc checkIfWeHaveNotifications[T](self: Module[T])
 proc createMemberItem[T](self: Module[T], memberId: string, requestId: string, state: MembershipRequestState, role: MemberRole, airdropAddress: string = ""): MemberItem
 proc getAllCommunityMemberItems[T](self: Module[T], community: CommunityDto): seq[MemberItem]
@@ -1017,6 +1019,10 @@ method onChatsLoaded*[T](
   if self.pendingProfileMigrationCheck:
     self.pendingProfileMigrationCheck = false
     self.checkAndPerformProfileMigrationIfNeeded()
+  if self.urlToOpenInNewBrowserTab != "":
+    let url = self.urlToOpenInNewBrowserTab
+    self.urlToOpenInNewBrowserTab = ""
+    self.openUrlInNewBrowserTab(url)
 
 method onCommunityDataLoaded*[T](
   self: Module[T],
@@ -2126,6 +2132,16 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
     self.onStatusUrlRequested(StatusUrlAction.DisplayUserProfile, communityId="", channelId="", url="",
       userId = urlData.contact.publicKey)
     return
+
+method openUrlInNewBrowserTab*[T](self: Module[T], url: string) =
+  ## Browser-tab route of the external intake seam: an externally received web
+  ## URL always opens as a new tab in the in-app browser, browser section
+  ## foregrounded. Buffered until the main view is loaded, mirroring the
+  ## deep-link route above.
+  if not self.chatsLoaded:
+    self.urlToOpenInNewBrowserTab = url
+    return
+  self.view.emitOpenUrlInNewBrowserTabSignal(url)
 
 method onDeactivateChatLoader*[T](self: Module[T], sectionId: string, chatId: string) =
   if (sectionId.len > 0 and self.chatSectionModules.contains(sectionId)):

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -79,6 +79,7 @@ import app/core/notifications/notifications_manager
 import app/core/notifications/details
 import app/core/eventemitter
 import app/core/custom_urls/urls_manager
+import app/core/intake/external_intake
 
 export io_interface
 
@@ -2117,6 +2118,14 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
     return
   let urlData = self.sharedUrlsModule.parseSharedUrl(statusDeepLink)
   if urlData.notASupportedStatusLink:
+    if isStatusWebUrl(statusDeepLink):
+      # Unresolvable status.app link: an external hand-off would route straight
+      # back here when Status holds the browser role (default browser on
+      # Android) — a dead-end bounce via the external-open dialog. Open it as
+      # an in-app browser tab instead, same as the browser-candidacy route of
+      # the external intake seam.
+      self.openUrlInNewBrowserTab(statusDeepLink)
+      return
     # Just open it in the browser
     self.view.emitOpenUrlSignal(statusDeepLink)
     return
@@ -2137,7 +2146,8 @@ method openUrlInNewBrowserTab*[T](self: Module[T], url: string) =
   ## Browser-tab route of the external intake seam: an externally received web
   ## URL always opens as a new tab in the in-app browser, browser section
   ## foregrounded. Buffered until the main view is loaded, mirroring the
-  ## deep-link route above.
+  ## deep-link route above. Also the fallback for unresolvable status.app deep
+  ## links, whose external hand-off would bounce back to Status itself.
   if not self.chatsLoaded:
     self.urlToOpenInNewBrowserTab = url
     return

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -430,6 +430,10 @@ QtObject:
   proc emitOpenUrlSignal*(self: View, url: string) =
     self.openUrl(url)
 
+  proc openUrlInNewBrowserTab*(self: View, url: string) {.signal.}
+  proc emitOpenUrlInNewBrowserTabSignal*(self: View, url: string) =
+    self.openUrlInNewBrowserTab(url)
+
   proc navigateToMessageDetails*(self: View) {.signal.}
   proc emitNavigateToMessageDetailsSignal*(self: View) =
     self.navigateToMessageDetails()

--- a/test/nim/external_intake_test.nim
+++ b/test/nim/external_intake_test.nim
@@ -1,0 +1,131 @@
+## Unit tests for the external intake seam (app/core/intake/external_intake).
+## Covers the routing decision (Status links keep deep-link behavior, any other
+## web URL becomes a browser-tab intake) and the pending intake slot semantics
+## (pre-ready buffering, single slot, last-wins, delivered once at ready).
+## Prior art: url_scheme_event_test.nim exercises the platform side of this
+## same boundary.
+
+import unittest
+import app/core/intake/external_intake
+
+type Capture = ref object
+  deepLinks: seq[string]
+  browserTabs: seq[string]
+
+proc newCapturingIntake(capture: Capture): ExternalIntake =
+  result = newExternalIntake()
+  result.onDeepLinkUrl = proc(url: string) =
+    capture.deepLinks.add(url)
+  result.onBrowserTabUrl = proc(url: string) =
+    capture.browserTabs.add(url)
+
+proc urlIntake(url: string): ExternalIntakeEvent =
+  ExternalIntakeEvent(kind: ExternalIntakeUrl, url: url)
+
+suite "external_intake routing":
+
+  test "status-app scheme routes as deep link":
+    check routeForUrl("status-app://c/community-id") == UrlIntakeDeepLink
+    check routeForUrl("status-app://u/user-key") == UrlIntakeDeepLink
+
+  test "status.app web links route as deep link":
+    check routeForUrl("https://status.app/c/community-id") == UrlIntakeDeepLink
+    check routeForUrl("http://status.app/u/user-key") == UrlIntakeDeepLink
+    check routeForUrl("https://status.app/") == UrlIntakeDeepLink
+
+  test "status.app subdomains route as deep link":
+    check routeForUrl("https://www.status.app/c/community-id") == UrlIntakeDeepLink
+
+  test "arbitrary web urls route to a browser tab":
+    check routeForUrl("https://example.com/article") == UrlIntakeBrowserTab
+    check routeForUrl("http://example.com") == UrlIntakeBrowserTab
+    check routeForUrl("https://notstatus.app/c/x") == UrlIntakeBrowserTab
+    check routeForUrl("https://status.app.evil.com/") == UrlIntakeBrowserTab
+
+  test "non-web schemes keep the historical deep-link path":
+    check routeForUrl("mailto:someone@example.com") == UrlIntakeDeepLink
+
+suite "external_intake dispatch":
+
+  test "deep-link url reaches the deep-link handler once ready":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+    intake.setReady()
+
+    intake.submit(urlIntake("https://status.app/c/community-id"))
+
+    check capture.deepLinks == @["https://status.app/c/community-id"]
+    check capture.browserTabs.len == 0
+
+  test "arbitrary web url reaches the browser-tab handler once ready":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+    intake.setReady()
+
+    intake.submit(urlIntake("https://example.com/article"))
+
+    check capture.browserTabs == @["https://example.com/article"]
+    check capture.deepLinks.len == 0
+
+suite "external_intake pending slot":
+
+  test "intake submitted before ready is buffered, not dispatched":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.submit(urlIntake("https://example.com/article"))
+
+    check capture.deepLinks.len == 0
+    check capture.browserTabs.len == 0
+    check intake.hasPending()
+
+  test "pending intake is delivered at ready":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.submit(urlIntake("https://example.com/article"))
+    intake.setReady()
+
+    check capture.browserTabs == @["https://example.com/article"]
+    check not intake.hasPending()
+
+  test "the slot is single and last-wins":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.submit(urlIntake("https://first.example.com/"))
+    intake.submit(urlIntake("https://status.app/c/community-id"))
+    intake.setReady()
+
+    check capture.browserTabs.len == 0
+    check capture.deepLinks == @["https://status.app/c/community-id"]
+
+  test "pending intake is delivered exactly once":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.submit(urlIntake("https://example.com/article"))
+    intake.setReady()
+    intake.setReady()
+
+    check capture.browserTabs == @["https://example.com/article"]
+
+  test "ready with an empty slot dispatches nothing":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.setReady()
+
+    check capture.deepLinks.len == 0
+    check capture.browserTabs.len == 0
+
+  test "after ready, intakes dispatch immediately without buffering":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+    intake.setReady()
+
+    intake.submit(urlIntake("https://example.com/one"))
+    intake.submit(urlIntake("https://example.com/two"))
+
+    check capture.browserTabs == @["https://example.com/one", "https://example.com/two"]
+    check not intake.hasPending()

--- a/test/nim/external_intake_test.nim
+++ b/test/nim/external_intake_test.nim
@@ -45,6 +45,27 @@ suite "external_intake routing":
   test "non-web schemes keep the historical deep-link path":
     check routeForUrl("mailto:someone@example.com") == UrlIntakeDeepLink
 
+suite "external_intake status web url classification":
+  ## Backs the unresolvable-deep-link fallback: a status.app web URL handed
+  ## off externally routes straight back to Status when it holds the browser
+  ## role, so the fallback must open it as an in-app browser tab instead.
+
+  test "status.app web urls (incl. subdomains) are Status's own web urls":
+    check isStatusWebUrl("https://status.app/c/invalid-community-key")
+    check isStatusWebUrl("http://status.app/u/user-key")
+    check isStatusWebUrl("https://status.app/")
+    check isStatusWebUrl("https://www.status.app/c/community-id")
+
+  test "other web urls are not Status's own":
+    check not isStatusWebUrl("https://example.com/article")
+    check not isStatusWebUrl("https://notstatus.app/c/x")
+    check not isStatusWebUrl("https://status.app.evil.com/")
+
+  test "non-web schemes are not renderable web urls":
+    check not isStatusWebUrl("status-app://c/community-id")
+    check not isStatusWebUrl("mailto:someone@example.com")
+    check not isStatusWebUrl("")
+
 suite "external_intake dispatch":
 
   test "deep-link url reaches the deep-link handler once ready":

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -225,6 +225,10 @@ QtObject {
                 root.openUrl(url)
             }
 
+            function onOpenUrlInNewBrowserTab(url) {
+                root.openUrlInNewBrowserTab(url)
+            }
+
             function onOpenActivityCenter(group) {
                 root.activityCenterStore.setActiveNotificationGroup(group)
                 root.openActivityCenter()
@@ -280,6 +284,7 @@ QtObject {
 
     signal ensNameResolved(string resolvedPubKey, string resolvedAddress, string uuid)
     signal openUrl(string link)
+    signal openUrlInNewBrowserTab(string link)
     signal openActivityCenter()
     signal wcLinkActivated(string link)
     signal profileMigrationFlowRequested(bool migrateToKeycard)

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -78,6 +78,7 @@ Item {
         thirdpartyServicesEnabled: appMain.featureFlagsStore.privacyModeFeatureEnabled ?
                                    appMain.privacyStore.thirdpartyServicesEnabled: true
         onOpenUrl: (link) => Global.requestOpenLink(link)
+        onOpenUrlInNewBrowserTab: (link) => d.openUrlInNewBrowserTab(link)
         onOpenActivityCenter: () => {
             d.closeActivityCenterOnNextBack = false
             mainLayoutItem.openACCenterPanel = true
@@ -1008,6 +1009,20 @@ Item {
                     !d.isBrowserEnabled ||
                     !appMain.rootStore.thirdpartyServicesEnabled) {
                 Qt.openUrlExternally(link)
+                return
+            }
+            globalConns.onAppSectionBySectionTypeChanged(Constants.appSection.browser)
+            Qt.callLater(() => browserLayoutContainer.item.openUrlInNewTab(link))
+        }
+
+        // External intake, browser-tab route: the OS handed us this URL explicitly
+        // (browser candidacy), so it opens as a new tab in the in-app browser with
+        // the browser section foregrounded — no confirmation popup and no external
+        // hand-off, which would bounce straight back when Status is the default
+        // browser.
+        function openUrlInNewBrowserTab(link: string) {
+            if (!d.isBrowserEnabled) {
+                Global.requestOpenLink(link)
                 return
             }
             globalConns.onAppSectionBySectionTypeChanged(Constants.appSection.browser)


### PR DESCRIPTION
Closes #21560. Part of #20439.

Platform-neutral plumbing that lets the OS hand external content and links to Status, consumed when the UI is ready (survives cold start, login and onboarding timing).

- External-intake seam (`src/app/core/intake/external_intake.nim`): normalized intake events + a single routing point between platform delivery code and the app
- Deep-link hardening: unresolvable status.app links open in the in-app browser tab instead of bouncing back through the external-open dialog
- Android browser candidacy: VIEW intent filters route http/https/status.app links through the seam, making Status selectable as a link handler
- Nim unit tests for the seam and routing

No visible share UI yet — the Android/iOS share-target PRs and the share flow build on this.

**How tested:** Nim unit tests (`external_intake_test`); Android deep-link flows exercised on a Galaxy S21 during the share-target work that follows.
