### PR TITLE
feat(android): direct-share shortcuts — recent chats in the share sheet

### DIFF
--- a/mobile/android/qt6/AndroidManifest.xml
+++ b/mobile/android/qt6/AndroidManifest.xml
@@ -150,6 +150,14 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
             </intent-filter>
+            <!--
+              Direct-share shortcuts: recent chats published as one-tap share
+              targets (ShareShortcutsHelper); the share-target declaration
+              lives in res/xml/share_shortcuts.xml.
+            -->
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/share_shortcuts" />
         </activity>
 
         <provider

--- a/mobile/android/qt6/res/xml/share_shortcuts.xml
+++ b/mobile/android/qt6/res/xml/share_shortcuts.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Direct-share declaration: dynamic shortcuts published with this category
+  (ShareShortcutsHelper) surface as one-tap targets in the share sheet for
+  exactly the payloads the share target accepts (text and images — mirrors
+  the SEND/SEND_MULTIPLE intent filters in AndroidManifest.xml).
+-->
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <share-target android:targetClass="app.status.mobile.StatusQtActivity">
+        <data android:mimeType="text/plain" />
+        <category android:name="app.status.mobile.directshare.category.SHARE_TARGET" />
+    </share-target>
+    <share-target android:targetClass="app.status.mobile.StatusQtActivity">
+        <data android:mimeType="image/*" />
+        <category android:name="app.status.mobile.directshare.category.SHARE_TARGET" />
+    </share-target>
+</shortcuts>

--- a/mobile/android/qt6/src/app/status/mobile/ShareShortcutsHelper.java
+++ b/mobile/android/qt6/src/app/status/mobile/ShareShortcutsHelper.java
@@ -1,0 +1,109 @@
+package app.status.mobile;
+
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Log;
+
+import androidx.core.app.Person;
+import androidx.core.content.pm.ShortcutInfoCompat;
+import androidx.core.content.pm.ShortcutManagerCompat;
+import androidx.core.graphics.drawable.IconCompat;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Publishes recent Status chats as Android sharing shortcuts, so they appear
+ * as one-tap direct-share targets at the top of the OS share sheet (share
+ * targets declared in res/xml/share_shortcuts.xml). Decision-free platform
+ * layer: the Qt side decides what to publish and when (recency model), and
+ * when to clear (logout). A shortcut's id is the destination chat id — the
+ * share sheet echoes it back via Intent.EXTRA_SHORTCUT_ID on tap, which
+ * StatusQtActivity forwards through the share intake so the app can skip the
+ * destination picker.
+ */
+public class ShareShortcutsHelper {
+    private static final String TAG = "ShareShortcutsHelper";
+
+    // Must match the <category> entries in res/xml/share_shortcuts.xml.
+    private static final String SHARE_CATEGORY =
+            "app.status.mobile.directshare.category.SHARE_TARGET";
+
+    /**
+     * Replaces the published set. shortcutsJson: JSON array of
+     * {id, name, iconPath?} objects in rank order (most recent first); an
+     * empty array clears the set. Called from Qt via JNI.
+     */
+    public static void publish(Context context, String shortcutsJson) {
+        try {
+            JSONArray shortcuts = new JSONArray(shortcutsJson != null ? shortcutsJson : "[]");
+            int count = Math.min(shortcuts.length(),
+                    ShortcutManagerCompat.getMaxShortcutCountPerActivity(context));
+
+            List<ShortcutInfoCompat> infos = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                JSONObject shortcut = shortcuts.getJSONObject(i);
+                String id = shortcut.optString("id");
+                String name = shortcut.optString("name");
+                if (id.isEmpty() || name.isEmpty()) continue;
+
+                // The share sheet launches the SEND intent itself (carrying
+                // EXTRA_SHORTCUT_ID); this intent only backs the launcher
+                // long-press entry, where the shortcut simply opens the app.
+                Intent launchIntent = new Intent(Intent.ACTION_MAIN)
+                        .setClass(context, StatusQtActivity.class)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+                ShortcutInfoCompat.Builder builder = new ShortcutInfoCompat.Builder(context, id)
+                        .setShortLabel(name)
+                        .setRank(i)
+                        .setIntent(launchIntent)
+                        .setCategories(Collections.singleton(SHARE_CATEGORY))
+                        .setPerson(new Person.Builder().setName(name).build());
+
+                String iconPath = shortcut.optString("iconPath");
+                if (!iconPath.isEmpty()) {
+                    Bitmap bitmap = BitmapFactory.decodeFile(iconPath);
+                    if (bitmap != null) {
+                        builder.setIcon(IconCompat.createWithBitmap(bitmap));
+                    }
+                }
+                infos.add(builder.build());
+            }
+
+            ShortcutManagerCompat.setDynamicShortcuts(context, infos);
+        } catch (Exception e) {
+            Log.w(TAG, "failed to publish share shortcuts", e);
+        }
+    }
+
+    /**
+     * Removes every published shortcut — logout hygiene: chat names and
+     * avatars live on OS surfaces outside the app and must not linger for a
+     * logged-out profile. Also drops any system-cached copies. Called from Qt
+     * via JNI.
+     */
+    public static void clear(Context context) {
+        try {
+            List<ShortcutInfoCompat> existing = ShortcutManagerCompat.getShortcuts(context,
+                    ShortcutManagerCompat.FLAG_MATCH_DYNAMIC
+                            | ShortcutManagerCompat.FLAG_MATCH_CACHED);
+            List<String> ids = new ArrayList<>();
+            for (ShortcutInfoCompat shortcut : existing) {
+                ids.add(shortcut.getId());
+            }
+            if (!ids.isEmpty()) {
+                ShortcutManagerCompat.removeLongLivedShortcuts(context, ids);
+            }
+            ShortcutManagerCompat.removeAllDynamicShortcuts(context);
+        } catch (Exception e) {
+            Log.w(TAG, "failed to clear share shortcuts", e);
+        }
+    }
+}

--- a/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
+++ b/mobile/android/qt6/src/app/status/mobile/StatusQtActivity.java
@@ -50,14 +50,17 @@ public class StatusQtActivity extends QtActivity {
     private static String pendingIntakeUrl = null;
     private static String pendingIntakeShareText = null;
     private static String[] pendingIntakeShareImagePaths = null;
+    private static String pendingIntakeShareDestinationChatId = null;
 
     // JNI hooks: implemented in native code (StatusQ urlschemeevent.cpp) to
     // forward external intake to Qt — URLs (deep links and arbitrary web
     // links) and shared content (share target; a shared link arrives as text
     // and must launch the share flow, not URL routing; imagePaths are the
-    // app-private cached copies, never OS-managed URIs).
+    // app-private cached copies, never OS-managed URIs; destinationChatId is
+    // the tapped direct-share shortcut's id, or "" for a plain share).
     private static native void passDeepLinkToQt(String deepLink);
-    private static native void passShareToQt(String text, String[] imagePaths);
+    private static native void passShareToQt(String text, String[] imagePaths,
+            String destinationChatId);
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -170,11 +173,13 @@ public class StatusQtActivity extends QtActivity {
             passDeepLinkToQt(pendingIntakeUrl);
             pendingIntakeUrl = null;
         }
-        // Text and image paths are always set (non-null) and cleared together.
+        // The share fields are always set (non-null) and cleared together.
         if (pendingIntakeShareText != null) {
-            passShareToQt(pendingIntakeShareText, pendingIntakeShareImagePaths);
+            passShareToQt(pendingIntakeShareText, pendingIntakeShareImagePaths,
+                    pendingIntakeShareDestinationChatId);
             pendingIntakeShareText = null;
             pendingIntakeShareImagePaths = null;
+            pendingIntakeShareDestinationChatId = null;
         }
     }
 
@@ -222,14 +227,21 @@ public class StatusQtActivity extends QtActivity {
                 : new String[0];
         if (text.isEmpty() && imagePaths.length == 0) return;
 
+        // A tap on a direct-share shortcut arrives as the same SEND intent
+        // with the shortcut id (the destination chat id) attached; forwarding
+        // it lets the app skip the destination picker.
+        String destinationChatId = intent.getStringExtra(Intent.EXTRA_SHORTCUT_ID);
+        if (destinationChatId == null) destinationChatId = "";
+
         if (!userLoggedIn.get()) {
             clearPendingShare();
             pendingIntakeShareText = text;
             pendingIntakeShareImagePaths = imagePaths;
+            pendingIntakeShareDestinationChatId = destinationChatId;
             pendingIntakeUrl = null;
             return;
         }
-        passShareToQt(text, imagePaths);
+        passShareToQt(text, imagePaths, destinationChatId);
     }
 
     // Last-wins: a replaced pending share must not leak its cached copies.
@@ -241,6 +253,7 @@ public class StatusQtActivity extends QtActivity {
         }
         pendingIntakeShareImagePaths = null;
         pendingIntakeShareText = null;
+        pendingIntakeShareDestinationChatId = null;
     }
 
     private static List<Uri> extractStreamUris(Intent intent, boolean multiple) {

--- a/src/app/android/share_shortcuts.nim
+++ b/src/app/android/share_shortcuts.nim
@@ -1,0 +1,18 @@
+## Android direct-share shortcuts, Nim side. Publishing is driven from QML
+## (the shortcut publisher consumes the recent-postable-destinations model and
+## calls SystemUtils.publishShareShortcuts); this binding covers the logout
+## path, where the shortcuts must be cleared unconditionally — chat names and
+## avatars live on OS surfaces outside the app and must not linger for a
+## logged-out profile.
+
+when defined(android):
+  {.push dynlib: "", importc.}
+  proc statusq_clearShareShortcuts*() {.cdecl, importc: "statusq_clearShareShortcuts".}
+  {.pop.}
+
+  proc clearShareShortcuts*() =
+    statusq_clearShareShortcuts()
+
+else:
+  # Stub for non-Android builds (direct-share shortcuts are Android-only)
+  proc clearShareShortcuts*() = discard

--- a/src/app/core/custom_urls/urls_manager.nim
+++ b/src/app/core/custom_urls/urls_manager.nim
@@ -29,8 +29,8 @@ QtObject:
       self, SLOT("onUrlActivated(QString)"), ConnectionType.QueuedConnection)
     discard QObject.connect(singleInstance, SIGNAL("eventReceived(QString)"),
       self, SLOT("onUrlActivated(QString)"), ConnectionType.QueuedConnection)
-    discard QObject.connect(urlSchemeEvent, SIGNAL("shareActivated(QString,QString)"),
-      self, SLOT("onShareActivated(QString,QString)"), ConnectionType.QueuedConnection)
+    discard QObject.connect(urlSchemeEvent, SIGNAL("shareActivated(QString,QString,QString)"),
+      self, SLOT("onShareActivated(QString,QString,QString)"), ConnectionType.QueuedConnection)
     discard QObject.connect(urlSchemeEvent, SIGNAL("appForegrounded()"),
       self, SLOT("onAppForegrounded()"), ConnectionType.QueuedConnection)
 
@@ -88,14 +88,18 @@ QtObject:
     ## next full app start. No-op when the slot is inactive or empty.
     self.consumePendingIntake()
 
-  proc onShareActivated*(self: UrlsManager, text: string, imagePathsJson: string) {.slot.} =
+  proc onShareActivated*(self: UrlsManager, text: string, imagePathsJson: string,
+      destinationChatId: string) {.slot.} =
     ## Share-target hand-off (Android SEND/SEND_MULTIPLE intents): shared
     ## text/links and images launch the share flow. The text is kept verbatim —
     ## unlike URLs it may legitimately contain whitespace and newlines; image
     ## paths are app-private cached copies made by the platform layer at
-    ## receipt.
+    ## receipt. destinationChatId is non-empty only for a direct-share shortcut
+    ## tap (the shortcut id is the chat id): the destination is already decided
+    ## and the picker step is skipped downstream.
     self.intake.submit(ExternalIntakeEvent(kind: ExternalIntakeShare,
-      text: text, imagePaths: parseImagePathsJson(imagePathsJson)))
+      text: text, imagePaths: parseImagePathsJson(imagePathsJson),
+      destinationChatId: destinationChatId))
 
   proc newUrlsManager*(events: EventEmitter, urlSchemeEvent: UrlSchemeEvent,
       singleInstance: SingleInstance, protocolUriOnStart: string,
@@ -113,9 +117,11 @@ QtObject:
     result.intake.onBrowserTabUrl = proc(url: string) =
       self.events.emit(SIGNAL_EXTERNAL_URL_INTAKE_BROWSER_TAB,
         ExternalUrlIntakeArgs(url: url))
-    result.intake.onShare = proc(text: string, imagePaths: seq[string]) =
+    result.intake.onShare = proc(text: string, imagePaths: seq[string],
+        destinationChatId: string) =
       self.events.emit(SIGNAL_EXTERNAL_SHARE_INTAKE,
-        ExternalShareIntakeArgs(text: text, imagePaths: imagePaths))
+        ExternalShareIntakeArgs(text: text, imagePaths: imagePaths,
+          destinationChatId: destinationChatId))
     result.intake.onShareImagesDiscarded = proc(imagePaths: seq[string]) =
       # A pending share was replaced last-wins before delivery: its cached
       # image copies are unreferenced now and must not accumulate.

--- a/src/app/core/intake/external_intake.nim
+++ b/src/app/core/intake/external_intake.nim
@@ -32,6 +32,9 @@ type
       text*: string ## shared plain text; shared links arrive as text too
       imagePaths*: seq[string] ## app-private cached copies of shared images
                                ## (copied at receipt; never OS-managed URIs)
+      destinationChatId*: string ## non-empty when the share arrived through a
+                                 ## direct-share shortcut: the destination is
+                                 ## already decided and the picker is skipped
 
   UrlIntakeRoute* = enum
     UrlIntakeDeepLink   ## existing Status deep-link routing
@@ -42,7 +45,7 @@ type
     pendingSlot: Option[ExternalIntakeEvent]
     onDeepLinkUrl*: proc(url: string)
     onBrowserTabUrl*: proc(url: string)
-    onShare*: proc(text: string, imagePaths: seq[string])
+    onShare*: proc(text: string, imagePaths: seq[string], destinationChatId: string)
     onShareImagesDiscarded*: proc(imagePaths: seq[string])
       ## A buffered share carrying images was dropped without dispatch
       ## (last-wins overwrite of the pending slot); the cached copies are now
@@ -92,7 +95,7 @@ proc dispatch(self: ExternalIntake, event: ExternalIntakeEvent) =
         self.onBrowserTabUrl(event.url)
   of ExternalIntakeShare:
     if not self.onShare.isNil:
-      self.onShare(event.text, event.imagePaths)
+      self.onShare(event.text, event.imagePaths, event.destinationChatId)
 
 proc discardPendingShareImages(self: ExternalIntake) =
   ## The pending slot is about to be overwritten (last-wins): if it holds a

--- a/src/app/global/app_signals.nim
+++ b/src/app/global/app_signals.nim
@@ -54,12 +54,16 @@ type
   ExternalShareIntakeArgs* = ref object of Args
     text*: string
     imagePaths*: seq[string]
+    destinationChatId*: string
 
 const SIGNAL_EXTERNAL_SHARE_INTAKE* = "externalShareIntake"
 ## Emitted for content shared to Status from another app (share target):
 ## it must launch the share flow (destination picker -> preview -> send).
 ## Text and links both arrive as `text`; shared images arrive as `imagePaths`
 ## (app-private cached copies made at receipt, never OS-managed URIs).
+## `destinationChatId` is non-empty only when the share arrived through a
+## direct-share shortcut: the destination chat is already decided and the
+## picker step is skipped.
 
 const SIGNAL_MAIN_LOADED* = "signalMainLoaded"
 

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -298,7 +298,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_EXTERNAL_SHARE_INTAKE) do(e: Args):
     let args = ExternalShareIntakeArgs(e)
-    self.delegate.launchShareFlow(args.text, args.imagePaths)
+    self.delegate.launchShareFlow(args.text, args.imagePaths, args.destinationChatId)
 
   self.events.on(SIGNAL_OS_NOTIFICATION_CLICKED) do(e: Args):
     var args = ClickedNotificationArgs(e)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -342,7 +342,8 @@ method activateStatusDeepLink*(self: AccessInterface, statusDeepLink: string) {.
 method openUrlInNewBrowserTab*(self: AccessInterface, url: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method launchShareFlow*(self: AccessInterface, text: string, imagePaths: seq[string]) {.base.} =
+method launchShareFlow*(self: AccessInterface, text: string, imagePaths: seq[string],
+    destinationChatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method releaseShareIntakeFiles*(self: AccessInterface, imagePathsJson: string) {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -12,6 +12,7 @@ import app/global/app_signals
 import app/global/[global_singleton, feature_flags]
 import app/global/app_lifecycle
 import app/android/lifecycle
+import app/android/share_shortcuts
 import app/global/utils as utils
 import app_service/service/activity_center/dto/notification as activity_center_notification_dto
 import constants
@@ -152,6 +153,7 @@ type
     urlToOpenInNewBrowserTab: string
     shareTextToDeliver: string
     shareImagePathsToDeliver: seq[string]
+    shareDestinationChatIdToDeliver: string
     shareToDeliverPending: bool
 
 {.push warning[Deprecated]: off.}
@@ -160,7 +162,8 @@ type
 proc switchToContactOrDisplayUserProfile[T](self: Module[T], publicKey: string)
 method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string)
 method openUrlInNewBrowserTab*[T](self: Module[T], url: string)
-method launchShareFlow*[T](self: Module[T], text: string, imagePaths: seq[string])
+method launchShareFlow*[T](self: Module[T], text: string, imagePaths: seq[string],
+  destinationChatId: string)
 proc checkIfWeHaveNotifications[T](self: Module[T])
 proc createMemberItem[T](self: Module[T], memberId: string, requestId: string, state: MembershipRequestState, role: MemberRole, airdropAddress: string = ""): MemberItem
 proc getAllCommunityMemberItems[T](self: Module[T], community: CommunityDto): seq[MemberItem]
@@ -1030,10 +1033,12 @@ method onChatsLoaded*[T](
   if self.shareToDeliverPending:
     let text = self.shareTextToDeliver
     let imagePaths = self.shareImagePathsToDeliver
+    let destinationChatId = self.shareDestinationChatIdToDeliver
     self.shareToDeliverPending = false
     self.shareTextToDeliver = ""
     self.shareImagePathsToDeliver = @[]
-    self.launchShareFlow(text, imagePaths)
+    self.shareDestinationChatIdToDeliver = ""
+    self.launchShareFlow(text, imagePaths, destinationChatId)
 
 method onCommunityDataLoaded*[T](
   self: Module[T],
@@ -2048,6 +2053,10 @@ method getKeycardManagementModule*[T](self: Module[T]): QVariant =
 method signOutAndQuit*[T](self: Module[T]) =
   info "signOutAndQuit: logging out and quitting"
   markShuttingDown()
+  # Direct-share shortcuts carry chat names and avatars on OS surfaces outside
+  # the app; clear them unconditionally before quitting so a logged-out
+  # profile's data cannot linger there (no-op off Android).
+  clearShareShortcuts()
   when defined(ios) or defined(android):
     # Since on mobile devices, application.exit() ends in _exit(0), a graceful status_go.logout() is unnecessary
     # cause it does a few other things (stops the node, closes the DBs, then re-initializes the node and restarts
@@ -2159,20 +2168,24 @@ method openUrlInNewBrowserTab*[T](self: Module[T], url: string) =
     return
   self.view.emitOpenUrlInNewBrowserTabSignal(url)
 
-method launchShareFlow*[T](self: Module[T], text: string, imagePaths: seq[string]) =
+method launchShareFlow*[T](self: Module[T], text: string, imagePaths: seq[string],
+    destinationChatId: string) =
   ## Share route of the external intake seam: content shared to Status from
   ## another app launches the share flow (destination picker -> preview ->
-  ## send). Buffered until the main view is loaded, mirroring the deep-link
-  ## and browser-tab routes above; the buffer is last-wins, and a replaced
-  ## share's cached image copies are released so they don't accumulate.
+  ## send); a non-empty destinationChatId (direct-share shortcut tap) skips
+  ## the picker step. Buffered until the main view is loaded, mirroring the
+  ## deep-link and browser-tab routes above; the buffer is last-wins, and a
+  ## replaced share's cached image copies are released so they don't
+  ## accumulate.
   if not self.chatsLoaded:
     if self.shareToDeliverPending:
       releaseCachedShareFiles(self.shareImagePathsToDeliver)
     self.shareToDeliverPending = true
     self.shareTextToDeliver = text
     self.shareImagePathsToDeliver = imagePaths
+    self.shareDestinationChatIdToDeliver = destinationChatId
     return
-  self.view.emitLaunchShareFlowSignal(text, $(%imagePaths))
+  self.view.emitLaunchShareFlowSignal(text, $(%imagePaths), destinationChatId)
 
 method releaseShareIntakeFiles*[T](self: Module[T], imagePathsJson: string) =
   ## Cache lifecycle, cancel path: the share flow was dismissed without

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -435,9 +435,11 @@ QtObject:
   proc emitOpenUrlInNewBrowserTabSignal*(self: View, url: string) =
     self.openUrlInNewBrowserTab(url)
 
-  proc launchShareFlow*(self: View, text: string, imagePathsJson: string) {.signal.}
-  proc emitLaunchShareFlowSignal*(self: View, text: string, imagePathsJson: string) =
-    self.launchShareFlow(text, imagePathsJson)
+  proc launchShareFlow*(self: View, text: string, imagePathsJson: string,
+    destinationChatId: string) {.signal.}
+  proc emitLaunchShareFlowSignal*(self: View, text: string, imagePathsJson: string,
+      destinationChatId: string) =
+    self.launchShareFlow(text, imagePathsJson, destinationChatId)
 
   proc releaseShareIntakeFiles*(self: View, imagePathsJson: string) {.slot.} =
     ## Share-flow cancel path: releases the cached copies of shared images

--- a/src/statusq_bridge.nim
+++ b/src/statusq_bridge.nim
@@ -19,7 +19,7 @@ proc statusq_urlscheme_create*(): pointer {.cdecl, importc.}
 proc statusq_urlscheme_set_instance*(obj: pointer) {.cdecl, importc.}
 proc statusq_urlscheme_install_event_filter*(obj: pointer) {.cdecl, importc.}
 proc statusq_urlscheme_emit_deeplink*(obj: pointer, url: cstring) {.cdecl, importc.}
-proc statusq_urlscheme_emit_share*(obj: pointer, text: cstring, imagePathsJson: cstring) {.cdecl, importc.}
+proc statusq_urlscheme_emit_share*(obj: pointer, text: cstring, imagePathsJson: cstring, destinationChatId: cstring) {.cdecl, importc.}
 proc statusq_urlscheme_emit_appforegrounded*(obj: pointer) {.cdecl, importc.}
 proc statusq_urlscheme_delete*(obj: pointer) {.cdecl, importc.}
 

--- a/storybook/pages/ShareShortcutsPublisherPage.qml
+++ b/storybook/pages/ShareShortcutsPublisherPage.qml
@@ -1,0 +1,174 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import mainui
+import mainui.adaptors
+
+SplitView {
+    id: root
+
+    ListModel {
+        id: destinationsModel
+
+        readonly property var data: [
+            {
+                chatId: "chat-alice",
+                name: "Alice",
+                color: "#ff7d46",
+                colorId: 1,
+                icon: "",
+                emoji: "",
+                sectionId: "personal-section",
+                sectionName: "Chat",
+                lastMessageTimestamp: 400,
+                canPost: true
+            },
+            {
+                chatId: "chat-design-group",
+                name: "Design crew",
+                color: "#7cda00",
+                colorId: 2,
+                icon: "",
+                emoji: "🎨",
+                sectionId: "personal-section",
+                sectionName: "Chat",
+                lastMessageTimestamp: 900,
+                canPost: true
+            },
+            {
+                chatId: "channel-announcements",
+                name: "announcements",
+                color: "#887af9",
+                colorId: 3,
+                icon: "",
+                emoji: "",
+                sectionId: "community-1",
+                sectionName: "CryptoKitties",
+                lastMessageTimestamp: 1000,
+                canPost: false
+            },
+            {
+                chatId: "channel-general",
+                name: "general",
+                color: "#887af9",
+                colorId: 4,
+                icon: "",
+                emoji: "",
+                sectionId: "community-1",
+                sectionName: "CryptoKitties",
+                lastMessageTimestamp: 700,
+                canPost: true
+            },
+            {
+                chatId: "chat-bob",
+                name: "Bob",
+                color: "#4360df",
+                colorId: 5,
+                icon: "",
+                emoji: "",
+                sectionId: "personal-section",
+                sectionName: "Chat",
+                lastMessageTimestamp: 300,
+                canPost: true
+            },
+            {
+                chatId: "chat-carol",
+                name: "Carol",
+                color: "#d37ef4",
+                colorId: 6,
+                icon: "",
+                emoji: "",
+                sectionId: "personal-section",
+                sectionName: "Chat",
+                lastMessageTimestamp: 200,
+                canPost: true
+            }
+        ]
+
+        Component.onCompleted: append(data)
+    }
+
+    RecentPostableDestinationsAdaptor {
+        id: adaptor
+        sourceModel: destinationsModel
+    }
+
+    ShareShortcutsPublisher {
+        id: publisher
+
+        property int publishCount: 0
+        property string lastPayload: "(nothing published yet)"
+
+        model: adaptor.model
+        onPublishRequested: (shortcutsJson) => {
+            publishCount++
+            lastPayload = JSON.stringify(JSON.parse(shortcutsJson), null, 2)
+        }
+    }
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label {
+                text: "publishRequested fired %1 time(s); last payload:".arg(publisher.publishCount)
+            }
+
+            Label {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                verticalAlignment: Text.AlignTop
+                wrapMode: Text.Wrap
+                font.family: "monospace"
+                text: publisher.lastPayload
+            }
+        }
+    }
+
+    Pane {
+        SplitView.fillHeight: true
+        SplitView.preferredWidth: 350
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label {
+                Layout.fillWidth: true
+                wrapMode: Text.Wrap
+                text: "The publisher watches the top %1 postable destinations "
+                      .arg(publisher.maxShortcuts)
+                      + "and emits a new payload only when the published set "
+                      + "would change (bump recency to reorder). On Android the "
+                      + "payload feeds SystemUtils.publishShareShortcuts."
+            }
+
+            Repeater {
+                model: destinationsModel
+
+                RowLayout {
+                    Layout.fillWidth: true
+
+                    CheckBox {
+                        text: "%1 canPost".arg(model.name)
+                        checked: model.canPost
+                        onToggled: destinationsModel.setProperty(index, "canPost", checked)
+                    }
+
+                    Button {
+                        text: "Bump"
+                        onClicked: destinationsModel.setProperty(index, "lastMessageTimestamp",
+                                                                 model.lastMessageTimestamp + 1000)
+                    }
+                }
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_ShareShortcutsPublisher.qml
+++ b/storybook/qmlTests/tests/tst_ShareShortcutsPublisher.qml
@@ -1,0 +1,225 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Core
+
+import mainui
+import mainui.adaptors
+
+Item {
+    id: root
+
+    width: 400
+    height: 400
+
+    Component {
+        id: publisherComponent
+
+        ShareShortcutsPublisher {
+            debounceIntervalMs: 0
+        }
+    }
+
+    Component {
+        id: adaptorComponent
+
+        RecentPostableDestinationsAdaptor {}
+    }
+
+    Component {
+        id: destinationsModelComponent
+
+        ListModel {
+            readonly property var data: [
+                {
+                    chatId: "chat-alice",
+                    name: "Alice",
+                    color: "#ff0000",
+                    colorId: "",
+                    icon: "",
+                    emoji: "",
+                    sectionId: "personal-section",
+                    sectionName: "Chat",
+                    lastMessageTimestamp: 500,
+                    canPost: true
+                },
+                {
+                    chatId: "chat-design-group",
+                    name: "Design crew",
+                    color: "#00ff00",
+                    colorId: "",
+                    icon: "",
+                    emoji: "",
+                    sectionId: "personal-section",
+                    sectionName: "Chat",
+                    lastMessageTimestamp: 900,
+                    canPost: true
+                },
+                {
+                    chatId: "channel-announcements",
+                    name: "announcements",
+                    color: "#0000ff",
+                    colorId: "",
+                    icon: "",
+                    emoji: "",
+                    sectionId: "community-1",
+                    sectionName: "CryptoKitties",
+                    lastMessageTimestamp: 1000,
+                    canPost: false
+                },
+                {
+                    chatId: "channel-general",
+                    name: "general",
+                    color: "#123456",
+                    colorId: "",
+                    icon: "",
+                    emoji: "🐱",
+                    sectionId: "community-1",
+                    sectionName: "CryptoKitties",
+                    lastMessageTimestamp: 700,
+                    canPost: true
+                },
+                {
+                    chatId: "chat-bob",
+                    name: "Bob",
+                    color: "#654321",
+                    colorId: "",
+                    icon: "",
+                    emoji: "",
+                    sectionId: "personal-section",
+                    sectionName: "Chat",
+                    lastMessageTimestamp: 300,
+                    canPost: true
+                },
+                {
+                    chatId: "chat-carol",
+                    name: "Carol",
+                    color: "#abcdef",
+                    colorId: "",
+                    icon: "",
+                    emoji: "",
+                    sectionId: "personal-section",
+                    sectionName: "Chat",
+                    lastMessageTimestamp: 200,
+                    canPost: true
+                }
+            ]
+
+            Component.onCompleted: append(data)
+        }
+    }
+
+    Component {
+        id: signalSpyComponent
+
+        SignalSpy {}
+    }
+
+    TestCase {
+        name: "ShareShortcutsPublisherTest"
+        when: windowShown
+
+        // Recency-sorted postable destinations for the publisher, exactly as
+        // AppMain provides them (source model -> adaptor -> publisher).
+        function createPublisher(props = {}) {
+            const sourceModel = createTemporaryObject(destinationsModelComponent, root)
+            const adaptor = createTemporaryObject(adaptorComponent, root,
+                                                  { sourceModel: sourceModel })
+            const publisher = createTemporaryObject(
+                                publisherComponent, root,
+                                Object.assign({ model: adaptor.model }, props))
+            const spy = createTemporaryObject(signalSpyComponent, root,
+                                              { target: publisher,
+                                                signalName: "publishRequested" })
+            return { sourceModel, publisher, spy }
+        }
+
+        function lastPayload(spy) {
+            return JSON.parse(spy.signalArguments[spy.count - 1][0])
+        }
+
+        function test_publishesTopFourPostableByRecency() {
+            const { spy } = createPublisher()
+
+            tryCompare(spy, "count", 1)
+
+            const payload = lastPayload(spy)
+            compare(payload.length, 4)
+            compare(payload.map(e => e.id),
+                    ["chat-design-group", "channel-general", "chat-alice", "chat-bob"])
+            compare(payload[0].name, "Design crew")
+            // non-postable "announcements" is never published
+            verify(!payload.some(e => e.id === "channel-announcements"))
+        }
+
+        function test_republishesWhenRecencyChanges() {
+            const { sourceModel, spy } = createPublisher()
+            tryCompare(spy, "count", 1)
+
+            // Carol (least recent, not in the top 4) gets a successful send:
+            // she must enter the published set at the top.
+            sourceModel.setProperty(5, "lastMessageTimestamp", 2000)
+
+            tryCompare(spy, "count", 2)
+            const payload = lastPayload(spy)
+            compare(payload.map(e => e.id),
+                    ["chat-carol", "chat-design-group", "channel-general", "chat-alice"])
+        }
+
+        function test_doesNotRepublishWhenPublishedSetUnchanged() {
+            const { sourceModel, spy } = createPublisher()
+            tryCompare(spy, "count", 1)
+
+            // The most recent chat gets even more recent: order, names and
+            // avatars are unchanged, so nothing new must be published.
+            sourceModel.setProperty(1, "lastMessageTimestamp", 3000)
+            wait(50)
+
+            compare(spy.count, 1)
+        }
+
+        function test_publishesAllWhenFewerThanMaxDestinations() {
+            const { sourceModel, spy } = createPublisher()
+            tryCompare(spy, "count", 1)
+
+            sourceModel.remove(4, 2) // drop Bob and Carol
+
+            tryCompare(spy, "count", 2)
+            const payload = lastPayload(spy)
+            compare(payload.map(e => e.id),
+                    ["chat-design-group", "channel-general", "chat-alice"])
+        }
+
+        function test_maxShortcutsCapsThePublishedSet() {
+            const { spy } = createPublisher({ maxShortcuts: 2 })
+
+            tryCompare(spy, "count", 1)
+            const payload = lastPayload(spy)
+            compare(payload.map(e => e.id), ["chat-design-group", "channel-general"])
+        }
+
+        function test_renamedDestinationIsRepublished() {
+            const { sourceModel, spy } = createPublisher()
+            tryCompare(spy, "count", 1)
+
+            sourceModel.setProperty(0, "name", "Alice Cooper")
+
+            tryCompare(spy, "count", 2)
+            const payload = lastPayload(spy)
+            compare(payload[2].name, "Alice Cooper")
+        }
+
+        function test_iconsAreRenderedIntoIconDirectory() {
+            const iconDir = SystemUtils.shareShortcutsIconDirectory()
+            const { spy } = createPublisher({ iconDirectory: iconDir })
+
+            tryCompare(spy, "count", 1)
+            const payload = lastPayload(spy)
+            compare(payload.length, 4)
+            for (let i = 0; i < payload.length; i++) {
+                verify(payload[i].iconPath.startsWith(iconDir),
+                       "iconPath should live in the icon directory: " + payload[i].iconPath)
+            }
+        }
+    }
+}

--- a/test/nim/external_intake_test.nim
+++ b/test/nim/external_intake_test.nim
@@ -14,6 +14,7 @@ type Capture = ref object
   browserTabs: seq[string]
   shares: seq[string]
   shareImagePaths: seq[seq[string]]
+  shareDestinations: seq[string]
   discardedImagePaths: seq[seq[string]]
 
 proc newCapturingIntake(capture: Capture): ExternalIntake =
@@ -22,17 +23,20 @@ proc newCapturingIntake(capture: Capture): ExternalIntake =
     capture.deepLinks.add(url)
   result.onBrowserTabUrl = proc(url: string) =
     capture.browserTabs.add(url)
-  result.onShare = proc(text: string, imagePaths: seq[string]) =
+  result.onShare = proc(text: string, imagePaths: seq[string], destinationChatId: string) =
     capture.shares.add(text)
     capture.shareImagePaths.add(imagePaths)
+    capture.shareDestinations.add(destinationChatId)
   result.onShareImagesDiscarded = proc(imagePaths: seq[string]) =
     capture.discardedImagePaths.add(imagePaths)
 
 proc urlIntake(url: string): ExternalIntakeEvent =
   ExternalIntakeEvent(kind: ExternalIntakeUrl, url: url)
 
-proc shareIntake(text: string, imagePaths: seq[string] = @[]): ExternalIntakeEvent =
-  ExternalIntakeEvent(kind: ExternalIntakeShare, text: text, imagePaths: imagePaths)
+proc shareIntake(text: string, imagePaths: seq[string] = @[],
+    destinationChatId: string = ""): ExternalIntakeEvent =
+  ExternalIntakeEvent(kind: ExternalIntakeShare, text: text,
+    imagePaths: imagePaths, destinationChatId: destinationChatId)
 
 suite "external_intake routing":
 
@@ -179,6 +183,55 @@ suite "external_intake share events":
 
     check capture.shares == @[""]
     check capture.shareImagePaths == @[@["/cache/share-intake/screenshot.png"]]
+
+  test "a share without a destination dispatches with an empty destination":
+    ## Regular share-sheet path: the user picks the destination in the app.
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+    intake.setReady()
+
+    intake.submit(shareIntake("no preselection"))
+
+    check capture.shareDestinations == @[""]
+
+  test "a direct-share destination rides the share event to the handler":
+    ## Direct-share shortcut path: the OS share sheet delivered the tap on a
+    ## published shortcut, so the destination chat is already decided and the
+    ## picker step is skipped downstream.
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+    intake.setReady()
+
+    intake.submit(shareIntake("to alice", @["/cache/share-intake/a.png"],
+      destinationChatId = "chat-alice"))
+
+    check capture.shares == @["to alice"]
+    check capture.shareImagePaths == @[@["/cache/share-intake/a.png"]]
+    check capture.shareDestinations == @["chat-alice"]
+
+  test "a direct-share destination buffered before ready survives to delivery":
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+
+    intake.submit(shareIntake("pre-login direct share",
+      destinationChatId = "chat-alice"))
+    check capture.shares.len == 0
+
+    intake.setReady()
+
+    check capture.shares == @["pre-login direct share"]
+    check capture.shareDestinations == @["chat-alice"]
+
+  test "an empty share is dropped even when it carries a destination":
+    ## The destination alone is not shareable content; an empty payload must
+    ## neither launch the flow nor clobber a pending intake.
+    let capture = Capture()
+    let intake = newCapturingIntake(capture)
+    intake.setReady()
+
+    intake.submit(shareIntake("  ", destinationChatId = "chat-alice"))
+
+    check capture.shares.len == 0
 
   test "an image share buffered before ready is delivered at ready":
     let capture = Capture()

--- a/test/nim/share_intake_wake_test.nim
+++ b/test/nim/share_intake_wake_test.nim
@@ -11,7 +11,8 @@
 ##    (degraded fallback: next manual app open, no data loss);
 ##  - the Android SEND/SEND_MULTIPLE hand-off (shareActivated signal) reaches
 ##    SIGNAL_EXTERNAL_SHARE_INTAKE — text-only and with cached image paths —
-##    with pre-ready buffering.
+##    with pre-ready buffering; a direct-share shortcut tap carries its
+##    destination chat id through (empty for plain shares and slot payloads).
 
 import unittest, os
 import nimqml
@@ -53,10 +54,12 @@ suite "share_intake_wake":
     let manager = newUrlsManager(events, urlSchemeEvent, singleInstance, "", slot)
     var sharedTexts: seq[string] = @[]
     var sharedImagePaths: seq[seq[string]] = @[]
+    var sharedDestinations: seq[string] = @[]
     events.on(SIGNAL_EXTERNAL_SHARE_INTAKE) do(e: Args):
       let args = ExternalShareIntakeArgs(e)
       sharedTexts.add(args.text)
       sharedImagePaths.add(args.imagePaths)
+      sharedDestinations.add(args.destinationChatId)
 
   teardown:
     removeDir(slotDir)
@@ -146,7 +149,7 @@ suite "share_intake_wake":
     manager.appReady()
 
     statusq_urlscheme_emit_share(urlSchemeEvent.vptr,
-      "look at this https://example.com/article", "[]")
+      "look at this https://example.com/article", "[]", "")
     processEventsUntil(proc(): bool = sharedTexts.len > 0)
 
     check sharedTexts == @["look at this https://example.com/article"]
@@ -156,7 +159,7 @@ suite "share_intake_wake":
     manager.appReady()
 
     statusq_urlscheme_emit_share(urlSchemeEvent.vptr, "gallery caption",
-      """["/cache/share-intake/a.png","/cache/share-intake/b.jpg"]""")
+      """["/cache/share-intake/a.png","/cache/share-intake/b.jpg"]""", "")
     processEventsUntil(proc(): bool = sharedTexts.len > 0)
 
     check sharedTexts == @["gallery caption"]
@@ -167,14 +170,47 @@ suite "share_intake_wake":
     manager.appReady()
 
     statusq_urlscheme_emit_share(urlSchemeEvent.vptr, "",
-      """["/cache/share-intake/screenshot.png"]""")
+      """["/cache/share-intake/screenshot.png"]""", "")
     processEventsUntil(proc(): bool = sharedTexts.len > 0)
 
     check sharedTexts == @[""]
     check sharedImagePaths == @[@["/cache/share-intake/screenshot.png"]]
 
+  test "android direct-share destination reaches the intake seam":
+    # Direct-share shortcut tap: the OS attached the shortcut id (the chat id)
+    # to the SEND intent, so the destination is already decided and the picker
+    # step is skipped downstream.
+    manager.appReady()
+
+    statusq_urlscheme_emit_share(urlSchemeEvent.vptr, "to alice",
+      """["/cache/share-intake/a.png"]""", "chat-alice")
+    processEventsUntil(proc(): bool = sharedTexts.len > 0)
+
+    check sharedTexts == @["to alice"]
+    check sharedImagePaths == @[@["/cache/share-intake/a.png"]]
+    check sharedDestinations == @["chat-alice"]
+
+  test "android share without a shortcut id carries no destination":
+    manager.appReady()
+
+    statusq_urlscheme_emit_share(urlSchemeEvent.vptr, "plain share", "[]", "")
+    processEventsUntil(proc(): bool = sharedTexts.len > 0)
+
+    check sharedDestinations == @[""]
+
+  test "slot share payload carries no direct-share destination":
+    # iOS App Group slot path: direct-share shortcuts are Android-only, the
+    # slot payload never preselects a destination.
+    manager.appReady()
+    slot.write("""{"type":"share","text":"from the extension"}""")
+
+    statusq_urlscheme_emit_deeplink(urlSchemeEvent.vptr, ShareIntakeWakeUrl.cstring)
+    processEventsUntil(proc(): bool = sharedTexts.len > 0)
+
+    check sharedDestinations == @[""]
+
   test "share text before appReady is buffered and delivered at appReady":
-    statusq_urlscheme_emit_share(urlSchemeEvent.vptr, "pre-login share", "[]")
+    statusq_urlscheme_emit_share(urlSchemeEvent.vptr, "pre-login share", "[]", "")
     drainEvents() # let the queued slot run; the seam must buffer, not dispatch
     check sharedTexts.len == 0
 

--- a/ui/StatusQ/include/StatusQ/lifecycleutils.h
+++ b/ui/StatusQ/include/StatusQ/lifecycleutils.h
@@ -7,4 +7,8 @@ extern "C" {
 // Stop the separate Android status-go service process. No-op if not Android.
 Q_DECL_EXPORT void statusq_stopBackgroundService();
 
+// Remove every published direct-share shortcut, including system-cached
+// copies (logout hygiene). No-op if not Android.
+Q_DECL_EXPORT void statusq_clearShareShortcuts();
+
 }

--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -40,7 +40,18 @@ public:
     // Background the whole Android task, revealing the app the user came from
     // (share flow cancel: "return to the source app"); no-op elsewhere
     Q_INVOKABLE void moveAppTaskToBack();
-    
+
+    // Android direct-share shortcuts (one-tap share-sheet targets).
+    // shortcutsJson: JSON array of {id, name, iconPath?} objects in rank order
+    // (most recent first); publishing replaces the previously published set.
+    // Both no-op off Android.
+    Q_INVOKABLE void publishShareShortcuts(const QString& shortcutsJson);
+    Q_INVOKABLE void clearShareShortcuts();
+    // App-private directory the rendered shortcut avatars are written to
+    // (created on demand); works on all platforms so the shortcut publisher
+    // stays testable off-device
+    Q_INVOKABLE QString shareShortcutsIconDirectory() const;
+
     // Get Android keyboard state (uses WindowInsets API, works Android 11-16+)
     Q_INVOKABLE int androidKeyboardHeight() const;
     Q_INVOKABLE bool androidKeyboardVisible() const;

--- a/ui/StatusQ/include/StatusQ/urlschemeevent.h
+++ b/ui/StatusQ/include/StatusQ/urlschemeevent.h
@@ -12,7 +12,8 @@ namespace Status
 
         public:
             void emitDeepLinkToQt(const QString& url);
-            void emitShareToQt(const QString& text, const QStringList& imagePaths);
+            void emitShareToQt(const QString& text, const QStringList& imagePaths,
+                               const QString& destinationChatId);
             void emitAppForegroundedToQt();
             static void setInstance(UrlSchemeEvent* instance);
 
@@ -30,7 +31,11 @@ namespace Status
             // Share-target hand-off: shared text/links plus app-private cached
             // copies of shared images, as a JSON array of absolute paths (a
             // JSON string keeps the Nim slot signature to plain QStrings).
-            void shareActivated(const QString& text, const QString& imagePathsJson);
+            // destinationChatId is non-empty only when the share arrived via a
+            // direct-share shortcut (the shortcut id is the chat id): the
+            // destination is already decided and the picker step is skipped.
+            void shareActivated(const QString& text, const QString& imagePathsJson,
+                                const QString& destinationChatId);
             void appForegrounded();
     };
 }

--- a/ui/StatusQ/src/externc.cpp
+++ b/ui/StatusQ/src/externc.cpp
@@ -136,7 +136,10 @@ Q_DECL_EXPORT void statusq_urlscheme_emit_deeplink(void* obj, const char* url) {
 
 // imagePathsJson: JSON array of absolute paths of app-private cached copies
 // of the shared images (may be null or "[]" for text-only shares).
-Q_DECL_EXPORT void statusq_urlscheme_emit_share(void* obj, const char* text, const char* imagePathsJson) {
+// destinationChatId: the tapped direct-share shortcut's id — the destination
+// chat — or null/"" for a plain share-sheet share.
+Q_DECL_EXPORT void statusq_urlscheme_emit_share(void* obj, const char* text, const char* imagePathsJson,
+                                                const char* destinationChatId) {
     QStringList paths;
     if (imagePathsJson) {
         const auto doc = QJsonDocument::fromJson(QByteArray(imagePathsJson));
@@ -144,7 +147,8 @@ Q_DECL_EXPORT void statusq_urlscheme_emit_share(void* obj, const char* text, con
         for (const auto& value : array)
             paths << value.toString();
     }
-    static_cast<Status::UrlSchemeEvent*>(obj)->emitShareToQt(QString::fromUtf8(text), paths);
+    static_cast<Status::UrlSchemeEvent*>(obj)->emitShareToQt(QString::fromUtf8(text), paths,
+                                                             QString::fromUtf8(destinationChatId));
 }
 
 Q_DECL_EXPORT void statusq_urlscheme_emit_appforegrounded(void* obj) {

--- a/ui/StatusQ/src/lifecycleutils_android.cpp
+++ b/ui/StatusQ/src/lifecycleutils_android.cpp
@@ -15,8 +15,9 @@ extern "C" Q_DECL_EXPORT void statusq_stopBackgroundService()
 
 // Logout hygiene: direct-share shortcuts carry chat names and avatars on OS
 // surfaces outside the app process, so they are removed unconditionally when
-// the profile logs out (called from the Nim main module), not only when QML
-// happens to republish.
+// the profile logs out (called from the Nim main module; also backs
+// SystemUtilsInternal::clearShareShortcuts), not only when QML happens to
+// republish.
 extern "C" Q_DECL_EXPORT void statusq_clearShareShortcuts()
 {
     QJniObject context = QNativeInterface::QAndroidApplication::context();

--- a/ui/StatusQ/src/lifecycleutils_android.cpp
+++ b/ui/StatusQ/src/lifecycleutils_android.cpp
@@ -2,6 +2,7 @@
 
 #ifdef Q_OS_ANDROID
 #include <QJniObject>
+#include <QtCore/qnativeinterface.h>
 
 extern "C" Q_DECL_EXPORT void statusq_stopBackgroundService()
 {
@@ -12,8 +13,27 @@ extern "C" Q_DECL_EXPORT void statusq_stopBackgroundService()
     );
 }
 
-#else // non-Android stub
+// Logout hygiene: direct-share shortcuts carry chat names and avatars on OS
+// surfaces outside the app process, so they are removed unconditionally when
+// the profile logs out (called from the Nim main module), not only when QML
+// happens to republish.
+extern "C" Q_DECL_EXPORT void statusq_clearShareShortcuts()
+{
+    QJniObject context = QNativeInterface::QAndroidApplication::context();
+    if (!context.isValid())
+        return;
+
+    QJniObject::callStaticMethod<void>(
+        "app/status/mobile/ShareShortcutsHelper",
+        "clear",
+        "(Landroid/content/Context;)V",
+        context.object()
+    );
+}
+
+#else // non-Android stubs
 
 extern "C" Q_DECL_EXPORT void statusq_stopBackgroundService() {}
+extern "C" Q_DECL_EXPORT void statusq_clearShareShortcuts() {}
 
 #endif

--- a/ui/StatusQ/src/lifecycleutils_android.cpp
+++ b/ui/StatusQ/src/lifecycleutils_android.cpp
@@ -1,8 +1,8 @@
 #include "StatusQ/lifecycleutils.h"
 
 #ifdef Q_OS_ANDROID
+#include <QCoreApplication>
 #include <QJniObject>
-#include <QtCore/qnativeinterface.h>
 
 extern "C" Q_DECL_EXPORT void statusq_stopBackgroundService()
 {

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -456,6 +456,49 @@ void SystemUtilsInternal::moveAppTaskToBack()
 #endif
 }
 
+void SystemUtilsInternal::publishShareShortcuts(const QString& shortcutsJson)
+{
+#ifdef Q_OS_ANDROID
+    QJniObject context = QNativeInterface::QAndroidApplication::context();
+    if (!context.isValid())
+        return;
+
+    QJniObject::callStaticMethod<void>(
+        "app/status/mobile/ShareShortcutsHelper",
+        "publish",
+        "(Landroid/content/Context;Ljava/lang/String;)V",
+        context.object(),
+        QJniObject::fromString(shortcutsJson).object<jstring>()
+    );
+#else
+    Q_UNUSED(shortcutsJson);
+#endif
+}
+
+void SystemUtilsInternal::clearShareShortcuts()
+{
+#ifdef Q_OS_ANDROID
+    QJniObject context = QNativeInterface::QAndroidApplication::context();
+    if (!context.isValid())
+        return;
+
+    QJniObject::callStaticMethod<void>(
+        "app/status/mobile/ShareShortcutsHelper",
+        "clear",
+        "(Landroid/content/Context;)V",
+        context.object()
+    );
+#endif
+}
+
+QString SystemUtilsInternal::shareShortcutsIconDirectory() const
+{
+    const QString dir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
+                        + QStringLiteral("/share-shortcuts");
+    QDir().mkpath(dir);
+    return dir;
+}
+
 int SystemUtilsInternal::androidKeyboardHeight() const
 {
     return m_androidKeyboardHeight;

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -1,5 +1,7 @@
 #include "StatusQ/systemutilsinternal.h"
 
+#include "StatusQ/lifecycleutils.h"
+
 #include <QDesktopServices>
 #include <QGuiApplication>
 #include <QMimeDatabase>
@@ -477,18 +479,7 @@ void SystemUtilsInternal::publishShareShortcuts(const QString& shortcutsJson)
 
 void SystemUtilsInternal::clearShareShortcuts()
 {
-#ifdef Q_OS_ANDROID
-    QJniObject context = QNativeInterface::QAndroidApplication::context();
-    if (!context.isValid())
-        return;
-
-    QJniObject::callStaticMethod<void>(
-        "app/status/mobile/ShareShortcutsHelper",
-        "clear",
-        "(Landroid/content/Context;)V",
-        context.object()
-    );
-#endif
+    statusq_clearShareShortcuts();
 }
 
 QString SystemUtilsInternal::shareShortcutsIconDirectory() const

--- a/ui/StatusQ/src/urlschemeevent.cpp
+++ b/ui/StatusQ/src/urlschemeevent.cpp
@@ -75,7 +75,8 @@ void UrlSchemeEvent::emitDeepLinkToQt(const QString& url)
     emit urlActivated(url);
 }
 
-void UrlSchemeEvent::emitShareToQt(const QString& text, const QStringList& imagePaths)
+void UrlSchemeEvent::emitShareToQt(const QString& text, const QStringList& imagePaths,
+                                   const QString& destinationChatId)
 {
     if (text.isEmpty() && imagePaths.isEmpty()) return;
 
@@ -83,7 +84,9 @@ void UrlSchemeEvent::emitShareToQt(const QString& text, const QStringList& image
     for (const auto& path : imagePaths)
         paths.append(path);
 
-    emit shareActivated(text, QString::fromUtf8(QJsonDocument(paths).toJson(QJsonDocument::Compact)));
+    emit shareActivated(text,
+                        QString::fromUtf8(QJsonDocument(paths).toJson(QJsonDocument::Compact)),
+                        destinationChatId);
 }
 
 static UrlSchemeEvent* g_urlSchemeEventInstance = nullptr;
@@ -109,8 +112,11 @@ Java_app_status_mobile_StatusQtActivity_passDeepLinkToQt(JNIEnv* /*env*/, jclass
 // separate from the URL channel — a shared link must launch the share flow,
 // not URL routing. Image paths are app-private cached copies made by the Java
 // layer at receipt (OS read grants expire), never OS-managed content URIs.
+// destinationChatId is the tapped direct-share shortcut's id (empty for a
+// plain share-sheet share).
 extern "C" JNIEXPORT void JNICALL
-Java_app_status_mobile_StatusQtActivity_passShareToQt(JNIEnv* env, jclass /*clazz*/, jstring text, jobjectArray imagePaths)
+Java_app_status_mobile_StatusQtActivity_passShareToQt(JNIEnv* env, jclass /*clazz*/, jstring text,
+                                                      jobjectArray imagePaths, jstring destinationChatId)
 {
     const QString shareText = QJniObject(text).toString();
 
@@ -125,7 +131,7 @@ Java_app_status_mobile_StatusQtActivity_passShareToQt(JNIEnv* env, jclass /*claz
     }
 
     if (g_urlSchemeEventInstance) {
-        g_urlSchemeEventInstance->emitShareToQt(shareText, paths);
+        g_urlSchemeEventInstance->emitShareToQt(shareText, paths, QJniObject(destinationChatId).toString());
     }
 }
 #endif

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -228,8 +228,8 @@ QtObject {
                 root.openUrlInNewBrowserTab(url)
             }
 
-            function onLaunchShareFlow(text, imagePathsJson) {
-                root.launchShareFlow(text, JSON.parse(imagePathsJson))
+            function onLaunchShareFlow(text, imagePathsJson, destinationChatId) {
+                root.launchShareFlow(text, JSON.parse(imagePathsJson), destinationChatId)
             }
 
             function onOpenActivityCenter(group) {
@@ -288,7 +288,7 @@ QtObject {
     signal ensNameResolved(string resolvedPubKey, string resolvedAddress, string uuid)
     signal openUrl(string link)
     signal openUrlInNewBrowserTab(string link)
-    signal launchShareFlow(string text, var imagePaths)
+    signal launchShareFlow(string text, var imagePaths, string destinationChatId)
     signal openActivityCenter()
     signal wcLinkActivated(string link)
     signal profileMigrationFlowRequested(bool migrateToKeycard)

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -79,7 +79,7 @@ Item {
                                    appMain.privacyStore.thirdpartyServicesEnabled: true
         onOpenUrl: (link) => Global.requestOpenLink(link)
         onOpenUrlInNewBrowserTab: (link) => d.openUrlInNewBrowserTab(link)
-        onLaunchShareFlow: (text, imagePaths) => d.launchShareFlow(text, imagePaths)
+        onLaunchShareFlow: (text, imagePaths, destinationChatId) => d.launchShareFlow(text, imagePaths, destinationChatId)
         onOpenActivityCenter: () => {
             d.closeActivityCenterOnNextBack = false
             mainLayoutItem.openACCenterPanel = true
@@ -1032,13 +1032,16 @@ Item {
 
         // External intake, share route: content shared to Status from another
         // app launches the share flow (destination picker -> preview -> send).
+        // A non-empty destinationChatId (direct-share shortcut tap) skips the
+        // picker and lands on the preview with that chat pre-selected.
         // Last-wins: a share arriving while the flow is open restarts it with
         // the new payload; the replaced share's cached image copies are
         // released so they don't accumulate.
-        function launchShareFlow(text: string, imagePaths) {
+        function launchShareFlow(text: string, imagePaths, destinationChatId) {
             d.releaseShareFlowImages()
             shareFlowLoader.sharedText = text
             shareFlowLoader.sharedImagePaths = imagePaths
+            shareFlowLoader.preselectedDestinationChatId = destinationChatId ?? ""
             if (!shareFlowLoader.active)
                 shareFlowLoader.active = true
             else
@@ -2658,6 +2661,30 @@ Item {
                                                                   Utils.getSettingsSubsectionForSection(d.activeSectionType))
     }
 
+    // Recent postable destinations (recency-sorted, postable-only), shared by
+    // the share flow's destination picker and the direct-share shortcut
+    // publisher — single recency source, no duplicated logic.
+    RecentPostableDestinationsAdaptor {
+        id: shareDestinationsAdaptor
+        sourceModel: rootStore.chatSearchModel
+    }
+
+    // Android direct-share shortcuts: the top recent postable destinations
+    // are published as one-tap targets in the OS share sheet. Event-driven:
+    // successful sends reorder the recency model, which republishes. Living
+    // inside AppMain, the publisher only exists while a profile is logged in;
+    // logout clears the published set unconditionally on the Nim side
+    // (main module signOutAndQuit).
+    Loader {
+        active: SQUtils.Utils.isAndroid
+
+        sourceComponent: ShareShortcutsPublisher {
+            model: shareDestinationsAdaptor.model
+            iconDirectory: SystemUtils.shareShortcutsIconDirectory()
+            onPublishRequested: (shortcutsJson) => SystemUtils.publishShareShortcuts(shortcutsJson)
+        }
+    }
+
     Loader {
         id: shareFlowLoader
         active: false
@@ -2665,9 +2692,12 @@ Item {
         // The shared payload (external intake, share route): text editable in
         // the preview step; image paths are app-private cached copies whose
         // lifecycle ends with the flow (released on cancel/replace, or by the
-        // image-send task after send).
+        // image-send task after send). A non-empty preselected destination
+        // (direct-share shortcut tap; the shortcut id is the chat id) skips
+        // the picker step.
         property string sharedText
         property var sharedImagePaths: []
+        property string preselectedDestinationChatId
 
         sourceComponent: Popup {
             id: shareFlowPopup
@@ -2682,16 +2712,31 @@ Item {
             closePolicy: Popup.NoAutoClose
             padding: Theme.padding
 
+            Component.onCompleted: applyPreselectedDestination()
+
             onClosed: shareFlowLoader.active = false
 
             function restart() {
                 shareFlowSteps.currentIndex = 0
                 sharePreviewPanel.text = shareFlowLoader.sharedText
+                applyPreselectedDestination()
             }
 
-            RecentPostableDestinationsAdaptor {
-                id: shareDestinationsAdaptor
-                sourceModel: rootStore.chatSearchModel
+            // Direct-share path: the destination is already decided, so land
+            // on the preview with it pre-selected. Falls back to the picker
+            // when the chat is no longer among the postable destinations.
+            function applyPreselectedDestination() {
+                const chatId = shareFlowLoader.preselectedDestinationChatId
+                if (chatId === "")
+                    return
+                const destination = SQUtils.ModelUtils.getByKey(
+                                      shareDestinationsAdaptor.model, "chatId", chatId)
+                if (!destination)
+                    return
+                sharePreviewPanel.destinationSectionId = destination.sectionId
+                sharePreviewPanel.destinationChatId = destination.chatId
+                sharePreviewPanel.destinationName = destination.name
+                shareFlowSteps.currentIndex = 1
             }
 
             StackLayout {

--- a/ui/app/mainui/ShareShortcutsPublisher.qml
+++ b/ui/app/mainui/ShareShortcutsPublisher.qml
@@ -1,0 +1,190 @@
+import QtQuick
+
+import StatusQ.Components
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Core.Utils as SQUtils
+
+import SortFilterProxyModel
+
+import utils
+
+/**
+  * Non-visual worker behind the Android direct-share shortcuts: watches the
+  * top of the recent postable destinations model (see
+  * RecentPostableDestinationsAdaptor — single recency source, no duplicated
+  * logic), renders each destination's avatar the same way the destination
+  * picker does, and emits publishRequested with the shortcut payload whenever
+  * the published set would actually change. Event-driven only: a successful
+  * send updates the source model's recency, which reorders the top rows and
+  * triggers a republish — no polling.
+  *
+  * Emits an intent signal out; the high-level consumer (AppMain) forwards the
+  * payload to the platform (SystemUtils.publishShareShortcuts).
+  */
+Item {
+    id: root
+
+    /* Recency-sorted model of postable destinations; expected roles: chatId,
+       name, color, colorId, icon, emoji (as rendered by the destination
+       picker delegate) */
+    required property var model
+
+    /* The Android share sheet surfaces at most 4 direct-share targets */
+    property int maxShortcuts: 4
+
+    /* Directory the rendered avatars are written to; when empty, shortcuts
+       are published without icons */
+    property string iconDirectory
+
+    /* Model churn coalescing window — a send updates several roles at once */
+    property int debounceIntervalMs: 250
+
+    /* shortcutsJson: JSON array of {id, name, iconPath?} in rank order (most
+       recent first). An empty array means "clear the published set". */
+    signal publishRequested(string shortcutsJson)
+
+    // The avatar strip is render-only input for grabToImage: clipped away
+    // visually (grabbing renders the delegates themselves, so the clip does
+    // not affect the result), but it must stay visible — invisible items have
+    // no scene-graph content to grab.
+    width: 0
+    height: 0
+    clip: true
+
+    QtObject {
+        id: d
+
+        readonly property int iconSize: 128
+
+        // Visual identity of what was last published; republishing is skipped
+        // when it would not change (e.g. the most recent chat got even more
+        // recent, keeping the same order).
+        property string lastPublishedSignature
+        property int publishSeq: 0
+
+        function schedulePublish() {
+            debounceTimer.restart()
+        }
+
+        function collectEntries() {
+            const entries = []
+            const count = topDestinations.rowCount()
+            for (let i = 0; i < count; i++) {
+                const row = SQUtils.ModelUtils.get(topDestinations, i)
+                entries.push({
+                    id: row.chatId,
+                    name: row.name,
+                    color: String(row.color ?? ""),
+                    colorId: String(row.colorId ?? ""),
+                    icon: String(row.icon ?? ""),
+                    emoji: String(row.emoji ?? "")
+                })
+            }
+            return entries
+        }
+
+        function publish() {
+            const entries = collectEntries()
+            const signature = JSON.stringify(entries)
+            if (signature === lastPublishedSignature)
+                return
+
+            publishSeq++
+            const seq = publishSeq
+
+            if (entries.length === 0 || root.iconDirectory === "") {
+                emitPublish(signature, entries.map(e => ({ id: e.id, name: e.name })))
+                return
+            }
+
+            // Icons are best effort: a shortcut without an avatar still works,
+            // so a failed grab never holds the publication back.
+            const iconPaths = new Array(entries.length).fill("")
+            let remaining = entries.length
+            const finishOne = function() {
+                remaining--
+                if (remaining > 0 || seq !== d.publishSeq)
+                    return
+                emitPublish(signature, entries.map((e, i) => {
+                    const entry = { id: e.id, name: e.name }
+                    if (iconPaths[i] !== "")
+                        entry.iconPath = iconPaths[i]
+                    return entry
+                }))
+            }
+
+            for (let i = 0; i < entries.length; i++) {
+                const item = avatarRepeater.itemAt(i)
+                const path = "%1/shortcut-%2.png".arg(root.iconDirectory).arg(i)
+                const index = i
+                const grabbing = !!item && item.grabToImage(result => {
+                    if (result.saveToFile(path))
+                        iconPaths[index] = path
+                    finishOne()
+                })
+                if (!grabbing)
+                    finishOne()
+            }
+        }
+
+        function emitPublish(signature, entries) {
+            lastPublishedSignature = signature
+            root.publishRequested(JSON.stringify(entries))
+        }
+    }
+
+    // The source model is already postable-only and recency-sorted; the index
+    // filter keeps the head of it.
+    SortFilterProxyModel {
+        id: topDestinations
+
+        sourceModel: root.model
+
+        filters: IndexFilter {
+            maximumIndex: root.maxShortcuts - 1
+        }
+    }
+
+    Connections {
+        target: topDestinations
+
+        function onDataChanged() { d.schedulePublish() }
+        function onLayoutChanged() { d.schedulePublish() }
+        function onModelReset() { d.schedulePublish() }
+        function onRowsInserted() { d.schedulePublish() }
+        function onRowsMoved() { d.schedulePublish() }
+        function onRowsRemoved() { d.schedulePublish() }
+    }
+
+    Timer {
+        id: debounceTimer
+
+        interval: root.debounceIntervalMs
+        onTriggered: d.publish()
+    }
+
+    Repeater {
+        id: avatarRepeater
+
+        model: topDestinations
+
+        // Mirrors the destination picker delegate's avatar (StatusListItem
+        // asset), so the share sheet shows the destinations exactly as the
+        // picker does.
+        delegate: StatusSmartIdenticon {
+            width: d.iconSize
+            height: d.iconSize
+            name: model.name
+            asset.width: d.iconSize
+            asset.height: d.iconSize
+            asset.color: model.color ? model.color
+                                     : Utils.colorForColorId(Theme.palette, model.colorId)
+            asset.name: model.icon ?? ""
+            asset.emoji: model.emoji ?? ""
+            asset.charactersLen: 2
+        }
+    }
+
+    Component.onCompleted: d.schedulePublish()
+}

--- a/ui/app/mainui/qmldir
+++ b/ui/app/mainui/qmldir
@@ -1,5 +1,6 @@
 AppMain 1.0 AppMain.qml
 GlobalBanner 1.0 GlobalBanner.qml
+ShareShortcutsPublisher 1.0 ShareShortcutsPublisher.qml
 SplashScreen 1.0 SplashScreen.qml
 Popups 1.0 Popups.qml
 StatusTrayIcon 1.0 StatusTrayIcon.qml


### PR DESCRIPTION
Closes #21685. Part of #20439. Depends on the Android share target PR (stacked; earlier commits drop as predecessors merge).

The user's recent Status chats appear directly in the Android share sheet (direct share), so sharing to a frequent contact is one tap.

- Recent postable destinations published as dynamic shortcuts with the SHARE_TARGET category (name + avatar), refreshed as the user chats
- Tapping a direct-share destination opens the share preview with that chat pre-selected, skipping the picker
- `ShareShortcutsPublisher` (QML) + `ShareShortcutsHelper` (Java) + shortcuts XML; storybook page and QML tests

**How tested:** QML unit tests; device-verified on a Galaxy S21 — 4 SHARE_TARGET shortcuts published and shown by the OS share sheet, pre-selected flow lands in the right chat.

**Stacked chain:** #21686 (core) → #21688 (Android target) → #21689 (direct share) → #21690 (iOS extension) → #21691 (donations) → #21692 (flow polish); #21687 (media lifecycle) is independent. Each PR is based on its predecessor's branch, so the diff shows only this PR's commits. When a predecessor merges, this PR is rebased and retargeted to master before review/merge.
