### PR TITLE
feat(ios): recent-contact share suggestions via send-message intent donations

### DIFF
--- a/mobile/ios/shareExtension/Info.plist
+++ b/mobile/ios/shareExtension/Info.plist
@@ -31,6 +31,16 @@
         <string>ShareViewController</string>
         <key>NSExtensionAttributes</key>
         <dict>
+            <!-- Recent-contact suggestion chips (#16): the host app donates
+                 INSendMessageIntents after successful sends; declaring the
+                 intent here makes iOS surface those conversations as one-tap
+                 chips above this extension in the share sheet. A chip tap
+                 hands the donated conversation id back via
+                 extensionContext.intent (ShareViewController.m). -->
+            <key>IntentsSupported</key>
+            <array>
+                <string>INSendMessageIntent</string>
+            </array>
             <!-- Exactly what ShareViewController extracts and chat can send:
                  text, at most one web URL (#14), and images (#15) up to the
                  in-app per-message limit (Constants.maxUploadFiles = 6 in

--- a/mobile/ios/shareExtension/ShareViewController.m
+++ b/mobile/ios/shareExtension/ShareViewController.m
@@ -1,5 +1,7 @@
 // Share extension: text, links & images (fork issues #14/#15, iOS
-// share-integration slices 2 and 3, on the hand-off plumbing from #13).
+// share-integration slices 2 and 3, on the hand-off plumbing from #13);
+// suggestion-chip taps carry their donated conversation id through the same
+// hand-off (#16, slice 4).
 //
 // Thin hand-off, the extension stays a dumb platform layer (fork issue #12):
 //   1. extract the shared text/URL/images from the extension context
@@ -7,7 +9,8 @@
 //      Group `share-intake` cache immediately at receipt — the provider's
 //      file representation is only valid during the load handler, the same
 //      expiring-access rule as Android's content-URI read grants;
-//   2. write a {"type":"share","text":...,"imagePaths":[...]} payload into
+//   2. write a {"type":"share","text":...,"imagePaths":[...],
+//      "destinationChatId":...} payload into
 //      the App Group container (the pending intake slot — see
 //      src/app/core/intake/pending_intake_slot.nim for the host side and
 //      CONTEXT.md for the vocabulary);
@@ -28,6 +31,7 @@
 //     directory, mirroring the host-side guard (share_intake_cache.nim).
 
 #import <UIKit/UIKit.h>
+#import <Intents/Intents.h>
 #import <objc/message.h>
 
 // Must match ui/StatusQ/src/shareintake_ios.mm and the entitlements files
@@ -90,6 +94,13 @@ static NSString *const kTypePlainText = @"public.plain-text";
         return;
     _handled = YES;
 
+    // Suggestion-chip path (#16): when the user tapped one of the donated
+    // conversation chips instead of the app row, iOS hands the donated
+    // INSendMessageIntent back here — its conversationIdentifier is the chat
+    // id the host donated, so the destination is already decided and the host
+    // skips the picker. nil/empty for a plain app-row share.
+    NSString *destinationChatId = [self donatedConversationId];
+
     [self extractSharedContentWithCompletion:^(NSString *text, NSArray<NSString *> *imagePaths) {
         BOOL hasText = [text stringByTrimmingCharactersInSet:
                 [NSCharacterSet whitespaceAndNewlineCharacterSet]].length > 0;
@@ -102,7 +113,9 @@ static NSString *const kTypePlainText = @"public.plain-text";
             [self.extensionContext completeRequestReturningItems:@[] completionHandler:nil];
             return;
         }
-        if (![self writePendingIntakeWithText:text imagePaths:imagePaths]) {
+        if (![self writePendingIntakeWithText:text
+                                   imagePaths:imagePaths
+                            destinationChatId:destinationChatId]) {
             // The hand-off failed after the copies were made: don't leak them
             // into the shared container.
             [ShareViewController deleteCachedCopies:imagePaths];
@@ -283,12 +296,25 @@ static NSString *const kTypePlainText = @"public.plain-text";
     return dest.path;
 }
 
+// The conversation id of the donated send-message intent the user tapped in
+// the share sheet; nil when the share came through the plain app row (or the
+// OS handed over something unexpected).
+- (NSString *)donatedConversationId
+{
+    INIntent *intent = self.extensionContext.intent;
+    if (![intent isKindOfClass:[INSendMessageIntent class]])
+        return nil;
+    return ((INSendMessageIntent *)intent).conversationIdentifier;
+}
+
 // Last-wins by design: an atomic overwrite of the single slot file. The
 // replaced payload's cached image copies are deleted with it — they were
 // never delivered and nothing references them anymore. Returns NO when the
 // hand-off could not be written (the caller then releases this share's own
 // copies).
-- (BOOL)writePendingIntakeWithText:(NSString *)text imagePaths:(NSArray<NSString *> *)imagePaths
+- (BOOL)writePendingIntakeWithText:(NSString *)text
+                        imagePaths:(NSArray<NSString *> *)imagePaths
+                 destinationChatId:(NSString *)destinationChatId
 {
     NSFileManager *fm = [NSFileManager defaultManager];
     NSURL *container = [fm containerURLForSecurityApplicationGroupIdentifier:kAppGroupId];
@@ -308,8 +334,9 @@ static NSString *const kTypePlainText = @"public.plain-text";
     }
 
     // Payload contract with the host (urls_manager.consumePendingIntake):
-    // {"type": "share", "text": ..., "imagePaths": [...]} — imagePaths
-    // optional; unknown extra keys are ignored there.
+    // {"type": "share", "text": ..., "imagePaths": [...],
+    // "destinationChatId": ...} — imagePaths and destinationChatId optional;
+    // unknown extra keys are ignored there.
     NSMutableDictionary *payload = [@{
         @"type" : @"share",
         @"text" : text,
@@ -317,6 +344,8 @@ static NSString *const kTypePlainText = @"public.plain-text";
     } mutableCopy];
     if (imagePaths.count > 0)
         payload[@"imagePaths"] = imagePaths;
+    if (destinationChatId.length > 0)
+        payload[@"destinationChatId"] = destinationChatId;
     NSData *json = [NSJSONSerialization dataWithJSONObject:payload options:0 error:&error];
     if (json == nil) {
         NSLog(@"StatusShareExtension: cannot serialize payload: %@", error);

--- a/mobile/wrapperApp/Status.pro
+++ b/mobile/wrapperApp/Status.pro
@@ -100,7 +100,8 @@ ios {
             -framework UIKit \
             -framework PhotosUI \
             -framework Foundation \
-            -framework UserNotifications
+            -framework UserNotifications \
+            -framework Intents
 
     # Base libraries (always included)
     LIBS += -L$$PWD/../lib/$$LIB_PREFIX -lnim_status_client -lstatusq -lMobileWebView -lstatus -lsds -lssl_3 -lcrypto_3 -lSCodes -lZXing -lresolv -lqrcodegen

--- a/scripts/validate-qml.sh
+++ b/scripts/validate-qml.sh
@@ -24,8 +24,9 @@ echo "qmllint: $QMLLINT"
 echo "Qt modules: $QT_QML_PATH"
 echo ""
 
-# Collect all QML files
-mapfile -d '' QML_FILES < <(find "$ROOT_DIR/ui" -name "*.qml" -print0)
+# Collect all QML files (skipping build trees — they hold fetched third-party
+# sources and copies, and make lint results depend on prior builds)
+mapfile -d '' QML_FILES < <(find "$ROOT_DIR/ui" -path "*/build" -prune -o -name "*.qml" -print0)
 echo "Checking ${#QML_FILES[@]} files..."
 
 # Run qmllint with JSON output for precise filtering

--- a/src/app/core/custom_urls/urls_manager.nim
+++ b/src/app/core/custom_urls/urls_manager.nim
@@ -59,9 +59,14 @@ QtObject:
     ## Delivers (reads + clears) the App Group pending intake slot written by
     ## the iOS share extension and feeds it into the external intake seam.
     ## Payload contract (ShareViewController.m):
-    ## {"type": "share", "text": ..., "imagePaths": [...]} (imagePaths
-    ## optional). Malformed payloads are logged and dropped — a broken slot
-    ## file must never take the app down.
+    ## {"type": "share", "text": ..., "imagePaths": [...],
+    ## "destinationChatId": ...} (imagePaths and destinationChatId optional).
+    ## destinationChatId is non-empty only when the share arrived through a
+    ## donated send-message suggestion chip (the donated conversation id is
+    ## the chat id): the destination is already decided and the picker step
+    ## is skipped downstream — same contract as an Android direct-share
+    ## shortcut tap. Malformed payloads are logged and dropped — a broken
+    ## slot file must never take the app down.
     if self.intakeSlot.isNil:
       return
     let payload = self.intakeSlot.take()
@@ -71,7 +76,8 @@ QtObject:
       let parsed = parseJson(payload)
       if parsed{"type"}.getStr() == "share":
         self.intake.submit(ExternalIntakeEvent(kind: ExternalIntakeShare,
-          text: parsed{"text"}.getStr(), imagePaths: intakeImagePaths(parsed)))
+          text: parsed{"text"}.getStr(), imagePaths: intakeImagePaths(parsed),
+          destinationChatId: parsed{"destinationChatId"}.getStr()))
       else:
         warn "pending intake slot payload has an unknown type", payload
     except CatchableError:

--- a/src/app/ios/intent_donations.nim
+++ b/src/app/ios/intent_donations.nim
@@ -1,0 +1,20 @@
+## iOS send-message intent donations, Nim side. Donating is driven from QML
+## (SendMessageIntentDonor consumes the recent-postable-destinations model and
+## calls MobileUI.donateSendMessageInteraction after each successful send);
+## this binding covers the logout path, where every donated interaction must
+## be deleted unconditionally — donated chat names and avatars power the iOS
+## share-sheet suggestion chips, OS surfaces outside the app, and must not
+## linger for a logged-out profile. The iOS counterpart of
+## app/android/share_shortcuts.nim.
+
+when defined(ios):
+  {.push dynlib: "", importc.}
+  proc statusq_deleteDonatedInteractions*() {.cdecl, importc: "statusq_deleteDonatedInteractions".}
+  {.pop.}
+
+  proc deleteDonatedInteractions*() =
+    statusq_deleteDonatedInteractions()
+
+else:
+  # Stub for non-iOS builds (intent donations are iOS-only)
+  proc deleteDonatedInteractions*() = discard

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -300,6 +300,10 @@ proc init*(self: Controller) =
     let args = ExternalShareIntakeArgs(e)
     self.delegate.launchShareFlow(args.text, args.imagePaths, args.destinationChatId)
 
+  self.events.on(SIGNAL_SENDING_SUCCESS) do(e: Args):
+    let args = MessageSendingSuccess(e)
+    self.delegate.onMessageSent(args.chat.id)
+
   self.events.on(SIGNAL_OS_NOTIFICATION_CLICKED) do(e: Args):
     var args = ClickedNotificationArgs(e)
     self.delegate.osNotificationClicked(args.details)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -349,6 +349,9 @@ method launchShareFlow*(self: AccessInterface, text: string, imagePaths: seq[str
 method releaseShareIntakeFiles*(self: AccessInterface, imagePathsJson: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onMessageSent*(self: AccessInterface, chatId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method setCommunityIdToSpectate*(self: AccessInterface, commnityId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -13,6 +13,7 @@ import app/global/[global_singleton, feature_flags]
 import app/global/app_lifecycle
 import app/android/lifecycle
 import app/android/share_shortcuts
+import app/ios/intent_donations
 import app/global/utils as utils
 import app_service/service/activity_center/dto/notification as activity_center_notification_dto
 import constants
@@ -2053,10 +2054,13 @@ method getKeycardManagementModule*[T](self: Module[T]): QVariant =
 method signOutAndQuit*[T](self: Module[T]) =
   info "signOutAndQuit: logging out and quitting"
   markShuttingDown()
-  # Direct-share shortcuts carry chat names and avatars on OS surfaces outside
-  # the app; clear them unconditionally before quitting so a logged-out
-  # profile's data cannot linger there (no-op off Android).
+  # Direct-share shortcuts (Android) and donated send-message interactions
+  # (iOS share-sheet suggestion chips) carry chat names and avatars on OS
+  # surfaces outside the app; clear them unconditionally before quitting so a
+  # logged-out profile's data cannot linger there (each is a no-op off its
+  # platform).
   clearShareShortcuts()
+  deleteDonatedInteractions()
   when defined(ios) or defined(android):
     # Since on mobile devices, application.exit() ends in _exit(0), a graceful status_go.logout() is unnecessary
     # cause it does a few other things (stops the node, closes the DBs, then re-initializes the node and restarts
@@ -2193,6 +2197,16 @@ method releaseShareIntakeFiles*[T](self: Module[T], imagePathsJson: string) =
   ## (The send path releases them in the image-send task, after the files
   ## have been consumed.)
   releaseCachedShareFiles(parseImagePathsJson(imagePathsJson))
+
+method onMessageSent*[T](self: Module[T], chatId: string) =
+  ## A message the user sent was accepted (SIGNAL_SENDING_SUCCESS, in-app and
+  ## share-flow sends alike). Surfaced to QML so per-send hooks can run there
+  ## — e.g. donating an iOS send-message intent for the destination so it
+  ## appears as a share-sheet suggestion chip. Sends can't happen before the
+  ## main view is up, so no pre-chatsLoaded buffering is needed.
+  if not self.chatsLoaded:
+    return
+  self.view.emitMessageSentToChatSignal(chatId)
 
 method onDeactivateChatLoader*[T](self: Module[T], sectionId: string, chatId: string) =
   if (sectionId.len > 0 and self.chatSectionModules.contains(sectionId)):

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -446,6 +446,12 @@ QtObject:
     ## (JSON array of absolute paths, as delivered by launchShareFlow).
     self.delegate.releaseShareIntakeFiles(imagePathsJson)
 
+  proc messageSentToChat*(self: View, chatId: string) {.signal.}
+  proc emitMessageSentToChatSignal*(self: View, chatId: string) =
+    ## Per-send hook for QML (e.g. iOS send-message intent donations): the
+    ## user's message to chatId was accepted for sending.
+    self.messageSentToChat(chatId)
+
   proc navigateToMessageDetails*(self: View) {.signal.}
   proc emitNavigateToMessageDetailsSignal*(self: View) =
     self.navigateToMessageDetails()

--- a/storybook/pages/SendMessageIntentDonorPage.qml
+++ b/storybook/pages/SendMessageIntentDonorPage.qml
@@ -1,0 +1,176 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core
+
+import mainui
+import mainui.adaptors
+
+SplitView {
+    id: root
+
+    ListModel {
+        id: destinationsModel
+
+        readonly property var data: [
+            {
+                chatId: "chat-alice",
+                name: "Alice",
+                color: "#ff7d46",
+                colorId: 1,
+                icon: "",
+                emoji: "",
+                sectionId: "personal-section",
+                sectionName: "Chat",
+                lastMessageTimestamp: 400,
+                canPost: true
+            },
+            {
+                chatId: "chat-design-group",
+                name: "Design crew",
+                color: "#7cda00",
+                colorId: 2,
+                icon: "",
+                emoji: "🎨",
+                sectionId: "personal-section",
+                sectionName: "Chat",
+                lastMessageTimestamp: 900,
+                canPost: true
+            },
+            {
+                chatId: "channel-announcements",
+                name: "announcements",
+                color: "#887af9",
+                colorId: 3,
+                icon: "",
+                emoji: "",
+                sectionId: "community-1",
+                sectionName: "CryptoKitties",
+                lastMessageTimestamp: 1000,
+                canPost: false
+            },
+            {
+                chatId: "channel-general",
+                name: "general",
+                color: "#887af9",
+                colorId: 4,
+                icon: "",
+                emoji: "",
+                sectionId: "community-1",
+                sectionName: "CryptoKitties",
+                lastMessageTimestamp: 700,
+                canPost: true
+            },
+            {
+                chatId: "chat-bob",
+                name: "Bob",
+                color: "#4360df",
+                colorId: 5,
+                icon: "",
+                emoji: "",
+                sectionId: "personal-section",
+                sectionName: "Chat",
+                lastMessageTimestamp: 300,
+                canPost: true
+            }
+        ]
+
+        Component.onCompleted: append(data)
+    }
+
+    RecentPostableDestinationsAdaptor {
+        id: adaptor
+        sourceModel: destinationsModel
+    }
+
+    SendMessageIntentDonor {
+        id: donor
+
+        property int donationCount: 0
+        property string lastDonation: "(nothing donated yet)"
+
+        model: adaptor.model
+        onDonationRequested: (conversationId, name, iconPath) => {
+            donationCount++
+            lastDonation = JSON.stringify({ conversationId, name, iconPath }, null, 2)
+        }
+    }
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label {
+                text: "donationRequested fired %1 time(s); last donation:".arg(donor.donationCount)
+            }
+
+            Label {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                verticalAlignment: Text.AlignTop
+                wrapMode: Text.Wrap
+                font.family: "monospace"
+                text: donor.lastDonation
+            }
+
+            Image {
+                Layout.preferredWidth: 64
+                Layout.preferredHeight: 64
+                source: {
+                    try {
+                        const iconPath = JSON.parse(donor.lastDonation).iconPath
+                        return iconPath ? "file://" + iconPath : ""
+                    } catch (e) {
+                        return ""
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.fillHeight: true
+        SplitView.preferredWidth: 350
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label {
+                Layout.fillWidth: true
+                wrapMode: Text.Wrap
+                text: "\"Send\" simulates a successful send to that chat: the "
+                      + "donor looks the destination up in the recent postable "
+                      + "destinations model, renders its avatar and emits a "
+                      + "donation. On iOS the donation feeds "
+                      + "MobileUI.donateSendMessageInteraction, powering the "
+                      + "share-sheet suggestion chips. A non-postable "
+                      + "destination (announcements) is never donated."
+            }
+
+            CheckBox {
+                id: renderIconsCheckBox
+                text: "render avatars (iconDirectory set)"
+                checked: false
+                onToggled: donor.iconDirectory = checked
+                           ? SystemUtils.shareShortcutsIconDirectory() : ""
+            }
+
+            Repeater {
+                model: destinationsModel
+
+                Button {
+                    text: "Send to %1".arg(model.name)
+                    onClicked: donor.donateForChat(model.chatId)
+                }
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_SendMessageIntentDonor.qml
+++ b/storybook/qmlTests/tests/tst_SendMessageIntentDonor.qml
@@ -1,0 +1,170 @@
+import QtQuick
+import QtTest
+
+import StatusQ.Core
+
+import mainui
+import mainui.adaptors
+
+Item {
+    id: root
+
+    width: 400
+    height: 400
+
+    Component {
+        id: donorComponent
+
+        SendMessageIntentDonor {}
+    }
+
+    Component {
+        id: adaptorComponent
+
+        RecentPostableDestinationsAdaptor {}
+    }
+
+    Component {
+        id: destinationsModelComponent
+
+        ListModel {
+            readonly property var data: [
+                {
+                    chatId: "chat-alice",
+                    name: "Alice",
+                    color: "#ff0000",
+                    colorId: "",
+                    icon: "",
+                    emoji: "",
+                    sectionId: "personal-section",
+                    sectionName: "Chat",
+                    lastMessageTimestamp: 500,
+                    canPost: true
+                },
+                {
+                    chatId: "chat-design-group",
+                    name: "Design crew",
+                    color: "#00ff00",
+                    colorId: "",
+                    icon: "",
+                    emoji: "🎨",
+                    sectionId: "personal-section",
+                    sectionName: "Chat",
+                    lastMessageTimestamp: 900,
+                    canPost: true
+                },
+                {
+                    chatId: "channel-announcements",
+                    name: "announcements",
+                    color: "#0000ff",
+                    colorId: "",
+                    icon: "",
+                    emoji: "",
+                    sectionId: "community-1",
+                    sectionName: "CryptoKitties",
+                    lastMessageTimestamp: 1000,
+                    canPost: false
+                }
+            ]
+
+            Component.onCompleted: append(data)
+        }
+    }
+
+    Component {
+        id: signalSpyComponent
+
+        SignalSpy {}
+    }
+
+    TestCase {
+        name: "SendMessageIntentDonorTest"
+        when: windowShown
+
+        // Postable destinations for the donor, exactly as AppMain provides
+        // them (source model -> adaptor -> donor).
+        function createDonor(props = {}) {
+            const sourceModel = createTemporaryObject(destinationsModelComponent, root)
+            const adaptor = createTemporaryObject(adaptorComponent, root,
+                                                  { sourceModel: sourceModel })
+            const donor = createTemporaryObject(
+                            donorComponent, root,
+                            Object.assign({ model: adaptor.model }, props))
+            const spy = createTemporaryObject(signalSpyComponent, root,
+                                              { target: donor,
+                                                signalName: "donationRequested" })
+            return { sourceModel, donor, spy }
+        }
+
+        function test_sendDonatesTheDestination() {
+            const { donor, spy } = createDonor()
+
+            donor.donateForChat("chat-alice")
+
+            tryCompare(spy, "count", 1)
+            compare(spy.signalArguments[0][0], "chat-alice")
+            compare(spy.signalArguments[0][1], "Alice")
+            compare(spy.signalArguments[0][2], "") // no iconDirectory -> no avatar
+        }
+
+        function test_noDonationWithoutASend() {
+            const { spy } = createDonor()
+
+            wait(50)
+            compare(spy.count, 0)
+        }
+
+        function test_unknownDestinationIsSkipped() {
+            // A chat missing from the postable destinations model (e.g. no
+            // longer postable) is never donated.
+            const { donor, spy } = createDonor()
+
+            donor.donateForChat("channel-announcements") // filtered: canPost false
+            donor.donateForChat("chat-gone")
+
+            wait(50)
+            compare(spy.count, 0)
+        }
+
+        function test_sendBurstDonatesEachDestinationInOrder() {
+            const { donor, spy } = createDonor()
+
+            donor.donateForChat("chat-alice")
+            donor.donateForChat("chat-design-group")
+
+            tryCompare(spy, "count", 2)
+            compare(spy.signalArguments[0][0], "chat-alice")
+            compare(spy.signalArguments[1][0], "chat-design-group")
+        }
+
+        function test_avatarIsRenderedIntoIconDirectory() {
+            const iconDir = SystemUtils.shareShortcutsIconDirectory()
+            const { donor, spy } = createDonor({ iconDirectory: iconDir })
+
+            donor.donateForChat("chat-alice")
+
+            tryCompare(spy, "count", 1)
+            compare(spy.signalArguments[0][0], "chat-alice")
+            verify(spy.signalArguments[0][2].startsWith(iconDir),
+                   "iconPath should live in the icon directory: "
+                   + spy.signalArguments[0][2])
+        }
+
+        function test_repeatSendWhileDonationInFlightIsCoalesced() {
+            // Avatar rendering makes donations asynchronous; a send burst to
+            // the same chat must not queue duplicate donations.
+            const iconDir = SystemUtils.shareShortcutsIconDirectory()
+            const { donor, spy } = createDonor({ iconDirectory: iconDir })
+
+            donor.donateForChat("chat-alice")
+            donor.donateForChat("chat-design-group")
+            donor.donateForChat("chat-design-group")
+
+            tryCompare(spy, "count", 2)
+            wait(50)
+            compare(spy.count, 2)
+            compare(spy.signalArguments[0][0], "chat-alice")
+            compare(spy.signalArguments[1][0], "chat-design-group")
+        }
+    }
+}

--- a/test/nim/share_intake_wake_test.nim
+++ b/test/nim/share_intake_wake_test.nim
@@ -15,7 +15,10 @@
 ##  - the Android SEND/SEND_MULTIPLE hand-off (shareActivated signal) reaches
 ##    SIGNAL_EXTERNAL_SHARE_INTAKE — text-only and with cached image paths —
 ##    with pre-ready buffering; a direct-share shortcut tap carries its
-##    destination chat id through (empty for plain shares and slot payloads).
+##    destination chat id through (empty for plain shares);
+##  - an iOS suggestion-chip tap (donated send-message intent) carries its
+##    destination chat id through the slot payload the same way (empty when
+##    the payload has none).
 
 import unittest, os, json
 import nimqml
@@ -288,9 +291,9 @@ suite "share_intake_wake":
 
     check sharedDestinations == @[""]
 
-  test "slot share payload carries no direct-share destination":
-    # iOS App Group slot path: direct-share shortcuts are Android-only, the
-    # slot payload never preselects a destination.
+  test "slot share payload without a destination carries none":
+    # iOS App Group slot path, plain share (the user picked the app row, not a
+    # suggestion chip): no preselected destination, picker step downstream.
     manager.appReady()
     slot.write("""{"type":"share","text":"from the extension"}""")
 
@@ -298,6 +301,34 @@ suite "share_intake_wake":
     processEventsUntil(proc(): bool = sharedTexts.len > 0)
 
     check sharedDestinations == @[""]
+
+  test "slot share destination chat id reaches the intake seam":
+    # iOS suggestion-chip tap (donated send-message intent): the extension put
+    # the conversation id the OS handed it into the slot payload, so the
+    # destination is already decided and the picker is skipped downstream —
+    # same contract as an Android direct-share shortcut tap.
+    manager.appReady()
+    slot.write("""{"type":"share","text":"to alice","destinationChatId":"chat-alice"}""")
+
+    statusq_urlscheme_emit_deeplink(urlSchemeEvent.vptr, ShareIntakeWakeUrl.cstring)
+    processEventsUntil(proc(): bool = sharedTexts.len > 0)
+
+    check sharedTexts == @["to alice"]
+    check sharedDestinations == @["chat-alice"]
+
+  test "slot share destination survives login-first buffering":
+    # Suggestion-chip share while logged out: the payload (and its destination)
+    # parks in the seam until appReady, then opens pre-selected.
+    slot.write("""{"type":"share","text":"parked","destinationChatId":"chat-bob"}""")
+
+    statusq_urlscheme_emit_deeplink(urlSchemeEvent.vptr, ShareIntakeWakeUrl.cstring)
+    processEventsUntil(proc(): bool = not fileExists(slot.filePath()))
+    check sharedTexts.len == 0
+
+    manager.appReady()
+
+    check sharedTexts == @["parked"]
+    check sharedDestinations == @["chat-bob"]
 
   test "share text before appReady is buffered and delivered at appReady":
     statusq_urlscheme_emit_share(urlSchemeEvent.vptr, "pre-login share", "[]", "")

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -369,6 +369,13 @@ FetchContent_Declare(
 
   GIT_REPOSITORY https://github.com/status-im/MobileUI.git
   GIT_TAG 50917eb9cde14cf96e61646cbed71f835ee72d1b
+  # Send-message interaction donations (iOS share-sheet contact suggestions).
+  # Carried as an upstream-ready commit (git-am-able format-patch) until the
+  # MobileUI PR lands — then drop the patch and bump GIT_TAG instead. The
+  # helper script makes re-running the patch step a no-op.
+  PATCH_COMMAND ${CMAKE_COMMAND}
+    -DPATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/cmake/0001-MobileUI-send-message-interaction-donations.patch
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/apply_patch.cmake
 )
 FetchContent_MakeAvailable(MobileUI)
 

--- a/ui/StatusQ/cmake/0001-MobileUI-send-message-interaction-donations.patch
+++ b/ui/StatusQ/cmake/0001-MobileUI-send-message-interaction-donations.patch
@@ -1,0 +1,262 @@
+From 6dbe42efffbdd29b9abebfff529903955db6db96 Mon Sep 17 00:00:00 2001
+From: Alex Jbanca <alexjb@status.im>
+Date: Mon, 13 Jul 2026 10:11:22 +0000
+Subject: [PATCH] feat: send-message interaction donations (iOS share-sheet
+ suggestions)
+
+Add a generic donation API:
+- donateSendMessageInteraction(conversationId, displayName, avatarImagePath):
+  donates an INSendMessageIntent via INInteraction so iOS can surface the
+  conversation as a suggestion (e.g. a one-tap contact chip in the share
+  sheet when the app's share extension declares INSendMessageIntent in
+  IntentsSupported). The avatar file is read eagerly so callers may reuse or
+  delete the rendered image afterwards.
+- deleteAllDonatedInteractions(): removes every donation (privacy: logout
+  must not leave conversation names/avatars on OS surfaces).
+
+No-ops on Android (share-sheet suggestions use sharing shortcuts there) and
+desktop. Links the Intents framework on iOS (CMake + qmake).
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ CMakeLists.txt       |  2 +-
+ MobileUI.cpp         | 14 +++++++++++
+ MobileUI.h           | 34 ++++++++++++++++++++++++++
+ MobileUI.pri         |  2 +-
+ MobileUI_android.cpp | 18 ++++++++++++++
+ MobileUI_dummy.cpp   | 13 ++++++++++
+ MobileUI_ios.mm      | 58 ++++++++++++++++++++++++++++++++++++++++++++
+ MobileUI_private.h   |  5 ++++
+ 8 files changed, 144 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9042edb..3fa06df 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,7 +31,7 @@ elseif(IOS)
+         pushnotification_ios.mm
+         mobileuiappdelegate_ios.h
+         mobileuiappdelegate_ios.mm)
+-    set(PLATFORM_LIBRARIES "-framework UIKit -framework UserNotifications")
++    set(PLATFORM_LIBRARIES "-framework UIKit -framework UserNotifications -framework Intents")
+ else()
+     set(PLATFORM_SOURCES MobileUI_dummy.cpp)
+ endif()
+diff --git a/MobileUI.cpp b/MobileUI.cpp
+index e3bffec..18b33bd 100644
+--- a/MobileUI.cpp
++++ b/MobileUI.cpp
+@@ -255,3 +255,17 @@ void MobileUI::stopAccessingPath(const QString& filePath)
+ }
+ 
+ /* ************************************************************************** */
++
++void MobileUI::donateSendMessageInteraction(const QString& conversationId,
++                                            const QString& displayName,
++                                            const QString& avatarImagePath)
++{
++    MobileUIPrivate::donateSendMessageInteraction(conversationId, displayName, avatarImagePath);
++}
++
++void MobileUI::deleteAllDonatedInteractions()
++{
++    MobileUIPrivate::deleteAllDonatedInteractions();
++}
++
++/* ************************************************************************** */
+diff --git a/MobileUI.h b/MobileUI.h
+index 5b41aae..58396be 100644
+--- a/MobileUI.h
++++ b/MobileUI.h
+@@ -237,6 +237,40 @@ public:
+      *        should be stopped.
+      */
+     Q_INVOKABLE static void stopAccessingPath(const QString& filePath);
++
++    // Interaction donations ///////////////////////////////////////////////////
++    /*!
++     * \brief Donate a send-message interaction for a conversation to the OS.
++     *
++     * On iOS this donates an INSendMessageIntent (via INInteraction) so the
++     * system can surface the conversation as a suggestion, e.g. as a one-tap
++     * contact chip in the share sheet for apps whose share extension declares
++     * INSendMessageIntent in IntentsSupported. Call it after the user sends a
++     * message to that conversation.
++     *
++     * On Android and desktop this method is a no-op (Android share-sheet
++     * suggestions use the sharing-shortcuts mechanism instead).
++     *
++     * \param conversationId Stable identifier of the conversation; handed back
++     *        by the OS (e.g. INSendMessageIntent.conversationIdentifier) when
++     *        the user picks the suggestion.
++     * \param displayName Name the OS shows on the suggestion.
++     * \param avatarImagePath Optional absolute path to an image file shown as
++     *        the suggestion's avatar; pass an empty string for no avatar.
++     */
++    Q_INVOKABLE static void donateSendMessageInteraction(const QString& conversationId,
++                                                         const QString& displayName,
++                                                         const QString& avatarImagePath);
++
++    /*!
++     * \brief Delete every interaction this app has donated to the OS.
++     *
++     * On iOS this removes all INInteraction donations (and with them the
++     * suggestions they power). Intended for privacy-sensitive moments such as
++     * logout, where donated conversation names/avatars must not linger on OS
++     * surfaces. No-op on Android and desktop.
++     */
++    Q_INVOKABLE static void deleteAllDonatedInteractions();
+ };
+ 
+ /* ************************************************************************** */
+diff --git a/MobileUI.pri b/MobileUI.pri
+index 5bd8eda..ccec5f3 100644
+--- a/MobileUI.pri
++++ b/MobileUI.pri
+@@ -10,7 +10,7 @@ INCLUDEPATH += $${PWD}
+ android {
+     SOURCES += $${PWD}/MobileUI_android.cpp
+ } else: ios {
+-    LIBS += -framework UIKit
++    LIBS += -framework UIKit -framework Intents
+     SOURCES += $${PWD}/MobileUI_ios.mm
+ } else {
+     SOURCES += $${PWD}/MobileUI_dummy.cpp
+diff --git a/MobileUI_android.cpp b/MobileUI_android.cpp
+index be2b74d..d517bf9 100644
+--- a/MobileUI_android.cpp
++++ b/MobileUI_android.cpp
+@@ -558,6 +558,24 @@ void MobileUIPrivate::stopAccessingPath(const QString& filePath)
+ 
+ /* ************************************************************************** */
+ 
++// Android share-sheet suggestions are published through the sharing-shortcuts
++// mechanism (ShortcutManagerCompat), owned by the application; there is no
++// interaction-donation counterpart to implement here.
++void MobileUIPrivate::donateSendMessageInteraction(const QString& conversationId,
++                                                   const QString& displayName,
++                                                   const QString& avatarImagePath)
++{
++    Q_UNUSED(conversationId)
++    Q_UNUSED(displayName)
++    Q_UNUSED(avatarImagePath)
++}
++
++void MobileUIPrivate::deleteAllDonatedInteractions()
++{
++}
++
++/* ************************************************************************** */
++
+ float MobileUI::getSmartScaleFactor(float baseWidth, float baseDpi, float baseScale)
+ {
+     return QNativeInterface::QAndroidApplication::runOnAndroidMainThread([=] {
+diff --git a/MobileUI_dummy.cpp b/MobileUI_dummy.cpp
+index 6a2a59a..2a6fb70 100644
+--- a/MobileUI_dummy.cpp
++++ b/MobileUI_dummy.cpp
+@@ -121,6 +121,19 @@ void MobileUIPrivate::stopAccessingPath(const QString& filePath)
+     Q_UNUSED(filePath)
+ }
+ 
++void MobileUIPrivate::donateSendMessageInteraction(const QString& conversationId,
++                                                   const QString& displayName,
++                                                   const QString& avatarImagePath)
++{
++    Q_UNUSED(conversationId)
++    Q_UNUSED(displayName)
++    Q_UNUSED(avatarImagePath)
++}
++
++void MobileUIPrivate::deleteAllDonatedInteractions()
++{
++}
++
+ float MobileUI::getSmartScaleFactor(float baseWidth, float baseDpi, float baseScale)
+ {
+     Q_UNUSED(baseWidth);
+diff --git a/MobileUI_ios.mm b/MobileUI_ios.mm
+index 3d62f2e..ed5a9b4 100644
+--- a/MobileUI_ios.mm
++++ b/MobileUI_ios.mm
+@@ -425,3 +425,61 @@ float MobileUI::getSmartScaleFactor(float baseWidth, float baseDpi, float baseSc
+ }
+ 
+ /* ************************************************************************** */
++
++/* ************************************************************************** */
++
++#include <Intents/Intents.h>
++
++void MobileUIPrivate::donateSendMessageInteraction(const QString& conversationId,
++                                                   const QString& displayName,
++                                                   const QString& avatarImagePath)
++{
++    if (conversationId.isEmpty() || displayName.isEmpty()) {
++        NSLog(@"MobileUI: donateSendMessageInteraction needs a conversation id and a display name");
++        return;
++    }
++
++    INSpeakableString *groupName =
++        [[INSpeakableString alloc] initWithSpokenPhrase:displayName.toNSString()];
++    INSendMessageIntent *intent =
++        [[INSendMessageIntent alloc] initWithRecipients:nil
++                                    outgoingMessageType:INOutgoingMessageTypeOutgoingMessageText
++                                                content:nil
++                                     speakableGroupName:groupName
++                                 conversationIdentifier:conversationId.toNSString()
++                                            serviceName:nil
++                                                 sender:nil
++                                            attachments:nil];
++
++    if (!avatarImagePath.isEmpty()) {
++        // Read the file now instead of handing over a URL: the caller may
++        // overwrite or delete the rendered avatar file after this returns.
++        NSData *imageData = [NSData dataWithContentsOfFile:avatarImagePath.toNSString()];
++        if (imageData) {
++            [intent setImage:[INImage imageWithImageData:imageData]
++           forParameterNamed:@"speakableGroupName"];
++        } else {
++            NSLog(@"MobileUI: cannot read the suggestion avatar at %@ (donating without it)",
++                  avatarImagePath.toNSString());
++        }
++    }
++
++    INInteraction *interaction = [[INInteraction alloc] initWithIntent:intent response:nil];
++    interaction.direction = INInteractionDirectionOutgoing;
++    [interaction donateInteractionWithCompletion:^(NSError * _Nullable error) {
++        if (error) {
++            NSLog(@"MobileUI: send-message interaction donation failed: %@", error);
++        }
++    }];
++}
++
++void MobileUIPrivate::deleteAllDonatedInteractions()
++{
++    [INInteraction deleteAllInteractionsWithCompletion:^(NSError * _Nullable error) {
++        if (error) {
++            NSLog(@"MobileUI: deleting the donated interactions failed: %@", error);
++        }
++    }];
++}
++
++/* ************************************************************************** */
+diff --git a/MobileUI_private.h b/MobileUI_private.h
+index 85c11b8..c2d7535 100644
+--- a/MobileUI_private.h
++++ b/MobileUI_private.h
+@@ -77,6 +77,11 @@ public:
+ 
+     static bool startAccessingPath(const QString& filePath);
+     static void stopAccessingPath(const QString& filePath);
++
++    static void donateSendMessageInteraction(const QString& conversationId,
++                                             const QString& displayName,
++                                             const QString& avatarImagePath);
++    static void deleteAllDonatedInteractions();
+ };
+ 
+ /* ************************************************************************** */
+-- 
+2.54.0
+

--- a/ui/StatusQ/cmake/0001-MobileUI-send-message-interaction-donations.patch
+++ b/ui/StatusQ/cmake/0001-MobileUI-send-message-interaction-donations.patch
@@ -179,14 +179,21 @@ diff --git a/MobileUI_ios.mm b/MobileUI_ios.mm
 index 3d62f2e..ed5a9b4 100644
 --- a/MobileUI_ios.mm
 +++ b/MobileUI_ios.mm
-@@ -425,3 +425,61 @@ float MobileUI::getSmartScaleFactor(float baseWidth, float baseDpi, float baseSc
+@@ -425,3 +425,68 @@ float MobileUI::getSmartScaleFactor(float baseWidth, float baseDpi, float baseSc
  }
  
  /* ************************************************************************** */
 +
 +/* ************************************************************************** */
 +
-+#include <Intents/Intents.h>
++// Targeted imports, NOT the <Intents/Intents.h> umbrella: the umbrella pulls
++// in headers (e.g. INActivateCarSignalIntentResponse.h) that use C++ keywords
++// as member names and fail to compile in Objective-C++.
++#import <Intents/INIntent.h>
++#import <Intents/INSpeakableString.h>
++#import <Intents/INSendMessageIntent.h>
++#import <Intents/INImage.h>
++#import <Intents/INInteraction.h>
 +
 +void MobileUIPrivate::donateSendMessageInteraction(const QString& conversationId,
 +                                                   const QString& displayName,

--- a/ui/StatusQ/cmake/apply_patch.cmake
+++ b/ui/StatusQ/cmake/apply_patch.cmake
@@ -1,0 +1,30 @@
+# Idempotently apply PATCH_FILE (git format-patch output) to the working
+# directory — the FetchContent PATCH_COMMAND helper. The patch step can re-run
+# on an already-patched source tree (e.g. a re-triggered update step), so a
+# patch that is already applied (reverse-applies cleanly) is a no-op instead
+# of an error.
+#
+# Usage: cmake -DPATCH_FILE=<path> -P apply_patch.cmake  (cwd = source dir)
+
+if(NOT DEFINED PATCH_FILE)
+    message(FATAL_ERROR "apply_patch.cmake: pass -DPATCH_FILE=<path>")
+endif()
+
+execute_process(
+    COMMAND git apply --reverse --check --ignore-whitespace "${PATCH_FILE}"
+    RESULT_VARIABLE already_applied
+    OUTPUT_QUIET ERROR_QUIET
+)
+
+if(already_applied EQUAL 0)
+    return()
+endif()
+
+execute_process(
+    COMMAND git apply --ignore-whitespace "${PATCH_FILE}"
+    RESULT_VARIABLE apply_result
+)
+
+if(NOT apply_result EQUAL 0)
+    message(FATAL_ERROR "apply_patch.cmake: failed to apply ${PATCH_FILE}")
+endif()

--- a/ui/StatusQ/include/StatusQ/lifecycleutils.h
+++ b/ui/StatusQ/include/StatusQ/lifecycleutils.h
@@ -11,4 +11,10 @@ Q_DECL_EXPORT void statusq_stopBackgroundService();
 // copies (logout hygiene). No-op if not Android.
 Q_DECL_EXPORT void statusq_clearShareShortcuts();
 
+// Delete every donated send-message interaction, and with them the iOS
+// share-sheet suggestion chips they power (logout hygiene — the iOS
+// counterpart of statusq_clearShareShortcuts). No-op if not iOS.
+// Implemented in externc.cpp via MobileUI::deleteAllDonatedInteractions().
+Q_DECL_EXPORT void statusq_deleteDonatedInteractions();
+
 }

--- a/ui/StatusQ/src/externc.cpp
+++ b/ui/StatusQ/src/externc.cpp
@@ -11,6 +11,7 @@
 #include <QNetworkDiskCache>
 
 #include <StatusQ/typesregistration.h>
+#include <StatusQ/lifecycleutils.h>
 #include <StatusQ/osnotification.h>
 #include <StatusQ/shareintake.h>
 #include <StatusQ/urlschemeevent.h>
@@ -68,6 +69,15 @@ Q_DECL_EXPORT void statusq_registerQmlTypes() {
 
 Q_DECL_EXPORT float statusq_getMobileUIScaleFactor(float baseWidth, float baseDpi, float baseScale) {
     return MobileUI::getSmartScaleFactor(baseWidth, baseDpi, baseScale);
+}
+
+// Logout hygiene (declared in StatusQ/lifecycleutils.h): donated send-message
+// interactions carry chat names and avatars on OS surfaces outside the app
+// process (iOS share-sheet suggestion chips), so they are deleted
+// unconditionally when the profile logs out (called from the Nim main
+// module). MobileUI implements the deletion on iOS and no-ops elsewhere.
+Q_DECL_EXPORT void statusq_deleteDonatedInteractions() {
+    MobileUI::deleteAllDonatedInteractions();
 }
 
 Q_DECL_EXPORT void statusq_installMessageHandler(StatusQMessageHandler cb) {

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -232,6 +232,10 @@ QtObject {
                 root.launchShareFlow(text, JSON.parse(imagePathsJson), destinationChatId)
             }
 
+            function onMessageSentToChat(chatId) {
+                root.messageSentToChat(chatId)
+            }
+
             function onOpenActivityCenter(group) {
                 root.activityCenterStore.setActiveNotificationGroup(group)
                 root.openActivityCenter()
@@ -289,6 +293,9 @@ QtObject {
     signal openUrl(string link)
     signal openUrlInNewBrowserTab(string link)
     signal launchShareFlow(string text, var imagePaths, string destinationChatId)
+    // A message the user sent to chatId was accepted (in-app and share-flow
+    // sends alike) — the per-send hook behind the iOS share-sheet suggestions
+    signal messageSentToChat(string chatId)
     signal openActivityCenter()
     signal wcLinkActivated(string link)
     signal profileMigrationFlowRequested(bool migrateToKeycard)

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2685,6 +2685,34 @@ Item {
         }
     }
 
+    // iOS share-sheet contact suggestions: after each successful send (in-app
+    // and share-flow) the destination is donated as a send-message intent, so
+    // iOS surfaces it as a one-tap suggestion chip in the share sheet.
+    // Event-driven only: donations repopulate organically as the user sends;
+    // logout deletes all of them unconditionally on the Nim side (main module
+    // signOutAndQuit), mirroring the Android shortcut clearing.
+    Loader {
+        id: intentDonorLoader
+
+        active: SQUtils.Utils.isIOS
+
+        sourceComponent: SendMessageIntentDonor {
+            model: shareDestinationsAdaptor.model
+            iconDirectory: SystemUtils.shareShortcutsIconDirectory()
+            onDonationRequested: (conversationId, name, iconPath) =>
+                MobileUI.donateSendMessageInteraction(conversationId, name, iconPath)
+        }
+    }
+
+    Connections {
+        target: appMain.rootStore
+        enabled: intentDonorLoader.active
+
+        function onMessageSentToChat(chatId) {
+            intentDonorLoader.item.donateForChat(chatId)
+        }
+    }
+
     Loader {
         id: shareFlowLoader
         active: false

--- a/ui/app/mainui/SendMessageIntentDonor.qml
+++ b/ui/app/mainui/SendMessageIntentDonor.qml
@@ -1,0 +1,143 @@
+import QtQuick
+
+import StatusQ.Components
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Core.Utils as SQUtils
+
+import utils
+
+/**
+  * Non-visual worker behind the iOS share-sheet contact suggestions: after
+  * each successful send (AppMain forwards rootStore.messageSentToChat into
+  * donateForChat), it looks the destination up in the recent postable
+  * destinations model (see RecentPostableDestinationsAdaptor — the single
+  * identity/recency source the destination picker uses, no duplicated logic),
+  * renders its avatar the same way the picker does, and emits
+  * donationRequested with the conversation id, display name and rendered
+  * avatar path. Event-driven only: no donation without a send.
+  *
+  * Emits an intent signal out; the high-level consumer (AppMain) forwards it
+  * to the platform donation call (MobileUI.donateSendMessageInteraction).
+  */
+Item {
+    id: root
+
+    /* Postable destinations; expected roles: chatId, name, color, colorId,
+       icon, emoji (as rendered by the destination picker delegate) */
+    required property var model
+
+    /* Directory the rendered avatars are written to; when empty, donations
+       are emitted without an avatar */
+    property string iconDirectory
+
+    /* iconPath is "" when no avatar could be rendered — a donation without
+       an avatar still works (best effort, like the shortcut publisher) */
+    signal donationRequested(string conversationId, string name, string iconPath)
+
+    /* A send to chatId just succeeded: donate it as a suggestion. Ids not in
+       the model are skipped — a destination that is no longer postable is
+       never donated. Safe to call in bursts: donations are processed one
+       avatar grab at a time, and a chat already waiting is not re-queued. */
+    function donateForChat(chatId) {
+        if (d.queue.indexOf(chatId) !== -1)
+            return
+        d.queue.push(chatId)
+        d.processNext()
+    }
+
+    // The avatar is render-only input for grabToImage: clipped away visually
+    // (grabbing renders the item itself, so the clip does not affect the
+    // result), but it must stay visible — invisible items have no
+    // scene-graph content to grab.
+    width: 0
+    height: 0
+    clip: true
+
+    QtObject {
+        id: d
+
+        readonly property int iconSize: 128
+
+        // Sends awaiting donation, processed one at a time (the avatar item
+        // is single and a grab is in flight while busy).
+        property var queue: []
+        property bool busy: false
+
+        property string currentName
+        property string currentColor
+        property string currentColorId
+        property string currentIcon
+        property string currentEmoji
+
+        // Guarded lookup: between donations (and for a destination without
+        // a colorId) there is nothing to look up, and colorForColorId("")
+        // would produce undefined — not assignable to a color.
+        function currentAssetColor() {
+            if (currentColor)
+                return currentColor
+            if (currentColorId === "")
+                return "transparent"
+            return Utils.colorForColorId(Theme.palette, currentColorId)
+        }
+
+        function processNext() {
+            if (busy || queue.length === 0)
+                return
+
+            const chatId = queue.shift()
+            const destination = SQUtils.ModelUtils.getByKey(root.model, "chatId", chatId)
+            if (!destination) {
+                processNext()
+                return
+            }
+
+            const name = destination.name
+            if (root.iconDirectory === "") {
+                root.donationRequested(chatId, name, "")
+                processNext()
+                return
+            }
+
+            busy = true
+            currentName = name
+            currentColor = String(destination.color ?? "")
+            currentColorId = String(destination.colorId ?? "")
+            currentIcon = String(destination.icon ?? "")
+            currentEmoji = String(destination.emoji ?? "")
+
+            // One file per conversation: a later donation for the same chat
+            // overwrites its previous avatar instead of accumulating files.
+            const path = "%1/donation-%2.png".arg(root.iconDirectory).arg(Qt.md5(chatId))
+            const grabbing = avatar.grabToImage(result => {
+                const saved = result.saveToFile(path)
+                d.finish(chatId, name, saved ? path : "")
+            })
+            if (!grabbing)
+                finish(chatId, name, "")
+        }
+
+        function finish(chatId, name, iconPath) {
+            busy = false
+            root.donationRequested(chatId, name, iconPath)
+            processNext()
+        }
+    }
+
+    // Mirrors the destination picker delegate's avatar (StatusListItem
+    // asset), so the share-sheet suggestion shows the destination exactly as
+    // the picker does.
+    StatusSmartIdenticon {
+        id: avatar
+
+        width: d.iconSize
+        height: d.iconSize
+        name: d.currentName
+        asset.width: d.iconSize
+        asset.height: d.iconSize
+        asset.color: d.currentAssetColor()
+        asset.name: d.currentIcon
+        asset.emoji: d.currentEmoji
+        asset.charactersLen: 2
+    }
+}

--- a/ui/app/mainui/SendMessageIntentDonor.qml
+++ b/ui/app/mainui/SendMessageIntentDonor.qml
@@ -40,7 +40,7 @@ Item {
        never donated. Safe to call in bursts: donations are processed one
        avatar grab at a time, and a chat already waiting is not re-queued. */
     function donateForChat(chatId) {
-        if (d.queue.indexOf(chatId) !== -1)
+        if (d.queue.includes(chatId))
             return
         d.queue.push(chatId)
         d.processNext()

--- a/ui/app/mainui/qmldir
+++ b/ui/app/mainui/qmldir
@@ -1,5 +1,6 @@
 AppMain 1.0 AppMain.qml
 GlobalBanner 1.0 GlobalBanner.qml
+SendMessageIntentDonor 1.0 SendMessageIntentDonor.qml
 ShareShortcutsPublisher 1.0 ShareShortcutsPublisher.qml
 SplashScreen 1.0 SplashScreen.qml
 Popups 1.0 Popups.qml


### PR DESCRIPTION
Closes #21564. Part of #20439. Depends on the iOS share extension PR (stacked; earlier commits drop as predecessors merge).

iOS suggests the user's recent Status contacts directly in the share sheet, the way Messages/WhatsApp contacts appear there.

- Every sent 1-1/group message donates an `INSendMessageIntent` (recipient name + avatar), so iOS pins recent Status conversations as share-sheet suggestions
- Tapping a suggested contact opens the share flow with that destination pre-selected
- MobileUI donation API as a vendored patch (until upstreamed to MobileUI) + `SendMessageIntentDonor` (QML); storybook page and QML tests

**How tested:** QML unit tests; device-verified on an iPhone 15 Pro Max — suggestions appear after sends and route to the pre-selected share flow.

**Stacked chain:** #21686 (core) → #21688 (Android target) → #21689 (direct share) → #21690 (iOS extension) → #21691 (donations) → #21692 (flow polish); #21687 (media lifecycle) is independent. Each PR is based on its predecessor's branch, so the diff shows only this PR's commits. When a predecessor merges, this PR is rebased and retargeted to master before review/merge.
