### PR TITLE
feat(sending): update message sending status to use publishing and delivered to use SDS

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -482,11 +482,13 @@ proc setActiveItem*(self: Controller, itemId: string) =
   let isSectionActive = self.getIsCurrentSectionActive()
   if not isSectionActive:
     return
+
+  # Ensure chat content modules are loaded and subscribed to message events
+  # before triggering async initial message loading.
+  self.delegate.activeItemSet(self.activeItemId)
+
   if self.activeItemId != "":
     self.messageService.asyncLoadInitialMessagesForChat(self.activeItemId)
-
-  # We need to take other actions here like notify status go that unviewed mentions count is updated and so...
-  self.delegate.activeItemSet(self.activeItemId)
 
 proc removeCommunityChat*(self: Controller, itemId: string) =
   self.communityService.deleteCommunityChat(self.getMySectionId(), itemId)

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -81,6 +81,7 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items*: seq[Item]
       firstUnseenMessageId: string
+      pendingOutgoingStatuses: Table[string, string]
 
   proc delete(self: Model)
   proc setup(self: Model)
@@ -89,6 +90,7 @@ QtObject:
     new(result, delete)
     result.setup
     result.firstUnseenMessageId = ""
+    result.pendingOutgoingStatuses = initTable[string, string]()
 
   proc delete(self: Model) =
     self.QAbstractListModel.delete
@@ -433,11 +435,37 @@ QtObject:
     let existingItems = toHashSet(self.items.map(x => x.id))
     return items.filter(item => not existingItems.contains(item.id))
 
+  proc shouldUpdateOutgoingStatus(currentStatus, nextStatus: string): bool =
+    if currentStatus == PARSED_TEXT_OUTGOING_STATUS_DELIVERED or
+        currentStatus == PARSED_TEXT_OUTGOING_STATUS_EXPIRED:
+      return false
+    if currentStatus == PARSED_TEXT_OUTGOING_STATUS_SENT:
+      return nextStatus == PARSED_TEXT_OUTGOING_STATUS_DELIVERED or
+        nextStatus == PARSED_TEXT_OUTGOING_STATUS_EXPIRED
+    return currentStatus != nextStatus
+
+  proc applyPendingOutgoingStatuses(self: Model, items: var seq[Item]) =
+    for item in items.mitems:
+      var bestPending = ""
+      if self.pendingOutgoingStatuses.hasKey(item.id):
+        bestPending = self.pendingOutgoingStatuses[item.id]
+        self.pendingOutgoingStatuses.del(item.id)
+      if item.albumId != "":
+        for mid in item.albumMessageIds:
+          if self.pendingOutgoingStatuses.hasKey(mid):
+            let pending = self.pendingOutgoingStatuses[mid]
+            if shouldUpdateOutgoingStatus(bestPending, pending):
+              bestPending = pending
+            self.pendingOutgoingStatuses.del(mid)
+      if bestPending.len > 0 and shouldUpdateOutgoingStatus(item.outgoingStatus, bestPending):
+        item.outgoingStatus = bestPending
+
   proc insertItemsBasedOnClock*(self: Model, items: seq[Item]) =
     # remove existing items and sort by most recent
     let sortCmp = proc(lhs, rhs: Item): int =
       return if isGreaterThan(lhs, rhs): -1 else: 1
-    let newItems = sorted(self.filterExistingItems(items), sortCmp)
+    var newItems = sorted(self.filterExistingItems(items), sortCmp)
+    self.applyPendingOutgoingStatuses(newItems)
 
     # bulk insert algorithm, "two-pointer" technique
     var currentIdx = 0
@@ -527,10 +555,18 @@ QtObject:
     return self.items[ind]
 
   proc setOutgoingStatus(self: Model, messageId: string, status: string) =
-    updateItemRolesAndNotify self.findIndexForMessageId(messageId):
-      if self.items[ind].outgoingStatus == PARSED_TEXT_OUTGOING_STATUS_DELIVERED:
-        return
-      updateRoleWithValue(outgoingStatus, status)
+    let ind = self.findIndexForMessageId(messageId)
+    if(ind == -1):
+      let pendingStatus = self.pendingOutgoingStatuses.getOrDefault(messageId)
+      if shouldUpdateOutgoingStatus(pendingStatus, status):
+        self.pendingOutgoingStatuses[messageId] = status
+      return
+    if not shouldUpdateOutgoingStatus(self.items[ind].outgoingStatus, status):
+      return
+    self.items[ind].outgoingStatus = status
+    let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
+    self.dataChanged(index, index, @[ModelRole.OutgoingStatus.int])
 
   proc itemSending*(self: Model, messageId: string) =
     self.setOutgoingStatus(messageId, PARSED_TEXT_OUTGOING_STATUS_SENDING)

--- a/test/nim/message_model_test.nim
+++ b/test/nim/message_model_test.nim
@@ -46,6 +46,20 @@ suite "empty model":
   test "initial size":
     require(model.rowCount() == 0)
 
+suite "outgoing status ordering":
+  test "applies an early sent signal when the message is inserted":
+    let model = newModel()
+    model.itemSent(message1.id)
+    model.insertItemBasedOnClock(message1)
+    check(model.getItemWithMessageId(message1.id).outgoingStatus == PARSED_TEXT_OUTGOING_STATUS_SENT)
+
+  test "keeps the highest early outgoing status":
+    let model = newModel()
+    model.itemSent(message1.id)
+    model.itemDelivered(message1.id)
+    model.insertItemBasedOnClock(message1)
+    check(model.getItemWithMessageId(message1.id).outgoingStatus == PARSED_TEXT_OUTGOING_STATUS_DELIVERED)
+
 # newest messages should be first, break ties by message id
 suite "inserting new messages":
   setup:

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
@@ -160,7 +160,7 @@ Item {
         Loader {
             id: deliveryStatusLoader
             Layout.alignment: Qt.AlignVCenter
-            active: root.outgoingStatus !== StatusMessage.OutgoingStatus.Unknown
+            active: root.amISender && root.outgoingStatus !== StatusMessage.OutgoingStatus.Unknown
             sourceComponent: RowLayout {
                 spacing: 0
                 StatusIcon {


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-app/issues/21598
status-go PR: https://github.com/status-im/status-go/pull/7666

Updates status-go to get the new logic of how to mark messages as sending and delivered. See status-go commits for more details.

Also, status-app now buffers early sent/delivered/expired status signals until their message DTO is inserted, making message status updates order-independent and preventing messages from getting stuck in `sending` when the signal arrives before the send response.

### Affected areas

- status-go
- message_model

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

Also ask Copilot to align feedback with repository architecture boundaries:

- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

[message-send-status.webm](https://github.com/user-attachments/assets/574c3f84-fed0-4bc4-a13b-343870dcfc89)

### Impact on end user

Makes the sending look more fluid and also adds the delivered status for communities

### How to test

Use two clients on this build. Chat between the two in different channels. 1-1 chats and groups update to delivered using ACKs from MVDS. Communities update using SDS, so you need to receive a new message from someone to confirm

### Risk 

Low. Sent Status is the only one that is affected, and it will be way more reliable now