### PR TITLE
fix(wallet): send modal crash when switching networks

### DIFF
--- a/makefiles/nim-tests.mk
+++ b/makefiles/nim-tests.mk
@@ -41,6 +41,7 @@ NIM_TESTS_MODEL_SPY := \
 	model_sync_move_test \
 	model_sync_unified_test \
 	token_groups_model_test \
+	token_lists_model_test \
 	token_selector_model_bench \
 	token_selector_model_test \
 	token_selector_producer_view_test

--- a/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/token_groups_model.nim
@@ -31,10 +31,27 @@ type
     Position
 
 
+proc tokensContentEqual(a, b: seq[TokenItem]): bool =
+  ## Equality of the token fields tokens_model displays (incl. customToken).
+  if a.len != b.len:
+    return false
+  for i in 0 ..< a.len:
+    if a[i].key != b[i].key or a[i].name != b[i].name or
+       a[i].symbol != b[i].symbol or a[i].decimals != b[i].decimals or
+       a[i].chainId != b[i].chainId or a[i].address != b[i].address or
+       a[i].logoUri != b[i].logoUri or
+       a[i].communityData.id != b[i].communityData.id or
+       a[i].customToken != b[i].customToken or a[i].`type` != b[i].`type`:
+      return false
+  true
+
 QtObject:
   type TokenGroupsModel* = ref object of QAbstractListModel
     delegate: io_interface.TokenGroupsModelDataSource
-    tokensModel: TokensModel
+    # Per-group "tokens" submodels, row lifetime: deleted after the parent's
+    # remove/reset signals, so consumers detach via the notification first.
+    tokensModels: Table[string, TokensModel]
+    emptyTokens: seq[TokenItem]
     marketValuesDelegate: io_interface.TokenMarketValuesDataSource
     # Market details keyed by group key (not row index): identity-independent of
     # insert/remove/move so survivors keep the SAME MarketDetailsItem instance the
@@ -66,6 +83,7 @@ QtObject:
     result.delegate = delegate
     result.marketValuesDelegate = marketValuesDelegate
     result.tokenMarketDetails = initTable[string, MarketDetailsItem]()
+    result.tokensModels = initTable[string, TokensModel]()
     result.modelModes = modelModes
     result.lazyLoadingBatchSize = lazyLoadingBatchSize
     result.lazyLoadingInitialCount = lazyLoadingInitialCount
@@ -131,10 +149,24 @@ QtObject:
       ModelRole.Position.int:"position"
     }.toTable
 
-  proc getTokensModelDataSource*(self: TokenGroupsModel, index: int): TokensModelDataSource =
+  proc tokensForGroupKey(self: TokenGroupsModel, groupKey: string): var seq[TokenItem] =
+    for i in 0 ..< self.getDisplayModel().len:
+      if self.getDisplayModel()[i].key == groupKey:
+        return self.getDisplayModel()[i].tokens
+    # Row gone: no rows, never another row's tokens.
+    self.emptyTokens.setLen(0)
+    return self.emptyTokens
+
+  proc getTokensModelDataSource*(self: TokenGroupsModel, groupKey: string): TokensModelDataSource =
     return (
-      getTokens: proc(): var seq[TokenItem] = self.getDisplayModel()[index].tokens,
+      getTokens: proc(): var seq[TokenItem] = self.tokensForGroupKey(groupKey),
     )
+
+  proc ensureTokensSubmodel*(self: TokenGroupsModel, groupKey: string): TokensModel =
+    ## One submodel per group key, reused across reads: consumers cache the pointer.
+    if not self.tokensModels.hasKey(groupKey):
+      self.tokensModels[groupKey] = newTokensModel(self.getTokensModelDataSource(groupKey))
+    return self.tokensModels[groupKey]
 
   method data(self: TokenGroupsModel, index: QModelIndex, role: int): QVariant =
     guardModelData(index, self.rowCount(), role, ModelRole)
@@ -159,9 +191,7 @@ QtObject:
       of ModelRole.LogoUri:
         return newQVariant(item.logoUri)
       of ModelRole.Tokens:
-        self.tokensModel = newTokensModel(self.getTokensModelDataSource(index.row))
-        self.tokensModel.modelsUpdated()
-        return newQVariant(self.tokensModel)
+        return newQVariant(self.ensureTokensSubmodel(item.key))
       of ModelRole.CommunityId:
         # since each token gorup item has at least one token, we're safe to use the first token's data
         return newQVariant(item.tokens[0].communityData.id)
@@ -247,20 +277,52 @@ QtObject:
     if oldItem.decimals != newItem.decimals: result.add(ModelRole.Decimals.int)
     if oldItem.logoUri != newItem.logoUri: result.add(ModelRole.LogoUri.int)
     if oldItem.`type` != newItem.`type`: result.add(ModelRole.Type.int)
-    # Tokens is a ref seq — compare by content signature, not reference identity.
-    # Includes customToken (tokens_model shows it) so a customToken flip on a
-    # surviving token key re-reads the Tokens sub-model.
-    let oldSig = oldItem.tokens.mapIt((it.key, it.name, it.symbol, it.decimals,
-      it.chainId, it.address, it.logoUri, it.communityData.id, it.customToken, it.`type`))
-    let newSig = newItem.tokens.mapIt((it.key, it.name, it.symbol, it.decimals,
-      it.chainId, it.address, it.logoUri, it.communityData.id, it.customToken, it.`type`))
-    if oldSig != newSig:
+    # Tokens is a ref seq — compare by content, not reference identity.
+    if not tokensContentEqual(oldItem.tokens, newItem.tokens):
       result.add(ModelRole.Tokens.int)
       result.add(ModelRole.MarketDetails.int)
       result.add(ModelRole.CommunityId.int)
       # Description is community-branched (isCommunityTokenGroup); a community-status
       # flip is captured by communityData.id in the signature above, so re-read it.
       result.add(ModelRole.Description.int)
+
+  proc planTokensSubmodelUpdates(self: TokenGroupsModel, newGroups: seq[TokenGroupItem]):
+      tuple[toReset: seq[TokensModel], removed: seq[string]] =
+    ## Per live submodel: reset when its token content changed, delete when its
+    ## key is gone. Computed pre-sync, applied after the row signals.
+    for key, sub in self.tokensModels:
+      var found = false
+      for item in newGroups:
+        if item.key != key:
+          continue
+        found = true
+        var changed = true
+        for old in self.getDisplayModel():
+          if old.key == key:
+            changed = not tokensContentEqual(old.tokens, item.tokens)
+            break
+        if changed:
+          result.toReset.add(sub)
+        break
+      if not found:
+        result.removed.add(key)
+
+  proc resetTokensSubmodels(self: TokenGroupsModel) =
+    ## After a full reset: drop removed keys' submodels, reset the survivors.
+    var removed: seq[string] = @[]
+    for key, sub in self.tokensModels:
+      var found = false
+      for item in self.getDisplayModel():
+        if item.key == key:
+          found = true
+          break
+      if found:
+        sub.modelsUpdated()
+      else:
+        removed.add(key)
+    for key in removed:
+      self.tokensModels[key].delete
+      self.tokensModels.del(key)
 
   proc modelsUpdated*(self: TokenGroupsModel, resetModelSize: bool = false, mandatoryKeys: seq[string] = @[]) =
     let isMainModel = ModelMode.UseLazyLoading notin self.modelModes and
@@ -288,11 +350,24 @@ QtObject:
       # signal fired. rebuildMarketDetails is identity-preserving, so survivors keep
       # their instances and the transient gating of a being-removed row is harmless.
       self.rebuildMarketDetails(newGroups)
+      let (toReset, removedKeys) = self.planTokensSubmodelUpdates(newGroups)
       self.modelSync(self.cachedGroups, newGroups)
       self.hasMoreItemsChanged()
+      # After the row signals: consumers must see them before submodels change.
+      for sub in toReset:
+        sub.modelsUpdated()
+      for key in removedKeys:
+        # Explicit delete: the self-capturing data-source closure makes the
+        # submodel a cycle candidate, so a plain ref drop frees it only at some
+        # later cycle collection.
+        self.tokensModels[key].delete
+        self.tokensModels.del(key)
       return
 
     self.beginResetModel()
+    defer:
+      # First-registered defer runs LAST — after endResetModel below.
+      self.resetTokensSubmodels()
     defer:
       self.endResetModel()
       self.hasMoreItemsChanged()

--- a/src/app/modules/main/wallet_section/all_tokens/token_lists_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/token_lists_model.nim
@@ -14,11 +14,13 @@ type
     LogoURI
     Tokens
 
-
 QtObject:
   type TokenListsModel* = ref object of QAbstractListModel
     delegate: io_interface.TokenListsModelDataSource
-    tokensModel: TokensModel
+    # Per-list "tokens" submodels, row lifetime: deleted after the reset that
+    # removes their row, so consumers detach via the notification first.
+    tokensModels: Table[string, TokensModel]
+    emptyTokens: seq[TokenItem]
 
   proc setup(self: TokenListsModel)
   proc delete(self: TokenListsModel)
@@ -26,6 +28,7 @@ QtObject:
     new(result, delete)
     result.setup
     result.delegate = delegate
+    result.tokensModels = initTable[string, TokensModel]()
 
   method rowCount(self: TokenListsModel, index: QModelIndex = nil): int =
     return self.delegate.getAllTokenLists().len
@@ -49,10 +52,24 @@ QtObject:
       ModelRole.Tokens.int:"tokens",
     }.toTable
 
-  proc getTokensModelDataSource*(self: TokenListsModel, index: int): TokensModelDataSource =
+  proc tokensForListId(self: TokenListsModel, listId: string): var seq[TokenItem] =
+    for i in 0 ..< self.delegate.getAllTokenLists().len:
+      if self.delegate.getAllTokenLists()[i].id == listId:
+        return self.delegate.getAllTokenLists()[i].tokens
+    # Row gone: no rows, never another row's tokens.
+    self.emptyTokens.setLen(0)
+    return self.emptyTokens
+
+  proc getTokensModelDataSource*(self: TokenListsModel, listId: string): TokensModelDataSource =
     return (
-      getTokens: proc(): var seq[TokenItem] = self.delegate.getAllTokenLists()[index].tokens,
+      getTokens: proc(): var seq[TokenItem] = self.tokensForListId(listId),
     )
+
+  proc ensureTokensSubmodel*(self: TokenListsModel, listId: string): TokensModel =
+    ## One submodel per list id, reused across reads: consumers cache the pointer.
+    if not self.tokensModels.hasKey(listId):
+      self.tokensModels[listId] = newTokensModel(self.getTokensModelDataSource(listId))
+    return self.tokensModels[listId]
 
   method data(self: TokenListsModel, index: QModelIndex, role: int): QVariant =
     guardModelData(index, self.rowCount(), role, ModelRole)
@@ -76,13 +93,32 @@ QtObject:
       of ModelRole.LogoURI:
         return newQVariant(item.logoUri)
       of ModelRole.Tokens:
-        self.tokensModel = newTokensModel(self.getTokensModelDataSource(index.row))
-        self.tokensModel.modelsUpdated()
-        return newQVariant(self.tokensModel)
+        return newQVariant(self.ensureTokensSubmodel(item.id))
+
+  proc resetTokensSubmodels(self: TokenListsModel) =
+    ## After the full reset: drop removed ids' submodels, reset the survivors.
+    var removed: seq[string] = @[]
+    for listId, sub in self.tokensModels:
+      var found = false
+      for item in self.delegate.getAllTokenLists():
+        if item.id == listId:
+          found = true
+          break
+      if found:
+        sub.modelsUpdated()
+      else:
+        removed.add(listId)
+    for listId in removed:
+      # Explicit delete: the self-capturing data-source closure makes the
+      # submodel a cycle candidate, so a plain ref drop frees it only at some
+      # later cycle collection.
+      self.tokensModels[listId].delete
+      self.tokensModels.del(listId)
 
   proc modelsUpdated*(self: TokenListsModel) =
     self.beginResetModel()
     self.endResetModel()
+    self.resetTokensSubmodels()
 
   proc setup(self: TokenListsModel) =
     self.QAbstractListModel.setup

--- a/src/app/modules/main/wallet_section/all_tokens/tokens_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/tokens_model.nim
@@ -18,12 +18,20 @@ type
     CommunityId
     Type
 
+when defined(testing) or defined(QT_MODEL_SPY):
+  # Destruction sentinel: QML consumers cache the submodel pointer, so tests
+  # assert a handed-out instance is never destroyed while its parent model lives.
+  var tokensModelDeleteCount*: int
+  # Reset sentinel: content changes must be announced through the cached
+  # submodel's own reset; stable refreshes must stay silent.
+  var tokensModelResetCount*: int
+
 QtObject:
   type TokensModel* = ref object of QAbstractListModel
     delegate: io_interface.TokensModelDataSource
 
   proc setup(self: TokensModel)
-  proc delete(self: TokensModel)
+  proc delete*(self: TokensModel)
 
   proc newTokensModel*(delegate: io_interface.TokensModelDataSource): TokensModel =
     new(result, delete)
@@ -89,11 +97,16 @@ QtObject:
         return newQVariant(ord(item.`type`))
 
   proc modelsUpdated*(self: TokensModel) =
+    when defined(testing) or defined(QT_MODEL_SPY):
+      inc tokensModelResetCount
     self.beginResetModel()
     self.endResetModel()
 
   proc setup(self: TokensModel) =
     self.QAbstractListModel.setup
 
-  proc delete(self: TokensModel) =
+  proc delete*(self: TokensModel) =
+    when defined(testing) or defined(QT_MODEL_SPY):
+      if cast[pointer](self.vptr) != nil:
+        inc tokensModelDeleteCount
     self.QAbstractListModel.delete

--- a/test/nim/token_groups_model_test.nim
+++ b/test/nim/token_groups_model_test.nim
@@ -9,6 +9,7 @@ import unittest, tables, sequtils
 import nimqml
 
 import app/modules/main/wallet_section/all_tokens/token_groups_model
+import app/modules/main/wallet_section/all_tokens/tokens_model
 import app/modules/main/wallet_section/all_tokens/io_interface
 import app/modules/main/wallet_section/all_tokens/market_details_item
 import app/modules/shared/qt_model_spy
@@ -46,6 +47,25 @@ proc newModel(): TokenGroupsModel =
   newTokenGroupsModel(groupsDataSource(), marketValuesDataSource())
 
 proc moves(spy: QtModelSpy): int = spy.calls.filterIt(it.kind == BeginMoveRows).len
+
+proc mkGroup2(key: string): TokenGroupItem =
+  ## Group with TWO tokens, distinguishable from mkGroup's one via rowCount.
+  result = mkGroup(key)
+  result.tokens.add(createTokenItem(TokenDto(
+    chainId: 10, address: "0x2" & key, crossChainId: key,
+    name: key, symbol: key, decimals: 18)))
+
+proc tokensRole(m: TokenGroupsModel): int =
+  for k, v in m.roleNames():
+    if v == "tokens": return k
+  doAssert false, "tokens role not found"
+
+proc readTokensRole(m: TokenGroupsModel, row: int) =
+  ## Read the tokens role through data(), the way the Qt view layer does.
+  let idx = m.createIndex(row, 0, nil)
+  defer: idx.delete
+  let v = m.data(idx, m.tokensRole())
+  if not v.isNil: v.delete
 
 suite "token_groups_model - identity, reorder, stable-set":
 
@@ -199,3 +219,87 @@ suite "token_groups_model - identity, reorder, stable-set":
     # within this same modelsUpdated call rather than empty until a later signal.
     for key in m.groupKeysInOrder():
       check not m.marketDetailsItemForKey(key).isNil
+
+suite "token_groups_model - tokens submodel lifetime":
+  ## QML consumers (ModelEntry item maps, delegates) cache the QObject pointer
+  ## returned for the "tokens" role. Destroying a previously handed-out submodel
+  ## on a later data() read leaves those consumers with a dangling pointer —
+  ## the send-modal network-switch UAF crash (rowCount on freed Nim object).
+
+  setup:
+    let spy = newQtModelSpy()
+    spy.enable()
+
+  teardown:
+    spy.disable()
+
+  test "re-reading the tokens role never destroys a previously handed-out submodel":
+    gGroups = @[mkGroup("a"), mkGroup("b")]
+    let m = newModel()
+    m.modelsUpdated()
+
+    let before = tokensModelDeleteCount
+    m.readTokensRole(0)   # hand out row a's submodel (QML caches the pointer)
+    m.readTokensRole(1)   # reading another row must not kill row a's submodel
+    m.readTokensRole(0)   # re-reading the same row must not kill row b's either
+    check tokensModelDeleteCount == before
+
+  test "same submodel instance handed out for the same group across reads and refreshes":
+    gGroups = @[mkGroup("a"), mkGroup("b")]
+    let m = newModel()
+    m.modelsUpdated()
+
+    let subA = m.ensureTokensSubmodel("a")
+    m.readTokensRole(0)                       # data() must reuse, not re-create
+    check m.ensureTokensSubmodel("a") == subA
+
+    gGroups = @[mkGroup("a"), mkGroup("b")]   # stable refresh
+    m.modelsUpdated()
+    check m.ensureTokensSubmodel("a") == subA
+
+  test "submodel follows its group key when rows shift, not its creation index":
+    gGroups = @[mkGroup("a"), mkGroup2("b")]
+    let m = newModel()
+    m.modelsUpdated()
+
+    let subB = m.ensureTokensSubmodel("b")
+    check subB.rowCount(nil) == 2
+
+    gGroups = @[mkGroup2("b"), mkGroup("a")]  # b moves to row 0
+    m.modelsUpdated()
+    check subB.rowCount(nil) == 2
+    check m.ensureTokensSubmodel("a").rowCount(nil) == 1
+
+  test "removed group's submodel is deleted after the remove; a returning key gets a fresh one":
+    gGroups = @[mkGroup("a"), mkGroup("b")]
+    let m = newModel()
+    m.modelsUpdated()
+
+    discard m.ensureTokensSubmodel("a")
+    let before = tokensModelDeleteCount
+
+    gGroups = @[mkGroup("b")]
+    m.modelsUpdated()
+    # Row gone -> its submodel is dropped and destroyed (consumers were notified
+    # by the remove signals and detach via destroyed()).
+    check tokensModelDeleteCount == before + 1
+
+    gGroups = @[mkGroup("b"), mkGroup("a")]
+    m.modelsUpdated()
+    check m.ensureTokensSubmodel("a").rowCount(nil) == 1   # fresh instance
+
+  test "submodel resets only on content change, never on a stable refresh":
+    gGroups = @[mkGroup("a"), mkGroup("b")]
+    let m = newModel()
+    m.modelsUpdated()
+    discard m.ensureTokensSubmodel("a")
+
+    var before = tokensModelResetCount
+    gGroups = @[mkGroup("a"), mkGroup("b")]   # stable
+    m.modelsUpdated()
+    check tokensModelResetCount == before
+
+    before = tokensModelResetCount
+    gGroups = @[mkGroup2("a"), mkGroup("b")]  # a's token set changes
+    m.modelsUpdated()
+    check tokensModelResetCount == before + 1 # exactly the submodel's own reset

--- a/test/nim/token_lists_model_test.nim
+++ b/test/nim/token_lists_model_test.nim
@@ -1,0 +1,110 @@
+## Tokens-submodel lifetime tests for token_lists_model. Compile with
+## -d:QT_MODEL_SPY. Consumers cache the pointer returned for the "tokens" role,
+## so a submodel must stay stable per row and die only with its row.
+
+import unittest, tables
+import nimqml
+
+import app/modules/main/wallet_section/all_tokens/token_lists_model
+import app/modules/main/wallet_section/all_tokens/tokens_model
+import app/modules/main/wallet_section/all_tokens/io_interface
+import app_service/service/token/items/token_list
+import app_service/service/token/dto/token_list as token_list_dto
+
+var gLists: seq[TokenListItem] = @[]
+
+proc listsDataSource(): TokenListsModelDataSource =
+  (
+    getAllTokenLists: proc(): var seq[TokenListItem] = gLists,
+  )
+
+proc mkList(id: string, tokenCount: int = 1): TokenListItem =
+  var toks: seq[TokenDtoSafe] = @[]
+  for i in 0 ..< tokenCount:
+    toks.add(TokenDto(chainId: 1, address: "0x" & id & $i, crossChainId: id & $i,
+      name: id, symbol: id, decimals: 18))
+  createTokenListItem(TokenListDto(id: id, name: id, timestamp: "",
+    fetchedTimestamp: "", source: "", version: VersionDto(), logoUri: "",
+    tokens: toks))
+
+proc tokensRole(m: TokenListsModel): int =
+  for k, v in m.roleNames():
+    if v == "tokens": return k
+  doAssert false, "tokens role not found"
+
+proc readTokensRole(m: TokenListsModel, row: int) =
+  ## Read the tokens role through data(), the way the Qt view layer does.
+  let idx = m.createIndex(row, 0, nil)
+  defer: idx.delete
+  let v = m.data(idx, m.tokensRole())
+  if not v.isNil: v.delete
+
+suite "token_lists_model - tokens submodel lifetime":
+
+  test "re-reading the tokens role never destroys a previously handed-out submodel":
+    gLists = @[mkList("la"), mkList("lb")]
+    let m = newTokenListsModel(listsDataSource())
+    m.modelsUpdated()
+
+    let before = tokensModelDeleteCount
+    m.readTokensRole(0)   # hand out row la's submodel (QML caches the pointer)
+    m.readTokensRole(1)   # reading another row must not kill row la's submodel
+    m.readTokensRole(0)   # re-reading the same row must not kill row lb's either
+    check tokensModelDeleteCount == before
+
+  test "same submodel instance handed out for the same list across reads and refreshes":
+    gLists = @[mkList("la"), mkList("lb")]
+    let m = newTokenListsModel(listsDataSource())
+    m.modelsUpdated()
+
+    let subA = m.ensureTokensSubmodel("la")
+    m.readTokensRole(0)                       # data() must reuse, not re-create
+    check m.ensureTokensSubmodel("la") == subA
+
+    gLists = @[mkList("la"), mkList("lb")]    # stable refresh
+    m.modelsUpdated()
+    check m.ensureTokensSubmodel("la") == subA
+
+  test "submodel follows its list id when rows shift, not its creation index":
+    gLists = @[mkList("la"), mkList("lb", tokenCount = 2)]
+    let m = newTokenListsModel(listsDataSource())
+    m.modelsUpdated()
+
+    let subB = m.ensureTokensSubmodel("lb")
+    check subB.rowCount(nil) == 2
+
+    gLists = @[mkList("lb", tokenCount = 2), mkList("la")]  # lb moves to row 0
+    m.modelsUpdated()
+    check subB.rowCount(nil) == 2
+    check m.ensureTokensSubmodel("la").rowCount(nil) == 1
+
+  test "removed list's submodel is deleted after the reset; a returning id gets a fresh one":
+    gLists = @[mkList("la"), mkList("lb")]
+    let m = newTokenListsModel(listsDataSource())
+    m.modelsUpdated()
+
+    discard m.ensureTokensSubmodel("la")
+    let before = tokensModelDeleteCount
+
+    gLists = @[mkList("lb")]
+    m.modelsUpdated()
+    # Row gone -> its submodel is dropped and destroyed (consumers were notified
+    # by the model reset and detach via destroyed()).
+    check tokensModelDeleteCount == before + 1
+
+    gLists = @[mkList("lb"), mkList("la")]
+    m.modelsUpdated()
+    check m.ensureTokensSubmodel("la").rowCount(nil) == 1   # fresh instance
+
+  test "surviving submodels reset with the parent's full reset":
+    # The lists model always resets fully; its live submodels follow suit.
+    gLists = @[mkList("la"), mkList("lb")]
+    let m = newTokenListsModel(listsDataSource())
+    m.modelsUpdated()
+    discard m.ensureTokensSubmodel("la")
+
+    let before = tokensModelResetCount
+    gLists = @[mkList("la", tokenCount = 2), mkList("lb")]
+    m.modelsUpdated()
+    check tokensModelResetCount == before + 1
+    check m.ensureTokensSubmodel("la").rowCount(nil) == 2

--- a/test/nim/token_selector_model_test.nim
+++ b/test/nim/token_selector_model_test.nim
@@ -174,6 +174,17 @@ suite "TokenSelectorModel - nested balances submodel":
   teardown:
     spy.disable()
 
+  test "deleting a model actually deletes the C++ object (owner flag set)":
+    # nimqml-seaqt QAbstractItemModel/ListModel/TableModel setups assign vptr but
+    # never set QObject.owner, so delete() silently no-ops: the C++ model leaks
+    # alive with a dangling Nim pointer, and any consumer callback afterwards
+    # (view rowAt -> rowCount, ModelQuery roleNames) is a use-after-free — the
+    # send-modal token-selector crash.
+    let doomed = newTokenSelectorBalancesModel(@[])
+    check doomed.vptr != nil
+    doomed.QAbstractListModel.delete()
+    check doomed.vptr == nil   # delete must reach the C++ side, not early-return
+
   test "balances submodel exposes the chips joined per chain":
     let m = newTokenSelectorModel()
     m.setSourceItems(@[


### PR DESCRIPTION
Closes #21704

Switching networks in the Send modal drops token-selector rows. The nested submodels of those rows (balance chips, per-chain tokens) were freed on the Nim side while their C++ objects stayed alive, because the nimqml-seaqt model wrappers never marked themselves as owners and `delete()` silently did nothing. QML still referenced the leaked C++ models, so the next access (reopening the selector, selecting a token) called into freed memory and crashed.

- Bump nimqml-seaqt with the ownership fix ([seaqt/nimqml-seaqt@fb1adfe](https://github.com/seaqt/nimqml-seaqt/commit/fb1adfe6f0247b7541aea3bf92e593f2414fd895)): models are now genuinely deleted when dropped, and consumers fall back to null via Qt's destroyed() tracking instead of dereferencing freed memory.
- Fix a related lifetime bug found while investigating: the `tokens` role of `token_groups_model`/`token_lists_model` created a fresh submodel on every read and destroyed the previously handed-out one. Submodels are now cached per group key.

Verified on macOS: the repro from the issue (send → select token → switch network → select again) no longer crashes; unit tests added for both fixes.
