### PR TITLE
feat(StatusAdaptiveDialog): Support `standardButtons` in `StatusAdapt…

### DIFF
--- a/storybook/pages/StatusAdaptiveDialogPage.qml
+++ b/storybook/pages/StatusAdaptiveDialogPage.qml
@@ -72,6 +72,9 @@ SplitView {
                 default:            return null
             }
         }
+        readonly property int standardButtons: footerButtonsMode.currentValue === "standard-ok-cancel"
+                                               ? Dialog.Cancel | Dialog.Ok
+                                               : Dialog.NoButton
         readonly property var footerErrorTagsModel: {
             switch (footerErrorsMode.currentValue) {
                 case "one": return errorTagsOneModel
@@ -137,9 +140,19 @@ SplitView {
             }
 
             // Footer API: left/right action groups and optional error tags.
+            standardButtons: d.standardButtons
             footerLeftButtons: d.footerLeftModel
             footerRightButtons: d.footerRightButtonsModel
             errorTags: d.footerErrorTagsModel
+
+            onAccepted: {
+                logs.logEvent("StatusAdaptiveDialog::accepted")
+                close()
+            }
+            onRejected: {
+                logs.logEvent("StatusAdaptiveDialog::rejected")
+                close()
+            }
         }
 
         // Extra header action used by the "custom" header action modes.
@@ -551,6 +564,7 @@ SplitView {
                         { text: "Back only",        value: "back-only" },
                         { text: "Info + Done",      value: "info-done" },
                         { text: "Done only",        value: "done-only" },
+                        { text: "Standard OK + Cancel", value: "standard-ok-cancel" },
                         { text: "None",             value: "none" }
                     ]
                 }

--- a/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
+++ b/storybook/qmlTests/tests/tst_StatusAdaptiveDialog.qml
@@ -57,6 +57,44 @@ Item {
     }
 
     Component {
+        id: standardButtonsDialogComponent
+
+        StatusAdaptiveDialog {
+            objectName: "standardButtonsDialog"
+            title: "Standard buttons dialog"
+            maximumWidthOverride: 420
+            standardButtons: Dialog.Cancel | Dialog.Ok
+            contentComponent: Component {
+                Item {
+                    implicitHeight: 80
+                }
+            }
+        }
+    }
+
+    Component {
+        id: explicitFooterWithStandardButtonsDialogComponent
+
+        StatusAdaptiveDialog {
+            objectName: "explicitFooterWithStandardButtonsDialog"
+            title: "Explicit footer dialog"
+            maximumWidthOverride: 420
+            standardButtons: Dialog.Ok
+            contentComponent: Component {
+                Item {
+                    implicitHeight: 80
+                }
+            }
+            footerRightButtons: ObjectModel {
+                StatusButton {
+                    objectName: "customFooterButton"
+                    text: "Custom"
+                }
+            }
+        }
+    }
+
+    Component {
         id: adaptiveWidthDialogComponent
 
         StatusAdaptiveDialog {
@@ -270,6 +308,31 @@ Item {
                     controlUnderTest.y + controlUnderTest.height - edgePadding - bottom);
         }
 
+        function createAndOpenDialog(component) {
+            if (controlUnderTest)
+                controlUnderTest.destroy();
+
+            controlUnderTest = createTemporaryObject(component, testWindow.contentItem);
+            controlUnderTest.open();
+            tryCompare(controlUnderTest, "opened", true);
+            return controlUnderTest;
+        }
+
+        function standardButton(button) {
+            const toolbar = findChild(controlUnderTest, "statusAdaptiveDialogFooter");
+            verify(!!toolbar);
+            const buttonBox = findChild(toolbar, "statusAdaptiveDialogStandardButtonBox");
+            verify(!!buttonBox);
+            return buttonBox.standardButton(button);
+        }
+
+        function signalSpy(signalName) {
+            return createTemporaryObject(signalSpyComponent, testWindow.contentItem, {
+                "target": controlUnderTest,
+                "signalName": signalName
+            });
+        }
+
         function test_centered_on_desktop() {
             controlUnderTest.open();
             tryCompare(controlUnderTest, "opened", true);
@@ -317,6 +380,53 @@ Item {
             tryCompare(divider, "visible", true);
             compare(divider.height, 1);
             compare(divider.width, controlUnderTest.width);
+        }
+
+        function test_standard_buttons_are_rendered_in_adaptive_footer() {
+            createAndOpenDialog(standardButtonsDialogComponent);
+
+            const cancelButton = standardButton(Dialog.Cancel);
+            const okButton = standardButton(Dialog.Ok);
+            verify(!!cancelButton);
+            verify(!!okButton);
+            tryCompare(cancelButton, "visible", true);
+            tryCompare(okButton, "visible", true);
+            compare(cancelButton.text, "Cancel");
+            compare(okButton.text, "OK");
+        }
+
+        function test_standard_ok_button_accepts_dialog() {
+            createAndOpenDialog(standardButtonsDialogComponent);
+            const acceptedSpy = signalSpy("accepted");
+
+            mouseClick(standardButton(Dialog.Ok));
+            compare(acceptedSpy.count, 1);
+            tryCompare(controlUnderTest, "opened", false);
+        }
+
+        function test_standard_cancel_button_rejects_dialog() {
+            createAndOpenDialog(standardButtonsDialogComponent);
+            const rejectedSpy = signalSpy("rejected");
+
+            mouseClick(standardButton(Dialog.Cancel));
+            compare(rejectedSpy.count, 1);
+            tryCompare(controlUnderTest, "opened", false);
+        }
+
+        function test_explicit_footer_buttons_take_precedence_over_standard_buttons() {
+            createAndOpenDialog(explicitFooterWithStandardButtonsDialogComponent);
+
+            const toolbar = findChild(controlUnderTest, "statusAdaptiveDialogFooter");
+            const customButton = findChild(toolbar, "customFooterButton");
+            verify(!!toolbar);
+            verify(!!customButton);
+            tryCompare(customButton, "visible", true);
+            compare(customButton.text, "Custom");
+            const standardButtonBoxLoader = findChild(toolbar, "statusAdaptiveDialogStandardButtonBoxLoader");
+            verify(!!standardButtonBoxLoader);
+            tryCompare(standardButtonBoxLoader, "active", false);
+            tryCompare(standardButtonBoxLoader, "visible", false);
+            verify(!findChild(toolbar, "statusAdaptiveDialogStandardButtonBox"));
         }
 
         function test_internal_popup_opens_in_parent_overlay_and_closes_from_overlay() {

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialog.qml
@@ -100,7 +100,8 @@ Dialog {
 
         readonly property bool hasHeader: !!root.title || !!root.subtitle
         readonly property bool hasContent: !!root.contentComponent
-        readonly property bool hasFooter: !!root.footerLeftButtons || !!root.footerRightButtons
+        readonly property bool hasStandardButtons: root.standardButtons !== Dialog.NoButton
+        readonly property bool hasFooter: !!root.footerLeftButtons || !!root.footerRightButtons || hasStandardButtons
         readonly property bool hasErrorTags: !!root.errorTags
         // Footer section is visible when either action buttons or error tags are present.
         // The bottom safe area is applied to whichever visible section sits at the sheet bottom.
@@ -329,6 +330,12 @@ Dialog {
 
             leftButtons: root.footerLeftButtons
             rightButtons: root.footerRightButtons
+            standardButtons: root.standardButtons
+            onAccepted: root.accept()
+            onRejected: root.reject()
+            onApplied: root.applied()
+            onReset: root.reset()
+            onHelpRequested: root.helpRequested()
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogFooter.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusAdaptiveDialogFooter.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts
 import QtQml.Models
 
 import StatusQ.Core
+import StatusQ.Controls
 import StatusQ.Core.Theme
 
 // Footer action surface for StatusAdaptiveDialog.
@@ -26,11 +27,27 @@ Control {
     property ObjectModel leftButtons
     // Typically the primary and secondary actions (e.g. Cancel + Confirm).
     property ObjectModel rightButtons
+    // Optional Dialog.standardButtons rendered with the same adaptive footer surface.
+    property int standardButtons: Dialog.NoButton
+
+    signal accepted
+    signal rejected
+    signal applied
+    signal reset
+    signal helpRequested
 
     property color color: Theme.palette.statusModal.backgroundColor
     property int radius: Theme.radius
 
-    visible: !!leftButtons || !!rightButtons
+    QtObject {
+        id: d
+
+        readonly property bool hasLeftButtons: !!root.leftButtons && root.leftButtons.count > 0
+        readonly property bool hasRightButtons: !!root.rightButtons && root.rightButtons.count > 0
+        readonly property bool hasStandardButtons: root.standardButtons !== Dialog.NoButton && !hasLeftButtons && !hasRightButtons
+    }
+
+    visible: d.hasLeftButtons || d.hasRightButtons || d.hasStandardButtons
     padding: 0
     spacing: Theme.defaultHalfPadding
 
@@ -55,6 +72,41 @@ Control {
 
         Repeater {
             model: root.rightButtons
+        }
+
+        Loader {
+            id: standardButtonBoxLoader
+
+            objectName: "statusAdaptiveDialogStandardButtonBoxLoader"
+            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+            active: d.hasStandardButtons
+            visible: active
+
+            sourceComponent: DialogButtonBox {
+                objectName: "statusAdaptiveDialogStandardButtonBox"
+                spacing: root.spacing
+                topPadding: 0
+                bottomPadding: 0
+                leftPadding: 0
+                rightPadding: 0
+                topInset: 0
+                bottomInset: 0
+                leftInset: 0
+                rightInset: 0
+                standardButtons: root.standardButtons
+                background: null
+
+                delegate: StatusButton {
+                    type: DialogButtonBox.buttonRole === DialogButtonBox.DestructiveRole ? StatusButton.Type.Danger
+                                                                                         : StatusButton.Type.Normal
+                }
+
+                onAccepted: root.accepted()
+                onRejected: root.rejected()
+                onApplied: root.applied()
+                onReset: root.reset()
+                onHelpRequested: root.helpRequested()
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #21702

### What does the PR do

Map `Dialog.standardButtons` into the existing `StatusAdaptiveDialog` footer instead of replacing the footer implementation.

- Add `standardButtons` support to `StatusAdaptiveDialogFooter` via `DialogButtonBox`
- Use `StatusButton` as the standard button delegate
- Preserve explicit `footerRightButtons` priority over `standardButtons`
- Add Storybook coverage for `Standard OK + Cancel`
- Add QML tests for render, signals, and explicit-footer precedence

### Affected areas

- StatusQ dialogs
- `StatusAdaptiveDialog`
- Storybook dialog examples/tests

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

No documentation update needed.

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

https://github.com/user-attachments/assets/a34e9a60-de75-43ee-b61e-3e41bd4cc694

### Impact on end user

Dialogs based on `StatusAdaptiveDialog` can now use the standard `Dialog.standardButtons` API and still render actions through the existing adaptive footer.

Existing dialogs using `footerLeftButtons` / `footerRightButtons` keep their current behavior.

### How to test

- Open Storybook.
- Go to `StatusAdaptiveDialog`.
- Set `Footer` to `Standard OK + Cancel`.
- Open the dialog.
- Verify `OK` and `Cancel` are rendered in the existing adaptive footer.
- Click `OK` and verify the dialog accepts/closes.
- Reopen and click `Cancel`; verify the dialog rejects/closes.
- Verify existing custom footer modes still render as before.