### PR TITLE
[Browser] various UI fixes

### DIFF
--- a/ui/app/AppLayouts/Browser/controls/BrowserAddressField.qml
+++ b/ui/app/AppLayouts/Browser/controls/BrowserAddressField.qml
@@ -31,7 +31,8 @@ StatusTextField {
     placeholderText: qsTr("Search or enter address")
     color: root.incognitoMode ? Theme.palette.privacyColors.tertiary : Theme.palette.textColor
 
-    inputMethodHints: Qt.ImhUrlCharactersOnly | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
+    inputMethodHints: (SQUtils.Utils.isIOS ? Qt.ImhNone : Qt.ImhUrlCharactersOnly) // iOS would hide the spacebar; space not being a valid URL character
+                      | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
     EnterKey.type: Qt.EnterKeyGo
 
     text: root.url

--- a/ui/app/AppLayouts/Browser/controls/BrowserAddressField.qml
+++ b/ui/app/AppLayouts/Browser/controls/BrowserAddressField.qml
@@ -25,9 +25,8 @@ StatusTextField {
         color: root.bgColor
         radius: Theme.radius
     }
-    verticalAlignment: TextInput.AlignVCenter
     leftPadding: showFavicon ? Theme.halfPadding + favicon.width + favicon.anchors.leftMargin
-                             : Theme.padding
+                             : Theme.smallPadding
     rightPadding: clearButton.width
     placeholderText: qsTr("Search or enter address")
     color: root.incognitoMode ? Theme.palette.privacyColors.tertiary : Theme.palette.textColor
@@ -40,7 +39,7 @@ StatusTextField {
         if (activeFocus) {
             selectAll()
         } else {
-            if (text === "") // restore the old URL
+            if (text !== root.url.toString() && root.url.toString() !== "") // restore the old (non empty) URL
                 text = Qt.binding(() => root.url)
         }
     }
@@ -51,7 +50,7 @@ StatusTextField {
         height: parent.height*.6
         width: height
         anchors.left: parent.left
-        anchors.leftMargin: height/2
+        anchors.leftMargin: height/3
         anchors.verticalCenter: parent.verticalCenter
         image.sourceSize: Qt.size(width, height)
         image.source: {

--- a/ui/app/AppLayouts/Browser/panels/BrowserTabView.qml
+++ b/ui/app/AppLayouts/Browser/panels/BrowserTabView.qml
@@ -41,7 +41,7 @@ FocusScope {
     }
 
     function createDownloadTab() {
-        var newTabButton = tabButtonComponent.createObject(tabBar, {tabTitle: qsTr("Downloads Page")})
+        var newTabButton = tabButtonComponent.createObject(tabBar, {tabTitle: qsTr("Downloads")})
         tabBar.addItem(newTabButton);
     }
 
@@ -123,7 +123,6 @@ FocusScope {
         height: d.tabHeight
         BrowserHeaderButton {
             anchors.fill: parent
-            anchors.margins: 4
             radius: Theme.radius
             icon.name: "add"
             incognitoMode: root.currentTabIncognito
@@ -140,8 +139,9 @@ FocusScope {
             id: tabButton
             property bool isStartPage: false
 
-            readonly property bool incognito: root.fnGetWebView(tabButton.TabBar.index)?.offTheRecord ?? false
             readonly property var webView: root.fnGetWebView(tabButton.TabBar.index)
+            readonly property bool incognito: webView?.offTheRecord ?? false
+            readonly property bool isDownloadView: webView?.isDownloadView ?? false
 
             readonly property string tabTitle: SQUtils.StringUtils.escapeHtml(
                 root.savedSessionContext.displayTitle(webView, isStartPage)
@@ -151,7 +151,7 @@ FocusScope {
             anchors.top: parent ? parent.top : undefined
             anchors.bottom: parent ? parent.bottom : undefined
             leftPadding: 12
-            rightPadding: 4
+            rightPadding: 0
             verticalPadding: 0
 
             background: Rectangle {
@@ -169,13 +169,13 @@ FocusScope {
             }
 
             contentItem: RowLayout {
-                spacing: 0
+                spacing: Theme.halfPadding
                 StatusIcon {
                     Layout.preferredWidth: d.iconSize
                     Layout.preferredHeight: d.iconSize
                     readonly property string favicon: {
-                        const icon = root.savedSessionContext.displayIcon(webView)
-                        return determineFaviconURL(icon) || ""
+                        const icon = root.savedSessionContext.displayIcon(tabButton.webView)
+                        return root.determineFaviconURL(icon) || ""
                     }
                     sourceSize: Qt.size(width, height)
                     icon: favicon || "globe"
@@ -185,13 +185,11 @@ FocusScope {
                     id: loadingIndicator
                     Layout.preferredWidth: d.iconSize
                     Layout.preferredHeight: d.iconSize
-                    visible: root.fnGetWebView(tabButton.TabBar.index)?.loading ?? false
+                    visible: tabButton.webView?.loading ?? false
                 }
 
                 StatusBaseText {
                     Layout.fillWidth: true
-                    Layout.maximumWidth: Math.ceil(implicitWidth - (closeButton.visible ? closeButton.width : 0))
-                    Layout.leftMargin: Theme.halfPadding
                     Layout.rightMargin: 2
                     elide: Qt.ElideRight
                     font.pixelSize: Theme.fontSize(14)
@@ -199,15 +197,18 @@ FocusScope {
                 }
 
                 StatusFlatButton {
-                    id: closeButton
-                    Layout.preferredWidth: visible ? implicitWidth : 0
                     Layout.alignment: Qt.AlignTrailing
                     icon.name: "close"
                     icon.color: hovered ? Theme.palette.directColor1 : Theme.palette.baseColor1
                     radius: width/2
-                    opacity: root.isMobile || tabButton.hovered ? 1 : 0
-                    visible: opacity > 0
+                    opacity: root.isMobile || tabButton.hovered || tabButton.isDownloadView ? 1 : 0
                     onClicked: root.removeView(tabButton.TabBar.index)
+                }
+
+                Rectangle {
+                    Layout.preferredWidth: 1
+                    Layout.preferredHeight: d.tabHeight
+                    color: tabButton.checked ? StatusColors.transparent : Theme.palette.indirectColor4
                 }
             }
 

--- a/ui/app/AppLayouts/Browser/panels/MobileAddressBar.qml
+++ b/ui/app/AppLayouts/Browser/panels/MobileAddressBar.qml
@@ -39,8 +39,7 @@ Control {
 
     implicitHeight: 48
 
-    leftPadding: 12
-    rightPadding: 4
+    horizontalPadding: 4
     verticalPadding: 2
 
     background: Rectangle {
@@ -115,20 +114,6 @@ Control {
             tooltip.text: qsTr("Wallet")
             tooltip.orientation: StatusToolTip.Orientation.Bottom
             onClicked: root.requestWalletMenu()
-        }
-
-        StatusFlatButton {
-            Layout.fillHeight: true
-            Layout.preferredWidth: height
-            visible: addressBar.cursorVisible
-            type: StatusBaseButton.Type.Primary
-            tooltip.text: qsTr("Close")
-            tooltip.orientation: StatusToolTip.Orientation.Bottom
-            icon.name: "close"
-            icon.width: 28
-            icon.height: 28
-            isRoundIcon: true
-            onClicked: root.deactivateAddressBar()
         }
     }
 }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2649,7 +2649,7 @@ Do you wish to override the security check and continue?</source>
 <context>
     <name>BrowserTabView</name>
     <message>
-        <source>Downloads Page</source>
+        <source>Downloads</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -11372,10 +11372,6 @@ to load</source>
         <source>Wallet</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Close</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>MobileSettingsMenu</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2658,8 +2658,8 @@ Přejete si obejít bezpečnostní kontrolu a pokračovat?</translation>
 <context>
     <name>BrowserTabView</name>
     <message>
-        <source>Downloads Page</source>
-        <translation>Stránka stahování</translation>
+        <source>Downloads</source>
+        <translation type="unfinished">Stažené soubory</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -11439,10 +11439,6 @@ selhalo</translation>
         <source>Wallet</source>
         <translation type="unfinished">Peněženka</translation>
     </message>
-    <message>
-        <source>Close</source>
-        <translation type="unfinished">Zavřít</translation>
-    </message>
 </context>
 <context>
     <name>MobileSettingsMenu</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -11385,10 +11385,6 @@ al cargar</translation>
         <source>Wallet</source>
         <translation type="unfinished">Billetera</translation>
     </message>
-    <message>
-        <source>Close</source>
-        <translation type="unfinished">Cerrar</translation>
-    </message>
 </context>
 <context>
     <name>MobileSettingsMenu</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2651,8 +2651,8 @@ Do you wish to override the security check and continue?</source>
 <context>
     <name>BrowserTabView</name>
     <message>
-        <source>Downloads Page</source>
-        <translation>Página de descargas</translation>
+        <source>Downloads</source>
+        <translation type="unfinished">Descargas</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -11332,10 +11332,6 @@ to load</source>
         <source>Wallet</source>
         <translation type="unfinished">지갑</translation>
     </message>
-    <message>
-        <source>Close</source>
-        <translation type="unfinished">닫기</translation>
-    </message>
 </context>
 <context>
     <name>MobileSettingsMenu</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2643,8 +2643,8 @@ Do you wish to override the security check and continue?</source>
 <context>
     <name>BrowserTabView</name>
     <message>
-        <source>Downloads Page</source>
-        <translation>다운로드 페이지</translation>
+        <source>Downloads</source>
+        <translation type="unfinished">다운로드</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
### What does the PR do

Separate commits with some smaller Browser UI fixes:
- tab bar fixes (5ccb0aa227d89fd1c8661172db3293fd63b52706; Fixes https://github.com/status-im/status-app/issues/20686)
- remove the close button from the mobile addressbar (d61425899aadad411b284a919b0e3a99744cc369; Fixes https://github.com/status-im/status-app/issues/20568)
- fix(BrowserAddressField): show spacebar again on iOS; Fixes #21726

### Affected areas

Browser

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="2944" height="1800" alt="image" src="https://github.com/user-attachments/assets/758b77a4-ca42-424d-9ca5-cf474ba56561" />


### Impact on end user

Improved Browser UX when entering URL/search

### How to test

- visit some sites, make some searches
- open a new tab, observe the the address field popup containing the visited/searched entries

### Risk 

<!-- Described potential risks and worst case scenarios. -->
