### PR TITLE
perf(chat): lazy load chat center panel in portrait mode

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -58,10 +58,10 @@ StackLayout {
     property var mutualContactsModel
     property var sectionItemModel
 
-    readonly property bool isOwner: sectionItemModel.memberRole === Constants.memberRole.owner
-    readonly property bool isAdmin: sectionItemModel.memberRole === Constants.memberRole.admin
-    readonly property bool isTokenMasterOwner: sectionItemModel.memberRole === Constants.memberRole.tokenMaster
-    readonly property bool isControlNode: sectionItemModel.isControlNode
+    readonly property bool isOwner: !!sectionItemModel && sectionItemModel.memberRole === Constants.memberRole.owner
+    readonly property bool isAdmin: !!sectionItemModel && sectionItemModel.memberRole === Constants.memberRole.admin
+    readonly property bool isTokenMasterOwner: !!sectionItemModel && sectionItemModel.memberRole === Constants.memberRole.tokenMaster
+    readonly property bool isControlNode: !!sectionItemModel && sectionItemModel.isControlNode
     readonly property bool isPrivilegedUser: isControlNode || isOwner || isAdmin || isTokenMasterOwner
     readonly property int isInvitationPending: root.rootStore.chatCommunitySectionModule.requestToJoinState !== Constants.RequestToJoinState.None
 
@@ -73,6 +73,7 @@ StackLayout {
     property string disabledTooltipText
 
     property int extraLeftPadding: 0
+    property bool isPortraitMode: false
 
     property var emojiPopup
     property var stickersPopup
@@ -99,7 +100,7 @@ StackLayout {
     signal tokenPaymentRequested(string recipientAddress, string tokenKey, string rawAmount)
 
     // Community transfer ownership related props/signals:
-    property bool isPendingOwnershipRequest: sectionItemModel.isPendingOwnershipRequest
+    property bool isPendingOwnershipRequest: !!sectionItemModel && sectionItemModel.isPendingOwnershipRequest
 
     // Contacts related data:
     property string myPublicKey
@@ -143,7 +144,7 @@ StackLayout {
 
         sourceComponent: {
             if (sectionItem.isCommunity() && !sectionItem.amIMember) {
-                if (sectionItemModel.amIBanned) {
+                if (!!sectionItemModel && sectionItemModel.amIBanned) {
                     return communityBanComponent
                 } else if (sectionItem.isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin) {
                     return controlNodeOfflineComponent
@@ -262,7 +263,7 @@ StackLayout {
             id: chatView
 
             readonly property var sectionItem: root.rootStore.chatCommunitySectionModule
-            readonly property string communityId: root.sectionItemModel.id
+            readonly property string communityId: root.sectionItemModel?.id ?? ""
 
             objectName: "chatViewComponent"
 
@@ -277,22 +278,25 @@ StackLayout {
             emojiPopup: root.emojiPopup
             stickersPopup: root.stickersPopup
             sectionItemModel: root.sectionItemModel
-            joinedMembersCount: sectionItemModel.joinedMembersCount
+            joinedMembersCount: root.sectionItemModel?.joinedMembersCount ?? 0
             areTestNetworksEnabled: root.networksStore.areTestNetworksEnabled
             amIChatAdmin: root.rootStore.amIChatAdmin()
             amIMember: sectionItem.amIMember
-            amISectionAdmin: root.sectionItemModel.memberRole === Constants.memberRole.owner ||
-                             root.sectionItemModel.memberRole === Constants.memberRole.admin ||
-                             root.sectionItemModel.memberRole === Constants.memberRole.tokenMaster
-            hasViewOnlyPermissions: root.communityPermissionsStore.viewOnlyPermissionsModel.count > 0
+            amISectionAdmin: root.isPrivilegedUser
+            hasViewOnlyPermissions: !!root.communityPermissionsStore &&
+                                    root.communityPermissionsStore.viewOnlyPermissionsModel.count > 0
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
             messageLinkSharingEnabled: root.messageLinkSharingEnabled
             disabledTooltipText: root.disabledTooltipText
             paymentRequestFeatureEnabled: root.paymentRequestFeatureEnabled
             extraLeftPadding: root.extraLeftPadding
+            isPortraitMode: root.isPortraitMode
             showUsersList: root.showUsersList
 
             hasUnrestrictedViewOnlyPermission: {
+                if (!root.communityPermissionsStore)
+                    return false
+
                 viewOnlyUnrestrictedPermissionHelper.revision
 
                 const model = root.communityPermissionsStore.viewOnlyPermissionsModel
@@ -311,7 +315,7 @@ StackLayout {
             Instantiator {
                 id: viewOnlyUnrestrictedPermissionHelper
 
-                model: root.communityPermissionsStore.viewOnlyPermissionsModel
+                model: !!root.communityPermissionsStore ? root.communityPermissionsStore.viewOnlyPermissionsModel : null
 
                 property int revision: 0
 
@@ -325,13 +329,14 @@ StackLayout {
             }
 
             ModelChangeTracker {
-                model: root.communityPermissionsStore.viewOnlyPermissionsModel
+                model: !!root.communityPermissionsStore ? root.communityPermissionsStore.viewOnlyPermissionsModel : null
                 onRevisionChanged: viewOnlyUnrestrictedPermissionHelper.revision++
             }
 
-            hasViewAndPostPermissions: root.communityPermissionsStore.viewAndPostPermissionsModel.count > 0
-            viewOnlyPermissionsModel: root.communityPermissionsStore.viewOnlyPermissionsModel
-            viewAndPostPermissionsModel: root.communityPermissionsStore.viewAndPostPermissionsModel
+            hasViewAndPostPermissions: !!root.communityPermissionsStore &&
+                                       root.communityPermissionsStore.viewAndPostPermissionsModel.count > 0
+            viewOnlyPermissionsModel: !!root.communityPermissionsStore ? root.communityPermissionsStore.viewOnlyPermissionsModel : null
+            viewAndPostPermissionsModel: !!root.communityPermissionsStore ? root.communityPermissionsStore.viewAndPostPermissionsModel : null
             assetsModel: root.rootStore.assetsModel
             collectiblesModel: root.rootStore.collectiblesModel
             requestToJoinState: sectionItem.requestToJoinState
@@ -339,11 +344,14 @@ StackLayout {
 
             // Community access related data:
             isPendingOwnershipRequest: root.isPendingOwnershipRequest
-            allChannelsAreHiddenBecauseNotPermitted: root.communityAccessStore.allChannelsAreHiddenBecauseNotPermitted
-            communityMemberReevaluationStatus: root.communityAccessStore.communityMemberReevaluationStatus
-            spectatedPermissionsModel: root.communityAccessStore.spectatedPermissionsModel
-            chatPermissionsCheckOngoing: root.communityAccessStore.chatPermissionsCheckOngoing
-            joined: root.isChatView ? root.rootStore.joined : root.communityAccessStore.joined
+            allChannelsAreHiddenBecauseNotPermitted: !!root.communityAccessStore &&
+                                                     root.communityAccessStore.allChannelsAreHiddenBecauseNotPermitted
+            communityMemberReevaluationStatus: !!root.communityAccessStore ?
+                                                   root.communityAccessStore.communityMemberReevaluationStatus : 0
+            spectatedPermissionsModel: !!root.communityAccessStore ? root.communityAccessStore.spectatedPermissionsModel : null
+            chatPermissionsCheckOngoing: !!root.communityAccessStore &&
+                                         root.communityAccessStore.chatPermissionsCheckOngoing
+            joined: root.isChatView ? root.rootStore.joined : (!!root.communityAccessStore && root.communityAccessStore.joined)
 
             // Unfurling related data:
             gifUnfurlingEnabled: root.gifUnfurlingEnabled

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -203,7 +203,11 @@ QtObject {
     function currentChatContentModule() {
         // When we decide to have the same struct as it's on the backend we will remove this function.
         // So far this is a way to deal with refactored backend from the current qml structure.
-        chatCommunitySectionModule.prepareChatContentModuleForChatId(chatCommunitySectionModule.activeItem.id)
+        const activeItem = chatCommunitySectionModule.activeItem
+        if (!activeItem || !activeItem.id)
+            return null
+
+        chatCommunitySectionModule.prepareChatContentModuleForChatId(activeItem.id)
         return chatCommunitySectionModule.getChatContentModule()
     }
 
@@ -633,7 +637,7 @@ QtObject {
             } else if (d.activeChatType === Constants.chatType.privateGroupChat) {
                 return d.amIMember
             } else if (d.activeChatType === Constants.chatType.communityChat) {
-                return currentChatContentModule().chatDetails.canPost
+                return currentChatContentModule()?.chatDetails?.canPost || false
             }
 
             return true

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -156,6 +156,9 @@ Item {
         property var preEditFileUrlsAndSources: []
 
         function getChatContentModule(chatId) {
+            if (!root.parentModule || !chatId)
+                return null
+
             root.parentModule.prepareChatContentModuleForChatId(chatId)
             return root.parentModule.getChatContentModule()
         }

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -86,6 +86,7 @@ StatusSectionLayout {
     property bool paymentRequestFeatureEnabled
 
     property int extraLeftPadding: 0
+    property bool isPortraitMode: false
 
     // Subsection back history keyed by the active chat/channel id.
     subsectionHistory: SubsectionNavigationHistory {
@@ -140,6 +141,19 @@ StatusSectionLayout {
     // Internal triggers for navigating between messaging panels
     property bool navToMsgDetails: false
     property bool navToMsgList: false
+
+    QtObject {
+        id: d
+
+        readonly property bool shouldLoadCenterPanel: !root.isPortraitMode ||
+                                                      centerPanelRequested ||
+                                                      root.currentIndex !== StatusSectionLayout.LeftPanel
+        property bool centerPanelRequested: false
+
+        function requestCenterPanel() {
+            centerPanelRequested = true
+        }
+    }
 
     // Users related signals
     signal groupMembersUpdateRequested(string membersPubKeysList)
@@ -218,9 +232,12 @@ StatusSectionLayout {
     }
 
     centerPanel: Loader {
+        id: centerPanelLoader
         anchors.fill: parent
+        active: d.shouldLoadCenterPanel
         sourceComponent: (root.allChannelsAreHiddenBecauseNotPermitted || root.contentLocked) ?
                              joinCommunityCenterPanelComponent : chatColumnViewComponent
+        onLoaded: d.requestCenterPanel()
     }
 
     showRightPanel: {
@@ -234,6 +251,7 @@ StatusSectionLayout {
 
     onNavToMsgDetailsChanged: {
         if (root.navToMsgDetails) {
+            d.requestCenterPanel()
             root.currentIndex = StatusSectionLayout.CentralPanel
             root.navToMsgDetailsRequested(false)
         }
@@ -303,9 +321,15 @@ StatusSectionLayout {
         //
         // NOTE: It only affects behavior in portrait mode
         if(root.navToMsgDetails) {
+            d.requestCenterPanel()
             root.currentIndex = StatusSectionLayout.CentralPanel
             root.navToMsgDetailsRequested(false)
         }
+    }
+
+    onCurrentIndexChanged: {
+        if (root.currentIndex !== StatusSectionLayout.LeftPanel)
+            d.requestCenterPanel()
     }
 
     Component {
@@ -446,7 +470,10 @@ StatusSectionLayout {
                     headerContentLoader.item.addRemoveGroupMember()
                 }
             }
-            onChatItemClicked: (id) => root.goToNextPanel()
+            onChatItemClicked: (id) => {
+                d.requestCenterPanel()
+                root.goToNextPanel()
+            }
         }
     }
 
@@ -468,7 +495,10 @@ StatusSectionLayout {
             onInfoButtonClicked: root.communityInfoButtonClicked()
             onManageButtonClicked: root.communityManageButtonClicked()
             onFinaliseOwnershipClicked: root.finaliseOwnershipClicked()
-            onChatItemClicked: (id) => root.goToNextPanel()
+            onChatItemClicked: (id) => {
+                d.requestCenterPanel()
+                root.goToNextPanel()
+            }
             onShareOwnProfileRequested: Global.shareProfileDialogRequested(root.myPublicKey)
 
             // Permissions Related requests:
@@ -503,8 +533,10 @@ StatusSectionLayout {
 
     onShowUsersListChanged: {
         Qt.callLater(() => {
-            if (root.showUsersList)
+            if (root.showUsersList) {
+                d.requestCenterPanel()
                 goToNextPanel()
+            }
         })
     }
 

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -417,7 +417,7 @@ Item {
             }
         }
         headerBackground: AccountHeaderGradient {
-            width: parent.width
+            width: parent ? parent.width : 0
             overview: RootStore.overview
         }
 
@@ -434,7 +434,7 @@ Item {
             readonly property bool isOwnerCommunityCollectible: isCommunityCollectible ? (walletStore.currentViewedCollectible.communityPrivilegesLevel === Constants.TokenPrivilegesLevel.Owner) : false
 
             visible: anyActionAvailable
-            width: parent.width
+            width: parent ? parent.width : 0
             height: visible ? implicitHeight: 0
             walletStore: RootStore
             transactionStore: root.transactionStore

--- a/ui/app/mainui/sectionLoaders/ChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ChatLoader.qml
@@ -125,6 +125,7 @@ Loader {
                                                    && root.advancedStore.copyMessageLinksEnabled),
             paymentRequestFeatureEnabled:   Qt.binding(() => root.featureFlagsStore.paymentRequestEnabled),
             extraLeftPadding:               Qt.binding(() => root.isPortraitMode ? SQUtils.Utils.swipeIndicatorWidth : 0),
+            isPortraitMode:                 Qt.binding(() => root.isPortraitMode),
             mutualContactsModel:            Qt.binding(() => root.contactsAdaptor.mutualContacts),
             gifUnfurlingEnabled:            Qt.binding(() => root.sharedRootStore.gifUnfurlingEnabled),
             neverAskAboutUnfurlingAgain:    Qt.binding(() => root.sharedRootStore.neverAskAboutUnfurlingAgain),


### PR DESCRIPTION
### What does the PR do

Fixes #21699

Lazily loads the chat (applies to communities too) center panel in portrait mode, so that opening the chat on mobile is faster.

The rationale is that on portrait, you do not even see the center panel yet, so loading it lazily makes more sense. We have a loading state for loading messages too already.

Also fixes some warnings

On Linux, in portrait mode, a medium account went from 330ms to 179ms so a 1.8x speedup

### Affected areas

ChatView for the actual fix
Rest is just warning fixes

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction

### Screencapture of the functionality

[lazy-load-chat.webm](https://github.com/user-attachments/assets/e2ca6b17-10dd-45f6-92e3-6103a96fe7da)

### Impact on end user

Should feel faster to open chats on phones

### How to test

Open the chat on new accounts and old ones

### Risk 

Low
