### PR TITLE
fix(ContactsView): prevent sending CR to self

### DIFF
--- a/storybook/pages/ContactsViewPage.qml
+++ b/storybook/pages/ContactsViewPage.qml
@@ -19,6 +19,9 @@ Item {
         contentWidth: 560
 
         contactsStore: AppLayoutStores.ContactsStore {
+            readonly property string myPublicKey: "0xdeadbeef"
+            readonly property string myCompressedPublicKey: "zx3shdeadbeef"
+
             function joinPrivateChat(pubKey) {
                 console.info("ContactsStore::joinPrivateChat", pubKey)
             }
@@ -29,7 +32,13 @@ Item {
                 console.info("ContactsStore::dismissContactRequest", pubKey, contactRequestId)
             }
 
-            function resolveENS(value) {}
+            function resolveENS(value) {
+                console.info("ContactsStore::resolveENS", value)
+                if (value.startsWith("0x") || value.startsWith("zx3sh"))
+                    resolvedENS(value, "", "")
+                else
+                    resolvedENS("", "", "")
+            }
 
             signal resolvedENS(string resolvedPubKey, string resolvedAddress,
                                string uuid)
@@ -43,12 +52,18 @@ Item {
                             ["👨🏻‍🍼", "🏃🏿‍♂️", "🌇", "🤶🏿", "🏮","🤷🏻‍♂️", "🤦🏻",
                              "📣", "🤎", "👷🏽", "😺", "🥞", "🔃", "🧝🏽‍♂️"])
             }
+            function isCompressedPubKey(key) {
+                return !!key && key.startsWith("zx3sh")
+            }
+            function getDecompressedPk(value) {
+                return "0x" + value
+            }
         }
 
         mutualContactsModel: adaptor.mutualContacts
         blockedContactsModel: adaptor.blockedContacts
         pendingContactsModel: adaptor.pendingContacts
-        dismissedReceivedRequestContactsModel: adaptor.dismissedReceivedRequestContactsModel
+        dismissedReceivedRequestContactsModel: adaptor.dismissedReceivedRequestContacts
         pendingReceivedContactsCount: adaptor.pendingReceivedRequestContacts.count
     }
 

--- a/ui/app/AppLayouts/Profile/popups/SendContactRequestToChatKeyModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/SendContactRequestToChatKeyModal.qml
@@ -90,6 +90,8 @@ StatusDialog {
                    || d.lookedUpContact.contactRequestState === Constants.ContactRequestState.Sent
                    || d.lookedUpContact.isBlocked === true
         }
+        readonly property bool isOwnKey: d.resolvedFullPubKey === root.contactsStore.myPublicKey ||
+                                         d.resolvedPubKey === root.contactsStore.myCompressedPublicKey
 
         property var lookupContact: Backpressure.debounce(root, 400, function (value) {
             root.contactsStore.resolveENS(value)
@@ -146,8 +148,8 @@ StatusDialog {
             anchors.verticalCenter: parent.verticalCenter
             StatusIcon {
                 anchors.fill: parent
-                icon: d.validChatKey? "checkmark-circle" : "close-circle"
-                color: d.validChatKey? Theme.palette.successColor1 : Theme.palette.dangerColor1
+                icon: d.validChatKey && !d.isOwnKey ? "checkmark-circle" : "close-circle"
+                color: d.validChatKey && !d.isOwnKey? Theme.palette.successColor1 : Theme.palette.dangerColor1
             }
         }
     }
@@ -192,27 +194,26 @@ StatusDialog {
                     d.textChanged(text)
                 }
             }
-        }
-
-        StatusBaseText {
-            visible: d.contactRequestAlreadySent
-            Layout.fillWidth: true
-            horizontalAlignment: Text.AlignHCenter
-            wrapMode: Text.Wrap
-            text: {
-                if (d.lookedUpContact?.isBlocked) {
-                    return qsTr("This user is blocked. Unblock to send a contact request.")
-                }
-                switch (d.lookedUpContact?.contactRequestState) {
+            errorMessageCmp {
+                visible: d.contactRequestAlreadySent || d.isOwnKey
+                horizontalAlignment: Text.AlignHCenter
+                font.pixelSize: Theme.fontSize(13)
+                text: {
+                    if (d.isOwnKey)
+                        return qsTr("Cannot send a contact request to oneself")
+                    if (d.lookedUpContact?.isBlocked) {
+                        return qsTr("This user is blocked. Unblock to send a contact request.")
+                    }
+                    switch (d.lookedUpContact?.contactRequestState) {
                     case Constants.ContactRequestState.Sent:
                         return qsTr("You already sent a contact request.")
                     case Constants.ContactRequestState.Mutual:
                         return qsTr("You are already contacts.")
                     default:
                         return ""
+                    }
                 }
             }
-            color: Theme.palette.dangerColor1
         }
 
         StatusInput {
@@ -242,7 +243,7 @@ StatusDialog {
 
         rightButtons: ObjectModel {
             StatusButton {
-                enabled: d.validChatKey && messageInput.valid && !d.contactRequestAlreadySent
+                enabled: d.validChatKey && messageInput.valid && !d.contactRequestAlreadySent && !d.isOwnKey
                 objectName: "SendContactRequestModal_Send_Button"
                 text: qsTr("Send Contact Request")
                 onClicked: {

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -217,13 +217,13 @@ SettingsContentBase {
     }
 
     component ContactsList: ContactsListPanel {
-        onProfilePopupRequested: Global.openProfilePopup(publicKey)
-        onContextMenuRequested: root.openContextMenu(model, publicKey)
+        onProfilePopupRequested: publicKey => Global.openProfilePopup(publicKey)
+        onContextMenuRequested: publicKey => root.openContextMenu(model, publicKey)
 
-        onSendMessageRequested: root.contactsStore.joinPrivateChat(publicKey)
-        onAcceptContactRequested: root.contactsStore.acceptContactRequest(publicKey, "")
-        onRejectContactRequested: root.contactsStore.dismissContactRequest(publicKey, "")
-        onRejectionRemoved: root.contactsStore.acceptContactRequest(publicKey, "")
+        onSendMessageRequested: publicKey => root.contactsStore.joinPrivateChat(publicKey)
+        onAcceptContactRequested: publicKey => root.contactsStore.acceptContactRequest(publicKey, "")
+        onRejectContactRequested: publicKey => root.contactsStore.dismissContactRequest(publicKey, "")
+        onRejectionRemoved: publicKey => root.contactsStore.acceptContactRequest(publicKey, "")
     }
 
     component SectionComponent: Rectangle {

--- a/ui/app/AppLayouts/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/stores/ContactsStore.qml
@@ -33,6 +33,7 @@ QtObject {
     }
 
     readonly property string myPublicKey: userProfile.pubKey
+    readonly property string myCompressedPublicKey: userProfile.compressedPubKey
 
     // contactsModel holds all available contacts
     readonly property var contactsModel: d.contactsModuleInst.contactsModel

--- a/ui/app/mainui/adaptors/ContactsModelAdaptor.qml
+++ b/ui/app/mainui/adaptors/ContactsModelAdaptor.qml
@@ -92,7 +92,7 @@ QObject {
         ]
     }
 
-    readonly property var dimissedReceivedRequestContacts: SortFilterProxyModel {
+    readonly property var dismissedReceivedRequestContacts: SortFilterProxyModel {
         sourceModel: root.allContacts ?? null
 
         filters: [

--- a/ui/app/mainui/sectionLoaders/ProfileLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ProfileLoader.qml
@@ -136,7 +136,7 @@ Loader {
             blockedContactsModel:                   Qt.binding(() => root.contactsAdaptor.blockedContacts),
             pendingContactsModel:                   Qt.binding(() => root.contactsAdaptor.pendingContacts),
             pendingReceivedContactsCount:           Qt.binding(() => root.contactsAdaptor.pendingReceivedRequestContacts.count),
-            dismissedReceivedRequestContactsModel:  Qt.binding(() => root.contactsAdaptor.dimissedReceivedRequestContacts),
+            dismissedReceivedRequestContactsModel:  Qt.binding(() => root.contactsAdaptor.dismissedReceivedRequestContacts),
             isKeycardEnabled:                       Qt.binding(() => root.featureFlagsStore.keycardEnabled),
             isBrowserEnabled:                       Qt.binding(() => root.featureFlagsStore.browserEnabled),
             messageLinkSharingFeatureEnabled:       Qt.binding(() => root.featureFlagsStore.messageLinkSharingEnabled),

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -14803,6 +14803,10 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Cannot send a contact request to oneself</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>This user is blocked. Unblock to send a contact request.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -14882,6 +14882,10 @@ selhalo</translation>
         <translation>Zde zadejte klíč chatu</translation>
     </message>
     <message>
+        <source>Cannot send a contact request to oneself</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>This user is blocked. Unblock to send a contact request.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -14818,6 +14818,10 @@ al cargar</translation>
         <translation>Ingresa la clave de chat aquí</translation>
     </message>
     <message>
+        <source>Cannot send a contact request to oneself</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>This user is blocked. Unblock to send a contact request.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -14755,6 +14755,10 @@ to load</source>
         <translation>여기에 채팅 키를 입력하세요</translation>
     </message>
     <message>
+        <source>Cannot send a contact request to oneself</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>This user is blocked. Unblock to send a contact request.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/imports/shared/stores/UtilsStore.qml
+++ b/ui/imports/shared/stores/UtilsStore.qml
@@ -13,12 +13,12 @@ QtObject {
 
     function isChatKey(value) {
         return (Utils.startsWith0x(value) && Utils.isHex(value) && value.length === 132)
-                || d.globalUtilsInst.isCompressedPubKey(value)
+                || isCompressedPubKey(value)
     }
 
     function isCommunityPublicKey(value) {
         return (Utils.startsWith0x(value) && Utils.isHex(value) && value.length === Constants.communityIdLength)
-                || d.globalUtilsInst.isCompressedPubKey(value)
+                || isCompressedPubKey(value)
     }
 
     function isCompressedPubKey(pubKey) {


### PR DESCRIPTION
### What does the PR do

- SendContactRequestToChatKeyModal: add an additional check for own pubKey, plus some smaller UI fixes
- ContactsStore: expose `myCompressedPublicKey`
- fix a typo in `di(s)missedReceivedRequestContacts` model name
- adjust and extend the SB page to be able to verify the behavior; update TS files

Fixes #21718
Needs https://github.com/status-im/status-go/pull/7674

### Affected areas

ContactsView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="3028" height="1994" alt="Snímek obrazovky z 2026-07-30 16-58-39" src="https://github.com/user-attachments/assets/61daab4b-da4f-49ac-8d31-38b54d546e37" />

SB, uncompressed key:
<img width="3024" height="1990" alt="Snímek obrazovky z 2026-07-30 16-57-41" src="https://github.com/user-attachments/assets/42180af1-e05f-4784-a94d-f17c0ae8114a" />

### Impact on end user

- better/correct Contacts / CR handling

### How to test

- go to Settings/Messaging/Contacts
- try to send a CR to yourself

### Risk 

low
