### PR TITLE
fix(StatusBaseInput): restore saner left/right padding

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -160,12 +160,12 @@ Item {
         \qmlproperty real StatusBaseInput::leftPadding
         This property sets the left padding.
     */
-    property real leftPadding: leftComponentLoader.status === Loader.Ready && leftComponentLoader.item ? 6 : Theme.halfPadding
+    property real leftPadding: leftComponentLoader.status === Loader.Ready && leftComponentLoader.item ? 6 : Theme.defaultSmallPadding
     /*!
         \qmlproperty real StatusBaseInput::rightPadding
         This property sets the right padding.
     */
-    property real rightPadding: rightComponentLoader.status === Loader.Ready && rightComponentLoader.item ? 6 : Theme.halfPadding
+    property real rightPadding: rightComponentLoader.status === Loader.Ready && rightComponentLoader.item ? 6 : Theme.defaultSmallPadding
     /*!
         \qmlproperty real StatusBaseInput::topPadding
         This property sets the top padding.


### PR DESCRIPTION
### What does the PR do

- the default variant works better even with a modified padding factor

Fixes #21725

### Affected areas

Status(Base)Input

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

Even when manually setting the smallest padding factor:

<img width="2944" height="1800" alt="Snímek obrazovky z 2026-07-31 15-45-09" src="https://github.com/user-attachments/assets/d1ac97a3-881d-4165-8344-2162f4d60347" />

### Impact on end user

Nicer UI/UX for inputs

### How to test

- check margins/padding of various input fields variations we use in the app

### Risk 

low
