### PR TITLE
fix(chat): remove temporary clipboard images after upload

### DIFF
--- a/src/app_service/common/utils.nim
+++ b/src/app_service/common/utils.nim
@@ -214,7 +214,7 @@ proc escape_html*(s: string): string =
 
 proc save_byte_image_to_file*(imagePathOrData: string): string =
   ## Accepts either a data URI (data:image/<fmt>;base64,<data>) or a file path.
-  ## Loads into a QImage and saves to ~/Pictures (falling back to tempPath).
+  ## Loads into a QImage and saves it in the OS temporary directory.
   ## Returns the saved file path, or "" on failure.
   var format = "jpg"
   var img = QImage.create()
@@ -233,13 +233,17 @@ proc save_byte_image_to_file*(imagePathOrData: string): string =
     warn "save_byte_image_to_file: failed to load image", path = imagePathOrData
     return ""
 
-  var destDirPath = QStandardPaths.writableLocation(
-    cint(QStandardPathsStandardLocationEnum.PicturesLocation))
+  var destDirPath = QStandardPaths.writableLocation(QStandardPathsStandardLocationEnum.TempLocation)
+  if destDirPath == "":
+    destDirPath = getTempDir()
+
   if not dirExists(destDirPath):
     try:
       createDir(destDirPath)
-    except:
-      destDirPath = getEnv("TMPDIR", "/tmp")
+    except OSError as e:
+      warn "save_byte_image_to_file: failed to create temporary directory",
+        dir = destDirPath, error = e.msg
+      return ""
 
   let uuid = QUuid.createUuid().toString(cint(QUuidStringFormatEnum.WithoutBraces))
   let newFilePath = destDirPath & "/" & uuid & "." & format

--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -117,12 +117,18 @@ const asyncSendImagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   try:
     var images = Json.decode(arg.imagePathsJson, seq[string])
     var imagePaths: seq[string] = @[]
+    var temporaryImagePaths: seq[string] = @[]
+    defer:
+      for imagePath in temporaryImagePaths:
+        if not tryRemoveFile(imagePath) and fileExists(imagePath):
+          warn "asyncSendImagesTask: failed to remove temporary image", imagePath = imagePath
 
     for imagePathOrSource in images.mitems:
       if utils.isBase64DataUrl(imagePathOrSource):
         let imagePath = common_utils.save_byte_image_to_file(imagePathOrSource)
         if imagePath != "":
           imagePaths.add(imagePath)
+          temporaryImagePaths.add(imagePath)
       else:
         imagePaths.add(imagePathOrSource)
 

--- a/test/nim/save_byte_image_test.nim
+++ b/test/nim/save_byte_image_test.nim
@@ -1,9 +1,10 @@
 ## Tests for save_byte_image_to_file (app_service/common/utils).
-## Exercises the data-URI base64 decode + QImage save path and the load-failure path.
+## Exercises the data-URI base64 decode + temporary QImage save path and the load-failure path.
 ## Requires the Qt runtime (QImage / QStandardPaths / QUuid), like qsettings_test.
 
 import unittest, os, strutils
 import app_service/common/utils
+import seaqt/qstandardpaths
 
 suite "save_byte_image_to_file":
 
@@ -11,13 +12,15 @@ suite "save_byte_image_to_file":
   const onePxPngB64 =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
 
-  test "data-URI base64 image is decoded and saved":
+  test "data-URI base64 image is decoded into the temporary directory":
     let dataUri = "data:image/png;base64," & onePxPngB64
     let savedPath = save_byte_image_to_file(dataUri)
     check savedPath.len > 0
     check savedPath.endsWith(".png")
     check fileExists(savedPath)
-    # Clean up the file written to PicturesLocation / TMPDIR.
+    check parentDir(savedPath) == QStandardPaths.writableLocation(
+      QStandardPathsStandardLocationEnum.TempLocation)
+    # Clean up the temporary file created by this direct helper test.
     if fileExists(savedPath):
       removeFile(savedPath)
 


### PR DESCRIPTION
### What does the PR do

Fixes #21601

Pasted clipboard images were decoded and written to the user's Pictures directory before being uploaded, leaving orphaned files behind.

Stage these images in the OS temporary directory instead and remove each generated file after the send RPC completes, including failure paths.

Add coverage to ensure clipboard images are staged outside Pictures.

### Affected areas

- utils
- chat/async_task

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review

Also ask Copilot to align feedback with repository architecture boundaries:

- Nim (`src/`): orchestration, signals, module wiring

### Screencapture of the functionality

[pasted-image.webm](https://github.com/user-attachments/assets/79d84e8f-0483-4c92-8736-42e1aa333948)

### Impact on end user

No longer pollutes the users' Pictures and no longer leaves temp images behind

### How to test

Paste images in the chat and send

### Risk 

Low
