### PR TITLE
fix(communities): fix members not populating airdrop list when they join

### DIFF
--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -44,11 +44,15 @@ QtObject:
       # O(1) pubkey -> row index lookup for hasMember and the various per-pubkey
       # update procs. Maintained by every mutation below.
       pubKeyIndex: Table[string, int]
+      # Revealed airdrop addresses can arrive before the corresponding member
+      # is inserted into the model. Keep them until that member is available.
+      pendingAirdropAddresses: Table[string, string]
 
   proc delete(self: Model)
   proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
+    result.pendingAirdropAddresses = initTable[string, string]()
     result.setup
 
   proc countChanged(self: Model) {.signal.}
@@ -58,10 +62,19 @@ QtObject:
     for i, it in self.items:
       self.pubKeyIndex[it.pubKey] = i
 
+  proc applyPendingAirdropAddress(self: Model, item: MemberItem) =
+    if not self.pendingAirdropAddresses.hasKey(item.pubKey):
+      return
+
+    item.airdropAddress = self.pendingAirdropAddresses[item.pubKey]
+    self.pendingAirdropAddresses.del(item.pubKey)
+
   proc setItems*(self: Model, items: seq[MemberItem]) =
     self.beginResetModel()
     self.items = items
     self.rebuildPubKeyIndex()
+    for item in self.items:
+      self.applyPendingAirdropAddress(item)
     self.endResetModel()
     self.countChanged()
 
@@ -185,6 +198,7 @@ QtObject:
     self.beginInsertRows(modelIndex, self.items.len, self.items.len)
     self.pubKeyIndex[item.pubKey] = self.items.len
     self.items.add(item)
+    self.applyPendingAirdropAddress(item)
     self.endInsertRows()
     self.countChanged()
 
@@ -212,6 +226,7 @@ QtObject:
     self.beginRemoveRows(parentModelIndex, index, index)
     self.items.delete(index)
     self.pubKeyIndex.del(removedPubKey)
+    self.pendingAirdropAddresses.del(removedPubKey)
     # seq.delete shifts every later entry left by one — reflect that in the index.
     for v in self.pubKeyIndex.mvalues:
       if v > index:
@@ -259,6 +274,8 @@ QtObject:
 
     self.beginInsertRows(modelIndex, first, last)
     self.items.add(newItems)
+    for index in first ..< self.items.len:
+      self.applyPendingAirdropAddress(self.items[index])
     self.endInsertRows()
     self.countChanged()
 
@@ -454,7 +471,16 @@ QtObject:
       updateRole(onlineStatus)
 
   proc setAirdropAddress*(self: Model, pubKey: string, airdropAddress: string) =
-    updateItemRolesAndNotify self.findIndexForMember(pubKey):
+    let ind = self.findIndexForMember(pubKey)
+    if ind == -1:
+      if airdropAddress.len == 0:
+        self.pendingAirdropAddresses.del(pubKey)
+      else:
+        self.pendingAirdropAddresses[pubKey] = airdropAddress
+      return
+
+    self.pendingAirdropAddresses.del(pubKey)
+    updateRolesAndNotify:
       updateRole(airdropAddress)
 
   proc getAirdropAddressForMember*(self: Model, pubKey: string): string =

--- a/test/nim/member_model_test.nim
+++ b/test/nim/member_model_test.nim
@@ -101,6 +101,17 @@ suite "updating member items":
     model.updateToTheseItems(@[memberA, memberB, memberD])
     check(model.rowCount == 3)
 
+  test "applies an airdrop address received before the member is added":
+    model.setAirdropAddress("0xd", "0xairdrop")
+    model.updateToTheseItems(@[memberA, memberB, memberC, memberD])
+    check(model.getAirdropAddressForMember("0xd") == "0xairdrop")
+
+  test "applies an airdrop address received before the model is populated":
+    let emptyModel = newModel()
+    emptyModel.setAirdropAddress("0xd", "0xairdrop")
+    emptyModel.setItems(@[memberA, memberB, memberC, memberD])
+    check(emptyModel.getAirdropAddressForMember("0xd") == "0xairdrop")
+
   test "add an item and update another using updateToTheseItems":
     let memberACopy = memberA
     memberACopy.displayName = "roger"

--- a/ui/app/AppLayouts/Communities/popups/MembersDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/MembersDropdown.qml
@@ -16,6 +16,7 @@ StatusDropdown {
     property var selectedKeys: new Set()
     property bool forceButtonDisabled: false
     property int maximumListHeight: 288
+    property string noContactsFoundText: qsTr("No contacts found")
 
     property alias model: listView.model
     readonly property alias count: listView.count
@@ -122,7 +123,7 @@ StatusDropdown {
 
             visible: listView.count === 0
 
-            text: qsTr("No contacts found")
+            text: root.noContactsFoundText
             color: Theme.palette.baseColor1
             font.pixelSize: Theme.tertiaryTextFontSize
             elide: Text.ElideRight

--- a/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
@@ -525,6 +525,7 @@ StatusScrollView {
 
                 directParent: airdropRecipientsSelector.addButton
                 relativeX: airdropRecipientsSelector.addButton.width
+                noContactsFoundText: qsTr("No members found")
 
                 forceButtonDisabled:
                     mode === MembersDropdown.Mode.Update &&

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -6287,6 +6287,10 @@ key pair. Keycard will be required for signing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>No members found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show fees (will be enabled once the form is filled)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -6319,6 +6319,10 @@ key pair. Keycard will be required for signing</source>
         <translation>Nejprve musíte vyrazit nebo importovat sběratelský předmět, než budete moci provést airdrop</translation>
     </message>
     <message>
+        <source>No members found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show fees (will be enabled once the form is filled)</source>
         <translation>Zobrazit poplatky (bude povoleno po vyplnění formuláře)</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -6298,6 +6298,10 @@ key pair. Keycard will be required for signing</source>
         <translation>Primero necesitas acuñar o importar un coleccionable antes de poder realizar un airdrop</translation>
     </message>
     <message>
+        <source>No members found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show fees (will be enabled once the form is filled)</source>
         <translation></translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -6276,6 +6276,10 @@ key pair. Keycard will be required for signing</source>
         <translation>에어드롭을 진행하려면 먼저 컬렉티블을 민트하거나 가져와야 합니다</translation>
     </message>
     <message>
+        <source>No members found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show fees (will be enabled once the form is filled)</source>
         <translation>수수료 표시(양식을 모두 입력하면 활성화됨)</translation>
     </message>


### PR DESCRIPTION
### What does the PR do

Fixes #21584

Fixes an issue where newly joined community members could be missing from the Airdrop recipient selector. Revealed Airdrop addresses are now retained when received before the member model is updated, then applied automatically once the member is added. This relies on existing signals and does not trigger additional refetches.

### Affected areas

members_model

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- Nim (`src/`): orchestration, signals, module wiring

### Screencapture of the functionality

[airdrop-member-list.webm](https://github.com/user-attachments/assets/de1d2b66-1782-4629-b26f-4d6f5b5ca3ad)

### Impact on end user

Fixes the issue, meaning they can have access to the member list at all times, without having to restart

### How to test

- Have a community with the owner token
- Go to the airdrop panel
- Join the community with another profile
- See that the new member is there in the member list of the airdrop

### Risk 

Low
