### PR TITLE
feat(@settings): checksum wallet address on settings

### DIFF
--- a/src/app/modules/main/profile_section/wallet/accounts/module.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/module.nim
@@ -79,7 +79,8 @@ proc convertWalletAccountDtoToKeyPairAccountItem(self: Module, account: WalletAc
     operability = account.operable,
     isDefaultAccount = account.isWallet,
     self.controller.areTestNetworksEnabled(),
-    hideFromTotalBalance = account.hideFromTotalBalance)
+    hideFromTotalBalance = account.hideFromTotalBalance,
+    mixedcaseAddress = account.mixedcaseAddress)
 
 proc setBalance(self: Module, accountAddresses: seq[string]) =
   let enabledChainIds = self.controller.getEnabledChainIds()

--- a/src/app/modules/shared/keypairs.nim
+++ b/src/app/modules/shared/keypairs.nim
@@ -49,7 +49,7 @@ proc buildKeypairItem*(keypair: KeypairDto, areTestNetworksEnabled: bool): KeyPa
       icon = "wallet"
     item.addAccount(newKeyPairAccountItem(acc.name, acc.path, acc.address, acc.publicKey, acc.emoji, acc.colorId,
       icon, newCurrencyAmount(), balanceFetched = true, operability = acc.operable, acc.isWallet, areTestNetworksEnabled,
-      acc.hideFromTotalBalance))
+      acc.hideFromTotalBalance, mixedcaseAddress = acc.mixedcaseAddress))
   return item
 
 proc buildKeyPairsList*(keypairs: seq[KeypairDto], excludeAlreadyMigratedPairs: bool,

--- a/src/app/modules/shared_models/keypair_account_item.nim
+++ b/src/app/modules/shared_models/keypair_account_item.nim
@@ -9,6 +9,7 @@ QtObject:
     name: string
     path: string
     address: string
+    mixedcaseAddress: string
     pubKey: string
     operability: string
     emoji: string
@@ -23,12 +24,14 @@ QtObject:
   proc delete*(self: KeyPairAccountItem)
   proc newKeyPairAccountItem*(name = "", path = "", address = "", pubKey = "", emoji = "", colorId = "", icon = "",
     balance = newCurrencyAmount(), balanceFetched = true, operability = wa_dto.AccountFullyOperable,
-    isDefaultAccount = false, areTestNetworksEnabled =false, hideFromTotalBalance = false): KeyPairAccountItem =
+    isDefaultAccount = false, areTestNetworksEnabled = false, hideFromTotalBalance = false,
+    mixedcaseAddress = ""): KeyPairAccountItem =
     new(result, delete)
     result.QObject.setup
     result.name = name
     result.path = path
     result.address = address
+    result.mixedcaseAddress = mixedcaseAddress
     result.pubKey = pubKey
     result.emoji = emoji
     result.colorId = colorId
@@ -45,6 +48,7 @@ QtObject:
       name: {self.name},
       path: {self.path},
       address: {self.address},
+      mixedcaseAddress: {self.mixedcaseAddress},
       pubKey: {self.pubKey},
       emoji: {self.emoji},
       colorId: {self.colorId},
@@ -89,6 +93,17 @@ QtObject:
     read = getAddress
     write = setAddress
     notify = addressChanged
+
+  proc mixedcaseAddressChanged*(self: KeyPairAccountItem) {.signal.}
+  proc getMixedcaseAddress*(self: KeyPairAccountItem): string {.slot.} =
+    return self.mixedcaseAddress
+  proc setMixedcaseAddress*(self: KeyPairAccountItem, value: string) {.slot.} =
+    self.mixedcaseAddress = value
+    self.mixedcaseAddressChanged()
+  QtProperty[string] mixedcaseAddress:
+    read = getMixedcaseAddress
+    write = setMixedcaseAddress
+    notify = mixedcaseAddressChanged
 
   proc pubKeyChanged*(self: KeyPairAccountItem) {.signal.}
   proc getPubKey*(self: KeyPairAccountItem): string {.slot.} =

--- a/storybook/pages/AccountViewPage.qml
+++ b/storybook/pages/AccountViewPage.qml
@@ -33,6 +33,7 @@ SplitView {
             dummyOverview = ({
                                  name: "helloworld",
                                  address: "0xcdc2ea3b6ba8fed3a3402f8db8b2fab53e7b7421",
+                                 mixedcaseAddress: "0xcDC2Ea3b6bA8FEd3a3402F8dB8b2fAb53E7B7421",
                                  ens: emptyString,
                                  colorId: clr,
                                  emoji: "⚽",

--- a/storybook/qmlTests/tests/tst_AccountView.qml
+++ b/storybook/qmlTests/tests/tst_AccountView.qml
@@ -1,0 +1,119 @@
+import QtQuick
+import QtTest
+
+import AppLayouts.Profile.views.wallet
+import AppLayouts.Profile.stores as ProfileStores
+
+import utils
+
+Item {
+    id: root
+
+    width: 600
+    height: 800
+
+    readonly property string lowercaseAddress: "0xcdc2ea3b6ba8fed3a3402f8db8b2fab53e7b7421"
+    readonly property string checksumAddress: "0xcDC2Ea3b6bA8FEd3a3402F8dB8b2fAb53E7B7421"
+
+    QtObject {
+        id: globalUtilsMock
+        function isCompressedPubKey(_publicKey) { return false }
+        function getCompressedPk(publicKey) { return publicKey }
+    }
+
+    ProfileStores.WalletStore {
+        id: walletStoreMock
+    }
+
+    ListModel {
+        id: emptyNetworks
+    }
+
+    Component {
+        id: componentUnderTest
+
+        AccountView {
+            width: root.width
+            walletStore: walletStoreMock
+            activeNetworks: emptyNetworks
+            emojiPopup: null
+            userProfilePublicKey: ""
+            keyPair: ({
+                          pairType: Constants.keypair.type.profile,
+                          migratedToColdWallet: false,
+                          operability: Constants.keypair.operability.fullyOperable,
+                          name: "Profile",
+                          pubKey: "",
+                          icon: "",
+                          image: "",
+                          accounts: []
+                      })
+        }
+    }
+
+    TestCase {
+        name: "AccountView"
+        when: windowShown
+
+        property var controlUnderTest: null
+
+        function initTestCase() {
+            Utils.globalUtilsInst = globalUtilsMock
+        }
+
+        function cleanupTestCase() {
+            Utils.globalUtilsInst = null
+        }
+
+        function cleanup() {
+            if (!!controlUnderTest) {
+                controlUnderTest.destroy()
+                controlUnderTest = null
+            }
+        }
+
+        function createView(account) {
+            cleanup()
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, { account: account })
+            verify(!!controlUnderTest)
+            waitForRendering(controlUnderTest)
+            return controlUnderTest
+        }
+
+        function test_addressListItemShowsMixedcaseAddress() {
+            createView({
+                            name: "Status account",
+                            address: root.lowercaseAddress,
+                            mixedcaseAddress: root.checksumAddress,
+                            emoji: "",
+                            colorId: "primary",
+                            path: "m/44'/60'/0'/0/0",
+                            isDefaultAccount: true,
+                            hideFromTotalBalance: false,
+                            balance: null
+                        })
+
+            const addressItem = findChild(controlUnderTest, "Address_ListItem")
+            verify(!!addressItem)
+            compare(addressItem.subTitle, root.checksumAddress)
+        }
+
+        function test_addressListItemFallsBackToAddress() {
+            createView({
+                            name: "Status account",
+                            address: root.lowercaseAddress,
+                            mixedcaseAddress: "",
+                            emoji: "",
+                            colorId: "primary",
+                            path: "m/44'/60'/0'/0/0",
+                            isDefaultAccount: true,
+                            hideFromTotalBalance: false,
+                            balance: null
+                        })
+
+            const addressItem = findChild(controlUnderTest, "Address_ListItem")
+            verify(!!addressItem)
+            compare(addressItem.subTitle, root.lowercaseAddress)
+        }
+    }
+}

--- a/storybook/stubs/AppLayouts/Profile/stores/WalletStore.qml
+++ b/storybook/stubs/AppLayouts/Profile/stores/WalletStore.qml
@@ -1,4 +1,18 @@
 import QtQuick
 
 QtObject {
+    property var walletModule: QtObject {
+        property bool hasPairedDevices: false
+    }
+
+    property var accountsModule: null
+    property var selectedAccount
+    property var accounts: null
+
+    signal loggedInUserAuthenticated(string requestedBy, string password, string pin, string keyUid, string keycardUid)
+
+    function authenticateLoggedInUser(_requestedBy) {}
+    function deleteAccount(_address, _password) { return "" }
+    function updateAccount(_address, _accountName, _colorId, _emoji) { return "" }
+    function updateWatchAccountHiddenFromTotalBalance(_address, _hideFromTotalBalance) {}
 }

--- a/test/e2e/configs/__init__.py
+++ b/test/e2e/configs/__init__.py
@@ -18,20 +18,35 @@ except ImportError:
     )
 
 def _resolve_aut_path(aut_path: str) -> SystemPath:
-    """On macOS, accept a .app bundle path and resolve to the MacOS binary."""
-    path = SystemPath(aut_path)
+    """Resolve AUT_PATH to the launchable binary.
+
+    macOS accepts:
+    - /path/to/Status.app
+    - /path/to/Status.app/Contents/MacOS/nim_status_client
+    - /path/to/status-app/bin/nim_status_client
+    """
+    resolved = SystemPath(aut_path)
     if get_platform() != 'Darwin':
-        return path
-    if path.suffix == '.app' and path.is_dir():
-        binary = path / 'Contents' / 'MacOS' / 'nim_status_client'
-        if binary.is_file():
-            return binary
-        exit(f'AUT_PATH bundle has no binary at {binary}')
-    if path.is_dir():
-        exit(
-            f'AUT_PATH must be Status.app or .../Contents/MacOS/nim_status_client, got: {path}'
-        )
-    return path
+        return resolved
+
+    if resolved.suffix == '.app':
+        if not resolved.is_dir():
+            exit(f'AUT_PATH .app bundle not found: {resolved}')
+        binary = resolved / 'Contents' / 'MacOS' / 'nim_status_client'
+        if not binary.is_file():
+            exit(f'AUT_PATH bundle has no binary at {binary}')
+        return binary
+
+    if resolved.is_file():
+        return resolved
+
+    exit(
+        f'AUT_PATH not found: {resolved}\n'
+        'On macOS set AUT_PATH to one of:\n'
+        '  /path/to/Status.app\n'
+        '  /path/to/Status.app/Contents/MacOS/nim_status_client\n'
+        '  /path/to/status-app/bin/nim_status_client'
+    )
 
 
 if AUT_PATH is None:
@@ -39,8 +54,6 @@ if AUT_PATH is None:
 if get_platform() == "Windows" and 'Status' not in AUT_PATH:
     exit('Please use launcher from "Status" folder in "AUT_PATH"')
 AUT_PATH = _resolve_aut_path(AUT_PATH)
-if get_platform() == 'Darwin' and not AUT_PATH.is_file():
-    exit(f'AUT_PATH must point to nim_status_client binary, got: {AUT_PATH}')
 WALLET_SEED = os.getenv('WALLET_TEST_USER_SEED')
 
 # Application and Squish logs (all platforms).

--- a/test/e2e/tests/crtitical_tests_prs/test_onboarding_import_seed.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_onboarding_import_seed.py
@@ -1,6 +1,7 @@
 import allure
 import pytest
 from allure_commons._allure import step
+from web3 import Web3
 
 from constants import UserAccount
 from constants.dock_buttons import DockButtons
@@ -42,9 +43,9 @@ def test_import_and_reimport_random_seed(
         address = status_acc_view.get_account_address_value()
 
         address_from_seed = get_wallet_address_from_mnemonic(seed_phrase)
-        # assert Web3.is_checksum_address(address) todo: https://github.com/status-im/status-desktop/issues/17648
-        assert address == address_from_seed, \
-            f"Recovered account should have address {address_from_seed}, but has {address}"
+        expected_address = Web3.to_checksum_address(address_from_seed)
+        assert address == expected_address, \
+            f"Recovered account should have address {expected_address}, but has {address}"
 
     with step('Verify that the user logged in via seed phrase correctly'):
         user_canvas = main_window.left_panel.open_online_identifier()

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
@@ -4,6 +4,7 @@ import string
 import allure
 import pytest
 from allure_commons._allure import step
+from web3 import Web3
 
 
 import configs
@@ -53,7 +54,7 @@ def test_settings_include_in_total_balance(main_screen: MainWindow, name, watche
         assert acc_view.get_account_name_value() == name, \
             f"Watched address name is incorrect, current name is {acc_view.get_account_name_value()}, expected {name}"
 
-        assert acc_view.get_account_address_value() == str(watched_address).lower(), \
+        assert acc_view.get_account_address_value() == Web3.to_checksum_address(watched_address), \
             f"Watched address in details view does not match {watched_address}"
 
         assert acc_view.get_account_origin_value() == WalletAccountSettings.WATCHED_ADDRESS_ORIGIN.value, \

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_private_key.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_private_key.py
@@ -1,6 +1,7 @@
 import allure
 import pytest
 from allure_commons._allure import step
+from web3 import Web3
 
 from constants import RandomWalletAccount
 from helpers.wallet_helper import authenticate_with_password
@@ -42,8 +43,9 @@ def test_plus_button_manage_account_from_private_key(main_screen: MainWindow, us
                 wallet_account.name,
                 account_index))
         address = settings_acc_view.get_account_address_value()
-        assert address == address_pair.wallet_address, \
-            f"Recovered account should have address {address_pair.wallet_address}, but has {address}"
+        expected_address = Web3.to_checksum_address(address_pair.wallet_address)
+        assert address == expected_address, \
+            f"Recovered account should have address {expected_address}, but has {address}"
 
     with step('Edit wallet account'):
         main_screen.left_panel.open_wallet()

--- a/ui/app/AppLayouts/Profile/controls/WalletAccountDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/WalletAccountDelegate.qml
@@ -20,7 +20,9 @@ StatusListItem {
 
     objectName: account.name
     title: account.name
-    subTitle: WalletUtils.addressToDisplay(Theme.palette, account.address, true, sensor.containsMouse)
+    subTitle: WalletUtils.addressToDisplay(Theme.palette,
+                                           WalletUtils.preferredAddress(account),
+                                           true, sensor.containsMouse)
     asset.color: !!account.colorId ? Utils.getColorForId(Theme.palette, account.colorId): ""
     asset.emoji: account.emoji
     asset.name: !account.emoji ? "filled-account": ""

--- a/ui/app/AppLayouts/Profile/popups/WalletAddressMenu.qml
+++ b/ui/app/AppLayouts/Profile/popups/WalletAddressMenu.qml
@@ -6,6 +6,7 @@ import StatusQ.Popups
 import shared.popups
 import utils
 
+import AppLayouts.Wallet
 import AppLayouts.Wallet.popups
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -25,11 +26,14 @@ StatusMenu {
 
     property var selectedAccount: ({
                                        address: "",
+                                       mixedcaseAddress: "",
                                        name: "",
                                        emoji: "",
                                        colorId: "",
                                    })
     property var flatNetworks
+
+    readonly property string displayAddress: WalletUtils.preferredAddress(root.selectedAccount)
 
     signal copyToClipboard(string address)
 
@@ -53,7 +57,7 @@ StatusMenu {
         successText:  qsTr("Address copied")
         text: qsTr("Copy address")
         icon.name: "copy"
-        onTriggered: root.copyToClipboard(root.selectedAccount.address?? "")
+        onTriggered: root.copyToClipboard(root.displayAddress)
     }
     StatusAction {
         id: showQrAction
@@ -65,6 +69,7 @@ StatusMenu {
                                                 hasFloatingButtons: false,
                                                 name: root.selectedAccount.name?? "",
                                                 address: root.selectedAccount.address?? "",
+                                                mixedcaseAddress: root.displayAddress,
                                                 emoji: root.selectedAccount.emoji?? "",
                                                 colorId: root.selectedAccount.colorId?? ""
                                             })

--- a/ui/app/AppLayouts/Profile/views/wallet/AccountOrderView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountOrderView.qml
@@ -93,7 +93,9 @@ ColumnLayout {
                 draggable: accountsList.count > 1
                 Drag.keys: [d.walletAccountDnDKey]
                 title: model.name
-                secondaryTitle: WalletUtils.addressToDisplay(Theme.palette, model.address, true, containsMouse)
+                secondaryTitle: WalletUtils.addressToDisplay(Theme.palette,
+                                                             WalletUtils.preferredAddress(model),
+                                                             true, containsMouse)
                 secondaryTitleIcon: model.walletType === Constants.watchWalletType? "show" :
                                                                                     model.migratedToColdWallet ? "keycard" : ""
                 hasEmoji: true

--- a/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
@@ -139,7 +139,7 @@ ColumnLayout {
                 isInteractive: true
                 moreButtonEnabled: true
                 title: qsTr("Address")
-                subTitle: !!root.account && root.account.address ? root.account.address: ""
+                subTitle: WalletUtils.preferredAddress(root.account)
                 onButtonClicked: addressMenu.openMenu(this)
             }
             Separator {

--- a/ui/app/AppLayouts/Wallet/WalletUtils.qml
+++ b/ui/app/AppLayouts/Wallet/WalletUtils.qml
@@ -34,6 +34,12 @@ QtObject {
         return hovered ? Utils.richColorText(finalAddress, palette.directColor1) : finalAddress
     }
 
+    function preferredAddress(account) {
+        if (!account)
+            return ""
+        return account.mixedcaseAddress || account.address || ""
+    }
+
     /**
       Calculate max safe amount to be used when making a transaction
 


### PR DESCRIPTION
### What does the PR do

- add checksummed address for wallet settings
- add tests in QML for added function
- update e2e to check checksummed address in settings

Fix #17648

### Affected areas

Wallet settings

### Screencapture of the functionality

<img width="1303" height="929" alt="image" src="https://github.com/user-attachments/assets/934475e0-74f0-49be-9ad6-bb77d92820d5" />

<img width="1303" height="929" alt="image" src="https://github.com/user-attachments/assets/78c9e202-4d6a-43e7-8519-285033e29692" />
