### PR TITLE
fix(Sidebar): can't mute community on mobile

### DIFF
--- a/storybook/qmlTests/tests/tst_PrimaryNavSidebar.qml
+++ b/storybook/qmlTests/tests/tst_PrimaryNavSidebar.qml
@@ -1,11 +1,15 @@
 import QtQuick
 import QtTest
 
+import StatusQ.Popups
+
 import AppLayouts.Profile.helpers
 
 import mainui
 import mainui.adaptors
 import utils
+
+import shared.controls.chat.menuItems
 
 import Models
 
@@ -62,6 +66,11 @@ Item {
         }
     }
 
+    QtObject {
+        id: d
+        property bool cascadeSubmenus: true
+    }
+
     SignalSpy {
         id: itemActivatedSpy
         signalName: "itemActivated"
@@ -91,6 +100,7 @@ Item {
             itemActivatedSpy.clear()
             activityCenterSpy.clear()
             sidebarAdaptor.reset()
+            d.cascadeSubmenus = true
         }
 
         function test_basic_geometry() {
@@ -275,9 +285,9 @@ Item {
 
         function test_community_buttons_have_object_name() {
             // Look for community buttons with specific objectName
-            const communityBtn = findChild(controlUnderTest, "CommunityNavBarButton")
-            // May or may not exist depending on model data, just verify no crash
-            verify(true)
+            const communityBtn = findChild(controlUnderTest, "CommunityNavBarButton_Status.app")
+            verify(!!communityBtn)
+            tryCompare(communityBtn, "visible", true)
         }
 
         function test_drawer_always_visible() {
@@ -288,6 +298,58 @@ Item {
             // Test non-interactive mode
             controlUnderTest.alwaysVisible = true
             tryCompare(controlUnderTest, "position", 1.0)
+        }
+
+        Component {
+            id: communityMuteContextMenu
+            StatusMenu {
+                objectName: "communityContextMenu"
+                required property var model
+                cascade: d.cascadeSubmenus
+                MuteChatMenuItem {
+                    objectName: "muteSubMenuPopup"
+                    title: qsTr("Mute Community")
+                }
+            }
+        }
+
+        function test_community_context_menu_mute_submenu_data() {
+            return [
+              { tag: "cascade (desktop)", cascade: true },
+              { tag: "no cascade (mobile)", cascade: false },
+            ]
+        }
+
+        function test_community_context_menu_mute_submenu(data) {
+            d.cascadeSubmenus = data.cascade
+
+            controlUnderTest.communityPopupMenu = communityMuteContextMenu
+            const communityBtn = findChild(controlUnderTest, "CommunityNavBarButton_Status.app")
+            verify(!!communityBtn)
+            tryCompare(communityBtn, "visible", true)
+            mouseClick(communityBtn, communityBtn.width/2, communityBtn.height/2, Qt.RightButton)
+
+            const menu = findChild(communityBtn, "communityContextMenu")
+            verify(!!menu)
+            tryCompare(menu, "visible", true)
+
+            const muteSubMenu = findChild(menu, "StatusMenuItemDelegate") // need the delegate here to click
+            verify(!!muteSubMenu)
+
+            if (d.cascadeSubmenus) {
+                mouseMove(muteSubMenu)
+                // both menus are shown, usually side by side
+                const muteSubMenuPopup = findChild(communityBtn, "muteSubMenuPopup")
+                verify(!!muteSubMenuPopup)
+                tryCompare(muteSubMenuPopup, "visible", true)
+            } else {
+                mouseClick(muteSubMenu)
+                // the old menu is gone; and we have a new one
+                tryCompare(menu, "visible", false)
+                const muteSubMenuPopup = findChild(communityBtn, "muteSubMenuPopup")
+                verify(!!muteSubMenuPopup)
+                tryCompare(muteSubMenuPopup, "visible", true)
+            }
         }
     }
 }

--- a/test/e2e/gui/main_window.py
+++ b/test/e2e/gui/main_window.py
@@ -114,16 +114,14 @@ class MainLeftPanel(QObject):
 
     @allure.step('Get communities names')
     def communities(self) -> typing.List[str]:
-        community_names = []
-        for obj in driver.findAllObjects(self.community_template_button.real_name):
-            try:
-                if obj is not None and hasattr(obj, 'text') and obj.text is not None:
-                    community_names.append(str(obj.text))
-            except Exception as e:
-                LOG.warning(f'Error getting community name: {e}')
-                continue
-
-        return community_names
+        self.community_template_button.real_name['objectName'] = (
+            names.statusCommunityMainNavBarListView_CommunityNavBarButton['objectName']
+        )
+        prefix = 'CommunityNavBarButton_'
+        return [
+            str(obj.objectName).removeprefix(prefix)
+            for obj in driver.findAllObjects(self.community_template_button.real_name)
+        ]
 
     @allure.step('Create community')
     def create_community(self, community_data: CommunityData) -> 'CommunityScreen':
@@ -172,41 +170,16 @@ class MainLeftPanel(QObject):
         raise Exception(f"Failed to open Communities Portal after {attempts} attempts with {last_exception}")
 
     def _get_community(self, name: str):
-        community_names = []
-        max_attempts = 10
-        attempt = 0
-        
-        LOG.info(f'Looking for community: {name}')
-        LOG.info(f'Using template: {self.community_template_button.real_name}')
-        
-        while attempt < max_attempts:
-            community_names = []
-            objects = driver.findAllObjects(self.community_template_button.real_name)
-            LOG.info(f'Attempt {attempt + 1}: Found {len(objects)} objects')
-            
-            for i, obj in enumerate(objects):
-                try:
-                    if obj is not None and hasattr(obj, 'text') and obj.text is not None:
-                        obj_name = str(obj.text)
-                        community_names.append(obj_name)
-                        LOG.info(f'  Object {i}: {obj_name}')
-                        if obj_name == str(name):
-                            LOG.info(f'Found target community: {name}')
-                            return obj
-                    else:
-                        LOG.warning(f'  Object {i}: null or missing name property')
-                except Exception as e:
-                    LOG.warning(f'  Object {i}: Error getting name - {e}')
-
-            LOG.info(f'Available communities: {community_names}')
-            attempt += 1
-            time.sleep(0.5)
-        
-        raise LookupError(f'Community: {name} not found in {community_names}')
+        self.community_template_button.real_name['objectName'] = f'CommunityNavBarButton_{name}'
+        try:
+            return self.community_template_button.object
+        except Exception as error:
+            raise LookupError(f'Community: {name} not found in {self.communities()}') from error
 
     @allure.step('Open community')
     def open_community(self, name: str) -> CommunityScreen:
-        driver.mouseClick(self._get_community(name))
+        self._get_community(name)
+        self.community_template_button.click()
         skip_message_backup_popup_if_visible()
         skip_intro_if_visible()
         community = CommunityScreen()
@@ -218,7 +191,8 @@ class MainLeftPanel(QObject):
         self, name: str, timeout_msec: int = configs.timeouts.APP_LOAD_TIMEOUT_MSEC
     ):
         start_time = time.time()
-        driver.mouseClick(self._get_community(name))
+        self._get_community(name)
+        self.community_template_button.click()
         skip_message_backup_popup_if_visible()
         skip_intro_if_visible()
         community = CommunityScreen()
@@ -248,12 +222,13 @@ class MainLeftPanel(QObject):
 
     @allure.step('Get community logo')
     def get_community_logo(self, name: str) -> Image:
-        return Image(driver.objectMap.realName(self._get_community(name)))
+        self._get_community(name)
+        return self.community_template_button.image
 
     @allure.step('Open context menu for community')
     def open_community_context_menu(self, name: str) -> ContextMenu:
-        community = QObject(driver.objectMap.realName(self._get_community(name)))
-        community.right_click()
+        self._get_community(name)
+        self.community_template_button.right_click()
         return ContextMenu().wait_until_appears()
 
 

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -73,7 +73,7 @@ onlineIdentifierButton = {"checkable": True, "container": primaryNavSidebar, "ob
 mainWindow_statusCommunityMainNavBarListView_ListView = {"container": statusDesktop_mainWindow,
                                                          "objectName": "statusCommunityMainNavBarListView",
                                                          "type": "ListView", "visible": True}
-statusCommunityMainNavBarListView_CommunityNavBarButton = {"container": primaryNavSidebar, "objectName": "CommunityNavBarButton", "type": "CommunitySectionButton", "visible": True}
+statusCommunityMainNavBarListView_CommunityNavBarButton = {"container": primaryNavSidebar, "objectName": RegularExpression("CommunityNavBarButton_.*"), "type": "CommunitySectionButton", "visible": True}
 
 scrollView_Add_members_StatusButton = {"container": mainWindow_scrollView_StatusScrollView,
                                        "objectName": "CommunityWelcomeBannerPanel_AddMembersButton",

--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -88,6 +88,9 @@ StatusListView {
                 property var menu: null
                 highlighted: menu?.opened ?? false
                 onClicked: {
+                    menu?.close()
+                    menu?.destroy()
+                    menu = null
                     menu = moreMenuComponent.createObject(this, {listItem, model})
                     menu.popup(-menu.width + width, height)
                 }
@@ -99,7 +102,6 @@ StatusListView {
         id: moreMenuComponent
         StatusMenu {
             id: moreMenu
-            onClosed: destroy()
 
             property var listItem
             property var model
@@ -183,7 +185,7 @@ StatusListView {
                     moreMenu.close()
                     if (listItem.isInvitationPending) {
                         root.cancelMembershipRequest(model.id)
-                        listItem.isInvitationPending = root.fnIsMyCommunityRequestPending(model.id)
+                        listItem.isInvitationPending = Qt.binding(() => root.fnIsMyCommunityRequestPending(model.id))
                     } else if (listItem.isSpectator)
                         root.closeCommunityClicked(model.id)
                     else

--- a/ui/app/mainui/panels/PrimaryNavSidebar.qml
+++ b/ui/app/mainui/panels/PrimaryNavSidebar.qml
@@ -131,15 +131,7 @@ Control {
                 root.close()
         }
 
-        // context menu guard
         property var popupMenuInstance: null
-        readonly property var _conn: Connections {
-            target: d.popupMenuInstance ?? null
-            function onClosed() {
-                d.popupMenuInstance.destroy()
-                d.popupMenuInstance = null
-            }
-        }
 
         // When true, disable snapping animation so the drawer tracks the finger precisely.
         property bool dragActive: false
@@ -338,7 +330,6 @@ Control {
         thirdpartyServicesEnabled: root.thirdpartyServicesEnabled
 
         onClicked: {
-            d.popupMenuInstance?.close()
             root.itemActivated(model.sectionType, model.id)
             if (root.interactive)
                 root.close()
@@ -381,14 +372,19 @@ Control {
             if (!root.communityPopupMenu)
                 return
 
-            if (!!d.popupMenuInstance)
-                d.popupMenuInstance.close() // will run destruction/cleanup
+            closeContextMenu()
 
             d.popupMenuInstance = root.communityPopupMenu.createObject(this, {model})
             this.highlighted = Qt.binding(() => !!d.popupMenuInstance && d.popupMenuInstance.opened && d.popupMenuInstance.parent === this)
             d.popupMenuInstance.popup(this, x, y)
         }
+        function closeContextMenu() {
+            d.popupMenuInstance?.close()
+            d.popupMenuInstance?.destroy()
+            d.popupMenuInstance = null
+        }
         onContextMenuRequested: (x, y) => openCommunityContextMenu(x, y)
+        onClicked: closeContextMenu()
 
         // "banned" decoration
         StatusRoundIcon {

--- a/ui/app/mainui/panels/PrimaryNavSidebar.qml
+++ b/ui/app/mainui/panels/PrimaryNavSidebar.qml
@@ -352,7 +352,7 @@ Control {
 
     component CommunitySectionButton: RegularSectionButton {
         id: communityNavBarButton
-        objectName: "CommunityNavBarButton"
+        objectName: "CommunityNavBarButton_" + model.name
 
         tooltipText: model.name
 


### PR DESCRIPTION
### What does the PR do

- fix displaying a submenu on mobile by not destroying the parent menu too early
- similar fix for the Settings/Communities more menu
- initial commit that adds the respective QML testcase

Fixes https://github.com/status-im/status-app/issues/21720

### Affected areas

PrimaryNavSidebar

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

(altered with enforcing `cascade: false` on desktop)

<img width="1644" height="1400" alt="image" src="https://github.com/user-attachments/assets/a68647a1-02db-4117-b4b4-bdf7815d515c" />


### Impact on end user

Better community mgmt UX on mobile

### How to test

- right click (long press) a community button
- move over (or tap) the "Mute" submenu item
- get the "Mute" submenu displayed

### Risk 

low
