### PR TITLE
fix(keycard): reset backend state on simulator restart

### DIFF
--- a/src/app_service/service/keycardV2/test_controller.nim
+++ b/src/app_service/service/keycardV2/test_controller.nim
@@ -57,8 +57,13 @@ when defined(useSimulatedKeycard):
 
     proc startSimulator*(self: KeycardTestController, version: string) {.slot.} =
       if not self.simProcess.isNil and self.simProcess.running:
-        info "keycard simulator already running"
-        return
+        self.simProcess.terminate()
+        self.simProcess.close()
+      self.simProcess = nil
+      discard callRPC("Stop")
+      discard keycard_go.keycardTestRemoveCard()
+      discard keycard_go.keycardTestUnplugReader()
+
       var safeVersion = ""
       for c in version:
         if c in {'0'..'9', '.'}: safeVersion.add(c)


### PR DESCRIPTION
"Keycard Simulator Restart" cleared its UI while the backend and lib kept the previous reader/card session. Now the process runs Stop -> RemoveCard -> UnplugReader.

Closes #21680