### PR TITLE
feat(SyncingView): make installationId visible and selectable

### DIFF
--- a/storybook/pages/CollectiblesViewPage.qml
+++ b/storybook/pages/CollectiblesViewPage.qml
@@ -9,7 +9,7 @@ import StatusQ.Models
 import StatusQ.Core
 import StatusQ.Core.Utils as SQUtils
 
-import mainui
+import mainui.sectionLoaders
 import utils
 
 import AppLayouts.stores as AppLayoutStores
@@ -51,12 +51,8 @@ SplitView {
         ]
     }
 
-    Keychain {
-        id: popupsKeychain
-    }
-
-    Popups {
-        keychain: popupsKeychain
+    PopupsLoader {
+        keychain: Keychain {}
         popupParent: root
         sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}

--- a/storybook/pages/CommunitiesPortalLayoutPage.qml
+++ b/storybook/pages/CommunitiesPortalLayoutPage.qml
@@ -12,19 +12,15 @@ import Storybook
 import Models
 
 import utils
-import mainui
+import mainui.sectionLoaders
 import shared.stores as SharedStores
 
 SplitView {
     id: root
     Logs { id: logs }
 
-    Keychain {
-        id: popupsKeychain
-    }
-
-    Popups {
-        keychain: popupsKeychain
+    PopupsLoader {
+        keychain: Keychain {}
         popupParent: root
         sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}

--- a/storybook/pages/CommunitiesViewPage.qml
+++ b/storybook/pages/CommunitiesViewPage.qml
@@ -7,7 +7,7 @@ import StatusQ.Core
 import AppLayouts.stores as AppLayoutsStores
 import AppLayouts.Profile.views
 import AppLayouts.Profile.stores
-import mainui
+import mainui.sectionLoaders
 import utils
 
 import shared.stores as SharedStores
@@ -23,15 +23,11 @@ SplitView {
 
     orientation: Qt.Vertical
 
-    Keychain {
-        id: popupsKeychain
-    }
-
-    Popups {
-        keychain: popupsKeychain
+    PopupsLoader {
+        keychain: Keychain {}
         popupParent: root
         sharedRootStore: SharedStores.RootStore {}
-        rootStore: AppLayoutsStores.RootStore
+        rootStore: AppLayoutsStores.RootStore {}
         communityTokensStore: SharedStores.CommunityTokensStore {}
         networksStore: SharedStores.NetworksStore {}
     }
@@ -48,7 +44,6 @@ SplitView {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
-        readonly property bool compactRowMode: contentWidth < 560
         contentWidth: width / 3 * 2
 
         communitiesList: ctrlEmptyView.checked ? emptyModel : communitiesModel

--- a/storybook/pages/CreateCommunityPopupPage.qml
+++ b/storybook/pages/CreateCommunityPopupPage.qml
@@ -7,7 +7,7 @@ import StatusQ
 import Storybook
 import Models
 
-import mainui
+import mainui.sectionLoaders
 
 import shared.stores as SharedStores
 
@@ -49,12 +49,8 @@ SplitView {
             }
         }
 
-        Keychain {
-            id: popupsKeychain
-        }
-
-        Popups {
-            keychain: popupsKeychain
+        PopupsLoader {
+            keychain: Keychain {}
             popupParent: root
             sharedRootStore: SharedStores.RootStore {}
             rootStore: AppLayoutStores.RootStore {}

--- a/storybook/pages/DAppsWorkflowPage.qml
+++ b/storybook/pages/DAppsWorkflowPage.qml
@@ -19,7 +19,6 @@ import StatusQ.Core.Utils as SQUtils
 import Models
 import Storybook as StoryBook
 
-import AppLayouts.Wallet.controls
 import AppLayouts.Wallet.services.dapps
 import AppLayouts.Wallet.services.dapps.types
 
@@ -32,20 +31,15 @@ import AppLayouts.Profile.stores
 import AppLayouts.Wallet.stores as WalletStore
 import AppLayouts.stores as AppLayoutStores
 
-import mainui
+import mainui.sectionLoaders
 import shared.stores as SharedStores
 import utils
 
 Item {
     id: root
 
-    // Needed for DAppsWorkflow->PairWCModal to open its instructions popup
-    Keychain {
-        id: popupsKeychain
-    }
-
-    Popups {
-        keychain: popupsKeychain
+    PopupsLoader {
+        keychain: Keychain {}
         popupParent: root
         sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}

--- a/storybook/pages/EditSettingsPanelPage.qml
+++ b/storybook/pages/EditSettingsPanelPage.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts
 
 import StatusQ
 
-import mainui
+import mainui.sectionLoaders
 import shared.stores as SharedStores
 import AppLayouts.stores as AppLayoutsStores
 import AppLayouts.Communities.panels
@@ -15,12 +15,8 @@ SplitView {
     id: root
     SplitView.fillWidth: true
 
-    Keychain {
-        id: popupsKeychain
-    }
-
-    Popups {
-        keychain: popupsKeychain
+    PopupsLoader {
+        keychain: Keychain {}
         popupParent: root
         sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutsStores.RootStore {}

--- a/storybook/pages/OverviewSettingsPanelPage.qml
+++ b/storybook/pages/OverviewSettingsPanelPage.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts
 
 import StatusQ
 
-import mainui
+import mainui.sectionLoaders
 import AppLayouts.stores as AppLayoutStores
 import AppLayouts.Communities.panels
 
@@ -16,12 +16,8 @@ SplitView {
     id: root
     SplitView.fillWidth: true
 
-    Keychain {
-        id: popupsKeychain
-    }
-
-    Popups {
-        keychain: popupsKeychain
+    PopupsLoader {
+        keychain: Keychain {}
         popupParent: root
         sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}

--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -5,7 +5,7 @@ import QtQuick.Layouts
 import utils
 import shared.views
 import shared.stores as SharedStores
-import mainui
+import mainui.sectionLoaders
 
 import StatusQ
 import StatusQ.Core.Theme
@@ -144,7 +144,7 @@ SplitView {
         id: popupsKeychain
     }
 
-    Popups {
+    PopupsLoader {
         keychain: popupsKeychain
         popupParent: root
         sharedRootStore: SharedStores.RootStore {}

--- a/storybook/pages/ProfileSocialLinksPanelPage.qml
+++ b/storybook/pages/ProfileSocialLinksPanelPage.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls
 import StatusQ
 import StatusQ.Core
 
-import mainui
+import mainui.sectionLoaders
 import AppLayouts.stores as AppLayoutStores
 import AppLayouts.Profile.panels
 import shared.stores as SharedStores
@@ -20,12 +20,8 @@ SplitView {
 
     orientation: Qt.Vertical
 
-    Keychain {
-        id: popupsKeychain
-    }
-
-    Popups {
-        keychain: popupsKeychain
+    PopupsLoader {
+        keychain: Keychain {}
         popupParent: root
         sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}

--- a/storybook/pages/StatusButtonPage.qml
+++ b/storybook/pages/StatusButtonPage.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
+import StatusQ.Core.Theme
 import StatusQ.Controls
 
 import Storybook

--- a/storybook/pages/SwapModalPage.qml
+++ b/storybook/pages/SwapModalPage.qml
@@ -12,7 +12,7 @@ import StatusQ.Core.Utils
 
 import utils
 
-import mainui
+import mainui.sectionLoaders
 import AppLayouts.Wallet.popups.swap
 import AppLayouts.Wallet.stores
 import AppLayouts.stores as AppLayoutStores
@@ -49,12 +49,8 @@ SplitView {
         }
     }
 
-    Keychain {
-        id: popupsKeychain
-    }
-
-    Popups {
-        keychain: popupsKeychain
+    PopupsLoader {
+        keychain: Keychain {}
         popupParent: root
         sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}

--- a/storybook/pages/SyncingEnterCodePage.qml
+++ b/storybook/pages/SyncingEnterCodePage.qml
@@ -6,7 +6,7 @@ import StatusQ
 
 import Storybook
 
-import mainui
+import mainui.sectionLoaders
 import shared.views
 import shared.stores as SharedStores
 import shared.popups
@@ -19,12 +19,8 @@ SplitView {
 
     Logs { id: logs }
 
-    Keychain {
-        id: popupsKeychain
-    }
-
-    Popups {
-        keychain: popupsKeychain
+    PopupsLoader {
+        keychain: Keychain {}
         popupParent: root
         sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}

--- a/storybook/pages/SyncingViewPage.qml
+++ b/storybook/pages/SyncingViewPage.qml
@@ -40,10 +40,6 @@ SplitView {
 
         onDeleteDeviceRequested: installationId => logs.logEvent("onDeleteDeviceRequested", ["installationId"], [installationId])
 
-        advancedStore: ProfileStores.AdvancedStore {
-            readonly property bool isDebugEnabled: ctrlDebugEnabled.checked
-        }
-
         devicesStore: ProfileStores.DevicesStore {
             function generateConnectionStringAndRunSetupSyncingPopup(enabled) {
                 logs.logEvent("devicesStore::generateConnectionStringAndRunSetupSyncingPopup", ["enabled"], arguments)
@@ -144,12 +140,6 @@ SplitView {
             Switch {
                 id: ctrlDevicesDeletionError
                 text: "Devices deletion error"
-            }
-
-            Switch {
-                id: ctrlDebugEnabled
-                text: "Debug enabled"
-                checked: true
             }
         }
     }

--- a/storybook/pages/SyncingViewPage.qml
+++ b/storybook/pages/SyncingViewPage.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts
 
 import Storybook
 
-import mainui
+import mainui.sectionLoaders
 import utils
 
 import StatusQ
@@ -20,12 +20,8 @@ SplitView {
 
     Logs { id: logs }
 
-    Keychain {
-        id: popupsKeychain
-    }
-
-    Popups {
-        keychain: popupsKeychain
+    PopupsLoader {
+        keychain: Keychain {}
         popupParent: root
         sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}
@@ -117,7 +113,7 @@ SplitView {
                     deviceType: "desktop"
                     isCurrentDevice: false
                     enabled: false
-                    installationId: "f"
+                    installationId: "This is a long selectable installation ID"
                 }
             }
         }

--- a/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
@@ -18,7 +18,6 @@ StatusListItem {
     property bool isCurrentDevice: false
     property bool showOnlineBadge: !isCurrentDevice
 
-    signal itemClicked
     signal pairRequested
     signal unpairRequested
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -259,6 +259,8 @@ Item {
     */
     property Component rightComponent
 
+    property alias readOnly: edit.readOnly
+
     /*!
         \qmlsignal
          This signal is emitted when the icon is clicked.
@@ -394,7 +396,7 @@ Item {
                         focus: !Utils.isMobile
                         font.pixelSize: Theme.primaryTextFontSize
                         font.family: Fonts.baseFont.family
-                        color: root.enabled ? Theme.palette.directColor1 : Theme.palette.baseColor1
+                        color: root.enabled && !edit.readOnly ? Theme.palette.directColor1 : Theme.palette.baseColor1
                         wrapMode: root.multiline ? Text.WrapAtWordBoundaryOrAnywhere : TextEdit.NoWrap
 
                         Keys.onReturnPressed: function (event) {
@@ -473,7 +475,7 @@ Item {
                             verticalAlignment: parent.verticalAlignment
                             wrapMode: root.multiline ? Text.WrapAnywhere : Text.NoWrap
                             elide: root.multiline? Text.ElideNone : Text.ElideRight
-                            color: root.enabled ? Theme.palette.baseColor1 : Theme.palette.directColor6
+                            color: root.enabled && !edit.readOnly ? Theme.palette.baseColor1 : Theme.palette.directColor6
                         }
                     }
                 } // Flickable

--- a/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
@@ -249,6 +249,8 @@ Control {
     */
     property string warningMessage: ""
 
+    property alias readOnly: statusBaseInput.readOnly
+
     /*!
         \qmlsignal
         This signal is emitted when the icon is clicked.

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -428,7 +428,6 @@ StatusSectionLayout {
                 profileStore: root.profileStore
                 devicesStore: root.devicesStore
                 privacyStore: root.privacyStore
-                advancedStore: root.advancedStore
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.syncingSettings)
                 contentWidth: d.contentWidth
 

--- a/ui/app/AppLayouts/Profile/popups/SyncDeviceCustomizationPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/SyncDeviceCustomizationPopup.qml
@@ -20,7 +20,6 @@ StatusDialog {
     id: root
 
     property ProfileStores.DevicesStore devicesStore
-    property ProfileStores.AdvancedStore advancedStore
     property var deviceModel
 
     readonly property string deviceName: d.deviceName
@@ -71,9 +70,8 @@ StatusDialog {
             id: idInput
             Layout.fillWidth: true
             label: qsTr("Installation ID")
-            enabled: false
+            readOnly: true
             text: root.deviceModel.installationId
-            visible: root.advancedStore.isDebugEnabled
         }
     }
 

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -27,7 +27,6 @@ SettingsContentBase {
     property ProfileStores.DevicesStore devicesStore
     property ProfileStores.ProfileStore profileStore
     property ProfileStores.PrivacyStore privacyStore
-    property ProfileStores.AdvancedStore advancedStore
 
     property string errorDeletingDeviceMessage
 
@@ -282,7 +281,6 @@ SettingsContentBase {
             SyncDeviceCustomizationPopup {
                 destroyOnClose: true
                 devicesStore: root.devicesStore
-                advancedStore: root.advancedStore
                 onDeleteDeviceRequested: installationId => d.setupDeleteDevice(installationId)
             }
         }


### PR DESCRIPTION
### What does the PR do

- make it readonly instead of not enabled so you can select the text with mouse
- make it always visible, not just in debug builds
- separate commits to:
  - expose the `readOnly` property from `Status(Base)Input`
  - fix loading and showing popups in Storybook 

Fixes https://github.com/status-im/status-app/issues/21747
Fixes https://github.com/status-im/status-app/issues/21749

### Affected areas

Settings/SyncingView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="2944" height="1800" alt="Snímek obrazovky z 2026-08-04 11-46-20" src="https://github.com/user-attachments/assets/2206ed75-848d-47dd-ad83-d3e60a47ab28" />


### Impact on end user

Better SDK integration

### How to test

- open Settings/Syncing
- click an item to customize it

### Risk 

low
