### PR TITLE
fix(KeycardManagementPopup): make the seedphrase grid scrollable

### DIFF
--- a/ui/imports/shared/popups/keycard_new/states/EnterSeedPhraseState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/EnterSeedPhraseState.qml
@@ -40,33 +40,37 @@ Control {
             font.pixelSize: Theme.fontSize(22)
         }
 
-        SharedPanels.EnterSeedPhrase {
-            id: seedPhraseInput
+        StatusScrollView {
+            id: scrollView
 
-            Layout.fillWidth: true
-
-            dictionary: BIP39_en {}
-            initialSeedPhrase: root.initialSeedPhrase
-
-            onSeedPhraseProvided: function(seedPhrase) {
-                const phrase = seedPhrase.join(" ")
-                const keyUid = root.validateSeedPhrase(phrase)
-                if (keyUid.length > 0) {
-                    root.seedPhraseValid = true
-                    root.validatedSeedPhrase = phrase
-                    setError("")
-                    root.seedPhraseValidated(phrase, keyUid)
-                } else {
-                    root.seedPhraseValid = false
-                    root.validatedSeedPhrase = ""
-                    setError(qsTr("Invalid recovery phrase"))
-                }
-            }
-        }
-
-        Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
+            contentWidth: availableWidth
+
+            SharedPanels.EnterSeedPhrase {
+                id: seedPhraseInput
+
+                flickable: scrollView.flickable
+                width: scrollView.availableWidth
+
+                dictionary: BIP39_en {}
+                initialSeedPhrase: root.initialSeedPhrase
+
+                onSeedPhraseProvided: function(seedPhrase) {
+                    const phrase = seedPhrase.join(" ")
+                    const keyUid = root.validateSeedPhrase(phrase)
+                    if (keyUid.length > 0) {
+                        root.seedPhraseValid = true
+                        root.validatedSeedPhrase = phrase
+                        setError("")
+                        root.seedPhraseValidated(phrase, keyUid)
+                    } else {
+                        root.seedPhraseValid = false
+                        root.validatedSeedPhrase = ""
+                        setError(qsTr("Invalid recovery phrase"))
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### What does the PR do

- it also clips the content by default

Fixes #21778

### Affected areas

KeycardManagementPopup/EnterSeedPhraseState

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="1244" height="1640" alt="Snímek obrazovky z 2026-08-04 16-05-47" src="https://github.com/user-attachments/assets/c1266c6c-c7e9-43cc-870c-fc206db146bb" />


### Impact on end user

Usable on smaller displays

### How to test

- Keycard -> Import new seedphrase

### Risk 

low
