### PR TITLE
fix(wallet): Render saved address removal subtitle as styled text

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusTitleSubtitle.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusTitleSubtitle.qml
@@ -9,6 +9,7 @@ Item {
 
     property alias title: title.text
     property alias subtitle: subtitle.text
+    property alias subtitleTextFormat: subtitle.textFormat
 
     implicitHeight: layout.implicitHeight
     implicitWidth: layout.implicitWidth

--- a/ui/app/AppLayouts/Wallet/popups/RemoveSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/RemoveSavedAddressPopup.qml
@@ -48,6 +48,7 @@ StatusDialog {
 
      header: StatusDialogHeader {
         headline.title: qsTr("Remove %1").arg(root.name)
+        headline.subtitleTextFormat: Text.StyledText
         headline.subtitle: {
             if (root.ens.length > 0)
                 return root.ens


### PR DESCRIPTION
Fixes #21765

### What does the PR do

Allows the saved address removal dialog subtitle to opt into styled text rendering so the existing richColorText markup is rendered as color instead of being displayed as raw XML tags.


### Affected areas
 Remove saved address popup

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="609" height="291" alt="Screenshot 2026-08-04 at 17 28 31" src="https://github.com/user-attachments/assets/deeb558e-37a2-49a0-ac27-8c467b2395ff" />

### Impact on end user

Better UX

### How to test

Open remove save address popup

### Risk 

Low
