### PR TITLE
feat(Browser): change homepage and home button

### DIFF
--- a/ui/app/AppLayouts/Browser/panels/BrowserPortraitToolbar.qml
+++ b/ui/app/AppLayouts/Browser/panels/BrowserPortraitToolbar.qml
@@ -82,10 +82,12 @@ BrowserToolbarBase {
         Item { Layout.fillWidth: true }
 
         BrowserHeaderButton {
-            incognitoMode: root.currentTabIncognito
-            icon.name: "home"
-            tooltip.text: qsTr("Home", "web browser home page")
-            onClicked: root.requestLaunchInBrowser(Constants.browserDefaultHomepage)
+            checkable: true
+            checked: root.currentTabIncognito
+            incognitoMode: checked
+            icon.name: checked ? "privacy-activated" : "privacy"
+            tooltip.text: checked ? qsTr("Exit Incognito mode") : qsTr("Go Incognito")
+            onToggled: root.goIncognito(checked)
         }
 
         Item { Layout.fillWidth: true }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2544,8 +2544,11 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Home</source>
-        <comment>web browser home page</comment>
+        <source>Exit Incognito mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Go Incognito</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2553,9 +2553,12 @@ Přejete si obejít bezpečnostní kontrolu a pokračovat?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Home</source>
-        <comment>web browser home page</comment>
-        <translation type="unfinished"></translation>
+        <source>Exit Incognito mode</source>
+        <translation type="unfinished">Ukončit anonymní režim</translation>
+    </message>
+    <message>
+        <source>Go Incognito</source>
+        <translation type="unfinished">Přejít do anonymního režimu</translation>
     </message>
     <message>
         <source>Menu</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2546,9 +2546,12 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Home</source>
-        <comment>web browser home page</comment>
-        <translation type="unfinished"></translation>
+        <source>Exit Incognito mode</source>
+        <translation type="unfinished">Salir del modo incógnito</translation>
+    </message>
+    <message>
+        <source>Go Incognito</source>
+        <translation type="unfinished">Ir a modo incógnito</translation>
     </message>
     <message>
         <source>Menu</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2538,9 +2538,12 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Home</source>
-        <comment>web browser home page</comment>
-        <translation type="unfinished"></translation>
+        <source>Exit Incognito mode</source>
+        <translation type="unfinished">시크릿 모드 종료</translation>
+    </message>
+    <message>
+        <source>Go Incognito</source>
+        <translation type="unfinished">시크릿 모드로 전환</translation>
     </message>
     <message>
         <source>Menu</source>

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -972,7 +972,7 @@ QtObject {
     readonly property string deepLinkPrefix: 'status-app://'
     readonly property string externalStatusLink: 'status.app'
     readonly property string externalStatusLinkWithHttps: 'https://' + externalStatusLink
-    readonly property string browserDefaultHomepage: 'https://hub.status.network/'
+    readonly property string browserDefaultHomepage: externalStatusLinkWithHttps
     readonly property string communityLinkPrefix: externalStatusLinkWithHttps + '/c/'
     readonly property string userLinkPrefix: externalStatusLinkWithHttps + '/u/'
     readonly property string statusLinkPrefix: 'https://status.im/'


### PR DESCRIPTION
### What does the PR do

- change default homepage to "https://status.app"
- in portrait view, replace the Home button with Incognito

Fixes #21717

### Affected areas

Browser

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="1522" height="1800" alt="Snímek obrazovky z 2026-08-04 18-18-57" src="https://github.com/user-attachments/assets/88fa92ae-8a89-488a-8a04-d4737ff1fa98" />


### Impact on end user

UX

### How to test

- press the Home button, should go to Status website
- on mobile/portrait view, the last button should be Incognito

### Risk 

low
