### PR TITLE
Fix crash related to AC notification for deleted channels

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -147,6 +147,9 @@ proc switchTo*(self: Controller, sectionId, chatId, messageId: string) =
   let data = ActiveSectionChatArgs(sectionId: sectionId, chatId: chatId, messageId: messageId)
   self.events.emit(SIGNAL_MAKE_SECTION_CHAT_ACTIVE, data)
 
+proc chatExists*(self: Controller, chatId: string): bool =
+  return self.chatService.chatExists(chatId)
+
 proc getChatDetails*(self: Controller, chatId: string): lent ChatDto =
   return self.chatService.getChatById(chatId)
 

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -94,6 +94,9 @@ method resetActivityCenterNotifications*(self: AccessInterface, activityCenterNo
 method switchTo*(self: AccessInterface, sectionId, chatId, messageId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method chatExists*(self: AccessInterface, chatId: string): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getDetails*(self: AccessInterface, sectionId: string, chatId: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -308,6 +308,9 @@ method getChatDetailsAsJson*(self: Module, chatId: string): string =
   jsonObject["emoji"] = %* chatDto.emoji
   return $jsonObject
 
+method chatExists*(self: Module, chatId: string): bool =
+  return self.controller.chatExists(chatId)
+
 method setActiveNotificationGroup*(self: Module, group: int) =
   self.controller.setActiveNotificationGroup(ActivityCenterGroup(group))
 

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -131,6 +131,9 @@ QtObject:
   proc switchTo*(self: View, sectionId: string, chatId: string, messageId: string) {.slot.} =
     self.delegate.switchTo(sectionId, chatId, messageId)
 
+  proc chatExists*(self: View, chatId: string): bool {.slot.} =
+    return self.delegate.chatExists(chatId)
+
   proc getDetails*(self: View, sectionId: string, chatId: string): string {.slot.} =
     return self.delegate.getDetails(sectionId, chatId)
 

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -342,6 +342,9 @@ QtObject:
   proc getChatsForCommunity*(self: Service, communityId: string): seq[ChatDto] =
     return self.getAllChats().filterIt(it.communityId == communityId)
 
+  proc chatExists*(self: Service, chatId: string): bool =
+    return self.chats.contains(chatId)
+
   proc getChatById*(self: Service, chatId: string, showWarning: bool = true): lent ChatDto =
     if(not self.chats.contains(chatId)):
       if (showWarning):

--- a/ui/app/AppLayouts/stores/ActivityCenterStore.qml
+++ b/ui/app/AppLayouts/stores/ActivityCenterStore.qml
@@ -37,8 +37,16 @@ QtObject {
         root.activityCenterModuleInst.markAsSeenActivityCenterNotifications()
     }
 
+    function chatExists(chatId) {
+        return root.activityCenterModuleInst.chatExists(chatId)
+    }
+
     function switchTo(sectionId, chatId, messageId) {
+        if (!root.chatExists(chatId))
+            return false
+
         root.activityCenterModuleInst.switchTo(sectionId, chatId, messageId)
+        return true
     }
 
     function setActiveNotificationGroup(group) {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1989,9 +1989,14 @@ Item {
                 onMarkNotificationUnread: (notificationId) => { appMain.activityCenterStore.markActivityCenterNotificationUnread(notificationId) }
                 onAvatarClicked: (avatarId) => { Global.openProfilePopup(avatarId) }
                 onRedirectToDetails: (sectionId, subsectionId, subsectionItemId) => {
-                                         d.recordActivityCenterHistory()
-                                         appMain.rootStore.setNavToMsgDetailsFlag(true) // It covers in-app link navigation in portrait mode
-                                         appMain.activityCenterStore.switchTo(sectionId, subsectionId, subsectionItemId)
+                                         if (appMain.activityCenterStore.chatExists(subsectionId)) {
+                                             d.recordActivityCenterHistory()
+                                             appMain.rootStore.setNavToMsgDetailsFlag(true) // It covers in-app link navigation in portrait mode
+                                             appMain.activityCenterStore.switchTo(sectionId, subsectionId, subsectionItemId)
+                                         } else {
+                                             Global.displayToastMessage(qsTr("This channel no longer exists"), "", "", false,
+                                                                        Constants.ephemeralNotificationType.normal, "")
+                                         }
 
                                          // Guard in case of portrait
                                          acPortraitPopup.close()

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1708,6 +1708,10 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>This channel no longer exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Invite People</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1715,6 +1715,10 @@ z &quot;%1&quot; na &quot;%2&quot;</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>This channel no longer exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Invite People</source>
         <translation>Pozvat lidi</translation>
     </message>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1709,6 +1709,10 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>This channel no longer exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Invite People</source>
         <translation>Invitar personas</translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1698,6 +1698,10 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>This channel no longer exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Invite People</source>
         <translation>사람들 초대하기</translation>
     </message>


### PR DESCRIPTION
### What does the PR do

Fixes #21755

status-go PR: https://github.com/status-im/status-go/pull/7686

You can review per commits:

- [fix(ac): fix crash when clicking deleted chat notification](https://github.com/status-im/status-app/commit/d9e14e9cd4934ef25f726d818527b4c64030ef67): Initial guard. Never crashes again
- [fix(ac): show toast when clicking deleted chat notification](https://github.com/status-im/status-app/commit/f1c0979f40cf43aa435726d6d0ea3aeded637427): Better UX if it happens again. Let's the user know why nothing happens
- [fix(ac): delete ac notifications when a chat is deleted](https://github.com/status-im/status-app/commit/3bfa9372861dd69fd0d1711ca6b0b77cecd49cec): Final fix, the notification should just be removed. Previous fixes are still necessary in case something wrong happened still

### Affected areas

- ac module
- AC Store
- AppMain
- status-go

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

[deleted-chat.webm](https://github.com/user-attachments/assets/5f8598fa-efcd-4fab-936c-a4daa7203f40)

### Impact on end user

Fixes the issue and adds better UX if it does happen again

### How to test

- Have two accounts
- create a new channel
- mention the other user
- see the AC notif appear
- remove the channel
- notif is deleted

### Risk 

Low
