### PR TITLE
fix(windows): maximize app back to the screen it was before

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -188,9 +188,19 @@ Window {
 
         readonly property bool macOSWindowed: SQUtils.Utils.isMacOS && applicationWindow.visibility !== Window.FullScreen
 
+        function restoreScreenAfterMinimizing() {
+            if (Qt.platform.os !== SQUtils.Utils.windows || !lastMinimizedScreen)
+                return
+
+            if (Qt.application.screens.includes(lastMinimizedScreen))
+                applicationWindow.screen = lastMinimizedScreen
+            lastMinimizedScreen = null
+        }
+
         function restoreWindowState() {
             if (SQUtils.Utils.isMobile) // no point in restoring window state
                 return
+            restoreScreenAfterMinimizing()
             switch(lastNonMinVisibility) {
             case Window.Windowed:
                 applicationWindow.showNormal()
@@ -205,6 +215,7 @@ Window {
         }
 
         property int lastNonMinVisibility
+        property var lastMinimizedScreen: null
 
         property bool showSkippedBiometricFlow: false
 
@@ -334,8 +345,13 @@ Window {
     Connections {
         target: applicationWindow
         function onVisibilityChanged(visibility) {
+            if (visibility === Window.Minimized) {
+                d.lastMinimizedScreen = applicationWindow.screen
+                return
+            }
             if (applicationWindow.visibility !== Window.Minimized
                         && applicationWindow.visibility !== Window.Hidden) {
+                d.restoreScreenAfterMinimizing()
                 d.lastNonMinVisibility = applicationWindow.visibility
             }
         }


### PR DESCRIPTION
### What does the PR do

Fixes #20157

Tested on Windows 11 with two monitors. Works now.

### Affected areas

main.qml

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction

### Impact on end user

Fixes the issue

### How to test

Follow the repro steps

### Risk 

Low
