### PR TITLE
fix(ci): add user in container to docker group at runtime

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -11,6 +11,7 @@ pipeline {
            '--cap-add=SYS_ADMIN ' +
            '--security-opt=apparmor:unconfined ' +
            '--device=/dev/fuse ' +
+           '--group-add docker ' +
            '--volume=/var/run/docker.sock:/var/run/docker.sock ' +
            '--volume=/home/jenkins/.squish-license:/home/jenkins/.squish-license ' +
            '--volume=/opt/squish-runner-9.2.2-qt-6.11:/opt/squish-runner-9.2.2-qt-6.11 ' +

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -15,6 +15,7 @@ pipeline {
       args '--cap-add SYS_ADMIN ' +
            '--security-opt apparmor:unconfined ' +
            '--device /dev/fuse ' +
+           '--group-add docker ' +
            '--volume=/var/run/docker.sock:/var/run/docker.sock ' +
            '--network=host ' +
            '--user jenkins'


### PR DESCRIPTION
To fix errors like these that happen on newer Ubuntu 24.04

```
  [2026-08-05T07:43:07.967Z] + docker compose -p e2e-fleet -f
docker-compose.waku.yml up -d

  [2026-08-05T07:43:07.968Z] permission denied while trying to connect
to the docker API at unix:///var/run/docker.sock

  script returned exit code 1

```