### PR TITLE
feat(Chat): adjust various chat related buttons

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -136,10 +136,9 @@ Item {
         visible: active
         anchors.verticalCenter: chatTextView.bottom
         anchors.horizontalCenter: parent.horizontalCenter
-        sourceComponent: StatusRoundButton {
-            implicitWidth: 24
-            implicitHeight: 24
-            type: StatusRoundButton.Type.Secondary
+        sourceComponent: StatusButton {
+            type: StatusBaseButton.Type.Primary
+            size: StatusBaseButton.Size.Small
             icon.name: d.readMore ? "chevron-up":  "chevron-down"
             onClicked: {
                 d.readMore = !d.readMore

--- a/ui/app/AppLayouts/Browser/controls/BrowserAddressField.qml
+++ b/ui/app/AppLayouts/Browser/controls/BrowserAddressField.qml
@@ -1,6 +1,7 @@
 import QtQuick
 
 import StatusQ.Core.Theme
+import StatusQ.Core.Utils as SQUtils
 import StatusQ.Controls
 import StatusQ.Components
 

--- a/ui/app/AppLayouts/Chat/panels/ChatAnchorButtonsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/ChatAnchorButtonsPanel.qml
@@ -33,15 +33,11 @@ Item {
     }
 
     component AnchorButton: StatusButton {
-        Layout.preferredHeight: 38
-        radius: height
+        Layout.preferredHeight: 40
         spacing: 2
 
-        icon.width: Theme.primaryTextFontSize + 5
-        icon.height: Theme.primaryTextFontSize + 5
         verticalPadding: Theme.halfPadding
         horizontalPadding: Theme.smallPadding
-        font.pixelSize: Theme.primaryTextFontSize
 
         layer.enabled: true
         layer.effect: DropShadow {
@@ -71,10 +67,11 @@ Item {
         AnchorButton {
             id: recentMessagesButton
 
+            leftPadding: text ? 8 : 2
+            rightPadding: 2
             text: root.recentMessagesCount <= 0 ? "" : d.limitNumberTo99(root.recentMessagesCount)
-            normalColor: Theme.palette.baseColor1
-            hoverColor: Theme.palette.hoverColor(normalColor)
-            textColor: StatusColors.white
+            normalColor: Theme.palette.primaryColor2
+            textColor: Theme.palette.primaryColor1
             textPosition: StatusBaseButton.TextPosition.Left
             icon.name: "arrow-down"
 

--- a/ui/imports/shared/status/StatusChatInputSendButton.qml
+++ b/ui/imports/shared/status/StatusChatInputSendButton.qml
@@ -8,7 +8,7 @@ Control {
     id: root
 
     property string limitText
-    property string iconName: "send"
+    property string iconName: "arrow-up"
     property alias interactive: mouseArea.enabled
 
     signal clicked
@@ -19,6 +19,7 @@ Control {
         readonly property int implicitHeight: 36
         readonly property real hoverExpandFactor: 1.2
         readonly property real pressedExpandFactor: 1.1
+        readonly property int cornerRadius: 8
     }
 
     contentItem: Item {
@@ -51,8 +52,8 @@ Control {
                 }
             }
 
-            topLeftRadius: height / 2
-            bottomLeftRadius: topLeftRadius
+            topLeftRadius: d.cornerRadius
+            bottomLeftRadius: d.cornerRadius
 
             border.color: StatusColors.alphaColor(
                               Theme.palette.customisationColors.orange, 0.2)
@@ -87,8 +88,6 @@ Control {
         Rectangle {
             anchors.centerIn: baseBackgroundRectangle
 
-            smooth: true
-
             property real factor: mouseArea.pressed
                                   ? d.pressedExpandFactor
                                   : (mouseArea.containsMouse
@@ -96,7 +95,7 @@ Control {
 
             width: baseBackgroundRectangle.width * factor
             height: width
-            radius: width / 2
+            radius: d.cornerRadius
 
             color: baseBackgroundRectangle.color
 
@@ -117,10 +116,9 @@ Control {
             anchors.bottom: parent.bottom
             anchors.top: parent.top
 
-            smooth: true
             color: root.enabled ? Theme.palette.primaryColor1
                                 : Theme.palette.baseColor1
-            radius: width / 2
+            radius: d.cornerRadius
 
             Behavior on color {
                 ColorAnimation {
@@ -134,7 +132,7 @@ Control {
                 anchors.centerIn: parent
 
                 icon: root.iconName
-                color: Theme.palette.baseColor3
+                color: Theme.palette.white
             }
 
             MouseArea {


### PR DESCRIPTION
### What does the PR do

- StatusChatInputSendButton: simpler (arrow) icon, radius 8 (no longer rounded), white icon color
- StatusTextMessage: expand/collapse button, not rounded, radius 8
- ChatAnchorButtonsPanel: radius 8, narrower

Fixes #21587

### Affected areas

Chat

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

StatusChatInputSendButton:
<img width="2390" height="1590" alt="image" src="https://github.com/user-attachments/assets/23e79a37-dd21-4805-adae-1f200462193a" />

StatusChatInputSendButton, disabled:
<img width="2390" height="1590" alt="image" src="https://github.com/user-attachments/assets/550e96fd-0ee3-4224-a2a3-29a3be9a09f9" />

StatusTextMessage expand/collapse button:
<img width="1710" height="1590" alt="image" src="https://github.com/user-attachments/assets/35309a60-e7f9-47ca-997e-291ae4d5ee94" />

ChatAnchorButtonsPanel:
<img width="1710" height="1590" alt="image" src="https://github.com/user-attachments/assets/e83cfc0c-4b65-4459-8dc6-7d69e7002b57" />


### Impact on end user

better UI/UX

### How to test

- inspect the mentioned button components in app

### Risk 

low
