### PR TITLE
fix(chat): Preserve message UI decorations while editing

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -375,9 +375,9 @@ Control {
         }
 
         Loader {
-            active: root.hovered && root.quickActions.length > 0
+            active: root.quickActions.length > 0
                     && !Utils.isMobile // hover menu disabled on mobile; we use the MessageContextMenuView
-            visible: active
+            visible: active && root.hovered
             anchors.right: parent.right
             anchors.rightMargin: Theme.padding
             anchors.verticalCenter: parent.top

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -245,7 +245,7 @@ Control {
                     Layout.leftMargin: profileImage.active ? 0 : root.messageDetails.sender.profileImage.assetSettings.width + parent.spacing
 
                     StatusPinMessageDetails {
-                        active: root.isPinned && !editMode
+                        active: root.isPinned
                         visible: active
                         pinnedMsgInfoText: root.pinnedMsgInfoText
                         pinnedBy: root.pinnedBy


### PR DESCRIPTION
Closes #21780

### What does the PR do

Fixes two chat message edit regressions:
- Restores hover quick actions after editing a message.
- Keeps the pinned message tag visible while editing pinned messages.

### Affected areas

Chat, message hover actions, pinned messages.

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/1730377c-9a98-412d-b81d-a513f47349e9

### Impact on end user

Editing messages no longer breaks message actions or pinned message decorations.

### How to test

Edit a regular message and verify hover actions reappear after saving.  
Edit a pinned message and verify the pinned tag remains visible.

### Risk

Low. QML-only visibility/lifecycle fixes.