### PR TITLE
fix(CommunityMembershipSetupDialog): use full screen (bottom) sheet

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesSigningPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesSigningPanel.qml
@@ -15,7 +15,7 @@ ColumnLayout {
 
     required property string componentUid
     required property bool isEditMode
-    property var keypairSigningModel
+    property var keypairSigningModel: []
 
     required property var selectedSharedAddressesMap // Map[address, [keyUid, selected, isAirdrop]
     required property int totalNumOfAddressesForSharing
@@ -123,21 +123,18 @@ ColumnLayout {
         spacing: Theme.padding
 
         StatusBaseText {
-            Layout.preferredWidth: parent.width
+            Layout.fillWidth: true
             elide: Text.ElideRight
+            wrapMode: Text.Wrap
             text: qsTr("To share %n address(s) with <b>%1</b>, sign with the associated key pairs...", "", d.selectedSharedAddressesCount).arg(root.communityName)
         }
 
-        RowLayout {
+        StatusBaseText {
             Layout.fillWidth: true
             visible: storedOnDeviceList.visible
-
-            StatusBaseText {
-                Layout.fillWidth: true
-                text: qsTr("Stored on device")
-                color: Theme.palette.baseColor1
-                wrapMode: Text.WordWrap
-            }
+            text: qsTr("Stored on device")
+            color: Theme.palette.baseColor1
+            wrapMode: Text.WordWrap
         }
 
         StatusListView {

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="en" sourcelanguage="en">
+<TS version="2.1" language="en_US" sourcelanguage="en_US">
 <context>
     <name>AddressesSelectorPanel</name>
     <message numerus="yes">
@@ -608,9 +608,9 @@
     </message>
     <message numerus="yes">
         <source>To share %n address(s) with &lt;b&gt;%1&lt;/b&gt;, sign with the associated key pairs...</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>To share %n address with &lt;b&gt;%1&lt;/b&gt;, sign with the associated key pairs...</numerusform>
+            <numerusform>To share %n addresses with &lt;b&gt;%1&lt;/b&gt;, sign with the associated key pairs...</numerusform>
         </translation>
     </message>
 </context>
@@ -638,7 +638,7 @@
     <name>StatusChatInput</name>
     <message numerus="yes">
         <source>%n Image(s)</source>
-        <translation type="unfinished">
+        <translation>
             <numerusform>%n Image</numerusform>
             <numerusform>%n Images</numerusform>
         </translation>

--- a/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
+++ b/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
@@ -22,6 +22,7 @@ StatusStackModal {
     id: root
 
     destroyOnClose: true
+    fullScreenSheet: true
     property bool isEditMode: false
 
     required property string communityId
@@ -45,7 +46,7 @@ StatusStackModal {
     required property var assetsModel
     required property var collectiblesModel
 
-    property var keypairSigningModel
+    property var keypairSigningModel: []
 
     property var currentSharedAddresses: []
     onCurrentSharedAddressesChanged: d.reEvaluateModels()


### PR DESCRIPTION
### What does the PR do

- to help with joining communities on a small phone

Fixes #21809

### Affected areas

CommunityMembershipSetupDialog

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/1f3fc8be-b502-4967-b3bf-b3cc2dc1ae1d" />


### Impact on end user

(small) phone UI/UX

### How to test

- try to join a community on a small phone 

### Risk 

low
