### PR TITLE
Chat input: small fixes related to accepting msg to send

### DIFF
--- a/storybook/qmlTests/tests/tst_StatusChatInput.qml
+++ b/storybook/qmlTests/tests/tst_StatusChatInput.qml
@@ -373,5 +373,26 @@ Item {
             const first = plain.charCodeAt(0)
             verify(first >= 0xD800 && first <= 0xDBFF, "starts with an emoji: " + JSON.stringify(plain))
         }
+
+        // A ":" shortcode with no matching emoji must not open an empty suggestion
+        // popup. Otherwise Enter is captured as "accept emoji" and deletes the typed text; instead
+        // it should send the text as-is.
+        function test_typedEmojiShortcode_noMatchSendsTextAsIs() {
+            signalSpy.setup(controlUnderTest, "sendMessageRequested")
+
+            controlUnderTest.textInput.forceActiveFocus()
+            typeText(":zzzznotanemoji")
+            waitForRendering(controlUnderTest)
+
+            // enteringEmoji is true (>= 2 chars after ":"), but there are no matches.
+            verify(controlUnderTest.textInput.enteringEmoji)
+
+            keyClick(Qt.Key_Return) // send (NoModifier maps to send on desktop/offscreen)
+            waitForRendering(controlUnderTest)
+
+            // The text is preserved (not replaced by an empty-emoji insert) and a send was requested.
+            compare(controlUnderTest.getPlainText(), ":zzzznotanemoji")
+            compare(signalSpy.count, 1)
+        }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -259,7 +259,9 @@ Item {
             // and would collapse newlines. Align with the new-message path (RootStore.cleanMessageText).
             const message = newMessageText
 
-            if (message.length <= 0)
+            // Reject blank/whitespace-only edits (mirrors the new-message send guard in
+            // RootStore.sendMessage): stay in edit mode instead of silently exiting.
+            if (message.trim().length <= 0)
                 return
 
             const messageId = editMessageId

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -335,7 +335,7 @@ Control {
     }
 
     function checkTextInsert() {
-        if (emojiSuggestions.visible) {
+        if (emojiSuggestions.visible && emojiSuggestions.unicode !== "") {
             d.insertEmoji(emojiSuggestions.unicode)
             return true
         }
@@ -839,12 +839,14 @@ Control {
                         // Emoji shortcode suggestions: ChatTextArea exposes enteringEmoji/emojiFilter
                         // (>= 2 chars); feed the twemoji suggestion popup off it.
                         onEmojiFilterChanged: {
-                            if (enteringEmoji) {
-                                const emojis = StatusQUtils.Emoji.getSuggestions(emojiFilter)
+                            // Only open when there are actual matches; otherwise the popup would be
+                            // visible-but-empty and hijack Enter (checkTextInsert) into deleting the
+                            // typed ":shortcode" instead of sending it.
+                            const emojis = enteringEmoji ? StatusQUtils.Emoji.getSuggestions(emojiFilter) : []
+                            if (emojis.length > 0)
                                 emojiSuggestions.openPopup(emojis, emojiFilter)
-                            } else {
+                            else
                                 emojiSuggestions.close()
-                            }
                         }
 
                         Shortcut {


### PR DESCRIPTION
### What does the PR do

Closes two tiny issues originally listed in https://github.com/status-im/status-app/issues/19672

Closes: https://github.com/status-im/status-app/issues/21815
Closes: https://github.com/status-im/status-app/issues/21816

### Affected areas
`Chat input`

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Low

### How to test

According to repro steps described it tickets

### Risk 
Low
