### PR TITLE
chore(@e2e): wait for geometry of button in onboarding screen

### DIFF
--- a/test/e2e/gui/elements/object.py
+++ b/test/e2e/gui/elements/object.py
@@ -221,6 +221,14 @@ class QObject:
         LOG.error(f'Object {self} is not visible within {timeout_msec} ms')
         raise TimeoutError(f'Object {self} is not visible within {timeout_msec} ms')
 
+    @allure.step('Wait until stable {0}')
+    def wait_until_stable(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
+        assert driver.waitFor(
+            lambda: self.is_visible and self.width > 0 and self.height > 0,
+            timeout_msec,
+        ), f'{self} geometry was not stable within {timeout_msec} ms'
+        return self
+
     @allure.step('Wait until hidden {0}')
     def wait_until_hidden(self, timeout_msec: int =  configs.timeouts.UI_LOAD_TIMEOUT_MSEC, check_interval=0.5):
         timeout_sec = timeout_msec / 1000

--- a/test/e2e/gui/screens/onboarding.py
+++ b/test/e2e/gui/screens/onboarding.py
@@ -720,9 +720,9 @@ class ReturningLoginView(QObject):
     @allure.step('Add existing user')
     def add_existing_status_user(self):
         self.user_selector_button.click()
-        OnboardingLoginUsersPopup().wait_until_appears().create_profile_button.click()
+        popup = OnboardingLoginUsersPopup().wait_until_appears()
+        popup.create_profile_button.wait_until_stable().click()
         return CreateYourProfileViewOnboarding().wait_until_appears()
-
 
     @allure.step('Select user by name')
     def select_user_by_name(self, user_name):


### PR DESCRIPTION
### What does the PR do

Fix https://github.com/status-im/status-app/issues/21752

Wait for button geometry first before clicking so test is not misclicking into wrong option. Workaround for sluggish UI under high load (lack of RAM)