### PR TITLE
Chat input: Unreachable unblock button removed / PermissionQualificationPanel positioning fixed

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -693,27 +693,6 @@ Item {
                     holdingsModel: root.viewAndPostHoldingsModel
                 }
             }
-
-            // Button wrapped into RowLayout as a workaround for QTBUG-146653 causing suggestions list inside
-            // StatusChatInput not clickable.
-            RowLayout {
-                Layout.fillWidth: false
-                Layout.fillHeight: false
-                visible: !!d.activeChatContentModule && d.activeChatContentModule.chatDetails.blocked
-
-                StatusButton {
-                    Layout.fillHeight: true
-                    Layout.maximumHeight: chatInput.implicitHeight
-                    verticalPadding: 0
-                    visible: !!d.activeChatContentModule && d.activeChatContentModule.chatDetails.blocked
-                    text: qsTr("Unblock")
-                    type: StatusBaseButton.Type.Danger
-                    onClicked: {
-                        if (!!d.activeChatContentModule)
-                            d.activeChatContentModule.unblockChat()
-                    }
-                }
-            }
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -684,8 +684,10 @@ Item {
                 ChatPermissionQualificationPanel {
                     id: channelPostRestrictions
 
-                    parent: chatInput.textInput
+                    parent: chatInput.textInput.parent
                     anchors.fill: parent
+                    anchors.leftMargin: Theme.padding
+                    anchors.rightMargin: Theme.padding
                     visible: (!!root.viewAndPostHoldingsModel && (root.viewAndPostHoldingsModel.count > 0)
                               && !root.amISectionAdmin && !root.canPost)
                     assetsModel: root.rootStore.assetsModel

--- a/ui/app/AppLayouts/Communities/panels/ChatPermissionQualificationPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/ChatPermissionQualificationPanel.qml
@@ -56,7 +56,7 @@ Item {
                                     enabled: false
                                     leftPadding: 2
                                     title: model.text
-                                    asset.name: model.imageSource
+                                    asset.name: model.imageSource || ""
                                     asset.isImage: true
                                     asset.bgColor: "transparent"
                                     asset.height: 16

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2930,10 +2930,6 @@ Do you wish to override the security check and continue?</source>
         <source>Sending...</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Unblock</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>ChatContentView</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2940,10 +2940,6 @@ Přejete si obejít bezpečnostní kontrolu a pokračovat?</translation>
         <source>Sending...</source>
         <translation>Odesílání...</translation>
     </message>
-    <message>
-        <source>Unblock</source>
-        <translation>Odblokovat</translation>
-    </message>
 </context>
 <context>
     <name>ChatContentView</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2932,10 +2932,6 @@ Do you wish to override the security check and continue?</source>
         <source>Sending...</source>
         <translation>Enviando...</translation>
     </message>
-    <message>
-        <source>Unblock</source>
-        <translation>Desbloquear</translation>
-    </message>
 </context>
 <context>
     <name>ChatContentView</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2923,10 +2923,6 @@ Do you wish to override the security check and continue?</source>
         <source>Sending...</source>
         <translation>보내는 중...</translation>
     </message>
-    <message>
-        <source>Unblock</source>
-        <translation>차단 해제</translation>
-    </message>
 </context>
 <context>
     <name>ChatContentView</name>


### PR DESCRIPTION
### What does the PR do

- removes "Unblock" button as it's currently not reachable in UI (chat is removed from chats list when blocked)
- simple fix for `PermissionQualificationPanel` positioning

Closes: #20814
Closes: #21819

### Affected areas
`ChatColumnView`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="1171" height="694" alt="Screenshot from 2026-08-06 17-46-27" src="https://github.com/user-attachments/assets/d84a89ae-6a47-4606-af07-4bd64f56e624" />

### Impact on end user

Low

### How to test

Go to token-gated chat when missing token.

### Risk 

Low
