### PR TITLE
Fix: UI fixes to ChatTextView and Status(Text)Message

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/ChatSingleLineTextView.qml
+++ b/ui/StatusQ/src/StatusQ/Components/ChatSingleLineTextView.qml
@@ -32,6 +32,9 @@ Control {
     // behind the text (the component's own background by default).
     property color fadeColor: Theme.palette.background
 
+    font.family: Fonts.baseFont.family
+    font.pixelSize: Theme.primaryTextFontSize
+
     contentItem: Text {
         id: label
 

--- a/ui/StatusQ/src/StatusQ/Components/ChatTextView.qml
+++ b/ui/StatusQ/src/StatusQ/Components/ChatTextView.qml
@@ -60,6 +60,9 @@ Control {
     property color mentionBackgroundColor: Theme.palette.baseColor2
     property color linkHoverColor: Theme.palette.primaryColor3
 
+    font.family: Fonts.baseFont.family
+    font.pixelSize: Theme.primaryTextFontSize
+
     // Copies the current cross-block selection to the clipboard.
     function copySelection() {
         if (root.selectedText.length > 0)

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -122,7 +122,6 @@ Control {
     }
 
     hoverEnabled: (!root.isActiveMessage && !root.disableHover)
-    opacity: outgoingStatus === StatusMessage.OutgoingStatus.Sending ? 0.5 : 1.0
     background: Rectangle {
         color: {
             if (root.overrideBackground)
@@ -259,12 +258,13 @@ Control {
                             amISender: root.messageDetails.amISender
                             messageOriginInfo: root.messageDetails.messageOriginInfo
                             resendError: root.messageDetails.amISender ? root.resendError : ""
-                            onClicked: (sender) => root.senderNameClicked(sender)
-                            onResendClicked: root.resendClicked()
                             timestamp: root.timestamp
                             displayNameClickable: root.profileClickable
                             outgoingStatus: root.outgoingStatus
-                            showOutgointStatusLabel: root.hovered && !root.isInPinnedPopup
+                            isMobile: root.isMobile
+                            showOutgoingStatusLabel: root.hovered && !root.isInPinnedPopup
+                            onClicked: (sender) => root.senderNameClicked(sender)
+                            onResendClicked: root.resendClicked()
                         }
                     }
                     Loader {
@@ -376,7 +376,7 @@ Control {
 
         Loader {
             active: root.quickActions.length > 0
-                    && !Utils.isMobile // hover menu disabled on mobile; we use the MessageContextMenuView
+                    && !root.isMobile // hover menu disabled on mobile; we use the MessageContextMenuView
             visible: active && root.hovered
             anchors.right: parent.right
             anchors.rightMargin: Theme.padding

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
@@ -26,7 +26,8 @@ Item {
     property string messageOriginInfo: ""
     property bool showFullTimestamp
     property int outgoingStatus: StatusMessage.OutgoingStatus.Unknown
-    property bool showOutgointStatusLabel: false
+    property bool showOutgoingStatusLabel: false
+    property bool isMobile
 
     signal clicked(var sender)
     signal resendClicked()
@@ -38,6 +39,7 @@ Item {
         id: d
 
         readonly property bool expired: root.outgoingStatus === StatusMessage.OutgoingStatus.Expired
+        readonly property bool failedToSend: root.resendError != ""
         readonly property color outgoingStatusColor: expired ? Theme.palette.warningColor1 : Theme.palette.baseColor1
     }
 
@@ -85,10 +87,11 @@ Item {
         Loader {
             id: messageOriginInfoLoader
             active: root.messageOriginInfo
+            visible: active
             sourceComponent: StatusBaseText {
                 verticalAlignment: Text.AlignVCenter
                 color: Theme.palette.baseColor1
-                font.pixelSize: Theme.asideTextFontSize
+                font.pixelSize: Theme.tertiaryTextFontSize
                 text: root.messageOriginInfo
             }
         }
@@ -96,6 +99,7 @@ Item {
         Loader {
             id: verificationIconsLoader
             active: !root.amISender
+            visible: active
             sourceComponent: StatusContactVerificationIcons {
                 isContact: root.isContact
                 trustIndicator: root.trustIndicator
@@ -109,7 +113,7 @@ Item {
             sourceComponent: StatusBaseText {
                 verticalAlignment: Text.AlignVCenter
                 color: Theme.palette.baseColor1
-                font.pixelSize: Theme.asideTextFontSize
+                font.pixelSize: Theme.tertiaryTextFontSize
                 text: `(${root.sender.secondaryName})`
             }
         }
@@ -118,6 +122,7 @@ Item {
             id: dotLoader
             sourceComponent: dotComponent
             active: secondaryDisplayNameLoader.active && tertiaryDetailTextLoader.active
+            visible: active
         }
 
         Loader {
@@ -126,8 +131,7 @@ Item {
             visible: active
             sourceComponent: StatusBaseText {
                 verticalAlignment: Text.AlignVCenter
-                font.pixelSize: Theme.asideTextFontSize
-                visible: text
+                font.pixelSize: Theme.tertiaryTextFontSize
                 elide: Text.ElideMiddle
                 color: Theme.palette.baseColor1
                 text: Utils.elideText(root.tertiaryDetail, 3, 6)
@@ -137,10 +141,12 @@ Item {
         Loader {
             id: secondDotLoader
             sourceComponent: dotComponent
-            active: verificationIconsLoader.active && verificationIconsLoader.item.width <= 0 || secondaryDisplayNameLoader.active || root.amISender || tertiaryDetailTextLoader.active
+            active: verificationIconsLoader.active || secondaryDisplayNameLoader.active || root.amISender || tertiaryDetailTextLoader.active
+            visible: active
         }
 
         StatusTimeStampLabel {
+            Layout.alignment: Qt.AlignVCenter
             id: timestampText
             verticalAlignment: Text.AlignVCenter
             timestamp: root.timestamp
@@ -151,7 +157,7 @@ Item {
             id: dotComponent
             StatusBaseText {
                 verticalAlignment: Text.AlignVCenter
-                font.pixelSize: Theme.asideTextFontSize
+                font.pixelSize: Theme.tertiaryTextFontSize
                 color: Theme.palette.baseColor1
                 text: "•"
             }
@@ -161,15 +167,15 @@ Item {
             id: deliveryStatusLoader
             Layout.alignment: Qt.AlignVCenter
             active: root.amISender && root.outgoingStatus !== StatusMessage.OutgoingStatus.Unknown
+            visible: active
             sourceComponent: RowLayout {
                 spacing: 0
                 StatusIcon {
-                    Layout.preferredHeight: 15
-                    Layout.preferredWidth: 15
-                    Layout.alignment: Qt.AlignVCenter
+                    Layout.preferredHeight: 16
+                    Layout.preferredWidth: 16
                     color: d.outgoingStatusColor
                     icon: {
-                        if (root.resendError != "")
+                        if (d.failedToSend)
                             return "tiny/tiny-exclamation"
                         switch (root.outgoingStatus) {
                         case StatusMessage.OutgoingStatus.Delivered:
@@ -186,11 +192,14 @@ Item {
                     }
                 }
                 Loader {
-                    active: root.showOutgointStatusLabel
+                    active: root.showOutgoingStatusLabel ||
+                            (root.isMobile && (d.expired || d.failedToSend)) // always show the Resend on mobile
+                    visible: active
+                    Layout.alignment: Qt.AlignVCenter
                     sourceComponent: StatusBaseText {
-                        Layout.alignment: Qt.AlignVCenter
+                        verticalAlignment: Text.AlignVCenter
                         color: d.outgoingStatusColor
-                        font.pixelSize: Theme.asideTextFontSize
+                        font.pixelSize: Theme.tertiaryTextFontSize
                         text: {
                             if (root.resendError != "")
                                 return qsTr("Failed to resend: %1").arg(root.resendError)
@@ -214,14 +223,15 @@ Item {
 
         Loader {
             id: resendButtonLoader
-            active: root.showOutgointStatusLabel && d.expired
+            Layout.alignment: Qt.AlignVCenter
+            active: (root.showOutgoingStatusLabel || root.isMobile) && d.expired
+            visible: active
             sourceComponent: StatusButton {
-                Layout.fillHeight: true
-                verticalPadding: 1
-                horizontalPadding: 5
-                size: StatusBaseButton.Tiny
-                type: StatusBaseButton.Warning
-                font.pixelSize: Theme.fontSize(9)
+                verticalPadding: 2
+                horizontalPadding: 6
+                size: StatusBaseButton.Size.Small
+                type: StatusBaseButton.Type.Warning
+                font.pixelSize: Theme.tertiaryTextFontSize
                 text: qsTr("Resend")
                 onClicked: root.resendClicked()
             }

--- a/ui/StatusQ/src/StatusQ/Components/StatusTimeStampLabel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusTimeStampLabel.qml
@@ -12,7 +12,7 @@ StatusBaseText {
     property bool showFullTimestamp
 
     color: Theme.palette.baseColor1
-    font.pixelSize: Theme.asideTextFontSize
+    font.pixelSize: Theme.tertiaryTextFontSize
     visible: !!text
     text: d.formattedLabel
     Accessible.role: Accessible.StaticText


### PR DESCRIPTION
### What does the PR do

- ChatTextView: use our own font instead of the system one when displaying text messages
- remove decreased opacity for a message being sent
- slightly increase the size of the header and the Resend button
- always show the Resend text+button on mobile, not just on hover
- fix gaps in the header due to inactive loaders

Fixes https://github.com/status-im/status-app/issues/21795

### Affected areas

Status(Text)Message, ChatTextView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Copilot review guidance

When asking GitHub Copilot to review this PR, include:

- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-qml-review
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-ui-design
- https://github.com/TheQtCompanyRnD/agent-skills/tree/main/skills/qt-cpp-review

Also ask Copilot to align feedback with repository architecture boundaries:

- QML/StatusQ: presentation and interaction
- Nim (`src/`): orchestration, signals, module wiring
- `vendor/status-go`: backend logic, persistence, protocol, notifications

### Screencapture of the functionality

<img width="2178" height="1800" alt="image" src="https://github.com/user-attachments/assets/66d74f24-0a1c-4d2e-9927-213b5a9f171e" />

### Impact on end user

Smoother UI on mobile

### How to test

- check the text message rendering, esp. when being sent or failed

### Risk 

low
