### PR TITLE
fix(wallet): mark BalanceItem/AssetGroupItem as {.acyclic.}

### DIFF
--- a/src/app_service/service/wallet_account/dto/asset_group_item.nim
+++ b/src/app_service/service/wallet_account/dto/asset_group_item.nim
@@ -1,7 +1,10 @@
 import stint
 
 type
-  BalanceItem* = ref object of RootObj
+  # {.acyclic.}: only value fields, no refs — without it ORC treats the inheritable
+  # ref as potentially cyclic, registers every item as a cycle root and runs a full
+  # collection from the balances hot path.
+  BalanceItem* {.acyclic.} = ref object of RootObj
     account*: string
     groupKey*: string
     tokenKey*: string
@@ -11,6 +14,8 @@ type
     loading*: bool ## true while status-go has no fetched balance for this (account, chain, token) yet
 
 type
-  AssetGroupItem* = ref object of RootObj
+  # {.acyclic.}: a group holds a seq of (acyclic) BalanceItems and no back-edge, so it
+  # is tree-shaped and ORC can skip cycle tracking for it too.
+  AssetGroupItem* {.acyclic.} = ref object of RootObj
     key*: string # crossChainId or tokenKey if crossChainId is empty
     balancesPerAccount*: seq[BalanceItem]


### PR DESCRIPTION
Both `BalanceItem` and `AssetGroupItem` are tree-shaped — only value fields, no back-edges — but being inheritable `ref object of RootObj` they are conservatively treated by ORC as potential cycle roots. Every item created on the balances hot path gets registered with the cycle collector, which then triggers full collections there.

Marking both types `{.acyclic.}` keeps them out of cycle tracking.

related to #21872 